### PR TITLE
[Chore] Use fossunited developers email address instead of frappe email address

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "fossunited"
 authors = [
-    { name = "FOSSUnited", email = "developers@frappe.io"}
+    { name = "FOSSUnited", email = "developers@fossunited.org"}
 ]
 description = "Built on Frappe"
 requires-python = ">=3.10"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕Feature
- [x] ⚙️Chore
- [ ] 🐛Bug Fix
- [ ] 🎨Style
- [ ] 🧑‍💻Refactor
- [ ] 📕Documentation
- [ ] 🏎️Optimization

## Description
The package metadata (in `pyproject.toml`) uses frappe email address but this PR updates the email address to use the foss united devs email address.

## Related Issues & Docs
N/A

## Checklist
- [ ] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [ ] I have tested these changes locally.
- [ ] ~I have updated the documentation (If applicable).~
- [ ] ~The code follows the project's coding standards.~
- [ ] ~I have added/updated tests, if applicable.~

## Screenshots/GIFs/Screen Recordings (if applicable)
N/A

## Additional context
N/A

## [optional] What gif best describes this PR or how it makes you feel?
N/A