### PR TITLE
fix(dashboard): replace `submitted_by` with `email` to render rsvp insights

### DIFF
--- a/dashboard/src/pages/EventRsvpInsights.vue
+++ b/dashboard/src/pages/EventRsvpInsights.vue
@@ -21,7 +21,7 @@
       <ListView
         :columns="[
           { label: 'Name', key: 'name1' },
-          { label: 'Email', key: 'submitted_by' },
+          { label: 'Email', key: 'email' },
           { label: 'I am a', key: 'im_a' },
         ]"
         :rows="submissions.data"
@@ -64,7 +64,7 @@ const submissions = createListResource({
   auto: true,
   transform(data) {
     data.forEach((submission) => {
-      submission.submitted_by = submission.submitted_by.replace(
+      submission.email = submission.email.replace(
         /(?<=.{3}).(?=[^@]*?@)/g,
         '*',
       )
@@ -75,7 +75,7 @@ const submissions = createListResource({
 const downloadAttendeeList = () => {
   const csv = submissions.data
     .map((submission) => {
-      return [submission.name1, submission.submitted_by, submission.im_a].join(
+      return [submission.name1, submission.email, submission.im_a].join(
         ',',
       )
     })


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] 🐛Bug Fix

## Description
<!-- Briefly describe the changes introduced by this pull request -->
- RSVP field `submitted by` which links a `User` doctype was made non-mandatory in one of the PRs before. But on insights tab for an organizer, submitted_by was still being rendered. This lead to errors with None values.
![image](https://github.com/fossunited/fossunited/assets/73123690/c05a75f5-6a85-4c0d-aea9-1624d7d6e7c1)

- This PR replaced the field `submitted_by` with `email` to render RSVP Insights correctly.
