### PR TITLE
chore: add permissions for `Localhost Organizer` role

### DIFF
--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -276,16 +276,20 @@ def get_localhost_requests_by_team(
     )
 
     for request in requests:
-        profile = frappe.get_doc(
-            "FOSS User Profile", request.user_profile
+        request["profile_route"] = frappe.db.get_value(
+            "FOSS User Profile", request.user_profile, "route"
         )
-        request["profile_route"] = profile.route
+        profile_photo = frappe.db.get_value(
+            "FOSS User Profile", request.user_profile, "profile_photo"
+        )
         request["profile_photo"] = (
-            profile.profile_photo
-            if profile.profile_photo
+            profile_photo
+            if profile_photo
             else "/assets/fossunited/images/defaults/user_profile_image.png"
         )
-        request["profile_username"] = profile.username
+        request["profile_username"] = frappe.db.get_value(
+            "FOSS User Profile", request.user_profile, "username"
+        )
 
     requests_by_team = {}
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.json
@@ -82,7 +82,7 @@
   }
  ],
  "links": [],
- "modified": "2024-06-25 13:11:34.567860",
+ "modified": "2024-07-09 16:30:29.466486",
  "modified_by": "Administrator",
  "module": "FOSS Hackathon",
  "name": "FOSS Hackathon LocalHost",
@@ -103,28 +103,15 @@
   },
   {
    "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
    "read": 1,
-   "report": 1,
-   "role": "FOSS Website User",
+   "role": "Localhost Organizer",
    "select": 1,
-   "share": 1,
    "write": 1
   },
   {
-   "create": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
    "read": 1,
-   "report": 1,
    "role": "All",
-   "select": 1,
-   "share": 1,
-   "write": 1
+   "select": 1
   }
  ],
  "show_title_field_in_link": 1,

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.json
@@ -82,7 +82,7 @@
   }
  ],
  "links": [],
- "modified": "2024-07-09 16:30:29.466486",
+ "modified": "2024-07-10 13:34:06.896205",
  "modified_by": "Administrator",
  "module": "FOSS Hackathon",
  "name": "FOSS Hackathon LocalHost",
@@ -102,7 +102,6 @@
    "write": 1
   },
   {
-   "create": 1,
    "read": 1,
    "role": "Localhost Organizer",
    "select": 1,

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.py
@@ -32,10 +32,10 @@ class FOSSHackathonLocalHost(Document):
         self.assign_localhost_organizer_role()
 
     def on_update(self):
-        self.assign_localhost_organizer_role()
+        self.check_if_member_removed()
 
     def before_save(self):
-        self.check_if_member_removed()
+        self.assign_localhost_organizer_role()
 
     def assign_localhost_organizer_role(self):
         for member in self.organizers:

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
+import frappe
 from frappe.model.document import Document
 
 
@@ -26,3 +27,58 @@ class FOSSHackathonLocalHost(Document):
         state: DF.Link | None
     # end: auto-generated types
     pass
+
+    def before_insert(self):
+        self.assign_localhost_organizer_role()
+
+    def on_update(self):
+        self.assign_localhost_organizer_role()
+
+    def before_save(self):
+        self.check_if_member_removed()
+
+    def assign_localhost_organizer_role(self):
+        for member in self.organizers:
+            user = frappe.get_doc(
+                "User",
+                frappe.db.get_value(
+                    "FOSS User Profile", member.profile, "user"
+                ),
+            )
+            user.add_roles("Localhost Organizer")
+
+    def check_if_member_removed(self):
+        prev_doc = self.get_doc_before_save()
+        if not len(prev_doc.organizers) > len(self.organizers):
+            return
+
+        for member in prev_doc.organizers:
+            if not member in self.organizers:
+                self.remove_organizer_role(member)
+
+    def remove_organizer_role(self, old_member):
+        if self.other_localhost_member(old_member):
+            return
+
+        user = frappe.get_doc(
+            "User",
+            frappe.db.get_value(
+                "FOSS User Profile", old_member.profile, "user"
+            ),
+        )
+        user.remove_roles("Localhost Organizer")
+
+    def other_localhost_member(self, old_member):
+        is_member = frappe.db.exists(
+            "FOSS Hackathon LocalHost",
+            [
+                [
+                    "FOSS Hackathon LocalHost Organizer",
+                    "profile",
+                    "=",
+                    old_member.profile,
+                ],
+                ["name", "!=", self.name],
+            ],
+        )
+        return bool(is_member)

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_localhost_organizer/foss_hackathon_localhost_organizer.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_localhost_organizer/foss_hackathon_localhost_organizer.json
@@ -6,21 +6,21 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "user"
+  "profile"
  ],
  "fields": [
   {
-   "fieldname": "user",
+   "fieldname": "profile",
    "fieldtype": "Link",
    "in_list_view": 1,
-   "label": "User",
-   "options": "User"
+   "label": "Profile",
+   "options": "FOSS User Profile"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-05-15 00:21:27.464216",
+ "modified": "2024-07-09 16:05:43.499703",
  "modified_by": "Administrator",
  "module": "FOSS Hackathon",
  "name": "FOSS Hackathon LocalHost Organizer",

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_localhost_organizer/foss_hackathon_localhost_organizer.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_localhost_organizer/foss_hackathon_localhost_organizer.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
+import frappe
 from frappe.model.document import Document
 
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_localhost_organizer/foss_hackathon_localhost_organizer.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_localhost_organizer/foss_hackathon_localhost_organizer.py
@@ -16,6 +16,6 @@ class FOSSHackathonLocalHostOrganizer(Document):
         parent: DF.Data
         parentfield: DF.Data
         parenttype: DF.Data
-        user: DF.Link | None
+        profile: DF.Link | None
     # end: auto-generated types
     pass

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.json
@@ -109,7 +109,8 @@
    "fieldname": "localhost_request_status",
    "fieldtype": "Select",
    "label": "LocalHost Request Status",
-   "options": "Pending\nAccepted\nRejected"
+   "options": "Pending\nAccepted\nRejected",
+   "permlevel": 1
   },
   {
    "fieldname": "column_break_pxgj",
@@ -129,7 +130,7 @@
   }
  ],
  "links": [],
