### PR TITLE
feat(hackathon): team invitation workflow

### DIFF
--- a/dashboard/src/components/hackathon/HackathonTeamMember.vue
+++ b/dashboard/src/components/hackathon/HackathonTeamMember.vue
@@ -1,0 +1,150 @@
+<template>
+  <div class="flex gap-4 mt-0 w-full border-b px-2">
+    <div
+      v-for="section in sections"
+      class="p-1 cursor-pointer transition-colors text-base"
+      :class="
+        inInvite == section.value
+          ? 'text-gray-900 border-b-2 border-gray-900 font-medium'
+          : ' text-gray-600'
+      "
+      @click="inInvite = section.value"
+    >
+      {{ section.name }}
+    </div>
+  </div>
+  <div class="px-2 py-3">
+    <div v-if="inInvite" class="mt-2">
+      <div class="text-sm">Invite members to join your team</div>
+      <div class="flex gap-2 my-2">
+        <FormControl
+          class="grow"
+          type="email"
+          v-model="inviteEmail"
+          placeholder="john.doe@fossunited.org"
+        />
+        <Button label="Invite" @click="createJoinRequest" variant="solid" />
+      </div>
+      <div class="w-full text-sm font-medium uppercase my-3 text-center">
+        Or
+      </div>
+      <div class="flex gap-2 items-center text-base flex-wrap">
+        <div class="">Invite via team code:</div>
+        <CopyToClipboard :route="teamCode" />
+      </div>
+      <div class="mt-2" v-if="outgoingInvites.data.length > 0">
+        <hr class="my-4" />
+        <div class="text-sm mb-2">Sent Invites:</div>
+        <div
+          v-for="invite in outgoingInvites.data"
+          class="flex items-center flex-wrap w-full gap-2 justify-between p-2 rounded-sm even:bg-gray-50"
+        >
+          <div class="text-sm text-gray-600">
+            {{ invite.reciever_email }}
+          </div>
+          <Badge
+            :label="invite.status"
+            :theme="
+              { Pending: 'orange', Accepted: 'green', Rejected: 'red' }[
+                invite.status
+              ]
+            "
+          />
+        </div>
+      </div>
+    </div>
+    <div v-else>
+      <div class="space-x-2 pt-4 px-2">
+        <div
+          v-for="member in props.team.data.members"
+          class="flex items-center gap-2"
+        >
+          <img :src="member.profile_photo" class="w-8 h-8 rounded-full" />
+          <div>
+            <div class="text-base font-medium">{{ member.full_name }}</div>
+            <div class="text-sm text-gray-600">{{ member.email }}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+<script setup>
+import { defineProps, onMounted, ref, inject } from 'vue'
+import {
+  createListResource,
+  FormControl,
+  Badge,
+  createResource,
+} from 'frappe-ui'
+import { toast } from 'vue-sonner'
+import CopyToClipboard from '@/components/CopyToClipboardComponent.vue'
+
+const inInvite = ref(0)
+const inviteEmail = ref('')
+const teamCode = ref('')
+const session = inject('$session')
+
+const sections = ref([
+  {
+    name: 'Members',
+    value: 0,
+  },
+  {
+    name: 'Invite',
+    value: 1,
+  },
+])
+
+const props = defineProps({
+  team: {
+    type: Object,
+    required: true,
+  },
+})
+
+const outgoingInvites = createListResource({
+  doctype: 'FOSS Hackathon Join Team Request',
+  fields: ['*'],
+  pageLength: 999,
+})
+
+onMounted(() => {
+  teamCode.value = props.team.data.name
+  outgoingInvites.update({
+    filters: {
+      team: props.team.data.name,
+      hackathon: props.team.data.hackathon,
+      is_outgoing_request: 1,
+    },
+  })
+  outgoingInvites.fetch()
+})
+
+const createJoinRequest = () => {
+  const invite = createResource({
+    url: 'frappe.client.insert',
+    makeParams() {
+      return {
+        doc: {
+          doctype: 'FOSS Hackathon Join Team Request',
+          team: props.team.data.name,
+          hackathon: props.team.data.hackathon,
+          requested_by: session.user,
+          reciever_email: inviteEmail.value,
+          is_outgoing_request: 1,
+        },
+      }
+    },
+    onSuccess(data) {
+      outgoingInvites.fetch()
+      inviteEmail.value = ''
+      toast.success('Invite sent successfully')
+    },
+    onError(error) {
+      toast.error('Failed to send invite' + error)
+    },
+  })
+  invite.fetch()
+}
+</script>

