### PR TITLE
fix: NoneType location rendering error

### DIFF
--- a/fossunited/templates/macros/event_card.html
+++ b/fossunited/templates/macros/event_card.html
@@ -31,7 +31,7 @@
         <div class="event-card--location-section">
             <div class="event-card--location">
                 <i class="ti ti-map-pin"></i>
-                <span>{{ event.event_location | truncate(25, True) or "To be Announced"}}</span>
+                <span>{{ (event.event_location or 'To Be Announced') | truncate(30, True) }}</span>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🐛Bug Fix

## Description

- Fixes the NoneType event location rendering error in events' timeline

Error: 

```
  File "apps/fossunited/fossunited/templates/macros/event_card.html", line 34, in template
    <span>{{ event.event_location | truncate(25, True) or "To be Announced"}}</span>
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "env/lib/python3.11/site-packages/jinja2/filters.py", line 898, in do_truncate
    if len(s) <= length + leeway:
       ^^^^^^
TypeError: object of type 'NoneType' has no len()
```