### PR TITLE
feat(localhost): attendance confirmation for localhost attendees

### DIFF
--- a/dashboard/src/components/localhost/AttendeeRequestList.vue
+++ b/dashboard/src/components/localhost/AttendeeRequestList.vue
@@ -1,6 +1,6 @@
 <template>
   <RequestDetailDialog
-  class="z-50 my-5"
+    class="z-50 my-5"
     :participant="selectedRequest"
     :showDialog="showDialog"
     @update:showDialog="showDialog = $event"
@@ -62,7 +62,7 @@
           {
             label: 'Status',
             key: 'localhost_request_status',
-            width: 1 / 2,
+            width: 1,
           },
           {
             label: 'Is Student',
@@ -106,9 +106,12 @@
                   ? 'orange'
                   : row[column.key] === 'Accepted'
                     ? 'green'
-                    : 'red'
+                    : row[column.key] === 'Pending Confirmation'
+                      ? 'blue'
+                      : 'red'
               "
               :label="row[column.key]"
+              size="lg"
             />
           </div>
           <div v-else-if="column.label == 'Git Profile'">
@@ -241,6 +244,11 @@ const listFilter = ref([
     isActive: false,
     value: ['Accepted'],
   },
+  {
+    label: 'Pending Confirmation',
+    isActive: false,
+    value: ['Pending Confirmation'],
+  },
 ])
 
 const selectedListFitler = ref(listFilter.value[0].label)
@@ -265,7 +273,6 @@ const requestByGroup = createResource({
   },
 })
 
