### PR TITLE
fix: caching issue for cfp and rsvp submissions

### DIFF
--- a/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.py
@@ -19,8 +19,6 @@ class FOSSEventRSVP(WebsiteGenerator):
             self.is_published = 0
 
     def get_context(self, context):
-        frappe.cache().set_value("linked_rsvp", self.name)
-
         context.event = frappe.get_doc(
             "FOSS Chapter Event", self.event
         )
@@ -63,7 +61,6 @@ class FOSSEventRSVP(WebsiteGenerator):
                     "submitted_by": frappe.session.user,
                 },
             )
-            frappe.cache().set_value("submission", context.submission)
 
         context.no_cache = 1
 
@@ -109,7 +106,6 @@ class FOSSEventRSVP(WebsiteGenerator):
 def create_rsvp(fields):
     fields_dict = {
         "doctype": "FOSS Event RSVP Submission",
-        "linked_rsvp": frappe.cache().get_value("linked_rsvp"),
         "submitted_by": frappe.session.user,
     }
     fields_dict.update(json.loads(fields))

--- a/fossunited/chapters/doctype/foss_event_rsvp/templates/foss_event_rsvp.html
+++ b/fossunited/chapters/doctype/foss_event_rsvp/templates/foss_event_rsvp.html
@@ -47,7 +47,7 @@
             <div class="foss-form-description">
                 {{ _("You have successfully RSVP'd for this event. If you need to make any changes, you can edit the rsvp form.") }}
             </div>
-            <button onclick="window.location.pathname+='/edit/{{submission}}'">Edit RSVP Response</button>
+            <button onclick="window.location.pathname+='/{{submission}}/edit'">Edit RSVP Response</button>
         </div>
     </div>
 {% endmacro %}
@@ -90,6 +90,7 @@
             const formData = $('.foss-form-body').serializeArray()
             const data = {}
 
+            data['linked_rsvp'] = '{{ doc.name }}'
             formData.forEach((field) => {
                 data[field.name] = field.value
             })

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.json
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.json
@@ -34,6 +34,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "columns": 2,
    "fieldname": "submitted_by",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -56,11 +57,11 @@
    "fetch_from": "linked_rsvp.event",
    "fieldname": "event",
    "fieldtype": "Data",
-   "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Event"
   },
   {
+   "columns": 3,
    "fetch_from": "linked_rsvp.chapter",
    "fieldname": "chapter",
    "fieldtype": "Data",
@@ -97,6 +98,7 @@
    "label": "Meta Info"
   },
   {
+   "columns": 3,
    "fetch_from": "linked_rsvp.event_name",
    "fieldname": "event_name",
    "fieldtype": "Data",
@@ -114,7 +116,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-19 16:57:43.974430",
+ "modified": "2024-04-08 14:57:50.796337",
  "modified_by": "Administrator",
  "module": "Chapters",
  "name": "FOSS Event RSVP Submission",

--- a/fossunited/fossunited/doctype/foss_event_cfp/foss_event_cfp.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp/foss_event_cfp.py
@@ -43,8 +43,7 @@ class FOSSEventCFP(WebsiteGenerator):
         )
 
     def get_context(self, context):
-        frappe.cache().set_value("linked_cfp", self.name)
-        context.submissions = get_cfp_submissions()
+        context.submissions = get_cfp_submissions(self.name)
         context.event = frappe.get_doc(
             "FOSS Chapter Event", self.event
         )
@@ -163,7 +162,6 @@ class FOSSEventCFP(WebsiteGenerator):
 def create_cfp_submission(fields):
     fields_dict = {
         "doctype": "FOSS Event CFP Submission",
-        "linked_cfp": frappe.cache().get_value("linked_cfp"),
         "submitted_by": frappe.session.user,
     }
     fields_dict.update(frappe.parse_json(fields))
@@ -171,13 +169,13 @@ def create_cfp_submission(fields):
 
 
 @frappe.whitelist()