--- a/dashboard/src/components/hackathon/HackathonTeamMember.vue
+++ b/dashboard/src/components/hackathon/HackathonTeamMember.vue
@@ -54,16 +54,24 @@
       </div>
     </div>
     <div v-else>
-      <div class="space-x-2 pt-4 px-2">
+      <div class="pt-2 px-2 flex flex-col gap-4">
         <div
           v-for="member in props.team.data.members"
-          class="flex items-center gap-2"
+          class="flex items-center w-full justify-between gap-2"
         >
-          <img :src="member.profile_photo" class="w-8 h-8 rounded-full" />
-          <div>
-            <div class="text-base font-medium">{{ member.full_name }}</div>
-            <div class="text-sm text-gray-600">{{ member.email }}</div>
-          </div>
+            <div class="flex gap-2 items-center">
+                <img :src="member.profile_photo" class="w-8 h-8 rounded-full" />
+                <div>
+                  <div class="text-base font-medium">{{ member.full_name }}</div>
+                  <div class="text-sm text-gray-600">{{ member.email }}</div>
+                </div>
+            </div>
+            <Button
+                v-if="member.email != props.team.data.owner"
+                :label="member.email == session.user ? 'Leave' : 'Remove'"
+                theme="red"
+                @click="removeTeamMember(member)"
+            />
         </div>
       </div>
     </div>
@@ -146,5 +154,30 @@ const createJoinRequest = () => {
     },
   })
   invite.fetch()
+}
+
+const removeTeamMember = (member) => {
+  const newMembers = props.team.data.members.filter(
+    (m) => m.email != member.email
+  )
+  const team = createResource({
+    url: 'frappe.client.set_value',
+    makeParams() {
+      return {
+        doctype: 'FOSS Hackathon Team',
+        name: props.team.data.name,
+        fieldname: 'members',
+        value: newMembers,
+      }
+    },
+    onSuccess() {
+      props.team.fetch()
+      toast.success('Member removed successfully')
+    },
+    onError(error) {
+      toast.error('Failed to remove member' + error)
+    },
+  })
+  team.fetch()
 }
 </script>

--- a/dashboard/src/components/hackathon/JoinTeam.vue
+++ b/dashboard/src/components/hackathon/JoinTeam.vue
@@ -1,0 +1,145 @@
+<template>
+  <div class="flex flex-col gap-4">
+    <div class="flex flex-col gap-2">
+      <div class="text-sm">Join a team using team code</div>
+      <div class="flex items-center gap-2">
+        <FormControl
+          type="text"
+          v-model="teamCode"
+          placeholder="Enter Team Code"
+          class="grow"
+        />
+        <Button variant="solid" label="Join" @click="joinThroughCode" />
+      </div>
+    </div>
+    <div v-if="invitations.data.length > 0">
+      <hr />
+      <div class="text-sm flex items-center gap-1 mt-4">
+        <span>Invitations</span>
+        <Badge
+          :label="invitations.data.length"
+          theme="red"
+          variant="solid"
+          size="sm"
+        />
+      </div>
+      <div class="flex flex-col py-2">
+        <div
+          v-for="invite in invitations.data"
+          :key="invite"
+          class="p-2 even:bg-gray-50 flex items-center justify-between"
+        >
+          <div class="flex flex-col gap-1">
+            <div
+              class="text-lg font-medium hover:underline hover:cursor-pointer"
+              @click="openNewTab(invite.project_link.data.route)"
+            >
+              {{ invite.team_name }}
+            </div>
+            <div class="text-sm flex gap-1 items-end">Invited by <span @click="openNewTab(invite.sender_profile.data.route)" class="hover:underline hover:cursor-pointer">{{ invite.sender_name }}</span></div>
+          </div>
+          <div class="flex gap-1">
+            <Button icon="check" theme="green" @click="acceptInvite(invite.name)"/>
+            <Button icon="x" theme="red" @click="rejectInvite(invite.name)"/>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- <pre>{{ invitations.data }}</pre> -->
+</div>
+</template>
+<script setup>
+import { FormControl, createResource, Badge, createDocumentResource } from 'frappe-ui'
+import Button from 'frappe-ui/src/components/Button.vue'
+import { ref, defineProps, onMounted } from 'vue'
+
+const teamCode = ref('')
+
+const props = defineProps({
+  hackathon: {
+    type: Object,
+    required: true,
+  },
+  invitations: {
+    type: Object,
+    default: {},
+  },
+})
+
+onMounted(() => {
+  if (props.invitations.data.length) {
+    Object.entries(props.invitations.data).forEach(([key, value]) => {
+      value.sender_profile = createResource({
+        url: 'fossunited.fossunited.utils.get_foss_profile',
+        params: {
+          email: value.requested_by,
+        },
+        fields: ['route', 'full_name', 'profile_photo'],
+        auto: true,
+        realtime: true,
+      })
+      value.project_link = createResource({
+        url: 'frappe.client.get_value',
+        params: {
+          doctype: 'FOSS Hackathon Project',
+          fieldname: 'route',
+          filters: {
+            team: value.team,
+            hackathon: value.hackathon,
+          },
+        },
+        auto: true,
+        realtime: true,
+      })
+
+      return value
+    })
+  }
+})
+
+const openNewTab = (route) => {
+  window.open(document.location.origin + '/' + route, '_blank')
+}
+
+const joinThroughCode = () => {}
+
+const acceptInvite = (inviteId) => {
+    console.log(inviteId, 'accept')
+    createResource({
+        url: 'frappe.client.set_value',
+        params: {
+            doctype: 'FOSS Hackathon Join Team Request',
+            name: inviteId,
+            fieldname: 'status',
+            value: 'Accepted',
+        },
+        auto: true,
+        onSuccess: (data) => {
+            window.location.reload()
+        },
+        onError(error) {
+            console.error(error)
+        },
+    })
+}
+
+const rejectInvite = (inviteId) => {
+    console.log(inviteId, 'reject')
+    createResource({
+        url: 'frappe.client.set_value',
+        params: {
+            doctype: 'FOSS Hackathon Join Team Request',
+            name: inviteId,
+            fieldname: 'status',
+            value: 'Rejected',
+        },
+        auto: true,
+        onSuccess: (data) => {
+            props.invitations.fetch()
+        },
+        onError(error) {
+            console.error(error)
+        },
+    })
+}
+</script>

