### PR TITLE
fix(event): replacing `self.paid_event` with `self.is_paid_event`

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -161,7 +161,7 @@ class FOSSChapterEvent(WebsiteGenerator):
 
         if not self.show_speakers:
             navbar_items.remove("speakers")
-        if not self.show_rsvp or self.paid_event:
+        if not self.show_rsvp or self.is_paid_event:
             navbar_items.remove("rsvp")
         if not self.show_cfp:
             navbar_items.remove("talk_proposal")


### PR DESCRIPTION
…vent

## What type of PR is this? (check all applicable)
- [ ] 🍕Feature
- [x] ⚙️Chore
- [x] 🐛Bug Fix
- [ ] 🎨Style
- [ ] 🧑‍💻Refactor
- [ ] 📕Documentation
- [ ] 🏎️Optimization

## Description
The field name for the paid event field in the doctype is set to is_paid_event for creating a paid event and in the python script it is called with `self.paid_event`. In this PR, the `self.paid_event` is replaced with ``self.is_paid_event`. 
