### PR TITLE
fix: flags added for no welcome mail on signup

### DIFF
--- a/fossunited/overrides/signup.py
+++ b/fossunited/overrides/signup.py
@@ -41,6 +41,7 @@ def sign_up(username, email, full_name, gender, new_password):
     )
     user.flags.ignore_permissions = True
     user.flags.ignore_password_policy = True
+    user.flags.no_welcome_email = True
     user.insert()
 
     # create FOSS User Profile
@@ -54,7 +55,10 @@ def sign_up(username, email, full_name, gender, new_password):
     )
     foss_profile.flags.ignore_permissions = True
     foss_profile.insert()
-    user.flags.redirect_to = "/" + foss_profile.route
+
+    frappe.cache.hset(
+        "redirect_after_login", user.name, f"/{foss_profile.route}"
+    )
 
     # set default signup role as per Portal Settings
     default_role = frappe.db.get_value(

--- a/fossunited/templates/custom_signup_form.html
+++ b/fossunited/templates/custom_signup_form.html
@@ -105,6 +105,8 @@
             return false;
         }
 
+        login.set_status('{{ _("Creating your account...") }}', 'blue');
+
         frappe.call({
             method: "fossunited.overrides.signup.sign_up",
             args: {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕Feature
- [ ] ⚙️Chore
- [x] 🐛Bug Fix
- [ ] 🎨Style
- [ ] 🧑‍💻Refactor
- [ ] 📕Documentation
- [ ] 🏎️Optimization

## Description
User was getting an email to reset password on signup. This should fix that

## Related Issues & Docs
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

## Checklist
- [x] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [x] I have tested these changes locally.
- [ ] I have updated the documentation (If applicable).
- [x] The code follows the project's coding standards.
- [ ] I have added/updated tests, if applicable.

## Screenshots/GIFs/Screen Recordings (if applicable)
<!-- Visually demonstrate the changes, if applicable -->

## Additional context
<!-- Add any additional information that might be relevant to the review process -->

## [optional] What gif best describes this PR or how it makes you feel?
