### PR TITLE
feat: external events

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
@@ -9,6 +9,9 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "is_external_event",
+  "column_break_okxh",
+  "external_event_url",
   "meta_info_section",
   "is_published",
   "column_break_yozf",
@@ -91,8 +94,8 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Event Type",
-   "options": "FOSS Event Type",
-   "reqd": 1
+   "mandatory_depends_on": "eval:doc.is_external_event == 0",
+   "options": "FOSS Event Type"
   },
   {
    "fieldname": "chapter_information_section",
@@ -128,13 +131,13 @@
    "fieldname": "event_start_date",
    "fieldtype": "Datetime",
    "label": "Event Start Date & Time",
-   "reqd": 1
+   "mandatory_depends_on": "eval:doc.is_external_event == 0"
   },
   {
    "fieldname": "event_end_date",
    "fieldtype": "Datetime",
    "label": "Event End Date & Time",
-   "reqd": 1
+   "mandatory_depends_on": "eval:doc.is_external_event == 0"
   },
   {
    "fieldname": "column_break_ae9v",
@@ -146,10 +149,11 @@
    "label": "Location"
   },
   {
+   "depends_on": "eval:doc.is_external_event == 0",
    "fieldname": "event_description",
    "fieldtype": "Text Editor",
    "label": "Description",
-   "reqd": 1
+   "mandatory_depends_on": "eval:doc.is_external_event == 0"
   },
   {
    "fieldname": "status",
@@ -236,11 +240,13 @@
    "label": "Secondary Button URL"
   },
   {
+   "depends_on": "eval:doc.is_external_event == 0",
    "fieldname": "volunteers_tab",
    "fieldtype": "Tab Break",
    "label": "Volunteers"
   },
   {
+   "depends_on": "eval:doc.is_external_event == 0",
    "fieldname": "schedule_tab",
    "fieldtype": "Tab Break",
    "label": "Schedule"
@@ -272,6 +278,7 @@
    "label": "Short Event Bio"
   },
   {
+   "depends_on": "eval:doc.is_external_event == 0",
    "fieldname": "navbar_controls_section",
    "fieldtype": "Section Break",
    "label": "Navbar Controls"
@@ -305,6 +312,7 @@
    "label": "Show Photos"
   },
   {
+   "depends_on": "eval:doc.is_external_event == 0",
    "fieldname": "meta_info_section",
    "fieldtype": "Section Break",
    "label": "Meta Info"
@@ -328,13 +336,14 @@
    "label": "Chapter Name"
   },
   {
+   "depends_on": "eval:doc.is_external_event == 0",
    "description": "Only enter the permalink endpoint.\nRoute will be set as events/< event_permalink >",
    "fieldname": "event_permalink",
    "fieldtype": "Data",
    "in_list_view": 1,
    "in_preview": 1,
    "label": "Event Permalink",
-   "reqd": 1,
+   "mandatory_depends_on": "eval:doc.is_external_event == 0",
    "unique": 1
   },
   {
@@ -400,6 +409,21 @@
    "fieldname": "ticket_form_description",
    "fieldtype": "Markdown Editor",
    "label": "Ticket Form Description"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_external_event",
+   "fieldtype": "Check",
+   "label": "Is External Event?"
+  },
+  {
+   "fieldname": "column_break_okxh",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "external_event_url",
+   "fieldtype": "Data",
+   "label": "External Event URL"
   }
  ],
  "has_web_view": 1,
@@ -421,7 +445,7 @@
    "link_fieldname": "event"
   }
  ],
- "modified": "2024-05-16 01:19:00.722061",
+ "modified": "2024-06-16 18:24:26.849365",
  "modified_by": "Administrator",
  "module": "Chapters",
  "name": "FOSS Chapter Event",

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -48,15 +48,17 @@ class FOSSChapterEvent(WebsiteGenerator):
         custom_fields: DF.Table[FOSSEventField]
         deck_link: DF.Data | None
         event_bio: DF.Data | None
-        event_description: DF.TextEditor
-        event_end_date: DF.Datetime
+        event_description: DF.TextEditor | None
+        event_end_date: DF.Datetime | None
         event_location: DF.Data | None
         event_members: DF.Table[FOSSChapterEventMember]
         event_name: DF.Data
-        event_permalink: DF.Data
+        event_permalink: DF.Data | None
         event_schedule: DF.Table[FOSSEventSchedule]