--- a/dashboard/src/pages/hackathon/InitRegister.vue
+++ b/dashboard/src/pages/hackathon/InitRegister.vue
@@ -4,6 +4,14 @@
     class="w-full p-4 flex justify-center items-center"
     v-if="hackathon.data && !team.loading"
   >
+    <Dialog class="z-50" v-model="inJoinTeam">
+      <template #body-title>
+        <div class="text-xl font-semibold">Join Team</div>
+      </template>
+      <template #body-content>
+        <JoinTeam :hackathon="hackathon" :invitations="team_invitations" />
+      </template>
+    </Dialog>
     <div class="w-full max-w-screen-xl">
       <div class="flex gap-2 my-6 items-center text-base uppercase">
         <span class="font-semibold">My Hackathons</span>
@@ -27,7 +35,7 @@
       <hr class="my-6" />
       <div class="grid grid-cols-1 gap-5 md:grid-cols-2 pt-6 md:p-0">
         <div
-          class="w-full md:h-40 flex flex-col gap-4 items-center justify-center md:border-r-2"
+          class="w-full md:h-40 flex flex-col gap-4 items-center justify-start md:border-r-2 md:pt-4"
         >
           <div
             class="px-4 py-2 w-3/4 text-center uppercase border-2 border-gray-900 md:w-fit font-semibold bg-white hover:bg-gray-900 hover:text-white transition-colors cursor-pointer"
@@ -42,13 +50,42 @@
         </div>
         <div class="md:hidden w-full text-center font-medium">OR</div>
         <div
-          class="w-full md:h-40 flex flex-col gap-4 items-center justify-center"
+          class="w-full md:h-40 flex flex-col gap-4 items-center justify-start md:pt-4"
         >
           <div
-            class="px-4 py-2 uppercase w-3/4 text-center border-2 border-gray-900 md:w-fit font-semibold bg-white hover:bg-gray-900 hover:text-white transition-colors cursor-pointer"
+            @click="inJoinTeam = true"
+            class="px-4 py-2 uppercase w-3/4 flex items-start justify-center -space-x-1 text-center border-2 border-gray-900 md:w-fit font-semibold bg-white hover:bg-gray-900 hover:text-white transition-colors cursor-pointer"
           >
-            Join team
+            <span> Join team </span>
+            <Badge
+              v-if="team_invitations.data.length > 0"
+              :label="team_invitations.data.length"
+              theme="red"
+              variant="solid"
+              size="sm"
+              class="z-10 -mt-1"
+            />
           </div>