-
 const changeLocalhostRequestStatus = (id, status) => {
   return createResource({
     url: 'frappe.client.set_value',
@@ -282,7 +289,7 @@ const changeLocalhostRequestStatus = (id, status) => {
 }
 
 const acceptRequest = (member) => {
-  changeLocalhostRequestStatus(member.name, 'Accepted').fetch()
+  changeLocalhostRequestStatus(member.name, 'Pending Confirmation').fetch()
 }
 
 const rejectRequest = (member) => {
@@ -299,5 +306,4 @@ const filterListByStatus = (filter) => {
   })
   requestByGroup.fetch()
 }
-
 </script>

--- a/dashboard/src/components/localhost/AttendeeRequestList.vue
+++ b/dashboard/src/components/localhost/AttendeeRequestList.vue
@@ -35,8 +35,11 @@
       class="border-none text-sm px-4 rounded w-44 h-fit items-center flex flex-col bg-gray-100 border-2"
       v-model="selectedListFilter"
     >
-      <option v-for="(_, label) in FILTERS">
-        {{ label }}
+      <option
+        v-for="(filter, index) in listFilter"
+        @click="filterListByStatus(filter)"
+      >
+        {{ filter.label }}
       </option>
     </select>
   </div>

--- a/dashboard/src/components/localhost/AttendeeRequestList.vue
+++ b/dashboard/src/components/localhost/AttendeeRequestList.vue
@@ -213,7 +213,7 @@ import {
   Button,
   ListView,
 } from 'frappe-ui'
-import { ref } from 'vue'
+import { ref, defineEmits } from 'vue'
 import RequestDetailDialog from '@/components/localhost/RequestDetailDialog.vue'
 import { truncateStr } from '@/helpers/utils'
 import { redirectRoute } from '@/helpers/utils'
@@ -227,6 +227,8 @@ const props = defineProps({
     required: true,
   },
 })
+
+const emit = defineEmits(['updateRequest'])
 
 const listFilter = ref([
   {
@@ -284,6 +286,7 @@ const changeLocalhostRequestStatus = (id, status) => {
     },
     onSuccess(data) {
       requestByGroup.fetch()
+      emit('updateRequest')
     },
   })
 }

--- a/dashboard/src/components/localhost/AttendeeRequestList.vue
+++ b/dashboard/src/components/localhost/AttendeeRequestList.vue
@@ -53,7 +53,7 @@
   <div class="w-full place-items-center">
     <div class="my-2" v-if="requestByGroup.data">
       <ListView
-        class="max-h-svh"
+        class="min-h-[440px]"
         :columns="[
           {
             label: 'Name',
@@ -94,6 +94,10 @@
           onRowClick: (row) => {
             selectedRequest = row
             showDialog = true
+          },
+          emptyState: {
+            title: 'No Requests',
+            description: 'No requests found',
           },
         }"
         row-key="name"
@@ -205,7 +209,7 @@
 </template>
 
 <script setup>
-import { defineProps } from 'vue'
+import { defineProps, defineSSRCustomElement } from 'vue'
 import {
   LoadingIndicator,
   createResource,
@@ -234,7 +238,7 @@ const listFilter = ref([
   {
     label: 'All Requests',
     isActive: true,
-    value: ['Pending', 'Rejected', 'Accepted'],
+    value: ['Pending', 'Rejected', 'Accepted', 'Pending Confirmation'],
   },
   {
     label: 'Pending Requests',
@@ -258,11 +262,12 @@ const selectedListFitler = ref(listFilter.value[0].label)
 const requestByGroup = createResource({
   url: 'fossunited.api.hackathon.get_localhost_requests_by_team',
   params: {
-    hackathon: props.localhost.doc.parent_hackathon,
-    localhost: props.localhost.doc.name,
+    hackathon: props.localhost.data.parent_hackathon,
+    localhost: props.localhost.data.name,
   },
   auto: true,
   transform(data) {
+    if (!data) return []
     let rows = []
     Object.entries(data).forEach((key) => {
       rows.push({
@@ -302,8 +307,8 @@ const rejectRequest = (member) => {
 const filterListByStatus = (filter) => {
   requestByGroup.update({
     params: {
-      hackathon: props.localhost.doc.parent_hackathon,
-      localhost: props.localhost.doc.name,
+      hackathon: props.localhost.data.parent_hackathon,
+      localhost: props.localhost.data.name,
       status: filter.value,
     },
   })

--- a/dashboard/src/components/localhost/LocalhostHeader.vue
+++ b/dashboard/src/components/localhost/LocalhostHeader.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="prose mt-4">
+    <h2>{{ localhost.localhost_name }}</h2>
+  </div>
+  <div class="flex gap-2 my-2 text-base font-medium items-center">
+    <div class="flex gap-1 items-center">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        class="icon w-5 h-5 icon-tabler icons-tabler-outline icon-tabler-map-pin"
+      >
+        <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+        <path d="M9 11a3 3 0 1 0 6 0a3 3 0 0 0 -6 0" />
+        <path
+          d="M17.657 16.657l-4.243 4.243a2 2 0 0 1 -2.827 0l-4.244 -4.243a8 8 0 1 1 11.314 0z"
+        />
+      </svg>
+      {{ localhost.location }}
+    </div>
+  </div>
+</template>
+<script setup>
+import { defineProps } from 'vue'
+
+const props = defineProps({
+    localhost : {
+        type: Object,
+        required: true,
+    }
+})
+</script>

--- a/dashboard/src/components/localhost/RequestDetailDialog.vue
+++ b/dashboard/src/components/localhost/RequestDetailDialog.vue
@@ -9,7 +9,7 @@
   <template #body-content>
     <div class="grid grid-cols-2 gap-4 text-base">
         <div class="col-span-2 text-base font-medium">
-            <span>Status: </span><span :class="{'Pending': 'text-orange-600', 'Accepted': 'text-green-600', 'Rejected': 'text-red-600'}[participant.localhost_request_status]">{{ participant.localhost_request_status }}</span>
+            <span>Status: </span><span :class="{'Pending': 'text-orange-600', 'Accepted': 'text-green-600', 'Rejected': 'text-red-600', 'Pending Confirmation': 'text-blue-600'}[participant.localhost_request_status]">{{ participant.localhost_request_status }}</span>
         </div>
         <div class="flex gap-2">
             <img :src="participant.profile_photo" alt="" class=" rounded-full h-8 w-8">
@@ -43,15 +43,17 @@
         </div>
     </div>
   </template>
-  <template #actions v-if="participant.localhost_request_status == 'Pending'">
+  <template #actions v-if="participant.localhost_request_status == 'Pending' || participant.localhost_request_status == 'Pending Confirmation'">
     <div class="grid grid-cols-2 gap-4">
         <Button
+            :class="participant.localhost_request_status == 'Pending Confirmation' ? 'col-span-2' : ''"
             label="Reject"
             theme="red"
             size="sm"
             @click="rejectRequest(participant)"
         />
         <Button
+            v-if="participant.localhost_request_status != 'Pending Confirmation'"
             label="Approve"
             theme="green"
             size="sm"

--- a/dashboard/src/components/localhost/StatusMessage.vue
+++ b/dashboard/src/components/localhost/StatusMessage.vue
@@ -1,0 +1,51 @@
+<template>
+  <div class="py-10 px-5 w-full flex justify-center">
+    <div v-if="status == 'Accepted'" class="flex flex-col gap-2 items-center justify-center">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        class="icon w-10 h-10 fill-green-600 icon-tabler icons-tabler-filled icon-tabler-circle-check"
+      >
+        <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+        <path
+          d="M17 3.34a10 10 0 1 1 -14.995 8.984l-.005 -.324l.005 -.324a10 10 0 0 1 14.995 -8.336zm-1.293 5.953a1 1 0 0 0 -1.32 -.083l-.094 .083l-3.293 3.292l-1.293 -1.292l-.094 -.083a1 1 0 0 0 -1.403 1.403l.083 .094l2 2l.094 .083a1 1 0 0 0 1.226 0l.094 -.083l4 -4l.083 -.094a1 1 0 0 0 -.083 -1.32z"
+        />
+      </svg>
+      <div class="text-center prose">
+        <h2>Attendance Confirmed</h2>
+        <p>
+            Your Attendance for the Localhost has been confirmed.
+        </p>
+      </div>
+    </div>
+    <div v-else class="flex flex-col gap-2 items-center justify-center">
+        <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        class="icon w-10 h-10 fill-red-600 icon-tabler icons-tabler-filled icon-tabler-circle-x"
+      >
+        <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+        <path
+          d="M17 3.34a10 10 0 1 1 -14.995 8.984l-.005 -.324l.005 -.324a10 10 0 0 1 14.995 -8.336zm-6.489 5.8a1 1 0 0 0 -1.218 1.567l1.292 1.293l-1.292 1.293l-.083 .094a1 1 0 0 0 1.497 1.32l1.293 -1.292l1.293 1.292l.094 .083a1 1 0 0 0 1.32 -1.497l-1.292 -1.293l1.292 -1.293l.083 -.094a1 1 0 0 0 -1.497 -1.32l-1.293 1.292l-1.293 -1.292l-.094 -.083z"
+        />
+      </svg>
+      <div class="prose text-center">
+        <h2>Rejected</h2>
+        <p>
+            You rejected the attendance confirmation. You will now attend the hackathon remotely.
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+<script setup>
+import { defineProps } from 'vue'
+
+const props = defineProps(['status'])
+</script>

--- a/dashboard/src/pages/localhost/LocalhostAttendanceProcess.vue
+++ b/dashboard/src/pages/localhost/LocalhostAttendanceProcess.vue
@@ -1,0 +1,182 @@
+<template>
+  <Dialog
+    class="z-50"
+    v-model="showDialog"
+    :options="{
+      title: 'Error',
+      message: dialogMessage,
+    }"
+  />
+  <Header />
+  <div class="w-full h-screen flex justify-center">
+    <div v-if="transferStatus" class="max-w-screen-xl w-full flex justify-center">
+        <HackathonHeader v-if="hackathon_doc.data" :hackathon="hackathon_doc"/>
+        <LocalhostHeader v-if="localhost_doc.data" :localhost="localhost_doc.data"/>
+        <StatusMessage :status="transferStatus" />
+    </div>
+    <div v-else class="flex w-full justify-center items-center">
+        <LoadingIndicator class="w-6"/>
+    </div>
+  </div>
+</template>
+<script setup>
+import Header from '@/components/Header.vue'
+import StatusMessage from '@/components/localhost/StatusMessage.vue'
+import HackathonHeader from '@/components/hackathon/HackathonParticipantHeader.vue'
+import LocalhostHeader from '@/components/localhost/LocalhostHeader.vue'
+import { createDocumentResource, createResource, Dialog, usePageMeta, LoadingIndicator } from 'frappe-ui'
+import { onMounted, ref } from 'vue'
+import { useRoute } from 'vue-router'
+
+const route = useRoute()
+
+const participant = route.query.participant
+const localhost = route.query.localhost
+const status = route.query.status
+
+const showDialog = ref(false)
+const dialogMessage = ref('')
+
+const transferStatus = ref('')
+
+usePageMeta(() => {
+  return {
+    title: 'Localhost Attendance Process',
+  }
+})
+
+onMounted(() => {
+    if (!isValidStatus()){
+        return
+    }
+    validateLocalhost.fetch()
+    validateParticipant.fetch()
+})
+
+const participant_doc = createResource({
+    url: 'frappe.client.get',
+    makeParams(){
+        return {
+            doctype: 'FOSS Hackathon Participant',
+            name: participant,
+            fields: ['name']
+        }
+    },
+    onSuccess(data){
+        if (status == 1){
+            confirmAttendance()
+        }
+        else{
+            rejectAttendance()
+        }
+    },
+    onError(err){
+        showDialog.value = true
+        dialogMessage.value = err.message
+    }
+})
+
+
+const hackathon_doc = createResource({
+    url: 'frappe.client.get',
+    makeParams() {
+        return {
+            doctype: 'FOSS Hackathon',
+            name: localhost_doc.data.parent_hackathon,
+        }
+    },
+    onSuccess(data){
+    }
+})
+
+const localhost_doc = createResource({
+    url: 'frappe.client.get_value',
+    makeParams() {
+        return {
+            doctype: 'FOSS Hackathon LocalHost',
+            filters: {
+                name: localhost
+            },
+            fieldname: ['localhost_name', 'parent_hackathon', 'city', 'state', 'location', 'map_link']
+        }
+    },
+    onSuccess(data){
+        hackathon_doc.fetch()
+    }
+})
+
+const isValidStatus = () => {
+    if (status != 0 && status != 1) {
+        showDialog.value = true
+        dialogMessage.value = 'Invalid status'
+        return false
+    }
+    return true
+}
+
+const validateLocalhost = createResource({
+    url: 'fossunited.api.hackathon.is_valid_localhost',
+    makeParams() {
+        return {
+            localhost_id: localhost
+        }
+    },
+    onSuccess(data){
+        if (!data){
+            showDialog.value = true
+            dialogMessage.value = 'Invalid Localhost'
+        }
+        else {
+            localhost_doc.fetch()
+        }
+    }
+})
+
+const validateParticipant = createResource({
+    url: 'fossunited.api.hackathon.validate_participant_for_localhost',
+    makeParams() {
+        return {
+            participant_id: participant
+        }
+    },
+    onSuccess(data){
+        if (data){
+            participant_doc.fetch()
+        }
+    },
+    onError(err){
+        showDialog.value = true
+        dialogMessage.value = err.messages.join('\n')
+    }
+})
+
+const changeLocalhostStatus = (_status) => {
+    createResource({
+        url: 'frappe.client.set_value',
+        makeParams(){
+            return {
+                doctype: 'FOSS Hackathon Participant',
+                name: participant,
+                fieldname: 'localhost_request_status',
+                value: _status,
+            }
+        },
+        onSuccess(data){
+            transferStatus.value = _status
+        },
+        onError(err){
+            showDialog.value=true
+            dialogMessage.value=err.message
+        },
+        auto: true
+    })
+}
+
+const confirmAttendance = () => {
+    changeLocalhostStatus("Accepted")
+}
+
+const rejectAttendance = () => {
+    changeLocalhostStatus("Rejected")
+}
+</script>

--- a/dashboard/src/pages/localhost/LocalhostAttendanceProcess.vue
+++ b/dashboard/src/pages/localhost/LocalhostAttendanceProcess.vue
@@ -9,9 +9,15 @@
   />
   <Header />
   <div class="w-full h-screen flex justify-center">
-    <div v-if="transferStatus" class="max-w-screen-xl w-full flex justify-center">
-        <HackathonHeader v-if="hackathon_doc.data" :hackathon="hackathon_doc"/>
-        <LocalhostHeader v-if="localhost_doc.data" :localhost="localhost_doc.data"/>
+    <div v-if="transferStatus" class="max-w-screen-xl w-full flex flex-col items-start">
+        <div class="flex flex-col justify-between md:flex-row md:items-center w-full p-2">
+            <div>
+                <HackathonHeader v-if="hackathon_doc.data" :hackathon="hackathon_doc" :showBanner="false"/>
+            </div>
+            <div class="flex flex-col md:items-end">
+                <LocalhostHeader v-if="localhost_doc.data" :localhost="localhost_doc.data"/>
+            </div>
+        </div>
         <StatusMessage :status="transferStatus" />
     </div>
     <div v-else class="flex w-full justify-center items-center">

--- a/dashboard/src/pages/localhost/ManageLocalhost.vue
+++ b/dashboard/src/pages/localhost/ManageLocalhost.vue
@@ -25,7 +25,7 @@
         </div>
       </div>
       <div
-        class="grid grid-cols-1 sm:grid-cols-4 mt-6 mb-4 gap-4"
+        class="grid grid-cols-1 sm:grid-cols-5 mt-6 mb-4 gap-4"
         v-if="requests.data"
       >
         <div class="flex flex-col gap-2 bg-gray-50 w-full p-4 rounded border">
@@ -38,6 +38,12 @@
           <div class="text-base font-medium">Pending Requests</div>
           <div class="text-2xl text-orange-600">
             {{ requests.data['Pending'].length }}
+          </div>
+        </div>
+        <div class="flex flex-col gap-2 w-full p-4 rounded border">
+          <div class="text-base font-medium">Pending Confirmation</div>
+          <div class="text-2xl text-blue-600">
+            {{ requests.data['Pending Confirmation'].length }}
           </div>
         </div>
         <div class="flex flex-col gap-2 w-full p-4 rounded border">
@@ -55,7 +61,7 @@
       </div>
       <hr>
       <div class="flex flex-col gap-2 py-4">
-        <AttendeeRequestList :localhost="localhost"/>
+        <AttendeeRequestList :localhost="localhost" @update-request="requests.reload()"/>
       </div>
     </div>
   </div>
@@ -65,6 +71,7 @@ import { useRoute } from 'vue-router'
 import {
   createDocumentResource,
   createListResource,
+  usePageMeta,
 } from 'frappe-ui'
 import AttendeeRequestList from '@/components/localhost/AttendeeRequestList.vue';
 import LocalhostHeader from '@/components/localhost/LocalhostHeader.vue'
@@ -72,11 +79,16 @@ import Header from '@/components/Header.vue'
 
 const route = useRoute()
 
+usePageMeta(() => {
+  return {
+    title: 'Manage Localhost',
+  }
+})
+
 const requests = createListResource({
   doctype: 'FOSS Hackathon Participant',
   fields: ['*'],
   filters: {
-    wants_to_attend_locally: 1,
     localhost: route.params.id,
   },
   transform(data) {
@@ -95,6 +107,9 @@ const requests = createListResource({
     }
     if (!data['Rejected']) {
       data['Rejected'] = []
+    }
+    if (!data['Pending Confirmation']) {
+      data['Pending Confirmation'] = []
     }
     return data
   },

--- a/dashboard/src/pages/localhost/ManageLocalhost.vue
+++ b/dashboard/src/pages/localhost/ManageLocalhost.vue
@@ -3,32 +3,7 @@
   <div class="w-full p-4 flex items-center justify-center" v-if="localhost.doc">
     <div class="max-w-screen-xl w-full">
       <div class="text-base font-medium mt-4">Manage LocalHost</div>
-      <div class="prose mt-4">
-        <h2>{{ localhost.doc.localhost_name }}</h2>
-      </div>
-      <div class="flex gap-2 my-2 text-base font-medium items-center">
-        <div class="flex gap-1 items-center">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="24"
-            height="24"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            class="icon w-5 h-5 icon-tabler icons-tabler-outline icon-tabler-map-pin"
-          >
-            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-            <path d="M9 11a3 3 0 1 0 6 0a3 3 0 0 0 -6 0" />
-            <path
-              d="M17.657 16.657l-4.243 4.243a2 2 0 0 1 -2.827 0l-4.244 -4.243a8 8 0 1 1 11.314 0z"
-            />
-          </svg>
-          {{ localhost.doc.location }}
-        </div>
-      </div>
+      <LocalhostHeader :localhost="localhost.doc"/>
       <div class="grid grid-cols-1 md:grid-cols-2">
         <div class="rounded-sm border-2 border-dashed border-gray-400 p-4 my-2">
           <div class="text-sm uppercase font-medium">Current Status</div>
@@ -92,6 +67,7 @@ import {
   createListResource,
 } from 'frappe-ui'
 import AttendeeRequestList from '@/components/localhost/AttendeeRequestList.vue';
+import LocalhostHeader from '@/components/localhost/LocalhostHeader.vue'
 import Header from '@/components/Header.vue'
 
 const route = useRoute()

--- a/dashboard/src/router.js
+++ b/dashboard/src/router.js
@@ -183,6 +183,12 @@ const routes = [
         component: () => import('@/pages/localhost/ManageLocalhost.vue')
       }
     ]
+  },
+  {
+    path: '/localhost-attendance-process',
+    name: 'LocalhostAttendanceProcess',
+    component: () => import('@/pages/localhost/LocalhostAttendanceProcess.vue'),
+    props: true
   }
 ]
 

--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -252,7 +252,12 @@ def get_project_by_email(hackathon: str, email: str):
 def get_localhost_requests_by_team(
     hackathon: str,
     localhost: str,
-    status: list[str] = ["Pending", "Accepted", "Rejected"],
+    status: list[str] = [
+        "Pending",
+        "Accepted",
+        "Rejected",
+        "Pending Confirmation",
+    ],
 ):
     """
     Get requests for a particular localhost grouped by team.
@@ -405,3 +410,74 @@ def delete_project(hackathon: str, team: str):
         return True
     except Exception as e:
         frappe.throw("Error deleting project")
+
+
+@frappe.whitelist()
+def is_valid_hackathon(hackathon_id: str):
+    """
+    Checks if the the hackathon is valid and exists in the db.
+
+    Returns:
+        Boolean True or False
+    """
+    return bool(frappe.db.exists("FOSS Hackathon", hackathon_id))
+
+
+@frappe.whitelist()
+def is_valid_localhost(localhost_id: str):
+    """
+    Checks if the localhost is valid and exists in the db.
+
+    Returns:
+        Boolean True or False
+    """
+
+    return bool(
+        frappe.db.exists("FOSS Hackathon LocalHost", localhost_id)
+    )
+
+
+@frappe.whitelist()
+def validate_participant_for_localhost(participant_id: str):
+    """
+    Validates if the participant is valid and exists in the db.
+    Also, validates that the participant is valid to make request for localhost.
+    """
+    if not frappe.db.exists(
+        "FOSS Hackathon Participant", participant_id
+    ):
+        frappe.throw("Participant does not exist")
+
+    participant = frappe.db.get(
+        "FOSS Hackathon Participant",
+        participant_id,
+        [
+            "user",
+            "wants_to_attend_locally",
+            "localhost",
+            "localhost_request_status",
+        ],
+    )
+    if participant.user != frappe.session.user:
+        frappe.throw("You are not authorized to perform this action")
+
+    if not participant.wants_to_attend_locally:
+        frappe.throw("Participant has not opted for local attendance")
+
+    if not participant.localhost:
+        frappe.throw("Participant has not selected a localhost")
+
+    if participant.localhost_request_status == "Accepted":
+        frappe.throw(
+            "Participant has already been accepted for local attendance"
+        )
+
+    if (
+        not participant.localhost_request_status
+        == "Pending Confirmation"
+    ):
+        frappe.throw(
+            "Participant has not been accepted for local attendance"
+        )
+
+    return True

--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -275,7 +275,6 @@ def get_localhost_requests_by_team(
         doctype="FOSS Hackathon Participant",
         filters={
             "hackathon": hackathon,
-            "wants_to_attend_locally": 1,
             "localhost": localhost,
             "localhost_request_status": ["in", status],
         },

--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -480,3 +480,34 @@ def validate_participant_for_localhost(participant_id: str):
         )
 
     return True
+
+
+@frappe.whitelist()
+def validate_user_as_localhost_member(localhost_id: str):
+    if not frappe.db.exists(
+        "Has Role",
+        {
+            "parent": frappe.session.user,
+            "role": "Localhost Organizer",
+        },
+    ):
+        frappe.throw(
+            "You are not a Localhost Organizer. You are not authorized to view this page"
+        )
+
+    if not frappe.db.exists(
+        "FOSS Hackathon LocalHost Organizer",
+        {
+            "parent": localhost_id,
+            "profile": frappe.db.get_value(
+                "FOSS User Profile",
+                {"user": frappe.session.user},
+                "name",
+            ),
+        },
+    ):
+        frappe.throw(
+            "You are not a member of this Localhost. You are not authorized to view this page"
+        )
+
+    return True

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.py
@@ -60,8 +60,12 @@ class FOSSHackathonLocalHost(Document):
         ):
             return
 
+        current_organizers = {
+            member.name for member in self.organizers
+        }
+
         for member in prev_doc.organizers:
-            if not member in self.organizers:
+            if member.name not in current_organizers:
                 self.remove_organizer_role(member)
 
     def remove_organizer_role(self, old_member):

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.py
@@ -36,7 +36,11 @@ class FOSSHackathonLocalHost(Document):
         self.check_if_member_removed()
 
     def before_save(self):
-        self.assign_localhost_organizer_role()
+        if self.has_value_changed("organizers") and (
+            len(self.organizers)
+            > len(self.get_doc_before_save().organizers)
+        ):
+            self.assign_localhost_organizer_role()
 
     def assign_localhost_organizer_role(self):
         for member in self.organizers:

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.json
@@ -90,7 +90,6 @@
    "label": "Wants to attend locally?"
   },
   {
-   "depends_on": "eval:doc.wants_to_attend_locally == 1",
    "fieldname": "section_break_pijd",
    "fieldtype": "Section Break"
   },
@@ -129,7 +128,7 @@
   }
  ],
  "links": [],
- "modified": "2024-07-17 17:19:00.866580",
+ "modified": "2024-07-18 10:44:30.991416",
  "modified_by": "Administrator",
  "module": "FOSS Hackathon",
  "name": "FOSS Hackathon Participant",

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.json
@@ -109,8 +109,7 @@
    "fieldname": "localhost_request_status",
    "fieldtype": "Select",
    "label": "LocalHost Request Status",
-   "options": "Pending\nAccepted\nRejected",
-   "permlevel": 1
+   "options": "Pending\nPending Confirmation\nAccepted\nRejected"
   },
   {
    "fieldname": "column_break_pxgj",
@@ -130,7 +129,7 @@
   }
  ],
  "links": [],
- "modified": "2024-07-11 15:41:08.687831",
+ "modified": "2024-07-17 17:19:00.866580",
  "modified_by": "Administrator",
  "module": "FOSS Hackathon",
  "name": "FOSS Hackathon Participant",

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -20,7 +20,7 @@ class FOSSHackathonParticipant(Document):
         is_student: DF.Check
         localhost: DF.Link | None
         localhost_request_status: DF.Literal[
-            "Pending", "Accepted", "Rejected"
+            "Pending", "Pending Confirmation", "Accepted", "Rejected"
         ]
         organization: DF.Data | None
         user: DF.Link | None


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🍕Feature

## Description
<!-- Briefly describe the changes introduced by this pull request -->
Localhost attendees who have their request as Confirmed from the organizer side will need to confirm their attendance for the event.
This will help the organizer get an accurate headcount for the event.

Need to setup: A notification that is sent to the localhost participant when the status for their localhost request status goes to 'Pending Confirmation'. This can be created from desk after this PR is merged.

- Also fixed: Rejected Proposals rendering in the list of all attendees. The count for each subtype was not changing with the proposal being accepted/rejected. Added an emit that handles it
- Added validation which checks whether the session user is a part of that localhost. If yes, then render the data. If no, then an error is thrown and user is redirected to dashboard home page

## Related Issues & Docs
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
closes #476 


## Screenshots
![image](https://github.com/user-attachments/assets/45b244a9-4eff-44bd-8c16-662a275f3d3e)
![image](https://github.com/user-attachments/assets/12d5dcf4-1b0a-4423-b591-c088138ae675)

#### Localhost dashboard
![image](https://github.com/user-attachments/assets/a8ab8f6e-010e-4e2b-a506-f4cc480fe46f)
![image](https://github.com/user-attachments/assets/41cd4e6f-9fd1-49b6-adf7-a1e4d54fca38)

#### Validation
![image](https://github.com/user-attachments/assets/2f0c1f72-06cd-4139-a8b9-293b2cfca129)

