### PR TITLE
[TEST] Add a unittest for adding "FOSSUnitedProfile"

### DIFF
--- a/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
@@ -6,4 +6,5 @@ from frappe.tests.utils import FrappeTestCase
 
 
 class TestFOSSUserProfile(FrappeTestCase):
-    pass
+    def test_create_user_profile(self):
+        self.assertFalse(True)

--- a/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
@@ -12,11 +12,11 @@ class TestFOSSUserProfile(FrappeTestCase):
         # Given a user that does not have a FOSSUnitedProfile
         inserted_username = "wisharya"
         inserted_name = "wish arya"
-        profiles_metadata = frappe.get_all(
-            doctype="FOSS User Profile",
-            filters={"username": inserted_username},
+        profile_exists = frappe.db.exists(
+            "FOSS User Profile",
+            {"username": inserted_username}
         )
-        self.assertEqual(profiles_metadata, [])
+        self.assertFalse(profile_exists)
 
         # When a FOSSUnitedProfile is created for the user
         # Note that a Frappe User needs to exist before a Profile can be created
@@ -40,7 +40,6 @@ class TestFOSSUserProfile(FrappeTestCase):
                 "is_published": 1,
             },
         ).insert()
-        inserted_name = profile.name
 
         # Then verify that the Profile has been stored as expected
         profile_exists = frappe.db.exists(

--- a/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
@@ -1,10 +1,52 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and Contributors
 # See license.txt
 
-# import frappe
+import uuid
+
+import frappe
 from frappe.tests.utils import FrappeTestCase
 
 
 class TestFOSSUserProfile(FrappeTestCase):
-    def test_create_user_profile(self):
-        self.assertFalse(True)
+    def test_add_profile(self):
+        # Given a user that does not have a FOSSUnitedProfile
+        inserted_username = "wisharya"
+        inserted_name = "wish arya"
+        profiles_metadata = frappe.get_all(
+            doctype="FOSS User Profile",
+            filters={"username": inserted_username},
+        )
+        self.assertEqual(profiles_metadata, [])
+
+        # When a FOSSUnitedProfile is created for the user
+        # Note that a Frappe User needs to exist before a Profile can be created
+        # Verify that only required values are provided below
+        frappe_user = frappe.get_doc(
+            {
+                "doctype": "User",
+                "username": inserted_username,
+                # Create a unique email address as it is used as a database key
+                "email": str(uuid.uuid4()) + "@fossunited.org",
+                "first_name": "wish",
+                "name": inserted_name,
+                "full_name": inserted_name,
+            },
+        )
+        frappe_user.db_insert()
+        profile = frappe.get_doc(
+            {
+                "doctype": "FOSS User Profile",
+                "user": frappe_user.name,
+                "username": frappe_user.username,
+                "is_published": 1,
+            },
+        )
+        profile.db_insert()
+        inserted_name = profile.name
+
+        # Then verify that the Profile has been stored as expected
+        profiles_metadata = frappe.get_all(
+            doctype="FOSS User Profile",
+            filters={"username": inserted_username},
+        )
+        self.assertEqual(profiles_metadata, [{"name": inserted_name}])

--- a/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
@@ -13,8 +13,7 @@ class TestFOSSUserProfile(FrappeTestCase):
         inserted_username = "wisharya"
         inserted_name = "wish arya"
         profile_exists = frappe.db.exists(
-            "FOSS User Profile",
-            {"username": inserted_username}
+            "FOSS User Profile", {"username": inserted_username}
         )
         self.assertFalse(profile_exists)
 
@@ -43,7 +42,6 @@ class TestFOSSUserProfile(FrappeTestCase):
 
         # Then verify that the Profile has been stored as expected
         profile_exists = frappe.db.exists(
-            "FOSS User Profile",
-            {"username": inserted_username}
+            "FOSS User Profile", {"username": inserted_username}
         )
         self.assertTrue(profile_exists)

--- a/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
@@ -31,8 +31,7 @@ class TestFOSSUserProfile(FrappeTestCase):
                 "name": inserted_name,
                 "full_name": inserted_name,
             },
-        )
-        frappe_user.db_insert()
+        ).insert()
         profile = frappe.get_doc(
             {
                 "doctype": "FOSS User Profile",
@@ -40,13 +39,12 @@ class TestFOSSUserProfile(FrappeTestCase):
                 "username": frappe_user.username,
                 "is_published": 1,
             },
-        )
-        profile.db_insert()
+        ).insert()
         inserted_name = profile.name
 
         # Then verify that the Profile has been stored as expected
-        profiles_metadata = frappe.get_all(
-            doctype="FOSS User Profile",
-            filters={"username": inserted_username},
+        profile_exists = frappe.db.exists(
+            "FOSS User Profile",
+            {"username": inserted_username}
         )
-        self.assertEqual(profiles_metadata, [{"name": inserted_name}])
+        self.assertTrue(profile_exists)

--- a/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
@@ -31,17 +31,10 @@ class TestFOSSUserProfile(FrappeTestCase):
                 "full_name": inserted_name,
             },
         ).insert()
-        profile = frappe.get_doc(
-            {
-                "doctype": "FOSS User Profile",
-                "user": frappe_user.name,
-                "username": frappe_user.username,
-                "is_published": 1,
-            },
-        ).insert()
 
         # Then verify that the Profile has been stored as expected
         profile_exists = frappe.db.exists(
-            "FOSS User Profile", {"username": inserted_username}
+            "FOSS User Profile", {"user": frappe_user.name}
         )
+
         self.assertTrue(profile_exists)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕Feature
- [ ] ⚙️Chore
- [ ] 🐛Bug Fix
- [ ] 🎨Style
- [ ] 🧑‍💻Refactor
- [ ] 📕Documentation
- [ ] 🏎️Optimization
- [x] Testing

## Description

This PR adds a unittest that tests the creation of a `FOSSUnitedProfile`. The unittest is written as follows

- check that the profile that we are interested in adding does not already exist
- add and insert a Frappe `User` and `FOSSUnitedProfile`. Note that this is because `FOSSUnitedProfile` requires the presence of a `User`
- verify that the inserted `FOSSUnitedProfile` was actually added by querying for it

Unittests usually follow the format "Given, When, Then" e.g. Given a scenario, When an action is performed, Then verify the expected outcomes.

The unittest runs on CI as expected

```
----------------------------------------------------------------------
Ran 1 test in 0.008s

OK
```

## Related Issues & Docs
N/A

## Checklist
- [ ] ~I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").~
- [x] I have tested these changes locally.
- [ ] ~I have updated the documentation (If applicable).~
- [x] The code follows the project's coding standards.
- [x] I have added/updated tests, if applicable.

## Screenshots/GIFs/Screen Recordings (if applicable)
N/A

## Additional context
N/A

## [optional] What gif best describes this PR or how it makes you feel?
N/A