+          <Badge size="lg" theme="orange" v-if="team_invitations.data.length > 0">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="icon w-4 icon-tabler icons-tabler-outline icon-tabler-alert-circle"
+            >
+              <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+              <path d="M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0" />
+              <path d="M12 8v4" />
+              <path d="M12 16h.01" />
+            </svg>
+            <span>You have pending invitations to join teams.</span>
+          </Badge>
           <p class="text-base text-center leading-normal">
             Join existing teams looking for members.
           </p>
@@ -64,8 +101,15 @@
 <script setup>
 import Header from '@/components/Header.vue'
 import HackathonHeader from '@/components/hackathon/HackathonParticipantHeader.vue'
-import { createResource, LoadingIndicator } from 'frappe-ui'
-import { inject } from 'vue'
+import JoinTeam from '@/components/hackathon/JoinTeam.vue'
+import {
+  createListResource,
+  createResource,
+  LoadingIndicator,
+  Badge,
+  Dialog,
+} from 'frappe-ui'
+import { inject, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 const session = inject('$session')
@@ -73,6 +117,38 @@ const route = useRoute()
 const router = useRouter()
 
 const hackathonPermalink = route.params.permalink
+const inJoinTeam = ref(false)
+
+const team_invitations = createListResource({
+  doctype: 'FOSS Hackathon Join Team Request',
+  fields: ['*'],
+  tranform(data){
+    return data.map((invite) => {
+      invite.sender_profile = createResource({
+        url: 'fossunited.fossunited.utils.get_foss_profile',
+        params: {
+          email: invite.sender_email,
+        },
+        auto: true,
+        realtime: true,
+      })
+      invite.team_link = createResource({
+        url: 'frappe.client.get_value',
+        params: {
+          doctype: 'FOSS Hackathon Team',
+          fieldname: 'route',
+          filters: {
+            name: invite.team,
+          },
+        },
+        auto: true,
+        realtime: true,
+      })
+
+      return invite
+    })
+  }
+})
 
 const hackathon = createResource({
   url: 'fossunited.api.hackathon.get_hackathon_from_permalink',
@@ -91,6 +167,15 @@ const hackathon = createResource({
       },
     })
     team.fetch()
+    team_invitations.update({
+      filters: {
+        reciever_email: session.user,
+        status: 'Pending',
+        is_outgoing_request: 1,
+        hackathon: data.name,
+      },
+    })
+    team_invitations.fetch()
   },
 })
 

--- a/dashboard/src/pages/hackathon/MyTeam.vue
+++ b/dashboard/src/pages/hackathon/MyTeam.vue
@@ -3,43 +3,8 @@
     <template #body-title>
       <h3 class="text-xl font-semibold">Manage Team</h3>
     </template>
-    <template v-if="!inAddMember" #body-content>
-      <div class="space-y-4">
-        <!-- <div class="flex items-center w-full flex-row-reverse justify-between">
-          <Button
-            icon-left="plus"
-            @click="inAddMember = true"
-            label="Add Member"
-          />
-        </div> -->
-        <div class="grid grid-cols-1 gap-4">
-          <div
-            v-for="member in team.data.members"
-            :key="member.email"
-            class="flex items-center justify-between gap-4"
-          >
-            <div class="flex items-center gap-4">
-              <img :src="member.profile_photo" class="w-12 h-12 rounded-full" />
-              <div class="flex flex-col gap-1">
-                <div class="font-semibold">{{ member.full_name }}</div>
-                <div class="text-sm">{{ member.email }}</div>
-              </div>
-            </div>
-            <Button
-              v-if="
-                team.data.owner != member.email &&
-                session.user == team.data.owner
-              "
-              theme="red"
-              label="Remove"
-              @click="removeMember(member)"
-            />
-          </div>
-        </div>
-      </div>
-    </template>
-    <template v-else #body-content>
-      <!-- TODO: Invitation Workflow -->
+    <template #body-content>
+      <HackathonTeamMember :team="team" />
     </template>
   </Dialog>
   <Header />
@@ -144,6 +109,7 @@
 <script setup>
 import Header from '@/components/Header.vue'
 import HackathonHeader from '@/components/hackathon/HackathonParticipantHeader.vue'
+import HackathonTeamMember from '@/components/hackathon/HackathonTeamMember.vue'
 import { createResource, usePageMeta, Dialog } from 'frappe-ui'
 import { inject, ref } from 'vue'
 import { useRoute } from 'vue-router'

