### PR TITLE
feat: add hackathons to event timeline and other style fixes in public pages

### DIFF
--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -1,8 +1,8 @@
 import itertools
 import json
+from datetime import datetime
 
 import frappe
-from frappe.utils import format_datetime, format_time
 from frappe.utils.data import now_datetime
 
 
@@ -203,6 +203,9 @@ def validate_profile_completion():
 
 
 def get_grouped_events():
+    """
+    Retrieves FOSS Chapter Events and Hackathons, then groups them by month and year, separating upcoming and past events.
+    """
     events = frappe.get_all(
         "FOSS Chapter Event",
         fields=["*"],
@@ -212,34 +215,74 @@ def get_grouped_events():
         },
         order_by="event_start_date",
     )
-    return get_month_grouped_events(events)
+
+    hackathons = frappe.get_all(
+        "FOSS Hackathon",
+        fields=["*"],
+        filters={
+            "is_published": 1,
+        },
+        order_by="start_date",
+    )
+    return get_month_grouped_events(events, hackathons)
 
 
-def get_month_grouped_events(events):
-    grouped_events = {"Upcoming FOSS Events": [], "Past Events": []}
-    month_grouped_events = {
-        "Upcoming FOSS Events": {},
-        "Past Events": {},
-    }
+def process_event(event, event_list):
+    """
+    Processes a single event or hackathon, adding it to the upcoming or past events list based on the current date.
+    """
     now = now_datetime()
+    event_date = (
+        event.event_start_date
+        if event.event_start_date
+        else event.start_date
+    )
+    event_month_year = frappe.utils.formatdate(
+        event_date, "MMMM yyyy"
+    )
+    event.month_year = event_month_year
+    if event_date > now:
+        event_list["Upcoming FOSS Events"].append(event)
+    else:
+        event_list["Past Events"].append(event)
+
+
+def get_month_grouped_events(events, hackathons):
+    """
+    Groups events and hackathons by month and year, ensuring they are sorted chronologically within each group.
+    """
+    grouped_events = {"Upcoming FOSS Events": [], "Past Events": []}
 
     for event in events:
-        event_month_year = frappe.utils.formatdate(
-            event.event_start_date, "MMMM yyyy"
-        )
-        event.month_year = event_month_year
-        if event.event_start_date > now:
-            grouped_events["Upcoming FOSS Events"].append(event)
-        else:
-            grouped_events["Past Events"].append(event)
+        process_event(event, grouped_events)
+
+    for hackathon in hackathons:
+        process_event(hackathon, grouped_events)
+
+    month_grouped_events = {key: {} for key in grouped_events}
 
     for key, values in grouped_events.items():
+        values.sort(
+            key=lambda x: x.event_start_date
+            if x.event_start_date
+            else x.start_date
+        )
         for month_year, month_year_events in itertools.groupby(
-            values, lambda x: x.month_year
+            values, key=lambda x: x.month_year
         ):
             month_grouped_events[key][month_year] = list(
                 month_year_events
             )
+
+    for key in month_grouped_events:
+        sorted_month_years = sorted(
+            month_grouped_events[key].keys(),
+            key=lambda x: datetime.strptime(x, "%B %Y"),
+        )
+        month_grouped_events[key] = {
+            month: month_grouped_events[key][month]
+            for month in sorted_month_years
+        }
 
     return month_grouped_events
 

--- a/fossunited/fossunited/web_template/events_timeline/events_timeline.html
+++ b/fossunited/fossunited/web_template/events_timeline/events_timeline.html
@@ -1,5 +1,7 @@
 {% from "fossunited/templates/macros/event_card.html" import event_card %}
 
+{% from "fossunited/templates/macros/hackathon_card.html" import hackathon_card %}
+
 <style>
   .events-timeline {
     padding-top: 7rem;
@@ -36,19 +38,18 @@
     align-items: center;
     flex-direction: row-reverse;
     border-radius: 8px;
-    background: #FFF;
+    background: #fff;
     padding: 1rem;
-    gap:0.5rem;
+    gap: 0.5rem;
   }
 
