### PR TITLE
fix(hackathon): whitelist `get_session_participant` method

### DIFF
--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -406,6 +406,7 @@ def get_session_user_localhosts():
     return localhosts
 
 
+@frappe.whitelist()
 def get_session_participant(hackathon: str) -> dict:
     """
     Get participant details of the current session user

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -49,6 +49,10 @@ class FOSSHackathonParticipant(Document):
             self.wants_to_attend_locally = False
 
     def handle_localhost_request(self):
+        prev_doc = self.get_doc_before_save()
+        if not prev_doc:
+            return
+
         if (
             frappe.db.get_value(
                 "User", frappe.session.user, "user_type"
@@ -61,7 +65,7 @@ class FOSSHackathonParticipant(Document):
             return
 
         if (
-            self.localhost == self.get_doc_before_save().localhost
+            self.localhost == prev_doc.localhost
         ) and self.localhost_request_status == "Rejected":
             frappe.throw(
                 "You have already been rejected from this localhost."


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🐛Bug Fix

## Description
<!-- Briefly describe the changes introduced by this pull request -->
- Crucial method not whitelisted. This results in errors when trying to change participation mode for hackathons 

## Related Issues & Docs
closes #483 
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