-        event_start_date: DF.Datetime
-        event_type: DF.Link
+        event_start_date: DF.Datetime | None
+        event_type: DF.Link | None
+        external_event_url: DF.Data | None
+        is_external_event: DF.Check
         is_paid_event: DF.Check
         is_published: DF.Check
         map_link: DF.Data | None
@@ -126,6 +128,8 @@ class FOSSChapterEvent(WebsiteGenerator):
         self.event_permalink = f"{event_permalink}-archive-{frappe.generate_hash(length=8)}"
 
     def set_route(self):
+        if self.is_external_event:
+            return
         self.route = f"events/{self.event_permalink}"
 
     def get_context(self, context):

--- a/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
+++ b/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
@@ -99,10 +99,13 @@
             {{ doc.event_description or 'No Description Available for this event'}}
         </div>
     </div>
-
-    {% if doc.sponsor_list %}
+    {% if doc.sponsor_list or doc.deck_link %}
     <div class="sponsors-section my-3">
         <h5 class="mt-3 mb-1">Sponsors</h5>
+        {% if doc.deck_link %}
+        <div class="my-2">Interested in sponsoring this event? Check out our sponsorship deck <a class="green-link" href="{{doc.deck_link}}" target="_blank">here</a> for all the details.</div>
+        {% endif %}
+        {% if doc.sponsor_list %}
         {% for k,v in sponsors_dict.items() %}
         <div class="sponsor--tier-block">
             <div class="sponsor--tier-heading">
@@ -117,6 +120,11 @@
             </div>
         </div>
         {% endfor %}
+        {% else %}
+        <div class="my-4">
+            No Sponsors Announced Yet
+        </div>
+        {% endif %}
     </div>
     {% endif %}
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.json
@@ -12,6 +12,10 @@
   "permalink",
   "column_break_ysex",
   "is_published",
+  "section_break_doxc",
+  "has_external_website",
+  "column_break_gttz",
+  "external_website_url",
   "hackathon_basic_info_section",
   "organizing_chapter",
   "hackathon_name",
@@ -21,6 +25,7 @@
   "column_break_jepp",
   "hackathon_description",
   "hackathon_details_section",
+  "only_show_logo",
   "hackathon_logo",
   "hackathon_rules",
   "column_break_frpz",
@@ -280,6 +285,34 @@
    "fieldname": "is_registration_live",
    "fieldtype": "Check",
    "label": "Is Registration Live?"
+  },
+  {
+   "fieldname": "section_break_doxc",
+   "fieldtype": "Section Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "has_external_website",
+   "fieldtype": "Check",
+   "label": "Has External Website?"
+  },
+  {
+   "fieldname": "column_break_gttz",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval: doc.has_external_website == 1",
+   "fieldname": "external_website_url",
+   "fieldtype": "Data",
+   "label": "External Website URL",
+   "mandatory_depends_on": "eval: doc.has_external_website == 1"
+  },
+  {
+   "default": "0",
+   "description": "Only show logo on hackathon card.",
+   "fieldname": "only_show_logo",
+   "fieldtype": "Check",
+   "label": "Only Show Logo"
   }
  ],
  "has_web_view": 1,
@@ -307,7 +340,7 @@
    "link_fieldname": "parent_hackathon"
   }
  ],
- "modified": "2024-06-10 13:02:28.163947",
+ "modified": "2024-06-16 23:02:21.003311",
  "modified_by": "Administrator",
  "module": "FOSS Hackathon",
  "name": "FOSS Hackathon",

--- a/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
@@ -36,6 +36,7 @@ class FOSSHackathon(WebsiteGenerator):
         contribution_project_guidelines: DF.MarkdownEditor | None
         enable_oss_contributon_projects: DF.Check
         end_date: DF.Datetime
+        external_website_url: DF.Data | None
         hackathon_banner: DF.AttachImage | None
         hackathon_description: DF.TextEditor
         hackathon_faq: DF.TextEditor | None
@@ -45,6 +46,7 @@ class FOSSHackathon(WebsiteGenerator):
         hackathon_type: DF.Literal[
             "", "Remote", "In-person", "Hybrid"
         ]
+        has_external_website: DF.Check
         has_localhosts: DF.Check
         has_partner_projects: DF.Check
         is_contribution_project_coming_soon: DF.Check
