### PR TITLE
chore(dashboard): replace textarea with texteditor

### DIFF
--- a/dashboard/src/components/TextEditor.vue
+++ b/dashboard/src/components/TextEditor.vue
@@ -1,5 +1,6 @@
 <template>
-  <div v-if="editor" class="flex flex-col">
+  <div v-if="editor" class="flex flex-col gap-1">
+    <div class="text-base text-gray-600">{{ props.label }}</div>
     <section
       class="flex flex-wrap items-center gap-x-4 border-t border-l border-r border-gray-200 buttons font-mono p-2"
     >
@@ -452,6 +453,10 @@ const props = defineProps({
     */
     type: String,
   },
+  label: {
+    type: String,
+    default: '',
+  }
 })
 
 const editor = useEditor({

--- a/dashboard/src/pages/ChapterDetails.vue
+++ b/dashboard/src/pages/ChapterDetails.vue
@@ -81,12 +81,12 @@
           label="Chapter Type"
         />
         <div class="col-span-2">
-          <!-- ToDo: Use a TextEditor in place of a FormControl -->
-          <FormControl
-            :type="'textarea'"
-            size="md"
-            v-model="chapter.doc.about_chapter"
-            label="About chapter"
+          <TextEditor
+            placeholder="Write a description about the chapter"
+            :modelValue="chapter.doc.about_chapter"
+            @update:modelValue="
+              ($event) => (chapter.doc.about_chapter = $event)
+            "
           />
         </div>
       </div>
@@ -299,6 +299,7 @@ import { useRoute } from 'vue-router'
 import { createDocumentResource, FormControl, FileUploader } from 'frappe-ui'
 import ChapterHeader from '@/components/ChapterHeader.vue'
 import { toast } from 'vue-sonner'
+import TextEditor from '@/components/TextEditor.vue'
 
 const route = useRoute()
 

--- a/dashboard/src/pages/CreateEventForm.vue
+++ b/dashboard/src/pages/CreateEventForm.vue
@@ -8,18 +8,15 @@
     >
       <div class="text-xl font-semibold">Create Event</div>
       <Button
-        label="Create Event"
+        label="Create"
         :variant="'solid'"
         size="md"
-        icon-left="plus"
         @click="createEvent"
       />
     </div>
     <div v-if="eventTypeOptions.data">
       <div class="flex flex-col gap-3 my-6">
-        <div class="font-semibold text-gray-800 border-b-2 pb-2">
-          Event Details
-        </div>
+        <div class="font-semibold text-gray-800 border-b-2 pb-2">Details</div>
         <div
           class="p-2 my-1 grid sm:grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-6"
         >
@@ -68,17 +65,17 @@
             v-model="temp_event.event_type"
             label="Event Type"
           />
-          <FormControl
-            class="col-span-2"
-            :type="'textarea'"
-            size="md"
-            v-model="temp_event.event_description"
+          <TextEditor
             label="Event Description"
+            class="col-span-2"
+            placeholder="Write an event description"
+            :modelValue="temp_event.event_description"
+            @update:modelValue="
+              ($event) => (temp_event.event_description = $event)
+            "
           />
         </div>
-        <div class="font-semibold text-gray-800 border-b-2 pb-2">
-          Location Details
-        </div>
+        <div class="font-semibold text-gray-800 border-b-2 pb-2">Location</div>
         <div
           class="p-2 my-1 grid sm:grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-6"
         >
@@ -95,9 +92,7 @@
             side="md"
           />
         </div>
-        <div class="font-semibold text-gray-800 border-b-2 pb-2">
-          Event Timeline
-        </div>
+        <div class="font-semibold text-gray-800 border-b-2 pb-2">Timeline</div>
         <div
           class="p-2 my-1 grid sm:grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-6"
         >
@@ -130,6 +125,7 @@ import { reactive } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { toast } from 'vue-sonner'
 import ChapterHeader from '@/components/ChapterHeader.vue'
+import TextEditor from '@/components/TextEditor.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -142,7 +138,7 @@ let temp_event = reactive({
   status: '',
   event_type: '',
   event_description: '',
-  location: '',
+  location: 'TBD',
   map_link: '',
   event_start_date: '',
   event_end_date: '',

--- a/dashboard/src/pages/EventCfpCreate.vue
+++ b/dashboard/src/pages/EventCfpCreate.vue
@@ -1,7 +1,8 @@
 <template>
   <div v-if="event.doc" class="px-4 py-8 md:p-8 flex flex-col gap-4">
-    <div class="flex flex-col md:flex-row-reverse justify-between gap-2">
-      <Button size="md" icon-left="plus" label="Save" @click="createCfpForm" />
+    <div class="flex flex-col md:flex-row justify-between gap-2">
+      <div class="text-xl font-medium">Create CFP</div>
+      <Button size="md" label="Create" variant="solid" @click="createCfpForm" />
     </div>
     <div>
       <div class="grid sm:grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
@@ -53,13 +54,12 @@
           />
           <span class="text-sm text-gray-600">Only accept talk proposals.</span>
         </div>
-        <FormControl
-          size="md"
-          class="col-span-2 h-32"
-          type="textarea"
+        <TextEditor
+          class="col-span-2"
+          placeholder="This will be shown on the CFP form."
           label="CFP Form Description"
-          description="This description will be shown on the CFP form. You can use elements like <strong>bold</strong>, <em>italic</em>, <a href='#'>links</a>, etc."
-          v-model="cfp_doc.cfp_form_description"
+          :modelValue="cfp_doc.cfp_form_description"
+          @update:modelValue="($event) => (cfp_doc.cfp_form_description = $event)"
         />
       </div>
     </div>
@@ -206,6 +206,7 @@ import {
 import { reactive, ref, defineEmits } from 'vue'
 import { useRoute } from 'vue-router'
 import { toast } from 'vue-sonner'
+import TextEditor from '@/components/TextEditor.vue'
 
 const route = useRoute()
 const emit = defineEmits(['rsvpCreated'])

--- a/dashboard/src/pages/EventCfpEdit.vue
+++ b/dashboard/src/pages/EventCfpEdit.vue
@@ -78,13 +78,12 @@
           />
           <span class="text-sm text-gray-600">Only accept talk proposals.</span>
         </div>
-        <FormControl
-          size="md"
-          class="col-span-2 h-32"
-          type="textarea"
-          label="CFP Form Description"
-          description="This description will be shown on the CFP form. You can use elements like <strong>bold</strong>, <em>italic</em>, <a href='#'>links</a>, etc."
-          v-model="cfp.doc.cfp_form_description"
+        <TextEditor
+          class="col-span-2"
+          label="Form Description"
+          placeholder="This description will be shown on the CFP form."
+          :modelValue="cfp.doc.cfp_form_description"
+          @update:modelValue="($event) => (cfp.doc.cfp_form_description = $event)"
         />
       </div>
     </div>
@@ -236,6 +235,7 @@ import { reactive, ref, watch, defineEmits } from 'vue'
 import { useRoute } from 'vue-router'
 import { toast } from 'vue-sonner'
 import CopyToClipboardComponent from '@/components/CopyToClipboardComponent.vue'
+import TextEditor from '@/components/TextEditor.vue'
 
 const route = useRoute()
 

--- a/dashboard/src/pages/EventDetails.vue
+++ b/dashboard/src/pages/EventDetails.vue
@@ -5,10 +5,10 @@
         :event="event"
         :form_exists="true"
         :form="{
-          data : {
+          data: {
             is_published: event.doc.is_published,
-            doctype: 'Event'
-          }
+            doctype: 'Event',
+          },
         }"
       />
       <Button
@@ -138,13 +138,13 @@
           label="Short Event Bio"
           description="This bio may be used in OG images and in event cards. Typically it is a one-liner."
         />
-        <FormControl
-          class="col-span-2"
-          :type="'textarea'"
-          size="md"
-          v-model="event.doc.event_description"
+        <TextEditor
           label="Event Description"
-          description="Detailed description of the event. You can use <bold>, <i>, <a> tags for bold, italic, anchor(link) etc respectively."
+          class="col-span-2"
+          :modelValue="event.doc.event_description"
+          @update:modelValue="
+            ($event) => (event.doc.event_description = $event)
+          "
         />
       </div>
     </div>
@@ -190,6 +190,7 @@
 </template>
 <script setup>
 import EventHeader from '@/components/EventHeader.vue'
+import TextEditor from '@/components/TextEditor.vue'
 import {
   createDocumentResource,
   createListResource,

--- a/dashboard/src/pages/EventRsvpCreate.vue
+++ b/dashboard/src/pages/EventRsvpCreate.vue
@@ -2,7 +2,7 @@
   <div v-if="event.doc" class="px-4 py-8 md:p-8 flex flex-col gap-4">
     <div class="flex flex-col md:flex-row justify-between gap-2">
       <div class="text-xl font-medium">Create RSVP Form</div>
-      <Button size="md" icon-left="plus" label="Save" @click="createRsvpForm" />
+      <Button size="md" label="Create" variant="solid" @click="createRsvpForm" />
     </div>
     <div>
       <div class="grid sm:grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
@@ -25,13 +25,12 @@
           description="Maximum RSVP Count for the event. Default is 100."
           v-model="rsvp_doc.max_rsvp_count"
         />
-        <FormControl
-          size="md"
-          class="col-span-2 h-32"
-          type="textarea"
+        <TextEditor
+          class="col-span-2"
           label="RSVP Form Description"
-          description="This description will be shown on the RSVP form. You can use elements like <strong>bold</strong>, <em>italic</em>, <a href='#'>links</a>, etc."
-          v-model="rsvp_doc.rsvp_description"
+          placeholder="Write a description to be shown in the RSVP Form"
+          :modelValue="rsvp_doc.rsvp_description"
+          @update:modelValue="($event) => (rsvp_doc.rsvp_description = $event)"
         />
       </div>
     </div>
@@ -177,6 +176,7 @@ import {
 import { reactive, ref, defineEmits } from 'vue'
 import { useRoute } from 'vue-router'
 import { toast } from 'vue-sonner'
+import TextEditor from '@/components/TextEditor.vue'
 
 const route = useRoute()
 const emit = defineEmits(['rsvpCreated'])

--- a/dashboard/src/pages/EventRsvpEdit.vue
+++ b/dashboard/src/pages/EventRsvpEdit.vue
@@ -4,31 +4,34 @@
     class="px-4 py-8 md:p-8 flex flex-col gap-4"
   >
     <div class="flex flex-col md:flex-row-reverse justify-between gap-2">
-      <Button
-        size="md"
-        variant="solid"
-        label="Update Form"
-        @click="updateRsvpForm"
-      />
+      <div class="flex items-center gap-2">
+        <Button
+              class="w-fit"
+              size="md"
+              :theme="rsvp.doc.is_published ? 'red' : 'green'"
+              :icon-left="rsvp.doc.is_published ? 'slash' : 'upload'"
+              :label="rsvp.doc.is_published ? 'Unpublish Form' : 'Publish Form'"
+              @click="togglePublishForm"
+            />
+        <Button
+          size="md"
+          variant="solid"
+          label="Update Form"
+          @click="updateRsvpForm"
+        />
+      </div>
     </div>
     <div>
       <div class="grid sm:grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
-        <div class="flex flex-col gap-4">
+        <div class="flex flex-col gap-3">
           <div class="text-lg font-semibold">
             <span>RSVP Form is </span>
-            <span v-if="rsvp.doc.is_published" class="text-green-500"
+            <span v-if="rsvp.doc.is_published" class="text-green-600"
               >Live</span
             >
             <span v-else class="text-red-500">Unpublished</span>
           </div>
-          <Button
-            class="w-fit"
-            size="md"
-            :theme="rsvp.doc.is_published ? 'red' : 'green'"
-            :icon-left="rsvp.doc.is_published ? 'slash' : 'upload'"
-            :label="rsvp.doc.is_published ? 'Unpublish Form' : 'Publish Form'"
-            @click="togglePublishForm"
-          />
+
           <span v-if="rsvp.doc.is_published" class="text-sm text-gray-600"
             >Unpublishing the form will make it unaccessible to users.</span
           >
@@ -66,13 +69,12 @@
           description="Maximum RSVP Count for the event. Default is 100."
           v-model="rsvp.doc.max_rsvp_count"
         />
-        <FormControl
-          size="md"
-          class="col-span-2 h-32"
-          type="textarea"
+        <TextEditor
           label="RSVP Form Description"
-          description="This description will be shown on the RSVP form. You can use elements like <strong>bold</strong>, <em>italic</em>, <a href='#'>links</a>, etc."
-          v-model="rsvp.doc.rsvp_description"
+          class="col-span-2"
+          placeholder="This description will be shown on the RSVP form."
+          :modelValue="rsvp.doc.rsvp_description"
+          @update:modelValue="($event) => (rsvp.doc.rsvp_description = $event)"
         />
       </div>
     </div>
@@ -223,6 +225,7 @@ import { reactive, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { toast } from 'vue-sonner'
 import CopyToClipboardComponent from '../components/CopyToClipboardComponent.vue'
+import TextEditor from '@/components/TextEditor.vue'
 
 const route = useRoute()
 


### PR DESCRIPTION
## Description
<!-- Briefly describe the changes introduced by this pull request -->
- Replaced textarea with texteditor in dashboards. This fixes the bug where html tags were visible in description fields

## Related Issues & Docs
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
closes #346 