### PR TITLE
fix: event fieldvalue empty in book-conference-ticket page

### DIFF
--- a/fossunited/www/book-conference-ticket/index.html
+++ b/fossunited/www/book-conference-ticket/index.html
@@ -34,7 +34,7 @@
         </div>
       </div>
 
-      <input type="text" class="form-control" id="event" name="event" required disabled hidden />
+      <input type="text" class="form-control" id="event" name="event" value="{{ event.name }}" required disabled hidden />
 
       <div class="form-padding form-group">
         <div class="form-row">

--- a/fossunited/www/book-conference-ticket/index.html
+++ b/fossunited/www/book-conference-ticket/index.html
@@ -40,22 +40,22 @@
         <div class="form-row">
           <div class="form-group col-md-6">
             <label for="first_name">First Name</label>
-            <input type="text" class="form-control" id="first_name" name="first_name" required />
+            <input type="text" class="form-control" id="first_name" name="first_name" value="{{ session_user.first_name or ''}}" required />
           </div>
           <div class="form-group col-md-6">
             <label for="last_name">Last Name</label>
-            <input type="text" class="form-control" id="last_name" name="last_name" required />
+            <input type="text" class="form-control" id="last_name" name="last_name" value="{{ session_user.last_name or ''}}" required />
           </div>
         </div>
 
         <div class="form-row">
           <div class="form-group col-md-6">
             <label for="email">Email</label>
-            <input type="email" class="form-control" id="email" name="email" required />
+            <input type="email" class="form-control" id="email" name="email" value="{{ session_user.email or ''}}" required />
           </div>
           <div class="form-group col-md-6">
             <label for="mobile">Phone</label>
-            <input type="text" class="form-control" id="phone" name="mobile" required />
+            <input type="text" class="form-control" id="phone" name="mobile" />
           </div>
         </div>
 

--- a/fossunited/www/book-conference-ticket/index.py
+++ b/fossunited/www/book-conference-ticket/index.py
@@ -14,6 +14,10 @@ def get_context(context):
         "FOSS Chapter Events",
         {"event_permalink": frappe.form_dict.event_permalink},
     ).as_dict()
+    context.session_user = frappe.get_doc(
+        "User", frappe.session.user
+    ).as_dict()
+    context.no_cache = 1
 
 
 # Script Script for creating order ID


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕Feature
- [x] ⚙️Chore
- [x] 🐛Bug Fix
- [ ] 🎨Style
- [ ] 🧑‍💻Refactor
- [ ] 📕Documentation
- [ ] 🏎️Optimization

## Description
<!-- Briefly describe the changes introduced by this pull request -->
- fix event field value being empty by fetching it from context
- autofill user fields using context script

## Related Issues & Docs
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

## Checklist
- [x] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [x] I have tested these changes locally.
- [x] I have updated the documentation (If applicable).
- [x] The code follows the project's coding standards.
- [ ] I have added/updated tests, if applicable.

## Screenshots/GIFs/Screen Recordings (if applicable)
<!-- Visually demonstrate the changes, if applicable -->

## Additional context
<!-- Add any additional information that might be relevant to the review process -->

## [optional] What gif best describes this PR or how it makes you feel?
