### PR TITLE
fix: remove jquery script addition in book-conference-ticket page

### DIFF
--- a/fossunited/www/book-conference-ticket/index.html
+++ b/fossunited/www/book-conference-ticket/index.html
@@ -138,7 +138,6 @@
 {% endblock %}
 {% block page_script %}
 <script src="https://checkout.razorpay.com/v1/checkout.js"></script>
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
 
 <script>
   /* function and jquery event listener to update the total_amount and also to pass this ahead in the tickets variable which adds data to document */


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕Feature
- [ ] ⚙️Chore
- [x] 🐛Bug Fix
- [ ] 🎨Style
- [ ] 🧑‍💻Refactor
- [ ] 📕Documentation
- [ ] 🏎️Optimization

## Description
<!-- Briefly describe the changes introduced by this pull request -->
- Double addition of Jquery Library was giving errors such as `Uncaught TypeError: this.$wrapper.modal is not a function frappe`

## Related Issues & Docs
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

## Checklist
- [x] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [x] I have tested these changes locally.
- [x] I have updated the documentation (If applicable).
- [x] The code follows the project's coding standards.
- [ ] I have added/updated tests, if applicable.

## Screenshots/GIFs/Screen Recordings (if applicable)
<!-- Visually demonstrate the changes, if applicable -->

## Additional context
<!-- Add any additional information that might be relevant to the review process -->

## [optional] What gif best describes this PR or how it makes you feel?
