### PR TITLE
fix(event): remove attendance_confirmed filter to get speaker list

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -112,7 +112,6 @@ class FOSSChapterEvent(WebsiteGenerator):
             filters={
                 "event": self.name,
                 "status": "Approved",
-                "attendance_confirmed": 1,
             },
             fields=["talk_title", "submitted_by"],
         )


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕Feature
- [ ] ⚙️Chore
- [x] 🐛Bug Fix
- [ ] 🎨Style
- [ ] 🧑‍💻Refactor
- [ ] 📕Documentation
- [ ] 🏎️Optimization

## Description
<!-- Briefly describe the changes introduced by this pull request -->
- Speakers were not rendering because of `confirm_attendance` in the filter
