### PR TITLE
[Chore] Use latest versions of pre commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.6.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
@@ -9,7 +9,7 @@ repos:
 # Run the Ruff linter.
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.1.1
+  rev: v0.5.1
   hooks:
     # Run the Ruff linter.
     - id: ruff

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -272,23 +272,23 @@ class FOSSChapterEvent(WebsiteGenerator):
                     }
                 else:
                     rsvp_status_block["show_primary_cta"] = True
-                    rsvp_status_block[
-                        "primary_cta"
-                    ] = "RSVP for the event"
+                    rsvp_status_block["primary_cta"] = (
+                        "RSVP for the event"
+                    )
 
             if not rsvp_form.is_published:
-                rsvp_status_block[
-                    "block_heading"
-                ] = "RSVP Form is Unpublished!"
+                rsvp_status_block["block_heading"] = (
+                    "RSVP Form is Unpublished!"
+                )
         else:
             rsvp_status_block["has_doc"] = False
-            rsvp_status_block[
-                "block_heading"
-            ] = "RSVP Form is not live yet!"
+            rsvp_status_block["block_heading"] = (
+                "RSVP Form is not live yet!"
+            )
             if is_user_team_member(self.chapter, frappe.session.user):
-                rsvp_status_block[
-                    "block_heading"
-                ] = "Create RSVP for the event"
+                rsvp_status_block["block_heading"] = (
+                    "Create RSVP for the event"
+                )
                 rsvp_status_block["is_team_member"] = True
                 rsvp_status_block["create_form"] = True
             else:
@@ -348,23 +348,23 @@ class FOSSChapterEvent(WebsiteGenerator):
                     }
 
                 cfp_status_block["show_primary_cta"] = True
-                cfp_status_block[
-                    "primary_cta"
-                ] = "Submit a talk proposal"
+                cfp_status_block["primary_cta"] = (
+                    "Submit a talk proposal"
+                )
 
             if not cfp_form.is_published:
-                cfp_status_block[
-                    "block_heading"
-                ] = "Talk Proposal Form is Unpublished!"
+                cfp_status_block["block_heading"] = (
+                    "Talk Proposal Form is Unpublished!"
+                )
         else:
             cfp_status_block["has_doc"] = False
-            cfp_status_block[
-                "block_heading"
-            ] = "Talk Proposal Form is not live yet!"
+            cfp_status_block["block_heading"] = (
+                "Talk Proposal Form is not live yet!"
+            )
             if is_user_team_member(self.chapter, frappe.session.user):
-                cfp_status_block[
-                    "block_heading"
-                ] = "Create Call for Proposal (CFP) for the event"
+                cfp_status_block["block_heading"] = (
+                    "Create Call for Proposal (CFP) for the event"
+                )
                 cfp_status_block["is_team_member"] = True
                 cfp_status_block["create_form"] = True
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,6 @@ build-backend = "flit_core.buildapi"
 
 [tool.ruff]
 line-length = 70
-select = [
+lint.select = [
     "I"
 ]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕Feature
- [x] ⚙️Chore
- [ ] 🐛Bug Fix
- [ ] 🎨Style
- [ ] 🧑‍💻Refactor
- [ ] 📕Documentation
- [ ] 🏎️Optimization

## Description

This PR updates the versions of the pre commit hooks to their latest versions. Specifically, pre-commit-hooks and ruff-pre-commit are updated. Because of this change, a ruff failure was discovered and fixed.

In addition, this PR addresses a warning raised by ruff related to the settings by making the recommended settings change.

```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'select' -> 'lint.select'
```

See logs in https://github.com/fossunited/fossunited/actions/runs/9817633639/job/27109207416?pr=437 for the above warning.

## Related Issues & Docs
N/A

## Checklist
- [ ] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [ ] I have tested these changes locally.
- [ ] ~I have updated the documentation (If applicable).~
- [ ] ~The code follows the project's coding standards.~
- [ ] ~I have added/updated tests, if applicable.~

## Screenshots/GIFs/Screen Recordings (if applicable)
N/A

## Additional context
N/A

## [optional] What gif best describes this PR or how it makes you feel?
N/A