### PR TITLE
chore: link chapter doctypes to foss user

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.json
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.json
@@ -65,7 +65,7 @@
    "fieldname": "chapter_lead",
    "fieldtype": "Link",
    "label": "Chapter Lead",
-   "options": "User",
+   "options": "FOSS User Profile",
    "reqd": 1
   },
   {
@@ -118,7 +118,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-07-20 14:01:15.394205",
+ "modified": "2023-07-20 15:45:45.128999",
  "modified_by": "Administrator",
  "module": "Chapters",
  "name": "FOSS Chapter",

--- a/fossunited/chapters/doctype/foss_chapter_event_member/foss_chapter_event_member.json
+++ b/fossunited/chapters/doctype/foss_chapter_event_member/foss_chapter_event_member.json
@@ -18,7 +18,7 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Member",
-   "options": "User",
+   "options": "FOSS User Profile",
    "reqd": 1
   },
   {
@@ -46,7 +46,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-07-09 12:12:46.935093",
+ "modified": "2023-07-20 15:46:00.804936",
  "modified_by": "Administrator",
  "module": "Chapters",
  "name": "FOSS Chapter Event Member",

--- a/fossunited/chapters/doctype/foss_chapter_event_participants/foss_chapter_event_participants.json
+++ b/fossunited/chapters/doctype/foss_chapter_event_participants/foss_chapter_event_participants.json
@@ -35,7 +35,7 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Participant",
-   "options": "User",
+   "options": "FOSS User Profile",
    "reqd": 1
   },
   {
@@ -48,7 +48,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-07-10 00:51:28.113154",
+ "modified": "2023-07-20 15:46:35.411640",
  "modified_by": "Administrator",
  "module": "Chapters",
  "name": "FOSS Chapter Event Participants",

--- a/fossunited/chapters/doctype/foss_chapter_lead_team_members/foss_chapter_lead_team_members.json
+++ b/fossunited/chapters/doctype/foss_chapter_lead_team_members/foss_chapter_lead_team_members.json
@@ -17,7 +17,7 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Chapter Member",
-   "options": "User",
+   "options": "FOSS User Profile",
    "reqd": 1
   },
   {
@@ -43,7 +43,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-07-09 12:13:09.915709",
+ "modified": "2023-07-20 15:46:54.979193",
  "modified_by": "Administrator",
  "module": "Chapters",
  "name": "FOSS Chapter Lead Team Members",


### PR DESCRIPTION
Replaced User Link fields with FOSS User Profile link fields