### PR TITLE
fix: redirect to user profile on visiting `/me` route

### DIFF
--- a/fossunited/www/redirect_to_foss_profile.html
+++ b/fossunited/www/redirect_to_foss_profile.html
@@ -1,13 +1,32 @@
+{% extends "templates/foss_base.html" %}
+
+{% block page_content %}
+{% endblock %}
+
+{% block page_script %}
 <script>
-    let session_user = frappe.session.user;
-    let route = frappe.db.get_value('FOSS User Profile', {'email': session_user}, 'route');
-    if (session_user == 'Administrator'){
-        window.location.href = '/app';
-    }
-    else if (route != 'None'){
-        window.location.href = '/' + route;
-    }
-    else{
-        window.location.href = '/';
-    }
+    frappe.ready(function(){
+        let session_user = frappe.session.user;
+        frappe.call({
+            method: 'frappe.client.get_value',
+            args:{
+                doctype: 'FOSS User Profile',
+                filters: {'email': session_user},
+                fieldname: ['route']
+            },
+            callback: (r) => {
+                let route = r.message.route;
+                if (session_user == 'Administrator'){
+                    window.location.href = '/app';
+                }
+                else if (route != 'None'){
+                    window.location.href = '/' + route;
+                }
+                else{
+                    window.location.href = '/';
+                }
+            }
+        })
+    })
 </script>
+{% endblock %}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕Feature
- [ ] ⚙️Chore
- [x] 🐛Bug Fix
- [ ] 🎨Style
- [ ] 🧑‍💻Refactor
- [ ] 📕Documentation
- [ ] 🏎️Optimization

## Description
Website was hallucinating on visiting `/me` route. This fix will hopefully fix that to route user to their FOSS User Profile Page 


## Checklist
- [x] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [x] I have tested these changes locally.
- [ ] I have updated the documentation (If applicable).
- [x] The code follows the project's coding standards.
- [ ] I have added/updated tests, if applicable.
