### PR TITLE
Freezing FOSS Profiles

### DIFF
--- a/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.json
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.json
@@ -99,7 +99,8 @@
    "fieldname": "email",
    "fieldtype": "Data",
    "label": "Email",
-   "options": "Email"
+   "options": "Email",
+   "read_only": 1
   },
   {
    "fieldname": "current_city",
@@ -278,7 +279,7 @@
  "index_web_pages_for_search": 1,
  "is_published_field": "is_published",
  "links": [],
- "modified": "2024-07-02 16:17:42.519778",
+ "modified": "2024-07-02 16:21:35.416189",
  "modified_by": "Administrator",
  "module": "FOSS Profiles",
  "name": "FOSS User Profile",

--- a/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.json
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.json
@@ -279,7 +279,7 @@
  "index_web_pages_for_search": 1,
  "is_published_field": "is_published",
  "links": [],
- "modified": "2024-07-02 16:21:35.416189",
+ "modified": "2024-07-02 17:36:34.436149",
  "modified_by": "Administrator",
  "module": "FOSS Profiles",
  "name": "FOSS User Profile",
@@ -305,14 +305,6 @@
    "read": 1,
    "report": 1,
    "role": "System Manager"
-  },
-  {
-   "read": 1,
-   "role": "Guest"
-  },
-  {
-   "read": 1,
-   "role": "All"
   }
  ],
  "quick_entry": 1,

--- a/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.json
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.json
@@ -82,7 +82,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "fetch_from": "user.full_name",
    "fieldname": "full_name",
    "fieldtype": "Data",
    "label": "Full Name"
@@ -279,7 +278,7 @@
  "index_web_pages_for_search": 1,
  "is_published_field": "is_published",
  "links": [],
- "modified": "2024-04-06 22:18:47.314419",
+ "modified": "2024-07-02 16:17:42.519778",
  "modified_by": "Administrator",
  "module": "FOSS Profiles",
  "name": "FOSS User Profile",
@@ -294,21 +293,25 @@
    "print": 1,
    "read": 1,
    "report": 1,
-   "role": "System Manager",
+   "role": "Administrator",
    "share": 1,
    "write": 1
   },
   {
-   "create": 1,
+   "delete": 1,
    "email": 1,
    "export": 1,
-   "print": 1,
    "read": 1,
    "report": 1,
-   "role": "All",
-   "select": 1,
-   "share": 1,
-   "write": 1
+   "role": "System Manager"
+  },
+  {
+   "read": 1,
+   "role": "Guest"
+  },
+  {
+   "read": 1,
+   "role": "All"
   }
  ],
  "quick_entry": 1,

--- a/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.py
@@ -6,6 +6,56 @@ from frappe.website.website_generator import WebsiteGenerator
 
 
 class FOSSUserProfile(WebsiteGenerator):
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        from fossunited.foss_profiles.doctype.foss_user_profile_education.foss_user_profile_education import (
+            FOSSUserProfileEducation,
+        )
+        from fossunited.foss_profiles.doctype.foss_user_profile_work_experience.foss_user_profile_work_experience import (
+            FOSSUserProfileWorkExperience,
+        )
+        from fossunited.foss_profiles.doctype.foss_user_projects.foss_user_projects import (
+            FOSSUserProjects,
+        )
+        from fossunited.foss_profiles.doctype.foss_user_skill_multiselect.foss_user_skill_multiselect import (
+            FOSSUserSkillMultiselect,
+        )
+
+        about: DF.TextEditor | None
+        bio: DF.SmallText | None
+        cover_image: DF.AttachImage | None
+        current_city: DF.Link | None
+        devto: DF.Data | None
+        education: DF.Table[FOSSUserProfileEducation]
+        email: DF.Data | None
+        experience: DF.Table[FOSSUserProfileWorkExperience]
+        full_name: DF.Data | None
+        gender: DF.Data | None
+        github: DF.Data | None
+        gitlab: DF.Data | None
+        instagram: DF.Data | None
+        is_private: DF.Check
+        is_published: DF.Check
+        linkedin: DF.Data | None
+        mastodon: DF.Data | None
+        medium: DF.Data | None
+        profile_photo: DF.AttachImage | None
+        projects: DF.Table[FOSSUserProjects]
+        route: DF.Data | None
+        skills: DF.TableMultiSelect[FOSSUserSkillMultiselect]
+        user: DF.Link
+        username: DF.Data
+        website: DF.Data | None
+        x: DF.Data | None
+        youtube: DF.Data | None
+
+    # end: auto-generated types
     def validate(self):
         self.validate_username()
         self.set_route()


### PR DESCRIPTION
Revamp FOSS Profile permissions.

Temporary fix
- Only logging as admin through frappe cloud can enable changing of details now.

![image](https://github.com/fossunited/fossunited/assets/73123690/d0fbdb4a-0ba3-485b-90af-86aef9a8859b)


### Additional Context about Testing

- Used scripts that made use of functions like `get_list` and `set_value` of one user to a different user via CLI. 

- We created test users there with normal logged user perms (without sys manager)

- Then tried running the scripts to test the permission levels of the doctypes. 

- The current permission settings of FOSS User Profiles blocks the effect of these methods. 

<img width="1127" alt="Screenshot 2024-07-03 at 1 19 47 PM" src="https://github.com/fossunited/fossunited/assets/60656677/abd655a6-7a62-452d-98c0-76da9516c33a">

