### PR TITLE
[TEST] add unit tests for ticket-transfer doctype

### DIFF
--- a/fossunited/ticketing/doctype/foss_event_ticket_transfer/test_foss_event_ticket_transfer.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket_transfer/test_foss_event_ticket_transfer.py
@@ -50,7 +50,6 @@ class TestFOSSEventTicketTransfer(FrappeTestCase):
         # Change status of transfer to completed
         transfer.status = "Completed"
         transfer.save()
-        self.assertEqual(transfer.status, "Completed")
 
         # Then check that a ticket with older credentials does not exists.
         # Also check that ticket has new details.
@@ -73,10 +72,6 @@ class TestFOSSEventTicketTransfer(FrappeTestCase):
             },
         )
         self.assertTrue(new_ticket_exists)
-
-        transfer.delete()
-        ticket.delete()
-        event.delete()
 
     def test_check_status_pending_on_create(self):
         # Given an event and a ticket linked to the event

--- a/fossunited/ticketing/doctype/foss_event_ticket_transfer/test_foss_event_ticket_transfer.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket_transfer/test_foss_event_ticket_transfer.py
@@ -1,8 +1,79 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
 
+from datetime import datetime, timedelta
+
+import frappe
 from frappe.tests.utils import FrappeTestCase
 
 
 class TestFOSSEventTicketTransfer(FrappeTestCase):
-    pass
+    def test_ticket_transfer(self):
+        # Given for an event, a ticket is created. For that ticket, a transfer is generated.
+        event = frappe.get_doc(
+            {
+                "doctype": "FOSS Chapter Event",
+                "event_name": "Test Event",
+                "event_permalink": "test_perma",
+                "status": "Approved",
+                "event_type": "Conference",
+                "event_start_date": datetime.today(),
+                "event_end_date": datetime.today() + timedelta(1),
+                "event_description": "testing",
+            }
+        )
+        event.insert()
+
+        ticket = frappe.get_doc(
+            {
+                "doctype": "FOSS Event Ticket",
+                "event": event.name,
+                "full_name": "Harsh Tandiya",
+                "email": "harsh@test.xyz",
+            }
+        )
+        ticket.insert()
+
+        transfer = frappe.get_doc(
+            {
+                "doctype": "FOSS Event Ticket Transfer",
+                "ticket": ticket.name,
+                "receiver_name": "Rahul",
+                "receiver_email": "rahul@test.xyz",
+            }
+        )
+        transfer.insert()
+
+        # When Ticket Transfer is created, status should be pending
+        self.assertEqual(transfer.status, "Pending Approval")
+
+        # Change status of transfer to completed
+        transfer.status = "Completed"
+        transfer.save()
+        self.assertEqual(transfer.status, "Completed")
+
+        # Then check that a ticket with older credentials does not exists.
+        # Also check that ticket has new details.
+        old_ticket_exists = frappe.db.exists(
+            "FOSS Event Ticket",
+            {
+                "email": "harsh@test.xyz",
+                "full_name": "Harsh Tandiya",
+                "event": event.name,
+            },
+        )
+        self.assertFalse(old_ticket_exists)
+
+        new_ticket_exists = frappe.db.exists(
+            "FOSS Event Ticket",
+            {
+                "email": "rahul@test.xyz",
+                "full_name": "Rahul",
+                "event": event.name,
+            },
+        )
+        self.assertTrue(new_ticket_exists)
+
+        transfer.delete()
+        ticket.delete()
+        event.delete()

--- a/fossunited/ticketing/doctype/foss_event_ticket_transfer/test_foss_event_ticket_transfer.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket_transfer/test_foss_event_ticket_transfer.py
@@ -77,3 +77,43 @@ class TestFOSSEventTicketTransfer(FrappeTestCase):
         transfer.delete()
         ticket.delete()
         event.delete()
+
+    def test_check_status_pending_on_create(self):
+        # Given an event and a ticket linked to the event
+        event = frappe.get_doc(
+            {
+                "doctype": "FOSS Chapter Event",
+                "event_name": "Test Event",
+                "event_permalink": "test_perma_2",
+                "status": "Approved",
+                "event_type": "Conference",
+                "event_start_date": datetime.today(),
+                "event_end_date": datetime.today() + timedelta(1),
+                "event_description": "testing",
+            }
+        )
+        event.insert()
+
+        # With a ticket created for a user, try to transfer this ticket to another user while passing "Completed" as the status
+        ticket = frappe.get_doc(
+            {
+                "doctype": "FOSS Event Ticket",
+                "event": event.name,
+                "full_name": "Harsh Tandiya",
+                "email": "harsh2@test.xyz",
+            }
+        )
+        ticket.insert()
+
+        # Then verify that this operation raises a ValidationError
+        with self.assertRaises(frappe.exceptions.ValidationError):
+            transfer = frappe.get_doc(
+                {
+                    "doctype": "FOSS Event Ticket Transfer",
+                    "ticket": ticket.name,
+                    "receiver_name": "Rahul",
+                    "receiver_email": "rahul2@test.xyz",
+                    "status": "Completed",
+                }
+            )
+            transfer.insert()

--- a/fossunited/ticketing/doctype/foss_event_ticket_transfer/test_foss_event_ticket_transfer.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket_transfer/test_foss_event_ticket_transfer.py
@@ -73,7 +73,7 @@ class TestFOSSEventTicketTransfer(FrappeTestCase):
         )
         self.assertTrue(new_ticket_exists)
 
-    def test_check_status_pending_on_create(self):
+    def test_status_pending_on_create(self):
         # Given an event and a ticket linked to the event
         event = frappe.get_doc(
             {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Test
## Description
This PR adds a couple of unit tests for the Ticket Transfer Doctype.
- Testing Ticket Transfer Workflow ->
   - Check that ticket is created only for a valid event.
   - Check that once the transfer is done, there is no ticket remaining with the details of the previous owner
   - Verify that the ticket has the details of the new owner after transfer 
- Testing Transfer Status to be "Pending Approval" at the time of creation, and that it throws a ValidationError if it is anything else.

```
----------------------------------------------------------------------
Ran 2 tests in 1.889s

```