### PR TITLE
chore(ticket-transfer): better api endpoints & permissions

### DIFF
--- a/dashboard/src/components/Header.vue
+++ b/dashboard/src/components/Header.vue
@@ -53,12 +53,9 @@ import FossUnitedLogo from '@/components/FossUnitedLogo.vue'
 let session = inject('$session')
 
 let user_profile = createResource({
-  url: 'frappe.client.get',
+  url: 'fossunited.fossunited.utils.get_foss_profile',
   params: {
-    doctype: 'FOSS User Profile',
-    filters: {
-      email: session.user,
-    },
+    email: session.user,
   },
 })
 

--- a/dashboard/src/pages/TicketTransfer.vue
+++ b/dashboard/src/pages/TicketTransfer.vue
@@ -159,11 +159,10 @@ const receiver = reactive({
 })
 
 const ticket = createResource({
-  url: 'frappe.client.get',
+  url: 'fossunited.api.tickets.get_ticket_details',
   makeParams() {
     return {
-      doctype: 'FOSS Event Ticket',
-      name: ticketId.value,
+      ticket_id: ticketId.value,
     }
   },
   onSuccess(data) {
@@ -194,16 +193,14 @@ const isTicketValid = () => {
   }
 
   createResource({
-    url: 'frappe.client.get_count',
+    url: 'fossunited.api.tickets.check_ticket_validity',
     params: {
-      doctype: 'FOSS Event Ticket',
-      filters: {
-        name: ticketId.value,
-      },
+      ticket_id: ticketId.value,
     },
     auto: true,
     onSuccess(data) {
       if (!data) {
+        ticket.data = null
         ticketValidateError.value = 'Invalid Ticket ID'
         return false
       }
@@ -236,19 +233,18 @@ const transferErrors = () => {
 }
 
 const createTransferDoc = createResource({
-  url: 'frappe.client.insert',
+  url: 'fossunited.api.tickets.create_transfer_request',
   makeParams() {
     return {
-      doc: {
-        doctype: 'FOSS Event Ticket Transfer',
         ticket: ticketId.value,
-        receiver_email: receiver.receiver_email,
-        receiver_name: receiver.receiver_name,
-        designation: receiver.designation,
-        organization: receiver.organization,
-        wants_tshirt: receiver.wants_tshirt,
-        tshirt_size: receiver.tshirt_size,
-      },
+        receiver_details: {
+          receiver_email: receiver.receiver_email,
+          receiver_name: receiver.receiver_name,
+          designation: receiver.designation,
+          organization: receiver.organization,
+          wants_tshirt: receiver.wants_tshirt,
+          tshirt_size: receiver.tshirt_size,
+        }
     }
   },
   onSuccess(data) {

--- a/dashboard/src/pages/TicketTransfer.vue
+++ b/dashboard/src/pages/TicketTransfer.vue
@@ -3,7 +3,7 @@
   <div class="w-full flex items-center justify-center">
     <TransferSuccess v-if="inSuccess" />
     <div v-else class="max-w-screen-xl w-full p-5">
-      <img v-if="transfer_settings.doc.banner_image" :src="transfer_settings.doc.banner_image" alt="" class="object-cover hidden md:block w-full border rounded-lg aspect-[4.96/1]">
+      <img v-if="transfer_settings.doc?.banner_image" :src="transfer_settings.doc.banner_image" alt="" class="object-cover hidden md:block w-full border rounded-lg aspect-[4.96/1]">
       <div class="mt-8">
         <div class="prose min-w-full">
           <div class="text-base uppercase font-medium text-gray-600 mb-2">

--- a/dashboard/src/pages/TicketTransferProcess.vue
+++ b/dashboard/src/pages/TicketTransferProcess.vue
@@ -43,11 +43,10 @@ const dialogTitle = ref('Error')
 const dialogMessage = ref('')
 
 const ticketDoc = createResource({
-    url: 'frappe.client.get',
+    url: 'fossunited.api.tickets.get_ticket_details',
     makeParams() {
         return {
-            doctype: 'FOSS Event Ticket',
-            name: ticket
+            ticket_id: ticket
         }
     },
 })
@@ -70,15 +69,12 @@ const isValidStatus = () => {
 }
 
 const validateTicket = createResource({
-    url: 'frappe.client.get_count',
+    url: 'fossunited.api.tickets.check_ticket_validity',
     params: {
-        doctype: 'FOSS Event Ticket',
-        filters: {
-            name: ticket
-        }
+        ticket_id: ticket
     },
     onSuccess(data) {
-        if (data === 0) {
+        if (!data) {
             showDialog.value = true
             dialogMessage.value += ' The ticket you are trying to transfer does not exist.'
         }
@@ -89,11 +85,10 @@ const validateTicket = createResource({
 })
 
 const transferDoc = createResource({
-    url: 'frappe.client.get',
+    url: 'fossunited.api.tickets.get_transfer_doc',
     makeParams() {
         return {
-            doctype: 'FOSS Event Ticket Transfer',
-            name: transferID
+            id: transferID
         }
     },
     loading: true,
@@ -117,12 +112,12 @@ const transferDoc = createResource({
 
 const approveTransfer = (data) => {
     createResource({
-        url: 'frappe.client.set_value',
-        params: {
-            doctype: 'FOSS Event Ticket Transfer',
-            name: data.name,
-            fieldname: 'status',
-            value: 'Completed'
+        url: 'fossunited.api.tickets.change_transfer_status',
+        makeParams(){
+            return {
+                transfer_id: data.name,
+                status: 'Completed'
+            }
         },
         auto: true,
         onSuccess(data) {
@@ -138,12 +133,10 @@ const approveTransfer = (data) => {
 
 const rejectTransfer = (data) => {
     createResource({
-        url: 'frappe.client.set_value',
+        url: 'fossunited.api.tickets.change_transfer_status',
         params: {
-            doctype: 'FOSS Event Ticket Transfer',
-            name: data.name,
-            fieldname: 'status',
-            value: 'Cancelled'
+            transfer_id: data.name,
+            status: 'Cancelled'
         },
         auto: true,
         onSuccess(data) {
@@ -158,15 +151,12 @@ const rejectTransfer = (data) => {
 }
 
 const validateTransferId = createResource({
-    url: 'frappe.client.get_count',
+    url: 'fossunited.api.tickets.check_transfer_doc_validity',
     params: {
-        doctype: 'FOSS Event Ticket Transfer',
-        filters: {
-            name: transferID
-        }
+        transfer_id: transferID
     },
     onSuccess(data) {
-        if (data === 0) {
+        if (!data) {
             showDialog.value = true
             dialogMessage.value += ' The transfer request you are trying to approve does not exist. '
             return false

--- a/dashboard/src/pages/TicketTransferProcess.vue
+++ b/dashboard/src/pages/TicketTransferProcess.vue
@@ -85,7 +85,7 @@ const validateTicket = createResource({
 })
 
 const transferDoc = createResource({
-    url: 'fossunited.api.tickets.get_transfer_doc',
+    url: 'fossunited.api.tickets.get_transfer_details',
     makeParams() {
         return {
             id: transferID
@@ -151,7 +151,7 @@ const rejectTransfer = (data) => {
 }
 
 const validateTransferId = createResource({
-    url: 'fossunited.api.tickets.check_transfer_doc_validity',
+    url: 'fossunited.api.tickets.get_transfer_doc_validity',
     params: {
         transfer_id: transferID
     },

--- a/fossunited/api/tickets.py
+++ b/fossunited/api/tickets.py
@@ -11,11 +11,8 @@ def check_ticket_validity(ticket_id: str):
     Check if the ticket is valid or not
     """
     is_ticket_valid = frappe.db.exists("FOSS Event Ticket", ticket_id)
-    print(is_ticket_valid)
-    if is_ticket_valid:
-        return True
 
-    return False
+    return bool(is_ticket_valid)
 
 
 @frappe.whitelist(allow_guest=True)
@@ -56,21 +53,19 @@ def create_transfer_request(ticket: str, receiver_details: dict):
 
 
 @frappe.whitelist()
-def check_transfer_doc_validity(transfer_id: str):
+def get_transfer_doc_validity(transfer_id: str):
     """
     Check the validity of transfer doc/id
     """
     is_valid_id = frappe.db.exists(
         "FOSS Event Ticket Transfer", transfer_id
     )
-    if is_valid_id:
-        return True
 
-    return False
+    return bool(is_valid_id)
 
 
 @frappe.whitelist()
-def get_transfer_doc(id: str):
+def get_transfer_details(id: str):
     """
     Get the transfer doc
     """

--- a/fossunited/api/tickets.py
+++ b/fossunited/api/tickets.py
@@ -1,0 +1,94 @@
+"""
+APIs for Tickets and Transfer Tickets
+"""
+
+import frappe
+
+
+@frappe.whitelist(allow_guest=True)
+def check_ticket_validity(ticket_id: str):
+    """
+    Check if the ticket is valid or not
+    """
+    is_ticket_valid = frappe.db.exists("FOSS Event Ticket", ticket_id)
+    print(is_ticket_valid)
+    if is_ticket_valid:
+        return True
+
+    return False
+
+
+@frappe.whitelist(allow_guest=True)
+def get_ticket_details(ticket_id: str):
+    """
+    Get the event for the ticket
+    """
+    ticket = frappe.db.get_value(
+        "FOSS Event Ticket",
+        ticket_id,
+        ["event", "tier", "wants_tshirt", "tshirt_size"],
+        as_dict=True,
+    )
+    return ticket
+
+
+@frappe.whitelist(allow_guest=True)
+def create_transfer_request(ticket: str, receiver_details: dict):
+    """
+    Create a transfer request for the ticket
+    """
+    print(receiver_details)
+    transfer_request = frappe.get_doc(
+        {
+            "doctype": "FOSS Event Ticket Transfer",
+            "ticket": ticket,
+            "receiver_name": receiver_details.get("receiver_name"),
+            "receiver_email": receiver_details.get("receiver_email"),
+            "designation": receiver_details.get("designation"),
+            "organization": receiver_details.get("organization"),
+            "wants_tshirt": receiver_details.get("wants_tshirt"),
+            "tshirt_size": receiver_details.get("tshirt_size"),
+            "status": "Pending Approval",
+        }
+    )
+    transfer_request.insert(ignore_permissions=True)
+    return transfer_request
+
+
+@frappe.whitelist()
+def check_transfer_doc_validity(transfer_id: str):
+    """
+    Check the validity of transfer doc/id
+    """
+    is_valid_id = frappe.db.exists(
+        "FOSS Event Ticket Transfer", transfer_id
+    )
+    if is_valid_id:
+        return True
+
+    return False
+
+
+@frappe.whitelist()
+def get_transfer_doc(id: str):
+    """
+    Get the transfer doc
+    """
+    doc = frappe.db.get_value(
+        "FOSS Event Ticket Transfer",
+        id,
+        ["name", "status", "ticket"],
+        as_dict=True,
+    )
+    return doc
+
+
+@frappe.whitelist()
+def change_transfer_status(transfer_id: str, status: str):
+    """
+    Change the status of the transfer request
+    """
+    doc = frappe.get_doc("FOSS Event Ticket Transfer", transfer_id)
+    doc.status = status
+    doc.save()
+    return True

--- a/fossunited/ticketing/doctype/foss_event_ticket_transfer/foss_event_ticket_transfer.json
+++ b/fossunited/ticketing/doctype/foss_event_ticket_transfer/foss_event_ticket_transfer.json
@@ -125,7 +125,7 @@
   }
  ],
  "links": [],
- "modified": "2024-06-25 13:13:18.249849",
+ "modified": "2024-07-07 21:26:22.906297",
  "modified_by": "Administrator",
  "module": "Ticketing",
  "name": "FOSS Event Ticket Transfer",
@@ -146,26 +146,16 @@
   },
   {
    "create": 1,
-   "delete": 1,
    "email": 1,
    "export": 1,
    "print": 1,
-   "read": 1,
    "report": 1,
    "role": "All",
    "share": 1,
    "write": 1
   },
   {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
    "role": "Guest",
-   "share": 1,
    "write": 1
   }
  ],

--- a/fossunited/ticketing/doctype/foss_event_ticket_transfer/foss_event_ticket_transfer.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket_transfer/foss_event_ticket_transfer.py
@@ -32,7 +32,7 @@ class FOSSEventTicketTransfer(Document):
 
     def before_insert(self):
         self.validate_ticket_exists()
-        self.check_status()
+        self.validate_status_is_pending()
 
     def before_save(self):
         if self.has_value_changed("status"):
@@ -44,7 +44,7 @@ class FOSSEventTicketTransfer(Document):
         if not frappe.db.exists("FOSS Event Ticket", self.ticket):
             frappe.throw("Ticket not found", frappe.DoesNotExistError)
 
-    def check_status(self):
+    def validate_status_is_pending(self):
         if self.status != "Pending Approval":
             frappe.throw(
                 "Invalid status change. Status should be 'Pending Approval'. Current status is {0}".format(

--- a/fossunited/ticketing/doctype/foss_event_ticket_transfer/foss_event_ticket_transfer.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket_transfer/foss_event_ticket_transfer.py
@@ -30,22 +30,44 @@ class FOSSEventTicketTransfer(Document):
     # end: auto-generated types
     pass
 
+    def before_insert(self):
+        self.validate_ticket_exists()
+        self.check_status()
+
     def before_save(self):
         if self.has_value_changed("status"):
             if self.status == "Completed":
+                self.validate_ticket_exists()
                 self.transfer_ticket()
 
-    def transfer_ticket(self):
-        try:
-            ticket = frappe.get_doc("FOSS Event Ticket", self.ticket)
-        except frappe.DoesNotExistError:
-            frappe.throw("Ticket not found")
-            return
+    def validate_ticket_exists(self):
+        if not frappe.db.exists("FOSS Event Ticket", self.ticket):
+            frappe.throw("Ticket not found", frappe.DoesNotExistError)
 
-        ticket.full_name = self.receiver_name
-        ticket.email = self.receiver_email
-        ticket.designation = self.designation
-        ticket.organization = self.organization
-        ticket.tshirt_size = self.tshirt_size
-        ticket.is_transfer_ticket = 1
-        ticket.save()
+    def check_status(self):
+        if self.status != "Pending Approval":
+            frappe.throw(
+                "Invalid status change. Status should be 'Pending Approval'. Current status is {0}".format(
+                    self.status
+                ),
+                frappe.ValidationError,
+            )
+
+    def transfer_ticket(self):
+        self.validate_ticket_exists()
+        try:
+            frappe.db.set_value(
+                "FOSS Event Ticket",
+                self.ticket,
+                {
+                    "full_name": self.receiver_name,
+                    "email": self.receiver_email,
+                    "designation": self.designation,
+                    "organization": self.organization,
+                    "wants_tshirt": self.wants_tshirt,
+                    "tshirt_size": self.tshirt_size,
+                    "is_transfer_ticket": 1,
+                },
+            )
+        except Exception as e:
+            frappe.throw(str(e), frappe.ValidationError)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] ⚙️Chore
- [x] 🧑‍💻Refactor

## Description
<!-- Briefly describe the changes introduced by this pull request -->
- Fixed an api endpoint to get profile data of the session user for dashboard header
- Refactored API endpoints to work with the new permissions for Ticket Transfer doctype.
- Less usage of `frappe.client.get` as it won't work with the new permissions. 
- New API endpoints make use of `frappe.db.get_value` to get only the required value, nothing more.
- Permissions given to Guest and All as follows:
This is done because write permissions are required to run the method when status is changed to `Completed`. `frappe.db.set_value` method won't call ORM triggers like `validate` and `before_save`.
![image](https://github.com/fossunited/fossunited/assets/73123690/70cb00dc-deaf-494b-9085-76cac4ae96bd)
- Validations added for transfer doctype which run at the time of creation. They check whether the transfer being created has a valid ticket.
- The validation also happens to ensure that the status at the time of creation is `Pending Approval` and nothing else.
