### PR TITLE
chore!: update FOSS Event CFP and RSVP submission forms

### DIFF
--- a/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.json
+++ b/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.json
@@ -126,7 +126,7 @@
  "index_web_pages_for_search": 1,
  "is_published_field": "is_published",
  "links": [],
- "modified": "2024-07-03 10:30:16.158558",
+ "modified": "2024-07-07 01:12:10.962928",
  "modified_by": "Administrator",
  "module": "Chapters",
  "name": "FOSS Event RSVP",
@@ -144,6 +144,16 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "read": 1,
+   "role": "Guest",
+   "select": 1
+  },
+  {
+   "read": 1,
+   "role": "All",
+   "select": 1
   }
  ],
  "route": "events/rsvp",

--- a/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.py
@@ -135,13 +135,15 @@ class FOSSEventRSVP(WebsiteGenerator):
 
 @frappe.whitelist(allow_guest=True)
 def create_rsvp(fields):
-    fields = json.loads(fields)
-    if not frappe.db.exists(
-        "FOSS Event RSVP", fields.get("linked_rsvp")
-    ):
+    _fields = json.loads(fields)
+
+    linked_rsvp_exists = frappe.db.exists(
+        "FOSS Event RSVP", _fields.get("linked_rsvp")
+    )
+    if not linked_rsvp_exists:
         frappe.throw("Invalid RSVP ID.", frappe.DoesNotExistError)
 
-    fields.update(
+    _fields.update(
         {
             "doctype": "FOSS Event RSVP Submission",
             "submitted_by": frappe.session.user
@@ -150,6 +152,6 @@ def create_rsvp(fields):
         }
     )
 
-    doc = frappe.get_doc(fields)
+    doc = frappe.get_doc(_fields)
     doc.insert(ignore_permissions=True)
     return doc

--- a/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.py
@@ -5,7 +5,6 @@ import json
 
 import frappe
 from frappe.website.website_generator import WebsiteGenerator
-from pydantic import BaseModel, validator
 
 
 class FOSSEventRSVP(WebsiteGenerator):

--- a/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.py
@@ -135,15 +135,15 @@ class FOSSEventRSVP(WebsiteGenerator):
 
 @frappe.whitelist(allow_guest=True)
 def create_rsvp(fields):
-    _fields = json.loads(fields)
+    fields = json.loads(fields)
 
     linked_rsvp_exists = frappe.db.exists(
-        "FOSS Event RSVP", _fields.get("linked_rsvp")
+        "FOSS Event RSVP", fields.get("linked_rsvp")
     )
     if not linked_rsvp_exists:
         frappe.throw("Invalid RSVP ID.", frappe.DoesNotExistError)
 
-    _fields.update(
+    fields.update(
         {
             "doctype": "FOSS Event RSVP Submission",
             "submitted_by": frappe.session.user
@@ -152,6 +152,6 @@ def create_rsvp(fields):
         }
     )
 
-    doc = frappe.get_doc(_fields)
+    doc = frappe.get_doc(fields)
     doc.insert(ignore_permissions=True)
     return doc

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.json
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.json
@@ -28,7 +28,8 @@
    "fieldname": "linked_rsvp",
    "fieldtype": "Link",
    "label": "Linked RSVP",
-   "options": "FOSS Event RSVP"
+   "options": "FOSS Event RSVP",
+   "reqd": 1
   },
   {
    "fieldname": "column_break_tpys",
@@ -59,7 +60,8 @@
    "fieldname": "event",
    "fieldtype": "Data",
    "in_standard_filter": 1,
-   "label": "Event"
+   "label": "Event",
+   "reqd": 1
   },
   {
    "columns": 3,
@@ -81,7 +83,7 @@
    "fieldname": "im_a",
    "fieldtype": "Select",
    "label": "I'm a",
-   "options": "\nStudent\nProfessional\nFOSS Enthusiast"
+   "options": "\nStudent\nProfessional\nFOSS Enthusiast\nOther"
   },
   {
    "fieldname": "column_break_bkxf",
@@ -124,7 +126,7 @@
   }
  ],
  "links": [],
- "modified": "2024-07-03 10:22:45.197158",
+ "modified": "2024-07-07 01:23:03.433237",
  "modified_by": "Administrator",
  "module": "Chapters",
  "name": "FOSS Event RSVP Submission",

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
@@ -34,14 +34,16 @@ class FOSSEventRSVPSubmission(Document):
     pass
 
     def validate(self):
-        self.validate_linked_rsvp()
+        self.validate_linked_rsvp_exists()
 