-  .must-attend-checkbox label{
+  .must-attend-checkbox label {
     margin: 0;
   }
 
   .search-filter-controlpanel {
     display: flex;
     gap: 1rem;
-
   }
 
   .event-group {
@@ -57,113 +58,128 @@
     gap: 1.5rem;
   }
 
-  @media (max-width: 768px){
-    .search-filter-controlpanel{
+  @media (max-width: 768px) {
+    .search-filter-controlpanel {
       flex-direction: column;
     }
 
-    .must-attend-checkbox{
+    .must-attend-checkbox {
       flex-direction: row;
-      width: fit-content
+      width: fit-content;
     }
 
-    .event-card-holder{
+    .event-card-holder {
       width: 90%;
     }
   }
-
 </style>
 
 <div v-scope>
   <div class="container events-timeline">
-
     <!--Search filter panel-->
     <div class="search-filter-controlpanel">
-        <div class="events-search">
-          <input
-            v-model="searchText"
-            type="text"
-            id="events-search"
-            placeholder="Search by event name and date"
-          />
-        </div>
+      <div class="events-search">
+        <input
+          v-model="searchText"
+          type="text"
+          id="events-search"
+          placeholder="Search by event name and date"
+        />
+      </div>
 
-        <div class="must-attend-checkbox">
-          <input
-            type="checkbox"
-            v-model="mustAttendOnly"
-          />
-          <label for="must-attend-checkbox">Must Attend</label>
-        </div>
-
+      <div class="must-attend-checkbox">
+        <input type="checkbox" v-model="mustAttendOnly" />
+        <label for="must-attend-checkbox">Must Attend</label>
+      </div>
     </div>
 
     <!--Primary Event cards listing-->
     {% set grouped_events = get_grouped_events() %} {% for group, events in
     grouped_events.items() %}
 
-      <div class="event-group" v-if="searchText.length == 0">
-        <h4>{{ group }}</h4>
-          {% for month, month_events in events.items() %}
-            <h5 class="event-month" v-show="ticker > 0 && $el?.nextElementSibling.style.display != 'none'">{{ month }}</h5>
-            <div class="events-grid-4" v-effect="updateTicker()" v-show="ticker > 0 && $el?.children.length > 0">
-              {% for event in month_events %}
-              <div class="event-card-holder" v-if="canShow('{{ event.event_name}}', '{{ event_date_text }}', !!{{ event.must_attend }})">
-                {{event_card(event)}}
-              </div>
-              {% endfor %}
-            </div>
-          {% endfor %}
-      </div>
-    {% endfor %}
-
-
-  <!--Searched and Filtered event cards listing-->
-  <div v-if="searchText.length > 0">
-    <div class="events-grid-4">
-      {% for group, events in grouped_events.items() %}
+    <div class="event-group" v-if="searchText.length == 0">
+      <h4>{{ group }}</h4>
       {% for month, month_events in events.items() %}
-        {% for event in month_events %}
-          {% set event_date_text = event.event_start_date.strftime("%d %b %Y") %}
-          <div class="event-card-holder"
+      <h5
+        class="event-month"
+        v-show="ticker > 0 && $el?.nextElementSibling.style.display != 'none'"
+      >
+        {{ month }}
+      </h5>
+      <div
+        class="events-grid-4"
+        v-effect="updateTicker()"
+        v-show="ticker > 0 && $el?.children.length > 0"
+      >
+        {% for event in month_events %} {% if event.event_name %}
+        <div
+          class="event-card-holder"
           v-if="canShow('{{ event.event_name}}', '{{ event_date_text }}', !!{{ event.must_attend }})"
-          >
-            {{ event_card(event)}}
-          </div>
+        >
+          {{event_card(event)}}
+        </div>
 
-        {% endfor %}
+        {% else %}
+        <div
+          class="event-card-holder"
+          v-if="canShow('{{ event.hackathon_name}}', '{{ event_date_text }}')"
+        >
+          {{hackathon_card(event)}}
+        </div>
+        {% endif %} {% endfor %}
+      </div>
       {% endfor %}
+    </div>
     {% endfor %}
+
+    <!--Searched and Filtered event cards listing-->
+    <div v-if="searchText.length > 0">
+      <div class="events-grid-4">
+        {% for group, events in grouped_events.items() %} {% for month,
+        month_events in events.items() %} {% for event in month_events %} {% set
+        event_date_text = event.event_start_date.strftime("%d %b %Y") if
+        event.event_start_date else event.start_date.strftime("%d %b %Y") %}
+        <div
+          class="event-card-holder"
+          v-if="canShow('{{ event.event_name}}', '{{ event_date_text }}', !!{{ event.must_attend }})"
+        >
+          {%if event.event_name %} {{ event_card(event)}} {% else %}
+          {{hackathon_card(event)}} {% endif %}
+        </div>
+
+        {% endfor %} {% endfor %} {% endfor %}
+      </div>
+    </div>
   </div>
 
-  </div>
-</div>
+  <script>
+    PetiteVue.createApp({
+      searchText: "",
+      ticker: 1,
+      mustAttendOnly: false,
+      canShow(eventName, eventDate, eventMustAttend) {
+        if (this.mustAttendOnly && !eventMustAttend) {
+          return false;
+        }
 
-<script>
-  PetiteVue.createApp({
-    searchText: '',
-    ticker: 1,
-    mustAttendOnly: false,
-    canShow(eventName, eventDate, eventMustAttend) {
-      if (this.mustAttendOnly && !eventMustAttend) {
-        return false
-      }
+        if (this.searchText.length == 0) {
+          return true;
+        }
 
-      if (this.searchText.length == 0) {
-        return true
-      }
-
-      return eventName.toLowerCase().includes(this.searchText) ||
-        eventDate.toLowerCase().includes(this.searchText);
-    },
-    updateTicker(){
-      this.mustAttendOnly;
-      PetiteVue.nextTick(() => {
-        this.ticker++;
+        return (
+          eventName.toLowerCase().includes(this.searchText) ||
+          eventDate.toLowerCase().includes(this.searchText)
+        );
+      },
+      updateTicker() {
+        this.mustAttendOnly;
         PetiteVue.nextTick(() => {
           this.ticker++;
+          PetiteVue.nextTick(() => {
+            this.ticker++;
+          });
         });
-      });
-    }
-  }).mount()
-</script>
+      },
+    }).mount();
+  </script>
+</div>

--- a/fossunited/fossunited/web_template/events_timeline/events_timeline.html
+++ b/fossunited/fossunited/web_template/events_timeline/events_timeline.html
@@ -48,12 +48,28 @@
   .search-filter-controlpanel {
     display: flex;
     gap: 1rem;
+
   }
 
   .event-group {
     display: flex;
     flex-direction: column;
     gap: 1.5rem;
+  }
+
+  @media (max-width: 768px){
+    .search-filter-controlpanel{
+      flex-direction: column;
+    }
+
+    .must-attend-checkbox{
+      flex-direction: row;
+      width: fit-content
+    }
+
+    .event-card-holder{
+      width: 90%;
+    }
   }
 
 </style>
@@ -92,7 +108,7 @@
             <h5 class="event-month" v-show="ticker > 0 && $el?.nextElementSibling.style.display != 'none'">{{ month }}</h5>
             <div class="events-grid-4" v-effect="updateTicker()" v-show="ticker > 0 && $el?.children.length > 0">
               {% for event in month_events %}
-              <div v-if="canShow('{{ event.event_name}}', '{{ event_date_text }}', !!{{ event.must_attend }})">
+              <div class="event-card-holder" v-if="canShow('{{ event.event_name}}', '{{ event_date_text }}', !!{{ event.must_attend }})">
                 {{event_card(event)}}
               </div>
               {% endfor %}
@@ -109,7 +125,7 @@
       {% for month, month_events in events.items() %}
         {% for event in month_events %}
           {% set event_date_text = event.event_start_date.strftime("%d %b %Y") %}
-          <div
+          <div class="event-card-holder"
           v-if="canShow('{{ event.event_name}}', '{{ event_date_text }}', !!{{ event.must_attend }})"
           >
             {{ event_card(event)}}

--- a/fossunited/fossunited/web_template/home_page___events/home_page___events.html
+++ b/fossunited/fossunited/web_template/home_page___events/home_page___events.html
@@ -22,7 +22,7 @@
         width: 100%;
     }
 
-    .events-block{
+    .flagship-events-block{
         display: grid;
         grid-template-columns: 1fr 1fr 1fr;
         justify-content: space-around;
@@ -77,7 +77,7 @@
 
         }
 
-        .events-block{
+        .flagship-events-block{
             grid-template-columns: 1fr;
             gap: 2.5rem;
             width: 100%
@@ -103,7 +103,7 @@
         <div class="events-subsection">
             <h5>Flagship Events</h5>
 
-            <div class="events-block">
+            <div class="flagship-events-block">
                 <a class="flagship-event-card" href="{{indiafoss_link}}">
                     <img class="flagship-card-image" src="assets/fossunited/icons/indiafoss-icon.svg" alt="IndiaFOSS">
                     <h6 class="flagship-card-heading">IndiaFOSS</h6>

--- a/fossunited/fossunited/web_template/home_page___industry_partnership/home_page___industry_partnership.html
+++ b/fossunited/fossunited/web_template/home_page___industry_partnership/home_page___industry_partnership.html
@@ -55,6 +55,7 @@
         display: flex;
         justify-content: center;
         align-items:center;
+        padding-left: 1rem;
     }
 
     .feature-partners img{
@@ -80,6 +81,7 @@
         .feature-partners{
             padding: 1rem;
             flex-direction: column;
+            gap: 0.5rem;
         }
 
         .feature-partners img{
@@ -110,9 +112,13 @@
 
             <div class="feature-partners">
 
-                <img src="assets/fossunited/images/partners/frappe-logo.png" alt="Frappe">
-                <img src="assets/fossunited/images/partners/zerodha-logo.png" alt="Zerodha">
+                {% set featurePartners = frappe.get_all("Industry Partners", fields=['name', 'logo', 'website'], filters={'tier': ['in', ["Patron", "Platinum", "Gold"]], 'is_current_partner': 1}, order_by='tier') %}
 
+                {% for partner in featurePartners %}
+                    <a href="{{partner.website}}">
+                        <img src="{{ partner.logo }}" alt="{{ partner.name }}">
+                    </a>
+                {% endfor %}
             </div>
 
         </div>

--- a/fossunited/fossunited/web_template/home_page___industry_partnership/home_page___industry_partnership.html
+++ b/fossunited/fossunited/web_template/home_page___industry_partnership/home_page___industry_partnership.html
@@ -84,6 +84,11 @@
             gap: 0.5rem;
         }
 
+        .feature-partners a{
+            display: flex;
+            justify-content: center;
+        }
+
         .feature-partners img{
             max-width: 60%;
             display: block;

--- a/fossunited/fossunited/web_template/home_page___team/home_page___team.html
+++ b/fossunited/fossunited/web_template/home_page___team/home_page___team.html
@@ -74,6 +74,10 @@
   }
 
   @media screen and (max-width: 768px) {
+
+    .team-section{
+      margin-top: 3rem;
+    }
     .team-block {
       justify-content: space-between;
       gap: 2rem;

--- a/fossunited/fossunited/web_template/project_grants/project_grants.html
+++ b/fossunited/fossunited/web_template/project_grants/project_grants.html
@@ -24,7 +24,7 @@
         gap: 2rem;
     }
 
-    .project-card{
+    .project-grant-card{
         display: flex;
         padding: 1rem;
         justify-content: flex-start;
@@ -34,7 +34,7 @@
     }
 
 
-    .project-card p{
+    .project-grant-card p{
         color: hsl(var(--clr-gray-500));
         font-size: var(--text-xs);
     }
@@ -86,7 +86,7 @@
     @media (max-width: 768px) {
 
 
-        .project-card{
+        .project-grant-card{
             padding: 0;
             flex-direction: column;
             gap: 1rem;
@@ -136,7 +136,7 @@
             {% set project_grants = frappe.get_all("FOSS Project Grant", fields=["project_name","about_project", "project_website", "grant_amount", "co_sponsor", "date_of_provision" ], filters={"grant_status": "Approved"}, order_by="date_of_provision desc") %}
             {% for grant in project_grants %}
 
-                <div class="project-card">
+                <div class="project-grant-card">
                     <div class="project-details">
 
                         <a class="project-name"href="{{grant.project_website}}">

--- a/fossunited/fossunited/web_template/upcoming_foss_events_section/upcoming_foss_events_section.html
+++ b/fossunited/fossunited/web_template/upcoming_foss_events_section/upcoming_foss_events_section.html
@@ -57,7 +57,7 @@
         </div>
 
         {% from "fossunited/templates/macros/event_card.html" import event_card %}
-        {% set events = frappe.get_all("FOSS Chapter Event", fields=["*"], filters={"status": ["in", ["Approved", "Live"]], "is_published": 1, "event_start_date": ['>=', frappe.utils.now()]}, page_length=4, order_by='event_start_date') %}
+        {% set events = frappe.get_all("FOSS Chapter Event", fields=["*"], filters={"status": ["in", ["Approved", "Live"]], "is_published": 1, "event_start_date": ['>=', frappe.utils.now()]}, page_length=8, order_by='event_start_date') %}
         <div class="events-grid-4">
             {% for event in events %}
                 {{ event_card(event) }}

--- a/fossunited/fossunited/web_template/upcoming_foss_events_section/upcoming_foss_events_section.html
+++ b/fossunited/fossunited/web_template/upcoming_foss_events_section/upcoming_foss_events_section.html
@@ -15,13 +15,6 @@
         width: 100%;
     }
 
-    .events-block{
-        display: grid;
-        grid-template-columns: 1fr 1fr 1fr 1fr;
-        justify-content: space-around;
-        gap: 2.5rem;
-    }
-
     .upcoming-events-header{
         display: flex;
         flex-direction: column;
@@ -64,7 +57,7 @@
         </div>
 
         {% from "fossunited/templates/macros/event_card.html" import event_card %}
-        {% set events = frappe.get_all("FOSS Chapter Event", fields=["*"], filters={"status": ["in", ["Approved", "Live"]], "is_published": 1, "event_start_date": ['>=', frappe.utils.now()]}, page_length=9, order_by='event_start_date') %}
+        {% set events = frappe.get_all("FOSS Chapter Event", fields=["*"], filters={"status": ["in", ["Approved", "Live"]], "is_published": 1, "event_start_date": ['>=', frappe.utils.now()]}, page_length=4, order_by='event_start_date') %}
         <div class="events-grid-4">
             {% for event in events %}
                 {{ event_card(event) }}

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -2565,7 +2565,7 @@ h6{
     }
 
     .event-card{
-        width: 80%;
+        width: 100%;
     }
 
     .members-grid-6{

--- a/fossunited/templates/macros/event_card.html
+++ b/fossunited/templates/macros/event_card.html
@@ -8,7 +8,7 @@
                 <img src="/assets/fossunited/images/chapter/fossclub_logo.svg" alt="">
                 <span>{{ chapter.chapter_name | truncate(25, True, '...', 0) }}</span>
                 {% else %}
-                <span class="fff-forward">{{ chapter.chapter_name | truncate(25, True, '...', 0) }}</span>
+                <span class="fff-forward">{{ chapter.city.upper() | truncate(25, True, '...', 0) }}</span>
                 {% endif %}
             </div>
         {% else %}
@@ -31,7 +31,7 @@
         <div class="event-card--location-section">
             <div class="event-card--location">
                 <i class="ti ti-map-pin"></i>
-                <span>{{ event.event_location or "To be Announced" | truncate(22, True)}}</span>
+                <span>{{ event.event_location | truncate(25, True) or "To be Announced"}}</span>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🎨Style
- [x] 🍕Feature
- [x] 🐛Bug Fix


## Description
This is a style-fix PR that patches some of the existing broken styles in the platform public pages. 

1. Fixed the project grants' section in grants page which was broken due to conflicting style classes

2. Updated home page IP section to include current partner fetched from doctype - it was hard-coded earlier 

3. The styles of event cards are broken in events' timeline - patched it up to make them cleaner. 

   - Fixed logic of truncating event location
   - Changed event card header from chapter_name to city - since city is relevant to understand the event location from card. 

4. Fixed minor styling in IP and team sections in homepage

5. Added Hackathons to Events' Timeline

    - Hackathons were a separated doctype from Events 
    - Updated the utils methods that fetches date to include hackathons and chronologically merge them with the other events. 

## Issues: 

- Closes #452

## Checklist
- [x] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [x] I have tested these changes locally.
- [x] I have updated the documentation (If applicable).
- [x] The code follows the project's coding standards.
- [x] I have added/updated tests, if applicable.

## Screenshots

### Hackathons in event timeline

![Event Timeline Hackathon](https://github.com/fossunited/fossunited/assets/60656677/63223222-c125-432a-bc13-af38341622f5)

### Events' Timeline

![events-timeline](https://github.com/fossunited/fossunited/assets/60656677/ca629c00-4d00-4b85-926c-0ff02acadbc6)

### IP Section

![ip-page](https://github.com/fossunited/fossunited/assets/60656677/117ce8bc-bf80-48d4-9d75-f5a8d67332af)

### Project Grants

![project-grants](https://github.com/fossunited/fossunited/assets/60656677/3006bfa1-097c-4d5f-a158-19c4f82a502f)


