### PR TITLE
feat: hackathon participant and team features

### DIFF
--- a/dashboard/src/components/hackathon/HackathonAttendanceMode.vue
+++ b/dashboard/src/components/hackathon/HackathonAttendanceMode.vue
@@ -211,7 +211,7 @@ const localhosts = createListResource({
   doctype: 'FOSS Hackathon LocalHost',
   filters: {
     parent_hackathon: props.hackathon.data.name,
-    is_enabled: 1,
+    is_accepting_attendees: 1,
   },
   fields: ['localhost_name', 'name', 'city', 'state', 'location', 'map_link'],
   auto: true,

--- a/dashboard/src/components/hackathon/HackathonAttendanceMode.vue
+++ b/dashboard/src/components/hackathon/HackathonAttendanceMode.vue
@@ -101,8 +101,8 @@
           attendanceMode == 'remote'
             ? 'Remote'
             : attendanceMode == 'local-pending'
-              ? 'On-Site (Pending Request)'
-              : 'On-site'
+              ? `${participant_localhost.data?.localhost_name} - On-Site (Pending Request)`
+              : `${participant_localhost.data?.localhost_name} - On-Site`
         }}
       </div>
       <Button
@@ -149,12 +149,11 @@ const props = defineProps({
 })
 
 const participant_localhost = createResource({
-  url: 'frappe.client.get_value',
+  url: 'frappe.client.get',
   makeParams(){
     return {
       doctype: 'FOSS Hackathon LocalHost',
       name: participant.data.localhost,
-      fieldname: 'localhost_name'
     }
   },
 })
