### PR TITLE
fix: ci mariadb install failing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,9 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install MariaDB Client
-        run: sudo apt-get install mariadb-client-10.6
+        run: |
+          sudo apt-get update
+          sudo apt-get install mariadb-client-10.6
 
       - name: Setup
         run: |


### PR DESCRIPTION


## What type of PR is this? (check all applicable)
- [ ] 🍕Feature
- [ ] ⚙️Chore
- [x] 🐛Bug Fix
- [ ] 🎨Style
- [ ] 🧑‍💻Refactor
- [ ] 📕Documentation
- [ ] 🏎️Optimization

## Description
Added `sudo apt-get update` before mariadb installation. This should hopefully fix the breaking CI

## Checklist
- [x] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [ ] I have tested these changes locally.
- [ ] I have updated the documentation (If applicable).
- [ ] The code follows the project's coding standards.
- [ ] I have added/updated tests, if applicable.
