### PR TITLE
fix: validate email field in event volunteering and add volunteer category

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter_lead_team_member/foss_chapter_lead_team_member.json
+++ b/fossunited/chapters/doctype/foss_chapter_lead_team_member/foss_chapter_lead_team_member.json
@@ -24,7 +24,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Role",
-   "options": "Core Team Member\nLead\nGraphic Designer\nContent Writer\nMarketing"
+   "options": "Lead\nCore Team Member\nVolunteer\nGraphic Designer\nContent Writer\nMarketing"
   },
   {
    "fetch_from": "chapter_member.full_name",
@@ -43,7 +43,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-04-02 01:51:58.206523",
+ "modified": "2024-04-24 13:33:03.028303",
  "modified_by": "Administrator",
  "module": "Chapters",
  "name": "FOSS Chapter Lead Team Member",

--- a/fossunited/volunteering/doctype/event_volunteer/event_volunteer.json
+++ b/fossunited/volunteering/doctype/event_volunteer/event_volunteer.json
@@ -57,6 +57,7 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Email",
+   "options": "Email",
    "reqd": 1
   },
   {
@@ -123,7 +124,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-04-16 14:49:52.541158",
+ "modified": "2024-04-24 13:31:01.108708",
  "modified_by": "Administrator",
  "module": "Volunteering",
  "name": "Event Volunteer",


### PR DESCRIPTION


## What type of PR is this? (check all applicable)
- [x] ⚙️Chore
- [x] 🐛Bug Fix


## Description

This small PR makes two changes: 

- [x] The email field in Event Volunteer doctype is validated to facilitate notifications. 
- [x] Added Volunteer category to FOSS Chapter Members


## Checklist
- [x] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [x] I have tested these changes locally.
- [ ] I have updated the documentation (If applicable).
- [x] The code follows the project's coding standards.
- [x] I have added/updated tests, if applicable.

