### PR TITLE
chore: hide `private` option on fileupload dialog in profiles

### DIFF
--- a/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
@@ -262,6 +262,28 @@
         })
     })
 
+    // Hide Private Option in File Preview Modal
+    $(document).on('DOMNodeInserted', (event) => {
+        if ($(event.target).hasClass('file-preview')) {
+            $(event.target).find('label:contains("Private")').each((index, labelElement) => {
+                // Hide the label
+                $(labelElement).hide();
+            });
+        }
+        if ($(event.target).hasClass('btn-secondary') && $(event.target).text().trim() === 'Set all public') {
+            // Handle "Set all Public" buttons
+            $(event.target).click(); // Simulate button click
+            $(event.target).hide(); // Hide the button
+        }
+        if ($(event.target).hasClass('modal')) {
+            // Handle "Set all private" buttons within modals
+            const setAllPrivateButton = $(event.target).find('button.btn-secondary:contains("Set all private")');
+            if (setAllPrivateButton.length > 0) {
+                setAllPrivateButton.hide();
+            }
+        }
+    });
+
     function setNavbarControl(){
         let navItems = document.querySelectorAll('.horizontal-navbar--item');
         let contentDivs = document.querySelectorAll('.content-div');


### PR DESCRIPTION
`private` checkbox is hidden and all the files that are uploaded are set to be public by default

## What type of PR is this? (check all applicable)
- [ ] 🍕Feature
- [x] ⚙️Chore
- [ ] 🐛Bug Fix
- [ ] 🎨Style
- [ ] 🧑‍💻Refactor
- [ ] 📕Documentation
- [ ] 🏎️Optimization

## Description
- Hidden the `private` checkbox that comes while uploading project images.
- All project cover images are public by default.
 
## Related Issues & Docs
#148 


## Checklist
- [x] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [x] I have tested these changes locally.
- [x] I have updated the documentation (If applicable).
- [x] The code follows the project's coding standards.
- [ ] I have added/updated tests, if applicable.

## Screenshots/GIFs/Screen Recordings (if applicable)
<!-- Visually demonstrate the changes, if applicable -->
![image](https://github.com/fossunited/fossunited/assets/73123690/fa6eb27e-32c2-45e8-b856-ca77453bfd93)


## Additional context
<!-- Add any additional information that might be relevant to the review process -->

## [optional] What gif best describes this PR or how it makes you feel?
