### PR TITLE
[Chore] Remove commented out import statements from the codebase

### DIFF
--- a/fossunited/chapters/doctype/conference_ticket/conference_ticket.py
+++ b/fossunited/chapters/doctype/conference_ticket/conference_ticket.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 import json
 
 import frappe

--- a/fossunited/chapters/doctype/conference_ticket/test_conference_ticket.py
+++ b/fossunited/chapters/doctype/conference_ticket/test_conference_ticket.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/chapters/doctype/foss_chapter/test_foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/test_foss_chapter.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/chapters/doctype/foss_chapter_event/test_foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/test_foss_chapter_event.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/chapters/doctype/foss_chapter_event_member/foss_chapter_event_member.py
+++ b/fossunited/chapters/doctype/foss_chapter_event_member/foss_chapter_event_member.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/chapters/doctype/foss_chapter_event_member/test_foss_chapter_event_member.py
+++ b/fossunited/chapters/doctype/foss_chapter_event_member/test_foss_chapter_event_member.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/chapters/doctype/foss_chapter_event_participant/foss_chapter_event_participant.py
+++ b/fossunited/chapters/doctype/foss_chapter_event_participant/foss_chapter_event_participant.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/chapters/doctype/foss_chapter_event_participant/test_foss_chapter_event_participant.py
+++ b/fossunited/chapters/doctype/foss_chapter_event_participant/test_foss_chapter_event_participant.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/chapters/doctype/foss_chapter_lead_team_member/foss_chapter_lead_team_member.py
+++ b/fossunited/chapters/doctype/foss_chapter_lead_team_member/foss_chapter_lead_team_member.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/chapters/doctype/foss_event_community_partner/foss_event_community_partner.py
+++ b/fossunited/chapters/doctype/foss_event_community_partner/foss_event_community_partner.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/chapters/doctype/foss_event_rsvp/test_foss_event_rsvp.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp/test_foss_event_rsvp.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/chapters/doctype/foss_event_type/foss_event_type.py
+++ b/fossunited/chapters/doctype/foss_event_type/foss_event_type.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/chapters/doctype/foss_event_type/test_foss_event_type.py
+++ b/fossunited/chapters/doctype/foss_event_type/test_foss_event_type.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon/test_foss_hackathon.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/test_foss_hackathon.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/test_foss_hackathon_join_team_request.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/test_foss_hackathon_join_team_request.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/test_foss_hackathon_localhost.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/test_foss_hackathon_localhost.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_localhost_organizer/foss_hackathon_localhost_organizer.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_localhost_organizer/foss_hackathon_localhost_organizer.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_mentor/foss_hackathon_mentor.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_mentor/foss_hackathon_mentor.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_mentor/test_foss_hackathon_mentor.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_mentor/test_foss_hackathon_mentor.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/test_foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/test_foss_hackathon_participant.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/foss_hackathon_partner_project.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/foss_hackathon_partner_project.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/test_foss_hackathon_partner_project.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/test_foss_hackathon_partner_project.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_project/test_foss_hackathon_project.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_project/test_foss_hackathon_project.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_team/test_foss_hackathon_team.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_team/test_foss_hackathon_team.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_team_member/foss_hackathon_team_member.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_team_member/foss_hackathon_team_member.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/foss_profiles/doctype/foss_user_profile_education/foss_user_profile_education.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile_education/foss_user_profile_education.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/foss_profiles/doctype/foss_user_profile_work_experience/foss_user_profile_work_experience.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile_work_experience/foss_user_profile_work_experience.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/foss_profiles/doctype/foss_user_projects/foss_user_projects.py
+++ b/fossunited/foss_profiles/doctype/foss_user_projects/foss_user_projects.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/foss_profiles/doctype/foss_user_skill/foss_user_skill.py
+++ b/fossunited/foss_profiles/doctype/foss_user_skill/foss_user_skill.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/foss_profiles/doctype/foss_user_skill/test_foss_user_skill.py
+++ b/fossunited/foss_profiles/doctype/foss_user_skill/test_foss_user_skill.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/foss_profiles/doctype/foss_user_skill_multiselect/foss_user_skill_multiselect.py
+++ b/fossunited/foss_profiles/doctype/foss_user_skill_multiselect/foss_user_skill_multiselect.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/fossunited/doctype/cfp_review_template/cfp_review_template.py
+++ b/fossunited/fossunited/doctype/cfp_review_template/cfp_review_template.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/fossunited/doctype/cfp_review_template/test_cfp_review_template.py
+++ b/fossunited/fossunited/doctype/cfp_review_template/test_cfp_review_template.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/fossunited/doctype/cfp_review_template_reason/cfp_review_template_reason.py
+++ b/fossunited/fossunited/doctype/cfp_review_template_reason/cfp_review_template_reason.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/fossunited/doctype/city/city.py
+++ b/fossunited/fossunited/doctype/city/city.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/fossunited/doctype/city/test_city.py
+++ b/fossunited/fossunited/doctype/city/test_city.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/fossunited/doctype/foss_custom_answer/foss_custom_answer.py
+++ b/fossunited/fossunited/doctype/foss_custom_answer/foss_custom_answer.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/fossunited/doctype/foss_custom_question/foss_custom_question.py
+++ b/fossunited/fossunited/doctype/foss_custom_question/foss_custom_question.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/fossunited/doctype/foss_event_cfp/test_foss_event_cfp.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp/test_foss_event_cfp.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/fossunited/doctype/foss_event_cfp_review/foss_event_cfp_review.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_review/foss_event_cfp_review.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/fossunited/doctype/foss_event_cfp_reviewer/foss_event_cfp_reviewer.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_reviewer/foss_event_cfp_reviewer.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/test_foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/test_foss_event_cfp_submission.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/fossunited/doctype/foss_event_field/foss_event_field.py
+++ b/fossunited/fossunited/doctype/foss_event_field/foss_event_field.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/fossunited/doctype/foss_event_grant/foss_event_grant.py
+++ b/fossunited/fossunited/doctype/foss_event_grant/foss_event_grant.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/fossunited/doctype/foss_event_grant/test_foss_event_grant.py
+++ b/fossunited/fossunited/doctype/foss_event_grant/test_foss_event_grant.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/fossunited/doctype/foss_event_schedule/foss_event_schedule.py
+++ b/fossunited/fossunited/doctype/foss_event_schedule/foss_event_schedule.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/fossunited/doctype/foss_event_sponsor/foss_event_sponsor.py
+++ b/fossunited/fossunited/doctype/foss_event_sponsor/foss_event_sponsor.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/fossunited/doctype/foss_global_cfp_review_member/foss_global_cfp_review_member.py
+++ b/fossunited/fossunited/doctype/foss_global_cfp_review_member/foss_global_cfp_review_member.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/fossunited/doctype/foss_global_cfp_review_settings/foss_global_cfp_review_settings.py
+++ b/fossunited/fossunited/doctype/foss_global_cfp_review_settings/foss_global_cfp_review_settings.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/fossunited/doctype/foss_global_cfp_review_settings/test_foss_global_cfp_review_settings.py
+++ b/fossunited/fossunited/doctype/foss_global_cfp_review_settings/test_foss_global_cfp_review_settings.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/fossunited/doctype/foss_project_grant/foss_project_grant.py
+++ b/fossunited/fossunited/doctype/foss_project_grant/foss_project_grant.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/fossunited/doctype/foss_project_grant/test_foss_project_grant.py
+++ b/fossunited/fossunited/doctype/foss_project_grant/test_foss_project_grant.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/fossunited/doctype/foss_united_team/foss_united_team.py
+++ b/fossunited/fossunited/doctype/foss_united_team/foss_united_team.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/fossunited/doctype/foss_united_team/test_foss_united_team.py
+++ b/fossunited/fossunited/doctype/foss_united_team/test_foss_united_team.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/fossunited/doctype/fossu_settings/fossu_settings.py
+++ b/fossunited/fossunited/doctype/fossu_settings/fossu_settings.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/fossunited/doctype/fossu_settings/test_fossu_settings.py
+++ b/fossunited/fossunited/doctype/fossu_settings/test_fossu_settings.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/fossunited/doctype/industry_partners/industry_partners.py
+++ b/fossunited/fossunited/doctype/industry_partners/industry_partners.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/fossunited/doctype/industry_partners/test_industry_partners.py
+++ b/fossunited/fossunited/doctype/industry_partners/test_industry_partners.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/fossunited/doctype/institute/institute.py
+++ b/fossunited/fossunited/doctype/institute/institute.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/fossunited/doctype/institute/test_institute.py
+++ b/fossunited/fossunited/doctype/institute/test_institute.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/fossunited/doctype/organization/organization.py
+++ b/fossunited/fossunited/doctype/organization/organization.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/fossunited/doctype/organization/test_organization.py
+++ b/fossunited/fossunited/doctype/organization/test_organization.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/fossunited/doctype/state/state.py
+++ b/fossunited/fossunited/doctype/state/state.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/fossunited/doctype/state/test_state.py
+++ b/fossunited/fossunited/doctype/state/test_state.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/payments/doctype/razorpay_payment/test_razorpay_payment.py
+++ b/fossunited/payments/doctype/razorpay_payment/test_razorpay_payment.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/payments/doctype/razorpay_settings/razorpay_settings.py
+++ b/fossunited/payments/doctype/razorpay_settings/razorpay_settings.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/payments/doctype/razorpay_settings/test_razorpay_settings.py
+++ b/fossunited/payments/doctype/razorpay_settings/test_razorpay_settings.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/payments/doctype/razorpay_webhook_log/razorpay_webhook_log.py
+++ b/fossunited/payments/doctype/razorpay_webhook_log/razorpay_webhook_log.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/payments/doctype/razorpay_webhook_log/test_razorpay_webhook_log.py
+++ b/fossunited/payments/doctype/razorpay_webhook_log/test_razorpay_webhook_log.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/ticketing/doctype/foss_event_ticket/test_foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/test_foss_event_ticket.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/ticketing/doctype/foss_event_ticket_transfer/test_foss_event_ticket_transfer.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket_transfer/test_foss_event_ticket_transfer.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/ticketing/doctype/foss_ticket_custom_field/foss_ticket_custom_field.py
+++ b/fossunited/ticketing/doctype/foss_ticket_custom_field/foss_ticket_custom_field.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/ticketing/doctype/foss_ticket_tier/foss_ticket_tier.py
+++ b/fossunited/ticketing/doctype/foss_ticket_tier/foss_ticket_tier.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/ticketing/doctype/ticket_transfer_settings/test_ticket_transfer_settings.py
+++ b/fossunited/ticketing/doctype/ticket_transfer_settings/test_ticket_transfer_settings.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/ticketing/doctype/ticket_transfer_settings/ticket_transfer_settings.py
+++ b/fossunited/ticketing/doctype/ticket_transfer_settings/ticket_transfer_settings.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/volunteering/doctype/event_volunteer/event_volunteer.py
+++ b/fossunited/volunteering/doctype/event_volunteer/event_volunteer.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/volunteering/doctype/event_volunteer/test_event_volunteer.py
+++ b/fossunited/volunteering/doctype/event_volunteer/test_event_volunteer.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/volunteering/doctype/meetup_volunteer/meetup_volunteer.py
+++ b/fossunited/volunteering/doctype/meetup_volunteer/meetup_volunteer.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/volunteering/doctype/meetup_volunteer/test_meetup_volunteer.py
+++ b/fossunited/volunteering/doctype/meetup_volunteer/test_meetup_volunteer.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/volunteering/doctype/ngo_or_npo_volunteer/ngo_or_npo_volunteer.py
+++ b/fossunited/volunteering/doctype/ngo_or_npo_volunteer/ngo_or_npo_volunteer.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/volunteering/doctype/ngo_or_npo_volunteer/test_ngo_or_npo_volunteer.py
+++ b/fossunited/volunteering/doctype/ngo_or_npo_volunteer/test_ngo_or_npo_volunteer.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/volunteering/doctype/volunteers/test_volunteers.py
+++ b/fossunited/volunteering/doctype/volunteers/test_volunteers.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/volunteering/doctype/volunteers/volunteers.py
+++ b/fossunited/volunteering/doctype/volunteers/volunteers.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
 
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕Feature
- [x] ⚙️Chore
- [ ] 🐛Bug Fix
- [ ] 🎨Style
- [ ] 🧑‍💻Refactor
- [ ] 📕Documentation
- [ ] 🏎️Optimization

## Description
This PR removes commented out import statements (`# import frappe`) from the entire codebase. When exploring the codebase, I came across these statements. I'm not sure why this code was added in the first place. Maybe it is part of the default template. There is no good reason to have dead code in the codebase so I removed them.

I did a codebase-wide search and replace to remove the line.

## Related Issues & Docs
N/A

## Checklist
- [ ] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [ ] I have tested these changes locally.
- [ ] ~I have updated the documentation (If applicable).~
- [ ] ~The code follows the project's coding standards.~
- [ ] ~I have added/updated tests, if applicable.~

## Screenshots/GIFs/Screen Recordings (if applicable)
N/A

## Additional context
N/A

## [optional] What gif best describes this PR or how it makes you feel?
N/A