### PR TITLE
chore!: set `send_welcome_email = 0` in signup.py

### DIFF
--- a/fossunited/overrides/signup.py
+++ b/fossunited/overrides/signup.py
@@ -41,6 +41,7 @@ def sign_up(username, email, full_name, gender, new_password):
     )
     user.flags.ignore_permissions = True
     user.flags.ignore_password_policy = True
+    user.send_welcome_email = 0
     user.flags.no_welcome_email = True
     user.insert()
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕Feature
- [x] ⚙️Chore
- [x] 🐛Bug Fix
- [ ] 🎨Style
- [ ] 🧑‍💻Refactor
- [ ] 📕Documentation
- [ ] 🏎️Optimization

## Description
Explicit set send_welcome_mail as 0. This should prohibit sending of reset password emails. Temporary fix.

## Related Issues & Docs
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

## Checklist
- [ ] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [ ] I have tested these changes locally.
- [ ] I have updated the documentation (If applicable).
- [ ] The code follows the project's coding standards.
- [ ] I have added/updated tests, if applicable.

## Screenshots/GIFs/Screen Recordings (if applicable)
<!-- Visually demonstrate the changes, if applicable -->

## Additional context
<!-- Add any additional information that might be relevant to the review process -->

## [optional] What gif best describes this PR or how it makes you feel?
