### PR TITLE
chore: add permissions for `CFP Reviewer` Role

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -207,7 +207,6 @@ class FOSSChapterEvent(WebsiteGenerator):
         )
         speakers = []
         for cfp in speaker_cfps:
-            print(cfp)
             user = frappe.get_doc(
                 "FOSS User Profile", {"email": cfp.submitted_by}
             )

--- a/fossunited/fossunited/doctype/foss_event_cfp/foss_event_cfp.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp/foss_event_cfp.py
@@ -43,8 +43,6 @@ class FOSSEventCFP(WebsiteGenerator):
         reviewers = frappe.get_single(
             "FOSS Global CFP Review Settings"
         ).members
-        print(reviewers)
-
         for reviewer in reviewers:
             self.append(
                 "cfp_reviewers",

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.json
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.json
@@ -143,7 +143,8 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Status",
-   "options": "Review Pending\nApproved\nRejected"
+   "options": "Review Pending\nApproved\nRejected",
+   "permlevel": 2
   },
   {
    "description": "Link relevant references for your talk.",
@@ -180,7 +181,8 @@
    "fieldname": "reviews",
    "fieldtype": "Table",
    "label": "Reviews",
-   "options": "FOSS Event CFP Review"
+   "options": "FOSS Event CFP Review",
+   "permlevel": 1
   },
   {
    "fieldname": "route",
@@ -230,17 +232,20 @@
   {
    "fieldname": "positive_reviews",
    "fieldtype": "Data",
-   "label": "Positive Reviews %"
+   "label": "Positive Reviews %",
+   "permlevel": 1
   },
   {
    "fieldname": "negative_reviews",
    "fieldtype": "Data",
-   "label": "Negative Reviews  %"
+   "label": "Negative Reviews  %",
+   "permlevel": 1
   },
   {
    "fieldname": "unsure_reviews",
    "fieldtype": "Data",
-   "label": "Unsure Reviews  %"
+   "label": "Unsure Reviews  %",
+   "permlevel": 1
   },
   {
    "fieldname": "column_break_fnih",
@@ -249,7 +254,8 @@
   {
    "fieldname": "approvability",
    "fieldtype": "Data",
-   "label": "Approvability  %"
+   "label": "Approvability  %",
+   "permlevel": 1
   },
   {
    "columns": 2,
@@ -289,7 +295,7 @@
  "has_web_view": 1,
  "is_published_field": "is_published",
  "links": [],
- "modified": "2024-07-08 15:08:48.376505",
+ "modified": "2024-07-11 12:14:23.120546",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "FOSS Event CFP Submission",
@@ -314,6 +320,24 @@
    "read": 1,
    "role": "Chapter Team Member",
    "select": 1,
+   "write": 1
+  },
+  {
+   "permlevel": 2,
+   "read": 1,
+   "role": "Chapter Team Member",
+   "write": 1
+  },
+  {
+   "read": 1,
+   "role": "CFP Reviewer",
+   "select": 1,
+   "write": 1
+  },
+  {
+   "permlevel": 1,
+   "read": 1,
+   "role": "CFP Reviewer",
    "write": 1
   }
  ],

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.json
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.json
@@ -295,7 +295,7 @@
  "has_web_view": 1,
  "is_published_field": "is_published",
  "links": [],
- "modified": "2024-07-11 12:14:23.120546",
+ "modified": "2024-07-11 12:21:24.738519",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "FOSS Event CFP Submission",
@@ -321,6 +321,12 @@
    "role": "Chapter Team Member",
    "select": 1,
    "write": 1
+  },
+  {
+   "permlevel": 1,
+   "read": 1,
+   "role": "Chapter Team Member",
+   "select": 1
   },
   {
    "permlevel": 2,

--- a/fossunited/fossunited/doctype/foss_global_cfp_review_settings/foss_global_cfp_review_settings.py
+++ b/fossunited/fossunited/doctype/foss_global_cfp_review_settings/foss_global_cfp_review_settings.py
@@ -1,8 +1,38 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
+import frappe
 from frappe.model.document import Document
 
 
 class FOSSGlobalCFPReviewSettings(Document):
-    pass
+    def before_save(self):
+        # assign 'CFP Reviewer' role to all members
+        self.assign_reviewer_role()
+
+    def on_update(self):
+        # unassign 'CFP Reviewer role to all the members removed
+        self.unassign_reviewer_role()
+
+    def assign_reviewer_role(self):
+        for member in self.members:
+            user = frappe.get_doc(
+                "User",
+                frappe.db.get_value(
+                    "FOSS User Profile", member.profile, "user"
+                ),
+            )
+            user.add_roles("CFP Reviewer")
+
+    def unassign_reviewer_role(self):
+        for old_member in self.get_doc_before_save().members:
+            if old_member not in self.members:
+                user = frappe.get_doc(
+                    "User",
+                    frappe.db.get_value(
+                        "FOSS User Profile",
+                        old_member.profile,
+                        "user",
+                    ),
+                )
+                user.remove_roles("CFP Reviewer")

--- a/fossunited/fossunited/doctype/foss_global_cfp_review_settings/foss_global_cfp_review_settings.py
+++ b/fossunited/fossunited/doctype/foss_global_cfp_review_settings/foss_global_cfp_review_settings.py
@@ -7,12 +7,10 @@ from frappe.model.document import Document
 
 class FOSSGlobalCFPReviewSettings(Document):
     def before_save(self):
-        # assign 'CFP Reviewer' role to all members
-        self.assign_reviewer_role()
-
-    def on_update(self):
         # unassign 'CFP Reviewer role to all the members removed
         self.unassign_reviewer_role()
+        # assign 'CFP Reviewer' role to all members
+        self.assign_reviewer_role()
 
     def assign_reviewer_role(self):
         for member in self.members:
@@ -25,13 +23,17 @@ class FOSSGlobalCFPReviewSettings(Document):
             user.add_roles("CFP Reviewer")
 
     def unassign_reviewer_role(self):
-        for old_member in self.get_doc_before_save().members:
-            if old_member not in self.members:
+        if self.is_new():
+            return
+        past_members = self.get_doc_before_save().members
+
+        for member in past_members:
+            if member not in self.members:
                 user = frappe.get_doc(
                     "User",
                     frappe.db.get_value(
                         "FOSS User Profile",
-                        old_member.profile,
+                        member.profile,
                         "user",
                     ),
                 )

--- a/fossunited/fossunited/doctype/foss_global_cfp_review_settings/test_foss_global_cfp_review_settings.py
+++ b/fossunited/fossunited/doctype/foss_global_cfp_review_settings/test_foss_global_cfp_review_settings.py
@@ -1,8 +1,83 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
 
+import frappe
 from frappe.tests.utils import FrappeTestCase
 
 
 class TestFOSSGlobalCFPReviewSettings(FrappeTestCase):
-    pass
+    def test_global_setting_creation(self):
+        # Given a new FOSS Global CFP Review Settings document
+        # When the document is inserted without any members
+        settings = frappe.get_doc(
+            {
+                "doctype": "FOSS Global CFP Review Settings",
+                "members": [],
+            }
+        )
+        settings.insert()
+        # Then the document should be created
+        self.assertTrue(settings)
+
+    def test_role_assign_on_member_addition(self):
+        # Given a new FOSS Global CFP Review Settings document
+        settings = frappe.get_doc(
+            {
+                "doctype": "FOSS Global CFP Review Settings",
+                "members": [],
+            }
+        )
+        settings.insert()
+
+        test_profile = frappe.get_doc(
+            "FOSS User Profile", {"user": "test1@example.com"}
+        )
+
+        # When a member is added to the members field
+        settings.append("members", {"profile": test_profile.name})
+        settings.save()
+
+        test_user = frappe.get_doc("User", test_profile.user)
+        # Then the user should have the 'CFP Reviewer' role
+        self.assertTrue(
+            frappe.db.exists(
+                "Has Role",
+                {"role": "CFP Reviewer", "parent": test_user.name},
+            )
+        )
+
+    def test_role_unassign_on_member_removal(self):
+        # Given a new FOSS Global CFP Review Settings document
+        settings = frappe.get_doc(
+            {
+                "doctype": "FOSS Global CFP Review Settings",
+                "members": [],
+            }
+        )
+        settings.insert()
+
+        test_profile = frappe.get_doc(
+            "FOSS User Profile", {"user": "test2@example.com"}
+        )
+        settings.append("members", {"profile": test_profile.name})
+        settings.save()
+
+        test_user = frappe.get_doc("User", test_profile.user)
+        self.assertTrue(
+            frappe.db.exists(
+                "Has Role",
+                {"role": "CFP Reviewer", "parent": test_user.name},
+            )
+        )
+
+        # When a member is removed from the members field
+        settings.members = []
+        settings.save()
+
+        # Then the user should not have the 'CFP Reviewer' role
+        self.assertFalse(
+            frappe.db.exists(
+                "Has Role",
+                {"role": "CFP Reviewer", "parent": test_user.name},
+            )
+        )


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] ⚙️Chore

## Description
<!-- Briefly describe the changes introduced by this pull request -->
- Introduce a new role `CFP Reviewer`
- Users assigned `CFP Reviewer` roles will be having the write permissions to level 0 and level 1 fields of CFP Submission doctype. This includes level 1 field `reviews` child table which has all the reviews for the cfp.
- Methods introduced which assign `CFP Reviewer` Role when a user is added to the Global CFP Reviewer List

- Added unit tests to FOSS Global CFP Review Settings doctype. These tests: 1. Creation of the single doctype without any members. 2. Role assignment on addition of a member. 3. Role de-assignment on removal of the member