@@ -175,7 +174,6 @@ const participant = createResource({
 
 const setAttendanceMode = (data) => {
   if (data.wants_to_attend_locally) {
-    selectedLocalhost.value = data.localhost
     if (data.localhost_request_status == 'Accepted') {
       attendanceMode.value = 'local'
       originalAttendanceMode.value = 'local'
@@ -190,6 +188,7 @@ const setAttendanceMode = (data) => {
       })
       return
     } else {
+      selectedLocalhost.value = data.localhost
       attendanceMode.value = 'local-pending'
       originalAttendanceMode.value = 'local-pending'
       originalLocalhost.value = data.localhost
@@ -246,6 +245,7 @@ const updateParticipantLocalhost = (localhost) => {
     },
     auto: true,
     onSuccess(data){
+      participant.fetch()
       showDialog.value = false
       errorMessage.value = ''
       toast.success('Attendance mode updated successfully!')

--- a/dashboard/src/components/hackathon/HackathonAttendanceMode.vue
+++ b/dashboard/src/components/hackathon/HackathonAttendanceMode.vue
@@ -1,0 +1,274 @@
+<template>
+  <Dialog
+    class="z-50"
+    v-model="showDialog"
+    :options="{
+      title: 'Change Mode of Attendance',
+    }"
+  >
+    <template #body-content>
+      <div
+        class="flex flex-col gap-2 items-center text-center p-3 rounded w-full bg-orange-50 text-orange-600 border-2 border-dashed border-orange-600 text-xs"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          class="icon icon-tabler h-6 w-6 icons-tabler-outline icon-tabler-alert-circle"
+        >
+          <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+          <path d="M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0" />
+          <path d="M12 8v4" />
+          <path d="M12 16h.01" />
+        </svg>
+        <p>
+          <b>Attention!</b> You are about to change your attendance mode for
+          this hackathon.<br /><br />
+          Please note that requests for in-person attendance are subject to
+          approval by the organizers due to limited on-site availability.
+        </p>
+      </div>
+      <FormControl
+        label="Mode of Attendance"
+        v-model="attendanceMode"
+        type="select"
+        class="mt-4"
+        :options="attendanceModeOptions"
+      />
+      <FormControl
+        v-if="attendanceMode == 'local' || attendanceMode == 'local-pending'"
+        label="Select LocalHost"
+        :disabled="attendanceMode == 'local'"
+        v-model="selectedLocalhost"
+        type="select"
+        class="mt-4"
+        :options="
+          localhosts.data.map((localhost) => ({
+            label: `${localhost.localhost_name}`,
+            value: localhost.name,
+          }))
+        "
+      />
+      <ErrorMessage :message="errorMessage" class="mt-2" />
+    </template>
+    <template #actions>
+      <div class="grid grid-cols-2 gap-4">
+        <Button
+          label="Cancel"
+          size="sm"
+          theme="gray"
+          @click="showDialog = false"
+        />
+        <Button
+          label="Change"
+          size="sm"
+          theme="green"
+          :disabled="handleDisabled()"
+          @click="handleAttendanceModeChange"
+        />
+      </div>
+    </template>
+  </Dialog>
+  <div
+    class="flex flex-col gap-1 border-2 rounded border-gray-500 border-dashed min-w-[220px] p-4"
+  >
+    <h5 class="text-xs text-gray-700 uppercase font-medium">
+      Your Mode of attendance
+    </h5>
+    <div class="flex w-full items-center justify-between">
+      <div
+        class="text-base font-medium"
+        :class="attendanceMode == 'local-pending' ? 'text-orange-600' : ''"
+      >
+        {{
+          attendanceMode == 'remote'
+            ? 'Remote'
+            : attendanceMode == 'local-pending'
+              ? 'On-Site (Pending Request)'
+              : 'On-site'
+        }}
+      </div>
+      <Button
+        v-if="hackathon.data.has_localhosts"
+        label="Change"
+        size="sm"
+        class="w-fit !text-sm"
+        @click="showDialog = true"
+      />
+    </div>
+  </div>
+</template>
+<script setup>
+import {
+  createResource,
+  createListResource,
+  Dialog,
+  FormControl,
+  ErrorMessage,
+} from 'frappe-ui'
+import { useRoute } from 'vue-router'
+import { defineProps, ref } from 'vue'
+import { toast } from 'vue-sonner'
+
+const route = useRoute()
+const showDialog = ref(false)
+const attendanceMode = ref(null)
+const selectedLocalhost = ref(null)
+const attendanceModeOptions = [
+  {
+    label: 'Remote',
+    value: 'remote',
+  },
+]
+
+const originalAttendanceMode = ref(null)
+const originalLocalhost = ref(null)
+
+const props = defineProps({
+  hackathon: {
+    type: Object,
+    required: true,
+  },
+})
+
+const participant = createResource({
+  url: 'fossunited.api.hackathon.get_session_participant',
+  makeParams() {
+    return {
+      hackathon: props.hackathon.data.name,
+    }
+  },
+  auto: true,
+  onSuccess(data) {
+    setAttendanceMode(data)
+  },
+})
+
+const setAttendanceMode = (data) => {
+  if (data.wants_to_attend_locally) {
+    selectedLocalhost.value = data.localhost
+    if (data.localhost_request_status == 'Accepted') {
+      attendanceMode.value = 'local'
+      originalAttendanceMode.value = 'local'
+      originalLocalhost.value = data.localhost
+      attendanceModeOptions.push({
+        label: 'On-site',
+        value: 'local',
+      })
+      attendanceModeOptions.push({
+        label: 'Request In-Person Attendance',
+        value: 'local-pending',
+      })
+      return
+    } else {
+      attendanceMode.value = 'local-pending'
+      originalAttendanceMode.value = 'local-pending'
+      originalLocalhost.value = data.localhost
+      attendanceModeOptions.push({
+        label: 'Pending On-site Request',
+        value: 'local-pending',
+      })
+      return
+    }
+  }
+  attendanceModeOptions.push({
+    label: 'Request In-Person Attendance',
+    value: 'local-pending',
+  })
+  attendanceMode.value = 'remote'
+  originalAttendanceMode.value = 'remote'
+}
+
+const localhosts = createListResource({
+  doctype: 'FOSS Hackathon LocalHost',
+  filter: {
+    parent_hackathon: props.hackathon.data.name,
+    is_enabled: 1,
+  },
+  fields: ['localhost_name', 'name', 'city', 'state', 'location', 'map_link'],
+  auto: true,
+})
+
+const handleDisabled = () => {
+  if (attendanceMode.value == originalAttendanceMode.value) {
+    if (
+      attendanceMode.value == 'local' ||
+      attendanceMode.value == 'local-pending'
+    ) {
+      return selectedLocalhost.value == originalLocalhost.value
+    }
+    return true
+  }
+  return false
+}
+
+const errorMessage = ref('')
+
+const updateParticipantLocalhost = (localhost) => {
+  createResource({
+    url: 'frappe.client.set_value',
+    params: {
+      doctype: 'FOSS Hackathon Participant',
+      name: participant.data.name,
+      fieldname: {
+        'wants_to_attend_locally': 1,
+        'localhost': localhost,
+      }
+    },
+    auto: true,
+    onSuccess(data){
+      showDialog.value = false
+      errorMessage.value = ''
+      toast.success('Attendance mode updated successfully!')
+    },
+    onError(err){
+      toast.error('Failed to update attendance mode.' + err.message)
+    }
+  })
+}
+
+const makeParticipantRemote = () => {
+  createResource({
+      url: 'frappe.client.set_value',
+      params: {
+        doctype: 'FOSS Hackathon Participant',
+        name: participant.data.name,
+        fieldname: {
+          'wants_to_attend_locally': 0,
+          'localhost': null,
+        }
+      },
+      auto: true,
+      onSuccess(data){
+        showDialog.value = false
+        errorMessage.value = ''
+        toast.success('Attendance mode updated successfully!')
+      },
+      onError(err){
+        toast.error('Failed to update attendance mode.' + err.message)
+      }
+    })
+}
+
+const handleAttendanceModeChange = () => {
+  if (attendanceMode.value == 'local-pending' && selectedLocalhost.value == null) {
+    errorMessage.value = 'Please select a LocalHost'
+    return
+  }
+
+  if (attendanceMode.value == 'local-pending') {
+    updateParticipantLocalhost(selectedLocalhost.value)
+    return
+  }
+
+  if (attendanceMode.value == 'remote') {
+    makeParticipantRemote()
+  }
+}
+</script>

--- a/dashboard/src/components/hackathon/HackathonAttendanceMode.vue
+++ b/dashboard/src/components/hackathon/HackathonAttendanceMode.vue
@@ -187,7 +187,7 @@ const setAttendanceMode = (data) => {
 
 const localhosts = createListResource({
   doctype: 'FOSS Hackathon LocalHost',
-  filter: {
+  filters: {
     parent_hackathon: props.hackathon.data.name,
     is_enabled: 1,
   },

--- a/dashboard/src/components/hackathon/HackathonAttendanceMode.vue
+++ b/dashboard/src/components/hackathon/HackathonAttendanceMode.vue
@@ -6,7 +6,7 @@
       title: 'Change Mode of Attendance',
     }"
   >
-    <template #body-content>
+  <template #body-content>
       <div
         class="flex flex-col gap-2 items-center text-center p-3 rounded w-full bg-orange-50 text-orange-600 border-2 border-dashed border-orange-600 text-xs"
       >
@@ -42,19 +42,30 @@
         :options="attendanceModeOptions"
       />
       <FormControl
-        v-if="attendanceMode == 'local' || attendanceMode == 'local-pending'"
-        label="Select LocalHost"
-        :disabled="attendanceMode == 'local'"
-        v-model="selectedLocalhost"
-        type="select"
-        class="mt-4"
-        :options="
-          localhosts.data.map((localhost) => ({
-            label: `${localhost.localhost_name}`,
-            value: localhost.name,
-          }))
-        "
+          v-if="attendanceMode == 'local'"
+          label="Your Localhost"
+          :disabled="1"
+          v-model="participant_localhost.data.localhost_name"
+          class="mt-4"
       />
+      <div v-if="attendanceMode == 'local-pending'">
+        <FormControl
+          v-if="localhosts.data.length > 0"
+          label="Select LocalHost"
+          v-model="selectedLocalhost"
+          type="select"
+          class="mt-4"
+          :options="
+            localhosts.data.map((localhost) => ({
+              label: `${localhost.localhost_name}`,
+              value: localhost.name,
+            }))
+          "
+        />
+        <div v-else class="mt-2 text-sm text-red-500">
+          <span>No LocalHost slots available at this moment.</span>
+        </div>
+      </div>
       <ErrorMessage :message="errorMessage" class="mt-2" />
     </template>
     <template #actions>
@@ -137,6 +148,17 @@ const props = defineProps({
   },
 })
 
+const participant_localhost = createResource({
+  url: 'frappe.client.get_value',
+  makeParams(){
+    return {
+      doctype: 'FOSS Hackathon LocalHost',
+      name: participant.data.localhost,
+      fieldname: 'localhost_name'
+    }
+  },
+})
+
 const participant = createResource({
   url: 'fossunited.api.hackathon.get_session_participant',
   makeParams() {
@@ -147,6 +169,7 @@ const participant = createResource({
   auto: true,
   onSuccess(data) {
     setAttendanceMode(data)
+    participant_localhost.fetch()
   },
 })
 
@@ -162,7 +185,7 @@ const setAttendanceMode = (data) => {
         value: 'local',
       })
       attendanceModeOptions.push({
-        label: 'Request In-Person Attendance',
+        label: 'Change Localhost Venue',
         value: 'local-pending',
       })
       return

--- a/dashboard/src/components/hackathon/HackathonTeamMember.vue
+++ b/dashboard/src/components/hackathon/HackathonTeamMember.vue
@@ -67,7 +67,7 @@
                 </div>
             </div>
             <Button
-                v-if="member.email != props.team.data.owner"
+                v-if="member.email != props.team.data.owner || session.user == props.team.data.owner"
                 :label="member.email == session.user ? 'Leave' : 'Remove'"
                 theme="red"
                 @click="removeTeamMember(member)"
@@ -85,6 +85,7 @@ import {
   Badge,
   createResource,
 } from 'frappe-ui'
+import { useRouter } from 'vue-router'
 import { toast } from 'vue-sonner'
 import CopyToClipboard from '@/components/CopyToClipboardComponent.vue'
 
@@ -92,6 +93,7 @@ const inInvite = ref(0)
 const inviteEmail = ref('')
 const teamCode = ref('')
 const session = inject('$session')
+const router = useRouter()
 
 const sections = ref([
   {
@@ -106,6 +108,10 @@ const sections = ref([
 
 const props = defineProps({
   team: {
+    type: Object,
+    required: true,
+  },
+  hackathon: {
     type: Object,
     required: true,
   },
@@ -171,6 +177,11 @@ const removeTeamMember = (member) => {
       }
     },
     onSuccess() {
+      if (member.email == session.user){
+        router.push(`/hack/${props.hackathon.permalink}`)
+        toast.warn('You have left the team.')
+        return
+      }
       props.team.fetch()
       toast.success('Member removed successfully')
     },

--- a/dashboard/src/components/hackathon/HackathonTeamMember.vue
+++ b/dashboard/src/components/hackathon/HackathonTeamMember.vue
@@ -179,7 +179,7 @@ const removeTeamMember = (member) => {
     onSuccess() {
       if (member.email == session.user){
         router.push(`/hack/${props.hackathon.permalink}`)
-        toast.warn('You have left the team.')
+        toast.warning('You have left the team.')
         return
       }
       props.team.fetch()

--- a/dashboard/src/pages/hackathon/InitRegister.vue
+++ b/dashboard/src/pages/hackathon/InitRegister.vue
@@ -32,6 +32,9 @@
         <span>{{ hackathon.data.hackathon_name }}</span>
       </div>
       <HackathonHeader :hackathon="hackathon" />
+      <div class="grid grid-cols-1 md:grid-cols-2 w-full mt-2">
+        <HackathonAttendanceMode :hackathon="hackathon" class="w-full"/>
+      </div>
       <hr class="my-6" />
       <div class="grid grid-cols-1 gap-5 md:grid-cols-2 pt-6 md:p-0">
         <div
@@ -102,6 +105,7 @@
 import Header from '@/components/Header.vue'
 import HackathonHeader from '@/components/hackathon/HackathonParticipantHeader.vue'
 import JoinTeam from '@/components/hackathon/JoinTeam.vue'
+import HackathonAttendanceMode from '@/components/hackathon/HackathonAttendanceMode.vue'
 import {
   createListResource,
   createResource,

--- a/dashboard/src/pages/hackathon/MyTeam.vue
+++ b/dashboard/src/pages/hackathon/MyTeam.vue
@@ -37,7 +37,7 @@
         <h2>{{ team.data.team_name }}</h2>
         <Button icon="edit-3" @click="inNameEdit = true" />
       </div>
-      <div class="grid grid-cols-1 md:grid-cols-2 w-full mb-4">
+      <div class="grid grid-cols-1 md:grid-cols-2 w-full mb-4 gap-6">
         <HackathonAttendanceMode :hackathon="hackathon" class="w-full" />
       </div>
       <hr />

--- a/dashboard/src/pages/hackathon/MyTeam.vue
+++ b/dashboard/src/pages/hackathon/MyTeam.vue
@@ -4,7 +4,7 @@
       <h3 class="text-xl font-semibold">Manage Team</h3>
     </template>
     <template #body-content>
-      <HackathonTeamMember :team="team" />
+      <HackathonTeamMember :team="team" :hackathon="hackathon.data" />
     </template>
   </Dialog>
   <Header />

--- a/dashboard/src/pages/hackathon/MyTeam.vue
+++ b/dashboard/src/pages/hackathon/MyTeam.vue
@@ -37,6 +37,9 @@
         <h2>{{ team.data.team_name }}</h2>
         <Button icon="edit-3" @click="inNameEdit = true" />
       </div>
+      <div class="grid grid-cols-1 md:grid-cols-2 w-full mb-4">
+        <HackathonAttendanceMode :hackathon="hackathon" class="w-full" />
+      </div>
       <hr />
       <div class="py-4 my-4 gap-6 grid grid-cols-1 md:grid-cols-2">
         <div
@@ -131,6 +134,7 @@
 import Header from '@/components/Header.vue'
 import HackathonHeader from '@/components/hackathon/HackathonParticipantHeader.vue'
 import HackathonTeamMember from '@/components/hackathon/HackathonTeamMember.vue'
+import HackathonAttendanceMode from '@/components/hackathon/HackathonAttendanceMode.vue'
 import { createResource, usePageMeta, Dialog } from 'frappe-ui'
 import { inject, ref } from 'vue'
 import { useRoute } from 'vue-router'

--- a/dashboard/src/pages/hackathon/Register.vue
+++ b/dashboard/src/pages/hackathon/Register.vue
@@ -329,6 +329,7 @@ watch(hackathon, () => {
       localhost.update({
         filters: {
           parent_hackathon: hackathon.data.name,
+          is_accepting_attendees: 1,
         },
       })
       localhost.fetch()

--- a/dashboard/src/pages/localhost/ManageLocalhost.vue
+++ b/dashboard/src/pages/localhost/ManageLocalhost.vue
@@ -29,6 +29,26 @@
           {{ localhost.doc.location }}
         </div>
       </div>
+      <div class="grid grid-cols-1 md:grid-cols-2">
+        <div class="rounded-sm border-2 border-dashed border-gray-400 p-4 my-2">
+          <div class="text-sm uppercase font-medium">Current Status</div>
+          <div class="flex items-center justify-between w-full">
+            <div class="flex items-center gap-2 text-lg font-medium pt-4" :class="localhost.doc.is_accepting_attendees ? 'text-green-700': ''">
+              <span v-if="localhost.doc.is_accepting_attendees" class="relative flex h-3 w-3">
+                <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>
+                <span class="relative inline-flex rounded-full h-3 w-3 bg-green-500"></span>
+              </span>
+              <span>
+                {{  localhost.doc.is_accepting_attendees ? 'Accepting Participants' : 'Not Accepting Participants' }}
+              </span>
+            </div>
+            <Button
+              :label="localhost.doc.is_accepting_attendees ? 'Disable' : 'Enable'"
+              @click="toggleAcceptingAttendees"
+            />
+          </div>
+        </div>
+      </div>
       <div
         class="grid grid-cols-1 sm:grid-cols-4 mt-6 mb-4 gap-4"
         v-if="requests.data"
@@ -111,5 +131,11 @@ const localhost = createDocumentResource({
   name: route.params.id,
   auto: true,
 })
+
+const toggleAcceptingAttendees = () => {
+  localhost.setValue.submit({
+    is_accepting_attendees: !localhost.doc.is_accepting_attendees,
+  })
+}
 
 </script>

--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -342,3 +342,35 @@ def join_team_via_code(team_code: str, user: str):
 
     team.append("members", {"member": participant.name})
     team.save()
+
+
+@frappe.whitelist()
+def get_session_participant(hackathon: str) -> dict:
+    """
+    Get participant details of the current session user
+
+    Args:
+        hackathon (str): Hackathon ID
+
+    Returns:
+        dict: Participant document as a dictionary
+    """
+    participant = frappe.db.get_value(
+        "FOSS Hackathon Participant",
+        {"hackathon": hackathon, "user": frappe.session.user},
+        [
+            "name",
+            "user_profile",
+            "full_name",
+            "email",
+            "is_student",
+            "git_profile",
+            "organization",
+            "hackathon",
+            "wants_to_attend_locally",
+            "localhost",
+            "localhost_request_status",
+        ],
+        as_dict=1,
+    )
+    return participant

--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -374,3 +374,30 @@ def get_session_participant(hackathon: str) -> dict:
         as_dict=1,
     )
     return participant
+
+
+@frappe.whitelist()
+def delete_project(hackathon: str, team: str):
+    """
+    Delete team project
+
+    Args:
+        hackathon (str): Hackathon ID
+        team (str): Team ID
+    """
+    team_doc = frappe.get_doc("FOSS Hackathon Team", team)
+    if frappe.session.user not in [
+        member.email for member in team_doc.members
+    ]:
+        frappe.throw("You are not authorized to delete this project")
+
+    project = get_project_by_team(hackathon, team)
+
+    try:
+        frappe.db.set_value(
+            "FOSS Hackathon Team", team, "project", None
+        )
+        frappe.db.delete("FOSS Hackathon Project", project.name)
+        return True
+    except Exception as e:
+        frappe.throw("Error deleting project")

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.json
@@ -6,6 +6,8 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "is_enabled",
+  "section_break_pnbh",
   "parent_hackathon",
   "localhost_name",
   "column_break_bvzk",
@@ -79,10 +81,20 @@
    "fieldtype": "Table",
    "label": "Organizers",
    "options": "FOSS Hackathon LocalHost Organizer"
+  },
+  {
+   "default": "1",
+   "fieldname": "is_enabled",
+   "fieldtype": "Check",
+   "label": "Is Enabled?"
+  },
+  {
+   "fieldname": "section_break_pnbh",
+   "fieldtype": "Section Break"
   }
  ],
  "links": [],
- "modified": "2024-07-10 13:34:06.896205",
+ "modified": "2024-07-14 16:33:10.270262",
  "modified_by": "Administrator",
  "module": "FOSS Hackathon",
  "name": "FOSS Hackathon LocalHost",

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.json
@@ -6,7 +6,7 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "is_enabled",
+  "is_accepting_attendees",
   "section_break_pnbh",
   "parent_hackathon",
   "localhost_name",
@@ -83,18 +83,18 @@
    "options": "FOSS Hackathon LocalHost Organizer"
   },
   {
-   "default": "1",
-   "fieldname": "is_enabled",
-   "fieldtype": "Check",
-   "label": "Is Enabled?"
-  },
-  {
    "fieldname": "section_break_pnbh",
    "fieldtype": "Section Break"
+  },
+  {
+   "default": "1",
+   "fieldname": "is_accepting_attendees",
+   "fieldtype": "Check",
+   "label": "Is Accepting Attendees?"
   }
  ],
  "links": [],
- "modified": "2024-07-14 16:33:10.270262",
+ "modified": "2024-07-16 16:32:35.592358",
  "modified_by": "Administrator",
  "module": "FOSS Hackathon",
  "name": "FOSS Hackathon LocalHost",

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.py
@@ -19,7 +19,7 @@ class FOSSHackathonLocalHost(Document):
         )
 
         city: DF.Link | None
-        is_enabled: DF.Check
+        is_accepting_attendees: DF.Check
         localhost_name: DF.Data
         location: DF.Data | None
         map_link: DF.Data | None

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.py
@@ -19,6 +19,7 @@ class FOSSHackathonLocalHost(Document):
         )
 
         city: DF.Link | None
+        is_enabled: DF.Check
         localhost_name: DF.Data
         location: DF.Data | None
         map_link: DF.Data | None

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -28,3 +28,18 @@ class FOSSHackathonParticipant(Document):
         wants_to_attend_locally: DF.Check
     # end: auto-generated types
     pass
+
+    def before_save(self):
+        self.handle_localhost_rejection()
+        if self.has_value_changed("localhost"):
+            self.update_request_status()
+
+    def update_request_status(self):
+        self.localhost_request_status = "Pending"
+
+    def handle_localhost_rejection(self):
+        if (
+            not self.has_value_changed("localhost")
+            and self.localhost_request_status == "Rejected"
+        ):
+            self.wants_to_attend_locally = 0

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -42,4 +42,4 @@ class FOSSHackathonParticipant(Document):
             not self.has_value_changed("localhost")
             and self.localhost_request_status == "Rejected"
         ):
-            self.wants_to_attend_locally = 0
+            self.wants_to_attend_locally = False

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_project/foss_hackathon_project.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_project/foss_hackathon_project.json
@@ -147,7 +147,7 @@
  "index_web_pages_for_search": 1,
  "is_published_field": "is_published",
  "links": [],
- "modified": "2024-06-18 14:13:38.820349",
+ "modified": "2024-07-15 17:44:19.295171",
  "modified_by": "Administrator",
  "module": "FOSS Hackathon",
  "name": "FOSS Hackathon Project",
@@ -168,27 +168,9 @@
   },
   {
    "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
    "read": 1,
-   "report": 1,
-   "role": "FOSS Website User",
-   "select": 1,
-   "share": 1,
-   "write": 1
-  },
-  {
-   "create": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
    "role": "All",
    "select": 1,
-   "share": 1,
    "write": 1
   }
  ],


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🍕Feature
- [x] ⚙️Chore

## Description
- Added an `is_enabled` checkbox for localhosts that lets them de-list themselves from the list of localhosts that are actively taking in participants.
- Hackathon Participants can now change their attendance mode: Remote -> Localhost, Localhost -> Remote, Localhost 1 -> Localhost 2. closes #461
- Team owners are now allowed to leave the team and create another team should they wish. closes #463
- Teams can now delete their project and work on something new. closes #464

## Screenshots:
![image](https://github.com/user-attachments/assets/87ae9ce6-0032-4704-842a-1d85876e5a99)
![image](https://github.com/user-attachments/assets/94629dab-1344-4a89-8d26-1b880ff4273c)
![image](https://github.com/user-attachments/assets/0959260c-41b5-4c5b-8418-894582f69f65)


![image](https://github.com/user-attachments/assets/f2395fc3-cd23-4d30-8d94-7c4700e753c2)

![image](https://github.com/user-attachments/assets/bf76909e-aa17-4ffc-aa6f-617ec19543ae)