-def get_cfp_submissions():
+def get_cfp_submissions(linked_cfp):
     submissions = frappe.get_all(
         "FOSS Event CFP Submission",
         fields=["*"],
         filters={
             "submitted_by": frappe.session.user,
-            "linked_cfp": frappe.cache().get_value("linked_cfp"),
+            "linked_cfp": linked_cfp,
         },
     )
     frappe.form_dict["submissions"] = submissions

--- a/fossunited/fossunited/doctype/foss_event_cfp/templates/foss_event_cfp.html
+++ b/fossunited/fossunited/doctype/foss_event_cfp/templates/foss_event_cfp.html
@@ -95,6 +95,7 @@
             const formData = $('.foss-form-body').serializeArray()
             const data = {}
 
+            data["linked_cfp"] = "{{ doc.name }}"
             formData.forEach((field) => {
                 data[field.name] = field.value
             })

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.json
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.json
@@ -15,6 +15,7 @@
   "attendance_confirmed",
   "column_break_vctq",
   "linked_cfp",
+  "chapter",
   "event",
   "event_name",
   "submitted_by",
@@ -62,17 +63,15 @@
   {
    "fieldname": "submitted_by",
    "fieldtype": "Link",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
    "label": "Submitted By",
    "options": "User"
   },
   {
+   "columns": 2,
    "fetch_from": "linked_cfp.event_name",
    "fieldname": "event_name",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "in_standard_filter": 1,
    "label": "Event Name"
   },
   {
@@ -115,6 +114,7 @@
    "label": "About Talk"
   },
   {
+   "columns": 3,
    "fieldname": "talk_title",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -139,6 +139,7 @@
    "reqd": 1
   },
   {
+   "columns": 2,
    "fieldname": "status",
    "fieldtype": "Select",
    "in_list_view": 1,
@@ -149,8 +150,6 @@
   {
    "fieldname": "category",
    "fieldtype": "Select",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
    "label": "Talk Category",
    "options": "\nFOSS\nHardware\nPolicy\nEducation\nCommunity\nSponsor\nPanel Discussion\nDiscussion\nDesign\nFOSS / GIS\nGov. / GIS\nGov.\nFOSS / Policy\nHardware / FOSS / Community\nFOSS project showcase\nOpening Note\nOther"
   },
@@ -258,13 +257,22 @@
    "fieldname": "approvability",
    "fieldtype": "Data",
    "label": "Approvability  %"
+  },
+  {
+   "columns": 2,
+   "fetch_from": "linked_cfp.chapter",
+   "fieldname": "chapter",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Chapter"
   }
  ],
  "has_web_view": 1,
  "index_web_pages_for_search": 1,
  "is_published_field": "is_published",
  "links": [],
- "modified": "2024-03-29 16:27:15.421131",
+ "modified": "2024-04-08 15:11:27.572131",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "FOSS Event CFP Submission",
@@ -306,6 +314,8 @@
    "write": 1
   }
  ],
+ "search_fields": "submitted_by, event, event_name, chapter",
+ "show_title_field_in_link": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [
@@ -322,6 +332,7 @@
    "title": "Approved"
   }
  ],
+ "title_field": "talk_title",
  "track_changes": 1,
  "track_seen": 1
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕Feature
- [ ] ⚙️Chore
- [x] 🐛Bug Fix
- [ ] 🎨Style
- [ ] 🧑‍💻Refactor
- [ ] 📕Documentation
- [ ] 🏎️Optimization

## Description
<!-- Briefly describe the changes introduced by this pull request -->
Noticed that the submissions were linking to wrong forms. This PR seeks to fix it.

## Related Issues & Docs
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

## Checklist
- [x] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [x] I have tested these changes locally.
- [x] I have updated the documentation (If applicable).
- [x] The code follows the project's coding standards.
- [ ] I have added/updated tests, if applicable.

## Screenshots/GIFs/Screen Recordings (if applicable)
<!-- Visually demonstrate the changes, if applicable -->

## Additional context
<!-- Add any additional information that might be relevant to the review process -->

## [optional] What gif best describes this PR or how it makes you feel?
