### PR TITLE
fix: unpublished events in upcoming events template

### DIFF
--- a/fossunited/fossunited/web_template/foss_events___upcoming_events_section/foss_events___upcoming_events_section.html
+++ b/fossunited/fossunited/web_template/foss_events___upcoming_events_section/foss_events___upcoming_events_section.html
@@ -238,7 +238,7 @@
         </div>
 
         {% from "fossunited/templates/macros/event_card.html" import event_card %}
-        {% set events = frappe.get_all("FOSS Chapter Event", fields=["event_name", "banner_image", "route", "must_attend", "event_location", "map_link", "event_start_date", "banner_image"], filters={"status": "Approved", "event_start_date": ['>=', frappe.utils.now()]}, page_length=6, order_by='event_start_date') %}
+        {% set events = frappe.get_all("FOSS Chapter Event", fields=["event_name", "banner_image", "route", "must_attend", "event_location", "map_link", "event_start_date", "banner_image"], filters={"status": "Approved", "is_published": 1, "event_start_date": ['>=', frappe.utils.now()]}, page_length=6, order_by='event_start_date') %}
         <div class="events-grid-4">
             {% for event in events %}
                 {{ event_card(event) }}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕Feature
- [ ] ⚙️Chore
- [x] 🐛Bug Fix
- [ ] 🎨Style
- [ ] 🧑‍💻Refactor
- [ ] 📕Documentation
- [ ] 🏎️Optimization

## Description
<!-- Briefly describe the changes introduced by this pull request -->
- Unpublished events were showing up in upcoming events section. Fixed that to only show events with published web views.

## Related Issues & Docs
closes #202 
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

## Checklist
- [x] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [x] I have tested these changes locally.
- [x] I have updated the documentation (If applicable).
- [x] The code follows the project's coding standards.
- [ ] I have added/updated tests, if applicable.