@@ -52,6 +54,7 @@ class FOSSHackathon(WebsiteGenerator):
         is_registration_live: DF.Check
         is_team_mandatory: DF.Check
         max_team_members: DF.Int
+        only_show_logo: DF.Check
         organizing_chapter: DF.Link | None
         partner_project_guidelines: DF.MarkdownEditor | None
         permalink: DF.Data | None

--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -506,18 +506,11 @@ def validate_profile_completion():
 def get_grouped_events():
     events = frappe.get_all(
         "FOSS Chapter Event",
-        fields=[
-            "event_name",
-            "chapter",
-            "banner_image",
-            "route",
-            "must_attend",
-            "event_location",
-            "map_link",
-            "event_start_date",
-            "banner_image",
-        ],
-        filters={"status": "Approved", "is_published": 1},
+        fields=["*"],
+        filters={
+            "status": ["in", ["Approved", "Live", "Concluded"]],
+            "is_published": 1,
+        },
         order_by="event_start_date",
     )
     return get_month_grouped_events(events)

--- a/fossunited/fossunited/web_template/events_timeline/events_timeline.html
+++ b/fossunited/fossunited/web_template/events_timeline/events_timeline.html
@@ -109,44 +109,12 @@
       {% for month, month_events in events.items() %}
         {% for event in month_events %}
           {% set event_date_text = event.event_start_date.strftime("%d %b %Y") %}
-          <div class="event-card show"
-            v-if="canShow('{{ event.event_name}}', '{{ event_date_text }}', !!{{ event.must_attend }})"
-            data-docname="{{ event.name }}"
-            data-route="{{ event.route }}"
-            onclick="window.location.pathname='/{{event.route}}'"
+          <div
+          v-if="canShow('{{ event.event_name}}', '{{ event_date_text }}', !!{{ event.must_attend }})"
           >
-            <div class="event-card-contents">
-                {% set chapter = frappe.get_doc("FOSS Chapter", event.chapter) %}
-                <div class="chapter-brand-block {% if chapter.chapter_type == 'FOSS Club' %} club-brand {% endif %}">
-                    {% if chapter.chapter_type == 'FOSS Club' %}
-                    <img src="/assets/fossunited/images/chapter/fossclub_logo.svg" alt="">
-                    <span>{{ chapter.chapter_name | truncate(25, True, '...', 0) }}</span>
-                    {% else %}
-                    <span class="fff-forward">{{ chapter.chapter_name | truncate(25, True, '...', 0) }}</span>
-                    {% endif %}
-                </div>
-                <div class="event-card--date-section">
-                    <div class="event-card--date">
-                        {{ event.event_start_date.strftime("%d %b %Y") }}
-                    </div>
-                    {% if event.must_attend %}
-                        <div class="event-card--must-attend">
-                            <i class="ti ti-star-filled"></i>
-                            {{ _("Must Attend") }}
-                        </div>
-                    {% endif %}
-                </div>
-                <div class="event-card--title">
-                    {{ event.event_name | truncate(26, True) }}
-                </div>
-                <div class="event-card--location-section">
-                    <div class="event-card--location">
-                        <i class="ti ti-map-pin"></i>
-                        <span>{{ event.event_location or "To be Announced" | truncate(22, True)}}</span>
-                    </div>
-                </div>
-            </div>
+            {{ event_card(event)}}
           </div>
+
         {% endfor %}
       {% endfor %}
     {% endfor %}

--- a/fossunited/fossunited/web_template/upcoming_foss_events_section/upcoming_foss_events_section.html
+++ b/fossunited/fossunited/web_template/upcoming_foss_events_section/upcoming_foss_events_section.html
@@ -66,7 +66,7 @@
         </div>
 
         {% from "fossunited/templates/macros/event_card.html" import event_card %}
-        {% set events = frappe.get_all("FOSS Chapter Event", fields=["event_name", "chapter", "banner_image", "route", "must_attend", "event_location", "map_link", "event_start_date", "banner_image"], filters={"status": "Approved", "is_published": 1, "event_start_date": ['>=', frappe.utils.now()]}, page_length=9, order_by='event_start_date') %}
+        {% set events = frappe.get_all("FOSS Chapter Event", fields=["*"], filters={"status": ["in", ["Approved", "Live"]], "is_published": 1, "event_start_date": ['>=', frappe.utils.now()]}, page_length=9, order_by='event_start_date') %}
         <div class="events-grid-4">
             {% for event in events %}
                 {{ event_card(event) }}