--- a/dashboard/src/pages/hackathon/Register.vue
+++ b/dashboard/src/pages/hackathon/Register.vue
@@ -74,9 +74,10 @@
           <h5 class="text-base font-medium text-gray-800">
             Select your platform
           </h5>
+          <div class="text-sm mt-2 text-gray-600">Link your <span class="font-semibold">{{ selected_platform.title }}</span> profile.</div>
           <RadioGroup
             v-model="selected_platform"
-            class="grid sm:grid-cols-3 lg:grid-cols-5 gap-2 my-3"
+            class="grid sm:grid-cols-3 lg:grid-cols-5 gap-2 my-4"
           >
             <RadioGroupOption
               as="template"

--- a/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.json
@@ -173,7 +173,6 @@
   },
   {
    "default": "2",
-   "depends_on": "eval:doc.is_team_mandatory == 1;",
    "fieldname": "max_team_members",
    "fieldtype": "Int",
    "label": "Max Team Members",
@@ -288,7 +287,7 @@
    "link_fieldname": "parent_hackathon"
   }
  ],
- "modified": "2024-06-02 20:52:14.428387",
+ "modified": "2024-06-04 14:28:14.125073",
  "modified_by": "Administrator",
  "module": "FOSS Hackathon",
  "name": "FOSS Hackathon",

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/foss_hackathon_join_team_request.js
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/foss_hackathon_join_team_request.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, Frappe x FOSSUnited and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("FOSS Hackathon Join Team Request", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/foss_hackathon_join_team_request.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/foss_hackathon_join_team_request.json
@@ -100,7 +100,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-05 15:25:24.262655",
+ "modified": "2024-06-05 17:29:19.450447",
  "modified_by": "Administrator",
  "module": "FOSS Hackathon",
  "name": "FOSS Hackathon Join Team Request",
@@ -115,6 +115,31 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "FOSS Website User",
+   "select": 1,
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "All",
+   "select": 1,
    "share": 1,
    "write": 1
   }

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/foss_hackathon_join_team_request.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/foss_hackathon_join_team_request.json
@@ -1,0 +1,125 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-06-04 13:57:34.071025",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "is_outgoing_request",
+  "section_break_kkvz",
+  "team",
+  "team_name",
+  "requested_by",
+  "sender_name",
+  "column_break_prrb",
+  "hackathon",
+  "hackathon_name",
+  "section_break_vjrk",
+  "reciever_email",
+  "column_break_vhdr",
+  "status"
+ ],
+ "fields": [
+  {
+   "fieldname": "team",
+   "fieldtype": "Link",
+   "label": "Team",
+   "options": "FOSS Hackathon Team"
+  },
+  {
+   "fieldname": "requested_by",
+   "fieldtype": "Link",
+   "label": "Requested By",
+   "options": "User"
+  },
+  {
+   "fieldname": "column_break_prrb",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "hackathon",
+   "fieldtype": "Link",
+   "label": "Hackathon",
+   "options": "FOSS Hackathon"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_outgoing_request",
+   "fieldtype": "Check",
+   "label": "Is Outgoing Request?"
+  },
+  {
+   "fieldname": "section_break_vjrk",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "reciever_email",
+   "fieldtype": "Data",
+   "label": "Reciever Email",
+   "options": "Email"
+  },
+  {
+   "fieldname": "column_break_vhdr",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "Pending",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "label": "Status",
+   "options": "Pending\nAccepted\nRejected"
+  },
+  {
+   "fieldname": "section_break_kkvz",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fetch_from": "requested_by.full_name",
+   "fieldname": "sender_name",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Sender Name",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "hackathon.hackathon_name",
+   "fieldname": "hackathon_name",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Hackathon Name",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "team.team_name",
+   "fieldname": "team_name",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Team Name",
+   "read_only": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2024-06-05 15:25:24.262655",
+ "modified_by": "Administrator",
+ "module": "FOSS Hackathon",
+ "name": "FOSS Hackathon Join Team Request",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/foss_hackathon_join_team_request.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/foss_hackathon_join_team_request.py
@@ -28,14 +28,18 @@ class FOSSHackathonJoinTeamRequest(Document):
 
     def before_save(self):
         if self.has_value_changed("status"):
-            self.add_member_to_team()
+            if self.status == "Accepted":
+                self.add_member_to_team()
 
     def add_member_to_team(self):
         # get participant doc
         try:
             participant_doc = frappe.get_doc(
                 "FOSS Hackathon Participant",
-                {"email": self.email, "hackathon": self.hackathon},
+                {
+                    "email": self.reciever_email,
+                    "hackathon": self.hackathon,
+                },
             )
         except frappe.DoesNotExistError:
             frappe.throw("Participant not found")

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/foss_hackathon_join_team_request.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/foss_hackathon_join_team_request.py
@@ -30,6 +30,7 @@ class FOSSHackathonJoinTeamRequest(Document):
         if self.has_value_changed("status"):
             if self.status == "Accepted":
                 self.add_member_to_team()
+                self.reject_other_requests()
 
     def add_member_to_team(self):
         # get participant doc
@@ -48,3 +49,19 @@ class FOSSHackathonJoinTeamRequest(Document):
         team_doc = frappe.get_doc("FOSS Hackathon Team", self.team)
         team_doc.append("members", {"member": participant_doc.name})
         team_doc.save()
+
+    def reject_other_requests(self):
+        requests = frappe.get_all(
+            "FOSS Hackathon Join Team Request",
+            filters={
+                "team": self.team,
+                "status": "Pending",
+                "reciever_email": self.reciever_email,
+            },
+        )
+        for request in requests:
+            request_doc = frappe.get_doc(
+                "FOSS Hackathon Join Team Request", request.name
+            )
+            request_doc.status = "Rejected"
+            request_doc.save()

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/foss_hackathon_join_team_request.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/foss_hackathon_join_team_request.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2024, Frappe x FOSSUnited and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.model.document import Document
+
+
+class FOSSHackathonJoinTeamRequest(Document):
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        hackathon: DF.Link | None
+        hackathon_name: DF.Data | None
+        is_outgoing_request: DF.Check
+        reciever_email: DF.Data | None
+        requested_by: DF.Link | None
+        sender_name: DF.Data | None
+        status: DF.Literal["Pending", "Accepted", "Rejected"]
+        team: DF.Link | None
+        team_name: DF.Data | None
+    # end: auto-generated types
+    pass
+
+    def before_save(self):
+        if self.has_value_changed("status"):
+            self.add_member_to_team()
+
+    def add_member_to_team(self):
+        # get participant doc
+        try:
+            participant_doc = frappe.get_doc(
+                "FOSS Hackathon Participant",
+                {"email": self.email, "hackathon": self.hackathon},
+            )
+        except frappe.DoesNotExistError:
+            frappe.throw("Participant not found")
+            return
+
+        team_doc = frappe.get_doc("FOSS Hackathon Team", self.team)
+        team_doc.append("members", {"member": participant_doc.name})
+        team_doc.save()

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/test_foss_hackathon_join_team_request.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/test_foss_hackathon_join_team_request.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, Frappe x FOSSUnited and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestFOSSHackathonJoinTeamRequest(FrappeTestCase):
+    pass

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_team/foss_hackathon_team.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_team/foss_hackathon_team.json
@@ -98,7 +98,7 @@
   }
  ],
  "links": [],
