### PR TITLE
fix: redirect to user profile on route `/me` from backend

### DIFF
--- a/fossunited/hooks.py
+++ b/fossunited/hooks.py
@@ -77,10 +77,6 @@ website_route_rules = [
         "from_route": "/<foss_user>/edit-profile",
         "to_route": "/foss_profile/edit",
     },
-    {
-        "from_route": "/me",
-        "to_route": "/redirect_to_foss_profile",
-    },
 ]
 
 # add methods and filters to jinja environment

--- a/fossunited/www/me.py
+++ b/fossunited/www/me.py
@@ -1,0 +1,19 @@
+import frappe
+
+
+def get_context(context):
+    if frappe.session.user == "Guest":
+        frappe.local.flags.redirect_location = (
+            f"/login?redirect-to={frappe.request.url}#signup"
+        )
+    elif frappe.session.user == "Administrator":
+        frappe.local.flags.redirect_location = "/desk"
+    else:
+        redirect_route = frappe.db.get_value(
+            "FOSS User Profile",
+            {"email": frappe.session.user},
+            "route",
+        )
+        frappe.local.flags.redirect_location = redirect_route
+
+    raise frappe.Redirect


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕Feature
- [x] ⚙️Chore
- [x] 🐛Bug Fix
- [ ] 🎨Style
- [ ] 🧑‍💻Refactor
- [ ] 📕Documentation
- [ ] 🏎️Optimization

## Description
<!-- Briefly describe the changes introduced by this pull request -->
Redirecting user to their foss profiles when they visit /me. This was being done in js, but this PR changes it to be done from backend instead.
## Related Issues & Docs
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

## Checklist
- [x] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [x] I have tested these changes locally.
- [x] I have updated the documentation (If applicable).
- [x] The code follows the project's coding standards.
- [ ] I have added/updated tests, if applicable.

## Screenshots/GIFs/Screen Recordings (if applicable)
<!-- Visually demonstrate the changes, if applicable -->

## Additional context
<!-- Add any additional information that might be relevant to the review process -->

## [optional] What gif best describes this PR or how it makes you feel?
