### PR TITLE
chore!: reduce permissions for rsvp, cfp & tickets

### DIFF
--- a/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.json
+++ b/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.json
@@ -126,7 +126,7 @@
  "index_web_pages_for_search": 1,
  "is_published_field": "is_published",
  "links": [],
- "modified": "2024-03-28 15:38:03.136622",
+ "modified": "2024-07-03 10:30:16.158558",
  "modified_by": "Administrator",
  "module": "Chapters",
  "name": "FOSS Event RSVP",
@@ -144,27 +144,6 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
-  },
-  {
-   "create": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "FOSS Website User",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "All",
-   "select": 1,
-   "share": 1
   }
  ],
  "route": "events/rsvp",

--- a/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.py
@@ -10,6 +10,30 @@ from fossunited.fossunited.forms import create_submission
 
 
 class FOSSEventRSVP(WebsiteGenerator):
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        from fossunited.fossunited.doctype.foss_custom_question.foss_custom_question import (
+            FOSSCustomQuestion,
+        )
+
+        allow_edit: DF.Check
+        chapter: DF.Data | None
+        custom_questions: DF.Table[FOSSCustomQuestion]
+        event: DF.Link | None
+        event_name: DF.Data | None
+        is_published: DF.Check
+        max_rsvp_count: DF.Int
+        route: DF.Data | None
+        rsvp_count: DF.Int
+        rsvp_description: DF.TextEditor | None
+
+    # end: auto-generated types
     def before_save(self):
         self.set_route()
         self.enable_rsvp_tab()

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.json
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.json
@@ -124,7 +124,7 @@
   }
  ],
  "links": [],
- "modified": "2024-06-25 13:13:35.755486",
+ "modified": "2024-07-03 10:22:45.197158",
  "modified_by": "Administrator",
  "module": "Chapters",
  "name": "FOSS Event RSVP Submission",
@@ -139,29 +139,6 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "FOSS Website User",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "All",
-   "select": 1,
    "share": 1,
    "write": 1
   }

--- a/fossunited/fossunited/doctype/foss_event_cfp/foss_event_cfp.json
+++ b/fossunited/fossunited/doctype/foss_event_cfp/foss_event_cfp.json
@@ -143,7 +143,7 @@
  "index_web_pages_for_search": 1,
  "is_published_field": "is_published",
  "links": [],
- "modified": "2024-06-10 12:35:05.456459",
+ "modified": "2024-07-03 10:38:14.041510",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "FOSS Event CFP",
@@ -161,27 +161,6 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
-  },
-  {
-   "create": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "FOSS Website User",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "All",
-   "select": 1,
-   "share": 1
   }
  ],
  "route": "cfp/new",

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.json
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.json
@@ -288,7 +288,7 @@
  "has_web_view": 1,
  "is_published_field": "is_published",
  "links": [],
- "modified": "2024-06-25 13:26:29.753016",
+ "modified": "2024-07-03 10:38:03.852604",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "FOSS Event CFP Submission",
@@ -304,29 +304,6 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "FOSS Website User",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "All",
-   "select": 1,
    "share": 1,
    "write": 1
   }

--- a/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.json
+++ b/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.json
@@ -140,7 +140,7 @@
   }
  ],
  "links": [],
- "modified": "2024-07-01 11:30:38.262647",
+ "modified": "2024-07-03 14:45:28.719114",
  "modified_by": "Administrator",
  "module": "Ticketing",
  "name": "FOSS Event Ticket",
@@ -155,17 +155,6 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "All",
-   "select": 1,
    "share": 1,
    "write": 1
   }


### PR DESCRIPTION
- Reduce permissions for RSVP doc, RSVP Submissions, CFP Doc and CFP Submissions
- Other than the System user, no person can do a `get_list` on CFP and RSVP submissions. Before this PR, it was easy to get all the RSVP or CFP submissions if the event id was know.
- System User still has permissions for Read/Write/Create/Delete for CFP and RSVP submission as it is heavily used by internal team comprising of system users. Do we want to change it too? I am afraid that may come with it's own set of problems.


- Dashboards will break on this. Working on fixing it in next pr
- Dashboards utilize a lot of get_list, get_value to render the CFP and RSVP submission lists to the organizers. With a change of permissions, the lists will stop getting rendered. One proposed solution: abstract the methods for getting lists such that they have validations that check if the person is an organizer in order to load the list of RSVP/CFP submissions.
- Organizers will not be able to create CFP / RSVP forms temporarily until a fix for this. It will all be done internally for the time being by desk users(our team).

![image](https://github.com/fossunited/fossunited/assets/73123690/dd6ce600-35a9-4f1c-a090-2e5c5eee5879)

---

Also reduced permissions for Tickets, removed the permission for `All` which included `select` `read` and `write`. Now only system manager has the permissions, as per above configuration.

Before, there was a chance that a third party can change the data of any ticket using APIs, that should no longer be the case.