- "modified": "2024-05-30 11:23:19.378240",
+ "modified": "2024-06-06 13:42:55.866654",
  "modified_by": "Administrator",
  "module": "FOSS Hackathon",
  "name": "FOSS Hackathon Team",
@@ -131,6 +131,7 @@
    "write": 1
   },
   {
+   "create": 1,
    "email": 1,
    "export": 1,
    "print": 1,
@@ -138,7 +139,8 @@
    "report": 1,
    "role": "All",
    "select": 1,
-   "share": 1
+   "share": 1,
+   "write": 1
   }
  ],
  "search_fields": "hackathon",

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_team/foss_hackathon_team.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_team/foss_hackathon_team.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 


### PR DESCRIPTION
## Description
<!-- Briefly describe the changes introduced by this pull request -->
- Team invitation workflow through team id
- Invite team member through email
- Invite acceptance and rejection workflow

## Related Issues & Docs
closes #206 

## Video / Gifs

### Sending Request
[Screencast from 2024-06-06 14-04-34.webm](https://github.com/fossunited/fossunited/assets/73123690/70e38d91-c892-4ccf-90db-c3c506c2c344)
- creates an entry for `FOSS Hackathon Join Team Request`
- Email is sent to the reciever(setup on desk)
- Reciever needs to register for the hackathon and then join team through their dashboard (Shown below)

### Acceptance 
[Screencast from 2024-06-06 14-07-17.webm](https://github.com/fossunited/fossunited/assets/73123690/ace1ee8f-1825-4bc0-8148-269d69f4a6be)

- The above video is reciever's POV
- After registration, they will be able to join the team through clicking on the Join Team button
- On acceptance, they will be redirected to their team page