### PR TITLE
Replacing FOSS User Profile with constant FOSS_USER_PROFILE

### DIFF
--- a/fossunited/api/dashboard.py
+++ b/fossunited/api/dashboard.py
@@ -1,6 +1,6 @@
 import frappe
 
-from fossunited.doctype_ids import FOSS_USER_PROFILE
+from fossunited.doctype_ids import USER_PROFILE
 from fossunited.utils.payments import (
     get_in_razorpay_money,
     get_razorpay_client,
@@ -102,7 +102,7 @@ def get_session_user_profile():
     Returns some basic information about the user profile.
     """
     user = frappe.db.get_value(
-        FOSS_USER_PROFILE,
+        USER_PROFILE,
         {"user": frappe.session.user},
         [
             "full_name",

--- a/fossunited/api/dashboard.py
+++ b/fossunited/api/dashboard.py
@@ -1,5 +1,6 @@
 import frappe
 
+from fossunited.doctype_ids import FOSS_USER_PROFILE
 from fossunited.utils.payments import (
     get_in_razorpay_money,
     get_razorpay_client,
@@ -101,7 +102,7 @@ def get_session_user_profile():
     Returns some basic information about the user profile.
     """
     user = frappe.db.get_value(
-        "FOSS User Profile",
+        FOSS_USER_PROFILE,
         {"user": frappe.session.user},
         [
             "full_name",

--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -4,8 +4,9 @@ APIs used for Hackathon based operations
 
 import frappe
 
+from fossunited.doctype_ids import USER_PROFILE
 from fossunited.integrations.github import GithubHelper
-from fossunited.doctype_ids import FOSS_USER_PROFILE
+
 
 @frappe.whitelist(allow_guest=True)
 def get_hackathon(name: str) -> dict:
@@ -298,10 +299,10 @@ def get_localhost_requests_by_team(
 
     for request in requests:
         request["profile_route"] = frappe.db.get_value(
-            FOSS_USER_PROFILE, request.user_profile, "route"
+            USER_PROFILE, request.user_profile, "route"
         )
         profile_photo = frappe.db.get_value(
-            FOSS_USER_PROFILE, request.user_profile, "profile_photo"
+            USER_PROFILE, request.user_profile, "profile_photo"
         )
         request["profile_photo"] = (
             profile_photo
@@ -309,7 +310,7 @@ def get_localhost_requests_by_team(
             else "/assets/fossunited/images/defaults/user_profile_image.png"
         )
         request["profile_username"] = frappe.db.get_value(
-            FOSS_USER_PROFILE, request.user_profile, "username"
+            USER_PROFILE, request.user_profile, "username"
         )
 
     requests_by_team = {}
@@ -399,7 +400,7 @@ def get_session_user_localhosts():
     """
 
     profile = frappe.db.get_value(
-        FOSS_USER_PROFILE, {"user": frappe.session.user}, "name"
+        USER_PROFILE, {"user": frappe.session.user}, "name"
     )
 
     localhosts = frappe.db.get_all(
@@ -567,7 +568,7 @@ def validate_user_as_localhost_member(localhost_id: str):
         {
             "parent": localhost_id,
             "profile": frappe.db.get_value(
-                FOSS_USER_PROFILE,
+                USER_PROFILE,
                 {"user": frappe.session.user},
                 "name",
             ),

--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -5,7 +5,7 @@ APIs used for Hackathon based operations
 import frappe
 
 from fossunited.integrations.github import GithubHelper
-
+from fossunited.doctype_ids import FOSS_USER_PROFILE
 
 @frappe.whitelist(allow_guest=True)
 def get_hackathon(name: str) -> dict:
@@ -298,10 +298,10 @@ def get_localhost_requests_by_team(
 
     for request in requests:
         request["profile_route"] = frappe.db.get_value(
-            "FOSS User Profile", request.user_profile, "route"
+            FOSS_USER_PROFILE, request.user_profile, "route"
         )
         profile_photo = frappe.db.get_value(
-            "FOSS User Profile", request.user_profile, "profile_photo"
+            FOSS_USER_PROFILE, request.user_profile, "profile_photo"
         )
         request["profile_photo"] = (
             profile_photo
@@ -309,7 +309,7 @@ def get_localhost_requests_by_team(
             else "/assets/fossunited/images/defaults/user_profile_image.png"
         )
         request["profile_username"] = frappe.db.get_value(
-            "FOSS User Profile", request.user_profile, "username"
+            FOSS_USER_PROFILE, request.user_profile, "username"
         )
 
     requests_by_team = {}
@@ -399,7 +399,7 @@ def get_session_user_localhosts():
     """
 
     profile = frappe.db.get_value(
-        "FOSS User Profile", {"user": frappe.session.user}, "name"
+        FOSS_USER_PROFILE, {"user": frappe.session.user}, "name"
     )
 
     localhosts = frappe.db.get_all(
@@ -567,7 +567,7 @@ def validate_user_as_localhost_member(localhost_id: str):
         {
             "parent": localhost_id,
             "profile": frappe.db.get_value(
-                "FOSS User Profile",
+                FOSS_USER_PROFILE,
                 {"user": frappe.session.user},
                 "name",
             ),

--- a/fossunited/api/profile.py
+++ b/fossunited/api/profile.py
@@ -3,6 +3,7 @@ from frappe.client import set_value
 from pydantic import BaseModel
 
 from fossunited.api.dashboard import get_session_user_profile
+from fossunited.doctype_ids import FOSS_USER_PROFILE
 
 
 @frappe.whitelist()
@@ -10,7 +11,7 @@ def set_profile_image(file_url):
     user_doc = get_session_user_profile()
     try:
         frappe.db.set_value(
-            "FOSS User Profile",
+            FOSS_USER_PROFILE,
             user_doc.name,
             "profile_photo",
             file_url,
@@ -25,7 +26,7 @@ def set_cover_image(file_url):
     user_doc = get_session_user_profile()
     try:
         frappe.db.set_value(
-            "FOSS User Profile",
+            FOSS_USER_PROFILE,
             user_doc.name,
             "cover_image",
             file_url,
@@ -40,7 +41,7 @@ def toggle_profile_privacy(value):
     user_doc = get_session_user_profile()
     try:
         frappe.db.set_value(
-            "FOSS User Profile", user_doc.name, "is_private", value
+            FOSS_USER_PROFILE, user_doc.name, "is_private", value
         )
         return True
     except Exception as e:
@@ -58,7 +59,7 @@ def update_profile(fields_dict):
 
     try:
         frappe.db.set_value(
-            "FOSS User Profile",
+            FOSS_USER_PROFILE,
             user_doc.name,
             {
                 "full_name": fields_dict.get("full_name"),
@@ -88,7 +89,7 @@ def is_unique_username(username, id):
     if (
         frappe.db.exists("FOSS Event Chapter", {"route": username})
         or frappe.db.exists(
-            "FOSS User Profile",
+            FOSS_USER_PROFILE,
             {"route": username, "name": ["!=", id]},
         )
         or frappe.db.exists(

--- a/fossunited/api/profile.py
+++ b/fossunited/api/profile.py
@@ -3,7 +3,7 @@ from frappe.client import set_value
 from pydantic import BaseModel
 
 from fossunited.api.dashboard import get_session_user_profile
-from fossunited.doctype_ids import FOSS_USER_PROFILE
+from fossunited.doctype_ids import USER_PROFILE
 
 
 @frappe.whitelist()
@@ -11,7 +11,7 @@ def set_profile_image(file_url):
     user_doc = get_session_user_profile()
     try:
         frappe.db.set_value(
-            FOSS_USER_PROFILE,
+            USER_PROFILE,
             user_doc.name,
             "profile_photo",
             file_url,
@@ -26,7 +26,7 @@ def set_cover_image(file_url):
     user_doc = get_session_user_profile()
     try:
         frappe.db.set_value(
-            FOSS_USER_PROFILE,
+            USER_PROFILE,
             user_doc.name,
             "cover_image",
             file_url,
@@ -41,7 +41,7 @@ def toggle_profile_privacy(value):
     user_doc = get_session_user_profile()
     try:
         frappe.db.set_value(
-            FOSS_USER_PROFILE, user_doc.name, "is_private", value
+            USER_PROFILE, user_doc.name, "is_private", value
         )
         return True
     except Exception as e:
@@ -59,7 +59,7 @@ def update_profile(fields_dict):
 
     try:
         frappe.db.set_value(
-            FOSS_USER_PROFILE,
+            USER_PROFILE,
             user_doc.name,
             {
                 "full_name": fields_dict.get("full_name"),
@@ -89,7 +89,7 @@ def is_unique_username(username, id):
     if (
         frappe.db.exists("FOSS Event Chapter", {"route": username})
         or frappe.db.exists(
-            FOSS_USER_PROFILE,
+            USER_PROFILE,
             {"route": username, "name": ["!=", id]},
         )
         or frappe.db.exists(

--- a/fossunited/chapters/doctype/conference_ticket/conference_ticket.py
+++ b/fossunited/chapters/doctype/conference_ticket/conference_ticket.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
-
 import json
 
 import frappe

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
@@ -4,7 +4,7 @@
 import frappe
 from frappe.website.website_generator import WebsiteGenerator
 
-from fossunited.doctype_ids import FOSS_USER_PROFILE
+from fossunited.doctype_ids import USER_PROFILE
 
 
 class FOSSChapter(WebsiteGenerator):
@@ -151,7 +151,7 @@ class FOSSChapter(WebsiteGenerator):
         members = []
         for member in self.chapter_members:
             profile = frappe.get_doc(
-                FOSS_USER_PROFILE, member.chapter_member
+                USER_PROFILE, member.chapter_member
             ).as_dict()
             members.append(
                 {

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
@@ -4,6 +4,8 @@
 import frappe
 from frappe.website.website_generator import WebsiteGenerator
 
+from fossunited.doctype_ids import FOSS_USER_PROFILE
+
 
 class FOSSChapter(WebsiteGenerator):
     # begin: auto-generated types
@@ -149,7 +151,7 @@ class FOSSChapter(WebsiteGenerator):
         members = []
         for member in self.chapter_members:
             profile = frappe.get_doc(
-                "FOSS User Profile", member.chapter_member
+                FOSS_USER_PROFILE, member.chapter_member
             ).as_dict()
             members.append(
                 {

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import frappe
 from frappe.website.website_generator import WebsiteGenerator
 
+from fossunited.doctype_ids import FOSS_USER_PROFILE
 from fossunited.fossunited.utils import is_user_team_member
 
 BASE_DATE = datetime.now().replace(
@@ -182,7 +183,7 @@ class FOSSChapterEvent(WebsiteGenerator):
         members = []
         for member in self.event_members:
             profile = frappe.get_doc(
-                "FOSS User Profile", member.member
+                FOSS_USER_PROFILE, member.member
             ).as_dict()
             members.append(
                 {
@@ -208,7 +209,7 @@ class FOSSChapterEvent(WebsiteGenerator):
         speakers = []
         for cfp in speaker_cfps:
             user = frappe.get_doc(
-                "FOSS User Profile", {"email": cfp.submitted_by}
+                FOSS_USER_PROFILE, {"email": cfp.submitted_by}
             )
             speakers.append(
                 {
@@ -405,7 +406,7 @@ class FOSSChapterEvent(WebsiteGenerator):
         for submission in submissions:
             if submission.status == "Approved":
                 user = frappe.get_doc(
-                    "FOSS User Profile",
+                    FOSS_USER_PROFILE,
                     {"email": submission.submitted_by},
                 )
                 submission["user_route"] = user.route
@@ -441,7 +442,7 @@ def get_speakers(schedule):
         "FOSS Event CFP Submission", schedule.linked_cfp
     )
     user = frappe.get_doc(
-        "FOSS User Profile", {"email": cfp.submitted_by}
+        FOSS_USER_PROFILE, {"email": cfp.submitted_by}
     )
     schedule.cfp_route = cfp.route
     schedule.speaker_route = user.route

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import frappe
 from frappe.website.website_generator import WebsiteGenerator
 
-from fossunited.doctype_ids import FOSS_USER_PROFILE
+from fossunited.doctype_ids import USER_PROFILE
 from fossunited.fossunited.utils import is_user_team_member
 
 BASE_DATE = datetime.now().replace(
@@ -183,7 +183,7 @@ class FOSSChapterEvent(WebsiteGenerator):
         members = []
         for member in self.event_members:
             profile = frappe.get_doc(
-                FOSS_USER_PROFILE, member.member
+                USER_PROFILE, member.member
             ).as_dict()
             members.append(
                 {
@@ -209,7 +209,7 @@ class FOSSChapterEvent(WebsiteGenerator):
         speakers = []
         for cfp in speaker_cfps:
             user = frappe.get_doc(
-                FOSS_USER_PROFILE, {"email": cfp.submitted_by}
+                USER_PROFILE, {"email": cfp.submitted_by}
             )
             speakers.append(
                 {
@@ -406,7 +406,7 @@ class FOSSChapterEvent(WebsiteGenerator):
         for submission in submissions:
             if submission.status == "Approved":
                 user = frappe.get_doc(
-                    FOSS_USER_PROFILE,
+                    USER_PROFILE,
                     {"email": submission.submitted_by},
                 )
                 submission["user_route"] = user.route
@@ -441,9 +441,7 @@ def get_speakers(schedule):
     cfp = frappe.get_doc(
         "FOSS Event CFP Submission", schedule.linked_cfp
     )
-    user = frappe.get_doc(
-        FOSS_USER_PROFILE, {"email": cfp.submitted_by}
-    )
+    user = frappe.get_doc(USER_PROFILE, {"email": cfp.submitted_by})
     schedule.cfp_route = cfp.route
     schedule.speaker_route = user.route
     schedule.speaker_full_name = user.full_name

--- a/fossunited/chapters/doctype/foss_chapter_event_member/foss_chapter_event_member.py
+++ b/fossunited/chapters/doctype/foss_chapter_event_member/foss_chapter_event_member.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
-
 from frappe.model.document import Document
 
 

--- a/fossunited/chapters/doctype/foss_chapter_event_member/test_foss_chapter_event_member.py
+++ b/fossunited/chapters/doctype/foss_chapter_event_member/test_foss_chapter_event_member.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and Contributors
 # See license.txt
-
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/chapters/doctype/foss_chapter_event_participant/test_foss_chapter_event_participant.py
+++ b/fossunited/chapters/doctype/foss_chapter_event_participant/test_foss_chapter_event_participant.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and Contributors
 # See license.txt
-
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/chapters/doctype/foss_chapter_lead_team_member/foss_chapter_lead_team_member.py
+++ b/fossunited/chapters/doctype/foss_chapter_lead_team_member/foss_chapter_lead_team_member.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
-
 from frappe.model.document import Document
 
 

--- a/fossunited/chapters/doctype/foss_event_community_partner/foss_event_community_partner.py
+++ b/fossunited/chapters/doctype/foss_event_community_partner/foss_event_community_partner.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
-
 from frappe.model.document import Document
 
 

--- a/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
-
 import json
 
 import frappe

--- a/fossunited/chapters/doctype/foss_event_rsvp/test_foss_event_rsvp.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp/test_foss_event_rsvp.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and Contributors
 # See license.txt
-
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/chapters/doctype/foss_event_type/foss_event_type.py
+++ b/fossunited/chapters/doctype/foss_event_type/foss_event_type.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
-
 from frappe.model.document import Document
 
 

--- a/fossunited/chapters/doctype/foss_event_type/test_foss_event_type.py
+++ b/fossunited/chapters/doctype/foss_event_type/test_foss_event_type.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and Contributors
 # See license.txt
-
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/doctype_ids.py
+++ b/fossunited/doctype_ids.py
@@ -1,0 +1,3 @@
+# Storing all the possible Doctype Identifiers in constants
+# FOSSUserProfile
+FOSS_USER_PROFILE = "FOSS User Profile"

--- a/fossunited/doctype_ids.py
+++ b/fossunited/doctype_ids.py
@@ -1,3 +1,3 @@
 # Storing all the possible Doctype Identifiers in constants
 # FOSSUserProfile
-FOSS_USER_PROFILE = "FOSS User Profile"
+USER_PROFILE = "FOSS User Profile"

--- a/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
@@ -5,6 +5,8 @@ from datetime import datetime
 import frappe
 from frappe.website.website_generator import WebsiteGenerator
 
+from fossunited.doctype_ids import FOSS_USER_PROFILE
+
 no_cache = 1
 
 BASE_DATE = datetime.now().replace(
@@ -137,7 +139,7 @@ def get_speakers(schedule):
         "FOSS Event CFP Submission", schedule.linked_cfp
     )
     user = frappe.get_doc(
-        "FOSS User Profile", {"email": cfp.submitted_by}
+        FOSS_USER_PROFILE, {"email": cfp.submitted_by}
     )
     schedule.cfp_route = cfp.route
     schedule.speaker_route = user.route

--- a/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import frappe
 from frappe.website.website_generator import WebsiteGenerator
 
-from fossunited.doctype_ids import FOSS_USER_PROFILE
+from fossunited.doctype_ids import USER_PROFILE
 
 no_cache = 1
 
@@ -138,9 +138,7 @@ def get_speakers(schedule):
     cfp = frappe.get_doc(
         "FOSS Event CFP Submission", schedule.linked_cfp
     )
-    user = frappe.get_doc(
-        FOSS_USER_PROFILE, {"email": cfp.submitted_by}
-    )
+    user = frappe.get_doc(USER_PROFILE, {"email": cfp.submitted_by})
     schedule.cfp_route = cfp.route
     schedule.speaker_route = user.route
     schedule.speaker_full_name = user.full_name

--- a/fossunited/foss_hackathon/doctype/foss_hackathon/test_foss_hackathon.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/test_foss_hackathon.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
-
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/test_foss_hackathon_join_team_request.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/test_foss_hackathon_join_team_request.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
-
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.py
@@ -3,7 +3,7 @@
 import frappe
 from frappe.model.document import Document
 
-from fossunited.doctype_ids import FOSS_USER_PROFILE
+from fossunited.doctype_ids import USER_PROFILE
 
 
 class FOSSHackathonLocalHost(Document):
@@ -48,7 +48,7 @@ class FOSSHackathonLocalHost(Document):
             user = frappe.get_doc(
                 "User",
                 frappe.db.get_value(
-                    FOSS_USER_PROFILE, member.profile, "user"
+                    USER_PROFILE, member.profile, "user"
                 ),
             )
             user.add_roles("Localhost Organizer")
@@ -76,7 +76,7 @@ class FOSSHackathonLocalHost(Document):
         user = frappe.get_doc(
             "User",
             frappe.db.get_value(
-                FOSS_USER_PROFILE, old_member.profile, "user"
+                USER_PROFILE, old_member.profile, "user"
             ),
         )
         user.remove_roles("Localhost Organizer")

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
-
 import frappe
 from frappe.model.document import Document
+
+from fossunited.doctype_ids import FOSS_USER_PROFILE
 
 
 class FOSSHackathonLocalHost(Document):
@@ -47,7 +48,7 @@ class FOSSHackathonLocalHost(Document):
             user = frappe.get_doc(
                 "User",
                 frappe.db.get_value(
-                    "FOSS User Profile", member.profile, "user"
+                    FOSS_USER_PROFILE, member.profile, "user"
                 ),
             )
             user.add_roles("Localhost Organizer")
@@ -75,7 +76,7 @@ class FOSSHackathonLocalHost(Document):
         user = frappe.get_doc(
             "User",
             frappe.db.get_value(
-                "FOSS User Profile", old_member.profile, "user"
+                FOSS_USER_PROFILE, old_member.profile, "user"
             ),
         )
         user.remove_roles("Localhost Organizer")

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/test_foss_hackathon_partner_project.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/test_foss_hackathon_partner_project.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
-
 from frappe.tests.utils import FrappeTestCase
 
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_project/foss_hackathon_project.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_project/foss_hackathon_project.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
-
 import frappe
 from frappe.website.website_generator import WebsiteGenerator
 
+from fossunited.doctype_ids import FOSS_USER_PROFILE
 from fossunited.fossunited.utils import get_doc_likes
 
 
@@ -71,7 +71,7 @@ def get_team_members(team):
             "user_profile",
         )
         profile = frappe.db.get_value(
-            "FOSS User Profile",
+            USER_PROFILE,
             profile_id,
             ["route", "full_name", "username", "profile_photo"],
             as_dict=True,

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_project/foss_hackathon_project.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_project/foss_hackathon_project.py
@@ -3,7 +3,7 @@
 import frappe
 from frappe.website.website_generator import WebsiteGenerator
 
-from fossunited.doctype_ids import FOSS_USER_PROFILE
+from fossunited.doctype_ids import USER_PROFILE
 from fossunited.fossunited.utils import get_doc_likes
 
 

--- a/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and Contributors
 # See license.txt
-
 import uuid
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
+
+from fossunited.doctype_ids import FOSS_USER_PROFILE
 
 
 class TestFOSSUserProfile(FrappeTestCase):
@@ -13,7 +14,7 @@ class TestFOSSUserProfile(FrappeTestCase):
         inserted_username = "wisharya"
         inserted_name = "wish arya"
         profile_exists = frappe.db.exists(
-            "FOSS User Profile", {"username": inserted_username}
+            FOSS_USER_PROFILE, {"username": inserted_username}
         )
         self.assertFalse(profile_exists)
 
@@ -34,7 +35,7 @@ class TestFOSSUserProfile(FrappeTestCase):
 
         # Then verify that the Profile has been stored as expected
         profile_exists = frappe.db.exists(
-            "FOSS User Profile", {"user": frappe_user.name}
+            FOSS_USER_PROFILE, {"user": frappe_user.name}
         )
 
         self.assertTrue(profile_exists)

--- a/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
@@ -5,7 +5,7 @@ import uuid
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from fossunited.doctype_ids import FOSS_USER_PROFILE
+from fossunited.doctype_ids import USER_PROFILE
 
 
 class TestFOSSUserProfile(FrappeTestCase):
@@ -14,7 +14,7 @@ class TestFOSSUserProfile(FrappeTestCase):
         inserted_username = "wisharya"
         inserted_name = "wish arya"
         profile_exists = frappe.db.exists(
-            FOSS_USER_PROFILE, {"username": inserted_username}
+            USER_PROFILE, {"username": inserted_username}
         )
         self.assertFalse(profile_exists)
 
@@ -35,7 +35,7 @@ class TestFOSSUserProfile(FrappeTestCase):
 
         # Then verify that the Profile has been stored as expected
         profile_exists = frappe.db.exists(
-            FOSS_USER_PROFILE, {"user": frappe_user.name}
+            USER_PROFILE, {"user": frappe_user.name}
         )
 
         self.assertTrue(profile_exists)

--- a/fossunited/fossunited/doctype/foss_custom_question/foss_custom_question.py
+++ b/fossunited/fossunited/doctype/foss_custom_question/foss_custom_question.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
-
 from frappe.model.document import Document
 
 

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -3,7 +3,7 @@
 import frappe
 from frappe.website.website_generator import WebsiteGenerator
 
-from fossunited.doctype_ids import FOSS_USER_PROFILE
+from fossunited.doctype_ids import USER_PROFILE
 from fossunited.fossunited.utils import (
     get_doc_likes,
     get_event_volunteers,
@@ -100,7 +100,7 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
             "FOSS Chapter Event", self.event
         )
         context.speaker = frappe.get_doc(
-            FOSS_USER_PROFILE, {"user": self.submitted_by}
+            USER_PROFILE, {"user": self.submitted_by}
         )
         context.likes = get_doc_likes(self.doctype, self.name)
         context.liked_by_user = frappe.session.user in context.likes
@@ -110,7 +110,7 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         ]
         context.nav_items = self.get_navbar_items(context)
         context.submitter_foss_profile = frappe.get_doc(
-            FOSS_USER_PROFILE, {"user": self.submitted_by}
+            USER_PROFILE, {"user": self.submitted_by}
         )
         context.review_statistics = self.get_review_statistics()
         context.reviews = self.get_reviews()

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
-
 import frappe
 from frappe.website.website_generator import WebsiteGenerator
 
+from fossunited.doctype_ids import FOSS_USER_PROFILE
 from fossunited.fossunited.utils import (
     get_doc_likes,
     get_event_volunteers,
@@ -100,7 +100,7 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
             "FOSS Chapter Event", self.event
         )
         context.speaker = frappe.get_doc(
-            "FOSS User Profile", {"user": self.submitted_by}
+            FOSS_USER_PROFILE, {"user": self.submitted_by}
         )
         context.likes = get_doc_likes(self.doctype, self.name)
         context.liked_by_user = frappe.session.user in context.likes
@@ -110,7 +110,7 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         ]
         context.nav_items = self.get_navbar_items(context)
         context.submitter_foss_profile = frappe.get_doc(
-            "FOSS User Profile", {"user": self.submitted_by}
+            FOSS_USER_PROFILE, {"user": self.submitted_by}
         )
         context.review_statistics = self.get_review_statistics()
         context.reviews = self.get_reviews()

--- a/fossunited/fossunited/doctype/foss_global_cfp_review_settings/foss_global_cfp_review_settings.py
+++ b/fossunited/fossunited/doctype/foss_global_cfp_review_settings/foss_global_cfp_review_settings.py
@@ -2,8 +2,9 @@
 # For license information, please see license.txt
 
 import frappe
-from document.doctype_ids import FOSS_USER_PROFILE
 from frappe.model.document import Document
+
+from fossunited.doctype_ids import USER_PROFILE
 
 
 class FOSSGlobalCFPReviewSettings(Document):
@@ -18,7 +19,7 @@ class FOSSGlobalCFPReviewSettings(Document):
             user = frappe.get_doc(
                 "User",
                 frappe.db.get_value(
-                    FOSS_USER_PROFILE, member.profile, "user"
+                    USER_PROFILE, member.profile, "user"
                 ),
             )
             user.add_roles("CFP Reviewer")
@@ -33,7 +34,7 @@ class FOSSGlobalCFPReviewSettings(Document):
                 user = frappe.get_doc(
                     "User",
                     frappe.db.get_value(
-                        FOSS_USER_PROFILE,
+                        USER_PROFILE,
                         member.profile,
                         "user",
                     ),

--- a/fossunited/fossunited/doctype/foss_global_cfp_review_settings/foss_global_cfp_review_settings.py
+++ b/fossunited/fossunited/doctype/foss_global_cfp_review_settings/foss_global_cfp_review_settings.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 
 import frappe
+from document.doctype_ids import FOSS_USER_PROFILE
 from frappe.model.document import Document
 
 
@@ -17,7 +18,7 @@ class FOSSGlobalCFPReviewSettings(Document):
             user = frappe.get_doc(
                 "User",
                 frappe.db.get_value(
-                    "FOSS User Profile", member.profile, "user"
+                    FOSS_USER_PROFILE, member.profile, "user"
                 ),
             )
             user.add_roles("CFP Reviewer")
@@ -32,7 +33,7 @@ class FOSSGlobalCFPReviewSettings(Document):
                 user = frappe.get_doc(
                     "User",
                     frappe.db.get_value(
-                        "FOSS User Profile",
+                        FOSS_USER_PROFILE,
                         member.profile,
                         "user",
                     ),

--- a/fossunited/fossunited/doctype/foss_global_cfp_review_settings/test_foss_global_cfp_review_settings.py
+++ b/fossunited/fossunited/doctype/foss_global_cfp_review_settings/test_foss_global_cfp_review_settings.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
-
 import frappe
 from frappe.tests.utils import FrappeTestCase
+
+from fossunited.doctype_ids import FOSS_USER_PROFILE
 
 
 class TestFOSSGlobalCFPReviewSettings(FrappeTestCase):
@@ -30,7 +31,7 @@ class TestFOSSGlobalCFPReviewSettings(FrappeTestCase):
         settings.insert()
 
         test_profile = frappe.get_doc(
-            "FOSS User Profile", {"user": "test1@example.com"}
+            FOSS_USER_PROFILE, {"user": "test1@example.com"}
         )
 
         # When a member is added to the members field
@@ -57,7 +58,7 @@ class TestFOSSGlobalCFPReviewSettings(FrappeTestCase):
         settings.insert()
 
         test_profile = frappe.get_doc(
-            "FOSS User Profile", {"user": "test2@example.com"}
+            FOSS_USER_PROFILE, {"user": "test2@example.com"}
         )
         settings.append("members", {"profile": test_profile.name})
         settings.save()

--- a/fossunited/fossunited/doctype/foss_global_cfp_review_settings/test_foss_global_cfp_review_settings.py
+++ b/fossunited/fossunited/doctype/foss_global_cfp_review_settings/test_foss_global_cfp_review_settings.py
@@ -3,7 +3,7 @@
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from fossunited.doctype_ids import FOSS_USER_PROFILE
+from fossunited.doctype_ids import USER_PROFILE
 
 
 class TestFOSSGlobalCFPReviewSettings(FrappeTestCase):
@@ -31,7 +31,7 @@ class TestFOSSGlobalCFPReviewSettings(FrappeTestCase):
         settings.insert()
 
         test_profile = frappe.get_doc(
-            FOSS_USER_PROFILE, {"user": "test1@example.com"}
+            USER_PROFILE, {"user": "test1@example.com"}
         )
 
         # When a member is added to the members field
@@ -58,7 +58,7 @@ class TestFOSSGlobalCFPReviewSettings(FrappeTestCase):
         settings.insert()
 
         test_profile = frappe.get_doc(
-            FOSS_USER_PROFILE, {"user": "test2@example.com"}
+            USER_PROFILE, {"user": "test2@example.com"}
         )
         settings.append("members", {"profile": test_profile.name})
         settings.save()

--- a/fossunited/fossunited/forms.py
+++ b/fossunited/fossunited/forms.py
@@ -2,7 +2,7 @@ import json
 
 import frappe
 
-from fossunited.doctype_ids import FOSS_USER_PROFILE
+from fossunited.doctype_ids import USER_PROFILE
 
 """
 Some utils and APIs for forms such as RSVP, CFP etc.
@@ -68,7 +68,7 @@ def post_review(submission, to_approve, remarks):
     :params remarks: Reviewer's remarks
     """
     reviewer = frappe.get_doc(
-        FOSS_USER_PROFILE, {"email": frappe.session.user}
+        USER_PROFILE, {"email": frappe.session.user}
     )
 
     submission_doc = frappe.get_doc(

--- a/fossunited/fossunited/forms.py
+++ b/fossunited/fossunited/forms.py
@@ -2,6 +2,8 @@ import json
 
 import frappe
 
+from fossunited.doctype_ids import FOSS_USER_PROFILE
+
 """
 Some utils and APIs for forms such as RSVP, CFP etc.
 """
@@ -66,7 +68,7 @@ def post_review(submission, to_approve, remarks):
     :params remarks: Reviewer's remarks
     """
     reviewer = frappe.get_doc(
-        "FOSS User Profile", {"email": frappe.session.user}
+        FOSS_USER_PROFILE, {"email": frappe.session.user}
     )
 
     submission_doc = frappe.get_doc(

--- a/fossunited/fossunited/user_utils.py
+++ b/fossunited/fossunited/user_utils.py
@@ -1,5 +1,7 @@
 import frappe
 
+from fossunited.doctype_ids import FOSS_USER_PROFILE
+
 
 def set_unique_username(doc, method):
     full_name = doc.full_name
@@ -13,12 +15,12 @@ def create_profile_on_user_create(doc, method):
     Automatically Create a FOSS User Profile on User Creation / Signup
     """
     if not frappe.db.exists(
-        "FOSS User Profile",
+        FOSS_USER_PROFILE,
         {"email": doc.email},
     ):
         profile = frappe.get_doc(
             {
-                "doctype": "FOSS User Profile",
+                "doctype": FOSS_USER_PROFILE,
                 "user": doc.name,
                 "full_name": doc.full_name,
                 "username": doc.username,
@@ -32,6 +34,6 @@ def generate_username(username, count=1):
     """
     Generate a Unique Username
     """
-    if frappe.db.exists("FOSS User Profile", {"username": username}):
+    if frappe.db.exists(FOSS_USER_PROFILE, {"username": username}):
         return generate_username(username + str(count), count + 1)
     return username

--- a/fossunited/fossunited/user_utils.py
+++ b/fossunited/fossunited/user_utils.py
@@ -1,6 +1,6 @@
 import frappe
 
-from fossunited.doctype_ids import FOSS_USER_PROFILE
+from fossunited.doctype_ids import USER_PROFILE
 
 
 def set_unique_username(doc, method):
@@ -15,12 +15,12 @@ def create_profile_on_user_create(doc, method):
     Automatically Create a FOSS User Profile on User Creation / Signup
     """
     if not frappe.db.exists(
-        FOSS_USER_PROFILE,
+        USER_PROFILE,
         {"email": doc.email},
     ):
         profile = frappe.get_doc(
             {
-                "doctype": FOSS_USER_PROFILE,
+                "doctype": USER_PROFILE,
                 "user": doc.name,
                 "full_name": doc.full_name,
                 "username": doc.username,
@@ -34,6 +34,6 @@ def generate_username(username, count=1):
     """
     Generate a Unique Username
     """
-    if frappe.db.exists(FOSS_USER_PROFILE, {"username": username}):
+    if frappe.db.exists(USER_PROFILE, {"username": username}):
         return generate_username(username + str(count), count + 1)
     return username

--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -5,6 +5,8 @@ from datetime import datetime
 import frappe
 from frappe.utils.data import now_datetime
 
+from fossunited.doctype_ids import FOSS_USER_PROFILE
+
 
 # Jinja Filter
 def get_profile_image(email):
@@ -102,7 +104,7 @@ def get_user_editable_doctype_fields(doctype, docname=None):
 
 
 def get_user_socials(foss_user):
-    user = frappe.get_doc("FOSS User Profile", foss_user).as_dict()
+    user = frappe.get_doc(FOSS_USER_PROFILE, foss_user).as_dict()
     SOCIAL_LINK_FIELDNAMES = [
         "github",
         "gitlab",
@@ -176,7 +178,7 @@ def get_signup_optin_checks():
 @frappe.whitelist(allow_guest=True)
 def check_username_availability(username):
     username_exists = frappe.db.exists(
-        "FOSS User Profile", {"username": username}
+        FOSS_USER_PROFILE, {"username": username}
     )
 
     is_cityname = frappe.db.exists("City", {"name": username})
@@ -186,7 +188,7 @@ def check_username_availability(username):
 @frappe.whitelist(allow_guest=True)
 def check_if_profile_owner(username):
     profile_user = frappe.get_doc(
-        "FOSS User Profile", {"username": username}
+        FOSS_USER_PROFILE, {"username": username}
     )
     return profile_user.user == frappe.session.user
 
@@ -197,7 +199,7 @@ def validate_profile_completion():
     Check if the user has completed their profile
     """
     return frappe.db.exists(
-        "FOSS User Profile",
+        FOSS_USER_PROFILE,
         {"email": frappe.session.user},
     )
 
@@ -295,4 +297,4 @@ def get_foss_profile(email):
     if email in ["guest@example.com", "admin@example.com"]:
         return None
 
-    return frappe.get_doc("FOSS User Profile", {"user": email})
+    return frappe.get_doc(FOSS_USER_PROFILE, {"user": email})

--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import frappe
 from frappe.utils.data import now_datetime
 
-from fossunited.doctype_ids import FOSS_USER_PROFILE
+from fossunited.doctype_ids import USER_PROFILE
 
 
 # Jinja Filter
@@ -104,7 +104,7 @@ def get_user_editable_doctype_fields(doctype, docname=None):
 
 
 def get_user_socials(foss_user):
-    user = frappe.get_doc(FOSS_USER_PROFILE, foss_user).as_dict()
+    user = frappe.get_doc(USER_PROFILE, foss_user).as_dict()
     SOCIAL_LINK_FIELDNAMES = [
         "github",
         "gitlab",
@@ -178,7 +178,7 @@ def get_signup_optin_checks():
 @frappe.whitelist(allow_guest=True)
 def check_username_availability(username):
     username_exists = frappe.db.exists(
-        FOSS_USER_PROFILE, {"username": username}
+        USER_PROFILE, {"username": username}
     )
 
     is_cityname = frappe.db.exists("City", {"name": username})
@@ -188,7 +188,7 @@ def check_username_availability(username):
 @frappe.whitelist(allow_guest=True)
 def check_if_profile_owner(username):
     profile_user = frappe.get_doc(
-        FOSS_USER_PROFILE, {"username": username}
+        USER_PROFILE, {"username": username}
     )
     return profile_user.user == frappe.session.user
 
@@ -199,7 +199,7 @@ def validate_profile_completion():
     Check if the user has completed their profile
     """
     return frappe.db.exists(
-        FOSS_USER_PROFILE,
+        USER_PROFILE,
         {"email": frappe.session.user},
     )
 
@@ -297,4 +297,4 @@ def get_foss_profile(email):
     if email in ["guest@example.com", "admin@example.com"]:
         return None
 
-    return frappe.get_doc(FOSS_USER_PROFILE, {"user": email})
+    return frappe.get_doc(USER_PROFILE, {"user": email})

--- a/fossunited/www/foss_profile/edit.py
+++ b/fossunited/www/foss_profile/edit.py
@@ -1,8 +1,10 @@
 import frappe
 
+from fossunited.doctype_ids import USER_PROFILE
+
 
 def get_context(context):
     context.foss_user = frappe.get_doc(
-        FOSS_USER_PROFILE,
+        USER_PROFILE,
         {"username": frappe.form_dict["foss_user"]},
     )

--- a/fossunited/www/foss_profile/edit.py
+++ b/fossunited/www/foss_profile/edit.py
@@ -3,6 +3,6 @@ import frappe
 
 def get_context(context):
     context.foss_user = frappe.get_doc(
-        "FOSS User Profile",
+        FOSS_USER_PROFILE,
         {"username": frappe.form_dict["foss_user"]},
     )

--- a/fossunited/www/me.py
+++ b/fossunited/www/me.py
@@ -1,5 +1,7 @@
 import frappe
 
+from fossunited.doctype_ids import FOSS_USER_PROFILE
+
 
 def get_context(context):
     if frappe.session.user == "Guest":
@@ -10,7 +12,7 @@ def get_context(context):
         frappe.local.flags.redirect_location = "/desk"
     else:
         redirect_route = frappe.db.get_value(
-            "FOSS User Profile",
+            FOSS_USER_PROFILE,
             {"email": frappe.session.user},
             "route",
         )

--- a/fossunited/www/me.py
+++ b/fossunited/www/me.py
@@ -1,6 +1,6 @@
 import frappe
 
-from fossunited.doctype_ids import FOSS_USER_PROFILE
+from fossunited.doctype_ids import USER_PROFILE
 
 
 def get_context(context):
@@ -12,7 +12,7 @@ def get_context(context):
         frappe.local.flags.redirect_location = "/desk"
     else:
         redirect_route = frappe.db.get_value(
-            FOSS_USER_PROFILE,
+            USER_PROFILE,
             {"email": frappe.session.user},
             "route",
         )


### PR DESCRIPTION
 Replacing FOSS User Profile with constant FOSS_USER_PROFILE #493 

## What type of PR is this? (check all applicable)
- [ ] 🍕Feature
- [x] ⚙️Chore
- [ ] 🐛Bug Fix
- [ ] 🎨Style
- [x] 🧑‍💻Refactor
- [ ] 📕Documentation
- [ ] 🏎️Optimization

## Description
This PR adds the doctype "FOSS User Profile" as a constant with FOSS_USER_PROFILE in the doctype_ids module and replaces "FOSS User Profile" in the codebase with the constant.

## Related Issues & Docs
#485 

## Screenshot 
![image](https://github.com/user-attachments/assets/d0145bc4-2d11-4053-81fc-b848b22c3220)

The FOSS User Profile works fine on the local