- "modified": "2024-07-09 16:36:02.904238",
+ "modified": "2024-07-10 11:40:19.605933",
  "modified_by": "Administrator",
  "module": "FOSS Hackathon",
  "name": "FOSS Hackathon Participant",
@@ -158,7 +159,17 @@
   {
    "read": 1,
    "role": "Localhost Organizer",
-   "select": 1,
+   "select": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "permlevel": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Localhost Organizer",
+   "share": 1,
    "write": 1
   }
  ],

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.json
@@ -130,7 +130,7 @@
   }
  ],
  "links": [],
- "modified": "2024-07-10 12:20:37.542366",
+ "modified": "2024-07-11 15:41:08.687831",
  "modified_by": "Administrator",
  "module": "FOSS Hackathon",
  "name": "FOSS Hackathon Participant",
@@ -158,7 +158,8 @@
   {
    "read": 1,
    "role": "Localhost Organizer",
-   "select": 1
+   "select": 1,
+   "write": 1
   },
   {
    "email": 1,

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.json
@@ -130,7 +130,7 @@
   }
  ],
  "links": [],
- "modified": "2024-07-10 11:40:19.605933",
+ "modified": "2024-07-10 12:20:37.542366",
  "modified_by": "Administrator",
  "module": "FOSS Hackathon",
  "name": "FOSS Hackathon Participant",
@@ -151,7 +151,6 @@
   },
   {
    "create": 1,
-   "delete": 1,
    "read": 1,
    "role": "All",
    "write": 1

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.json
@@ -129,7 +129,7 @@
   }
  ],
  "links": [],
- "modified": "2024-06-25 13:11:18.905930",
+ "modified": "2024-07-09 16:36:02.904238",
  "modified_by": "Administrator",
  "module": "FOSS Hackathon",
  "name": "FOSS Hackathon Participant",
@@ -151,13 +151,14 @@
   {
    "create": 1,
    "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
    "read": 1,
-   "report": 1,
    "role": "All",
-   "share": 1,
+   "write": 1
+  },
+  {
+   "read": 1,
+   "role": "Localhost Organizer",
+   "select": 1,
    "write": 1
   }
  ],

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_team/foss_hackathon_team.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_team/foss_hackathon_team.json
@@ -98,7 +98,7 @@
   }
  ],
  "links": [],
- "modified": "2024-06-06 13:42:55.866654",
+ "modified": "2024-07-10 12:25:54.595850",
  "modified_by": "Administrator",
  "module": "FOSS Hackathon",
  "name": "FOSS Hackathon Team",
@@ -114,19 +114,6 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "FOSS Website User",
-   "select": 1,
    "share": 1,
    "write": 1
   },


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] ⚙️Chore

## Description
<!-- Briefly describe the changes introduced by this pull request -->
- Introduce a new role `Localhost Organizer` which will be given to all the hackathon localhost team members
- Permissions for Localhost Organzier. 
- Level 1 permission for Localhost organizer on Hackathon Participant doctype for `localhost_request_status` field. This gives only the Localhost Organizer to change the localhost request status for any participant.
- Controller methods introduced which assign the role at the time when a person's profile is added to the team member child table for a localhost.
- When a user is removed from the localhost team member, another method takes care to remove the organizer role from the user profile.

## Related Issues & Docs
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
closes #448 