--- a/fossunited/fossunited/web_template/upcoming_foss_events_section/upcoming_foss_events_section.html
+++ b/fossunited/fossunited/web_template/upcoming_foss_events_section/upcoming_foss_events_section.html
@@ -5,8 +5,6 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        padding-bottom: 7rem;
-        padding-top: 7rem;
     }
 
     .events-list-container{

--- a/fossunited/fossunited/web_template/upcoming_hackathons_section/upcoming_hackathons_section.html
+++ b/fossunited/fossunited/web_template/upcoming_hackathons_section/upcoming_hackathons_section.html
@@ -1,0 +1,26 @@
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@2.46.0/tabler-icons.min.css">
+
+<div class="events-list-section container">
+    <div class="events-list-container">
+        <div class="upcoming-events-header">
+            <h5>{{ title }}</h5>
+            {% if subtitle %}
+            <div>{{ subtitle }}</div>
+            {% endif %}
+        </div>
+        {% from "fossunited/templates/macros/hackathon_card.html" import hackathon_card %}
+        {% set hackathons = frappe.get_all("FOSS Hackathon", fields=["*"], filters={"is_published": 1, "start_date": ['>=', frappe.utils.now()]}, page_length=8, order_by='start_date') %}
+        {% if not hackathons %}
+            <div class="no-events mb-6 pb-6">
+                <div>No upcoming hackathons</div>
+            </div>
+        {% else %}
+        <div class="events-grid-4">
+            {% for hackathon in hackathons %}
+                {{ hackathon_card(hackathon) }}
+            {% endfor %}
+        </div>
+        {% endif %}
+
+    </div>
+</div>

--- a/fossunited/fossunited/web_template/upcoming_hackathons_section/upcoming_hackathons_section.json
+++ b/fossunited/fossunited/web_template/upcoming_hackathons_section/upcoming_hackathons_section.json
@@ -1,0 +1,34 @@
+{
+ "__islocal": true,
+ "__unsaved": 1,
+ "creation": "2024-06-16 21:53:24.549599",
+ "docstatus": 0,
+ "doctype": "Web Template",
+ "fields": [
+  {
+   "__islocal": 1,
+   "__unsaved": 1,
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "label": "Title",
+   "reqd": 0
+  },
+  {
+   "__islocal": 1,
+   "__unsaved": 1,
+   "fieldname": "subtitle",
+   "fieldtype": "Small Text",
+   "label": "Subtitle",
+   "reqd": 0
+  }
+ ],
+ "idx": 0,
+ "modified": "2024-06-16 21:53:24.549599",
+ "modified_by": "Administrator",
+ "module": "FOSSUnited",
+ "name": "Upcoming Hackathons Section",
+ "owner": "Administrator",
+ "standard": 1,
+ "template": "",
+ "type": "Section"
+}

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -1464,6 +1464,11 @@ h6{
     color: hsl(var(--clr-foss-mint-600));
 }
 
+.event-card--logo{
+    width: 10rem;
+    height: auto;
+}
+
 .event-card--title{
     width: 15.625rem;
     height: 3.125rem;

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -1414,12 +1414,12 @@ h6{
     border-radius: 0.5rem;
     cursor: pointer;
     background: #FFF;
-    box-shadow: 0px 0px 0px 1px hsl(var(--clr-open-gray-100));
-    transition: box-shadow 0.1s ease-in-out;
+    border: 2px solid hsl(var(--clr-open-gray-100));
+    transition: border 0.2s ease-in-out;
 }
 
 .event-card:hover{
-    box-shadow: 0px 0px 0px 2px hsl(var(--clr-open-gray-200));
+    border: 2px solid hsl(var(--clr-code-night-300));
 }
 
 .event-card--banner{

--- a/fossunited/templates/macros/event_card.html
+++ b/fossunited/templates/macros/event_card.html
@@ -1,15 +1,19 @@
 {% macro event_card(event) %}
-<div class="event-card" data-docname="{{ event.name }}" data-route="{{ event.route }}" onclick="window.location.pathname='/{{event.route}}'">
+<div class="event-card" data-docname="{{ event.name }}" data-route="{{ event.route }}" {% if event.is_external_event %} onclick="window.open('{{ event.external_event_url }}', '_blank')" {% else %} onclick="window.location.pathname='/{{event.route}}'" {% endif%}>
     <div class="event-card-contents">
-        {% set chapter = frappe.get_doc("FOSS Chapter", event.chapter) %}
-        <div class="chapter-brand-block {% if chapter.chapter_type == 'FOSS Club' %} club-brand {% endif %}">
-            {% if chapter.chapter_type == 'FOSS Club' %}
-            <img src="/assets/fossunited/images/chapter/fossclub_logo.svg" alt="">
-            <span>{{ chapter.chapter_name | truncate(25, True, '...', 0) }}</span>
-            {% else %}
-            <span class="fff-forward">{{ chapter.chapter_name | truncate(25, True, '...', 0) }}</span>
-            {% endif %}
-        </div>
+        {% if not event.is_external_event %}
+            {% set chapter = frappe.get_doc("FOSS Chapter", event.chapter) %}
+            <div class="chapter-brand-block {% if chapter.chapter_type == 'FOSS Club' %} club-brand {% endif %}">
+                {% if chapter.chapter_type == 'FOSS Club' %}
+                <img src="/assets/fossunited/images/chapter/fossclub_logo.svg" alt="">
+                <span>{{ chapter.chapter_name | truncate(25, True, '...', 0) }}</span>
+                {% else %}
+                <span class="fff-forward">{{ chapter.chapter_name | truncate(25, True, '...', 0) }}</span>
+                {% endif %}
+            </div>
+        {% else %}
+        <div></div>
+        {% endif %}
         <div class="event-card--date-section">
             <div class="event-card--date">
                 {{ event.event_start_date.strftime("%d %b %Y") }}

--- a/fossunited/templates/macros/hackathon_card.html
+++ b/fossunited/templates/macros/hackathon_card.html
@@ -1,0 +1,46 @@
+{% macro hackathon_card(hackathon) %}
+
+<div
+  class="event-card"
+  data-docname="{{ hackathon.name }}"
+  data-route="{{ hackathon.route }}"
+  {% if hackathon.has_external_website %} onclick="window.open('{{ hackathon.external_website_url }}', '_blank')" {% else %} onclick="window.location.pathname='/{{hackathon.route}}'" {% endif%}
+>
+  <div class="event-card-contents">
+    {% if hackathon.organizing_chapter %} {% set chapter = frappe.get_doc("FOSS
+    Chapter", hackathon.organizing_chapter) %}
+    <div
+      class="chapter-brand-block {% if chapter.chapter_type == 'FOSS Club' %} club-brand {% endif %}"
+    >
+      {% if chapter.chapter_type == 'FOSS Club' %}
+      <img src="/assets/fossunited/images/chapter/fossclub_logo.svg" alt="" />
+      <span>{{ chapter.chapter_name | truncate(25, True, '...', 0) }}</span>
+      {% else %}
+      <span class="fff-forward"
+        >{{ chapter.chapter_name | truncate(25, True, '...', 0) }}</span
+      >
+      {% endif %}
+    </div>
+    {% endif %}
+    <div class="event-card--date-section">
+      <div class="event-card--date">
+        {{ hackathon.start_date.strftime("%d %b %Y") }}
+      </div>
+      <div class="event-card--date">
+        <i class="mr-2 ti {% if hackathon.hackathon_type == 'In-Person' %} ti-building {% else %} ti-world {% endif %}"></i>
+        {{ hackathon.hackathon_type }}
+      </div>
+    </div>
+    <div class="mt-5 mb-2">
+        {% if hackathon.hackathon_logo %}
+        <img class="event-card--logo" src="{{ hackathon.hackathon_logo }}" alt="">
+        {% endif %}
+        {% if not hackathon.only_show_logo %}
+        <div class="mt-2 text-lg">
+            {{ hackathon.hackathon_name | truncate(26, True) }}
+        </div>
+        {% endif %}
+    </div>
+  </div>
+</div>
+{% endmacro %}


### PR DESCRIPTION
## Description 
- Ability to add external events. These events will have their cards shown on our event pages, and on clicking them, the user is redirected to the event's dedicated website.
- Sponsorship deck can be linked and shown in the event page now.
- Added Upcoming Hackathon Web Template

closes #329 