-    def validate_linked_rsvp(self):
+    def validate_linked_rsvp_exists(self):
         if not frappe.db.exists("FOSS Event RSVP", self.linked_rsvp):
             frappe.throw("Invalid RSVP", frappe.DoesNotExistError)
 
-        rsvp = frappe.get_doc("FOSS Event RSVP", self.linked_rsvp)
-        if not rsvp.is_published:
+        is_rsvp_published = frappe.db.get_value(
+            "FOSS Event RSVP", self.linked_rsvp, "is_published"
+        )
+        if not is_rsvp_published:
             frappe.throw(
                 "RSVP is not published", frappe.PermissionError
             )

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
+import frappe
 from frappe.model.document import Document
 
 
@@ -21,13 +22,26 @@ class FOSSEventRSVPSubmission(Document):
         confirm_attendance: DF.Check
         custom_answers: DF.Table[FOSSCustomAnswer]
         email: DF.Data
-        event: DF.Data | None
+        event: DF.Data
         event_name: DF.Data | None
         im_a: DF.Literal[
-            "", "Student", "Professional", "FOSS Enthusiast"
+            "", "Student", "Professional", "FOSS Enthusiast", "Other"
         ]
-        linked_rsvp: DF.Link | None
+        linked_rsvp: DF.Link
         name1: DF.Data
         submitted_by: DF.Link | None
     # end: auto-generated types
     pass
+
+    def validate(self):
+        self.validate_linked_rsvp()
+
+    def validate_linked_rsvp(self):
+        if not frappe.db.exists("FOSS Event RSVP", self.linked_rsvp):
+            frappe.throw("Invalid RSVP", frappe.DoesNotExistError)
+
+        rsvp = frappe.get_doc("FOSS Event RSVP", self.linked_rsvp)
+        if not rsvp.is_published:
+            frappe.throw(
+                "RSVP is not published", frappe.PermissionError
+            )

--- a/fossunited/fossunited/doctype/foss_event_cfp/foss_event_cfp.json
+++ b/fossunited/fossunited/doctype/foss_event_cfp/foss_event_cfp.json
@@ -143,7 +143,7 @@
  "index_web_pages_for_search": 1,
  "is_published_field": "is_published",
  "links": [],
- "modified": "2024-07-03 10:38:14.041510",
+ "modified": "2024-07-07 01:12:51.165428",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "FOSS Event CFP",
@@ -161,6 +161,11 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "read": 1,
+   "role": "All",
+   "select": 1
   }
  ],
  "route": "cfp/new",

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.json
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.json
@@ -61,7 +61,8 @@
    "fetch_from": "linked_cfp.event",
    "fieldname": "event",
    "fieldtype": "Data",
-   "label": "Event"
+   "label": "Event",
+   "reqd": 1
   },
   {
    "fieldname": "submitted_by",
@@ -288,7 +289,7 @@
  "has_web_view": 1,
  "is_published_field": "is_published",
  "links": [],
- "modified": "2024-07-03 10:38:03.852604",
+ "modified": "2024-07-07 01:13:46.527023",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "FOSS Event CFP Submission",

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -58,7 +58,7 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
 
     def before_insert(self):
         self.check_status()
-        self.validate_linked_cfp()
+        self.validate_linked_cfp_exists()
 
     def before_save(self):
         self.set_name()
@@ -83,12 +83,12 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         self.approvability = statistics[3]["percentage"]
 
     def check_status(self):
-        if not self.status == "Review Pending":
+        if self.status != "Review Pending":
             frappe.throw(
                 "Illegal status change", frappe.ValidationError
             )
 
-    def validate_linked_cfp(self):
+    def validate_linked_cfp_exists(self):
         if not frappe.db.exists("FOSS Event CFP", self.linked_cfp):
             frappe.throw("Invalid CFP", frappe.DoesNotExistError)
 


### PR DESCRIPTION

## Description
- Simplified the `create_submission` method for creating RSVP submissions. Schemas were used with the help of pydantic. That has been refactored to be simpler. It was supposedly the cause of the "Email Missing" error for RSVP submissions.

- Validations added for RSVP Submissions to check for the validity of Linked RSVP to the submission. This will prevent creation of submissions without a valid rsvp.

- Added validation for CFP Submission doctype. Before creating a CFP Submission doctype, the linked CFP and the Status of the CFP Submission will be validated. The linked cfp validation is same as rsvp, i.e., it will be checked that the submission is linked to a valid CFP. The status is validated to be "Review Pending" such that no malicious submission can be created using APIs with direct "Approval" as status

- Added a couple of permissions for `All` and `Guest` for _FOSS Event CFP_ and _FOSS Event RSVP_ doctypes. this is done in order to use the `frappe.db.exists` methods for validations at the time of creation.