### PR TITLE
feat(rsvp): auto close rsvp on max submission count

### DIFF
--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
@@ -33,9 +33,6 @@ class FOSSEventRSVPSubmission(Document):
     # end: auto-generated types
     pass
 
-    def before_insert(self):
-        self.validate_form_published()
-
     def validate(self):
         self.validate_linked_rsvp_exists()
 
@@ -62,16 +59,6 @@ class FOSSEventRSVPSubmission(Document):
             "FOSS Event RSVP", self.linked_rsvp, "max_rsvp_count"
         )
         return max_count
-
-    def validate_form_published(self):
-        is_published = frappe.db.get_value(
-            "FOSS Event RSVP", self.linked_rsvp, "is_published"
-        )
-
-        if not is_published:
-            frappe.throw(
-                "RSVP form is closed", frappe.ValidationError
-            )
 
     def validate_linked_rsvp_exists(self):
         if not frappe.db.exists("FOSS Event RSVP", self.linked_rsvp):

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
@@ -33,8 +33,45 @@ class FOSSEventRSVPSubmission(Document):
     # end: auto-generated types
     pass
 
+    def before_insert(self):
+        self.validate_form_published()
+
     def validate(self):
         self.validate_linked_rsvp_exists()
+
+    def after_insert(self):
+        self.close_rsvp_on_max_count()
+
+    def close_rsvp_on_max_count(self):
+        max_count = self.get_max_count()
+        submission_count = frappe.db.count(
+            "FOSS Event RSVP Submission",
+            {"linked_rsvp": self.linked_rsvp},
+        )
+
+        if submission_count >= max_count:
+            frappe.db.set_value(
+                "FOSS Event RSVP",
+                self.linked_rsvp,
+                "is_published",
+                False,
+            )
+
+    def get_max_count(self):
+        max_count = frappe.db.get_value(
+            "FOSS Event RSVP", self.linked_rsvp, "max_rsvp_count"
+        )
+        return max_count
+
+    def validate_form_published(self):
+        is_published = frappe.db.get_value(
+            "FOSS Event RSVP", self.linked_rsvp, "is_published"
+        )
+
+        if not is_published:
+            frappe.throw(
+                "RSVP form is closed", frappe.ValidationError
+            )
 
     def validate_linked_rsvp_exists(self):
         if not frappe.db.exists("FOSS Event RSVP", self.linked_rsvp):

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
@@ -1,8 +1,90 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and Contributors
 # See license.txt
 
+from datetime import datetime, timedelta
+
+import frappe
+from faker import Faker
 from frappe.tests.utils import FrappeTestCase
 
 
+def create_event(event_type: str = "FOSS Meetup"):
+    if frappe.flags.test_event_created:
+        return
+
+    event = frappe.get_doc(
+        {
+            "doctype": "FOSS Chapter Event",
+            "event_name": "_Test_Event",
+            "event_permalink": "test-event-1234",
+            "status": "Live",
+            "event_type": event_type,
+            "event_start_date": datetime.today(),
+            "event_end_date": datetime.today() + timedelta(1),
+            "event_description": "testing",
+        }
+    )
+    event.insert()
+
+    frappe.flags.test_event_created = True
+
+
 class TestFOSSEventRSVPSubmission(FrappeTestCase):
-    pass
+    def setUp(self):
+        create_event
+        self.create_rsvp()
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+
+    def create_rsvp(self):
+        if frappe.flags.test_rsvp_created:
+            return
+
+        if not frappe.flags.test_event_created:
+            create_event()
+
+        event = frappe.db.get_value(
+            "FOSS Chapter Event",
+            {"event_name": "_Test_Event"},
+            "name",
+        )
+
+        rsvp = frappe.get_doc(
+            {
+                "doctype": "FOSS Event RSVP",
+                "event": event,
+                "max_rsvp_count": 5,
+            }
+        )
+        rsvp.insert()
+
+        self.test_rsvp_id = rsvp.name
+        frappe.flags.test_rsvp_created = True
+
+    def test_submission_on_unpublished_rsvp(self):
+        # Given an RSVP which is not published
+        rsvp = frappe.get_doc(
+            {
+                "doctype": "FOSS Event RSVP",
+                "max_rsvp_count": 5,
+                "is_published": False,
+            }
+        )
+        rsvp.insert()
+
+        # When a submission is made for this RSVP
+        # Then it should throw an error
+
+        fake = Faker()
+        with self.assertRaises(frappe.exceptions.ValidationError):
+            submission = frappe.get_doc(
+                {
+                    "doctype": "FOSS Event RSVP Submission",
+                    "linked_rsvp": rsvp.name,
+                    "name1": fake.name(),
+                    "email": fake.email(),
+                    "im_a": "Professional",
+                }
+            )
+            submission.insert()

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
@@ -9,49 +9,6 @@ from frappe.tests.utils import FrappeTestCase
 
 
 class TestFOSSEventRSVPSubmission(FrappeTestCase):
-    def test_submission_on_unpublished_rsvp(self):
-        # Given an RSVP which is not published
-
-        event = frappe.get_doc(
-            {
-                "doctype": "FOSS Chapter Event",
-                "event_name": "_Test_Event",
-                "event_permalink": "test-event-1234",
-                "status": "Live",
-                "event_type": "FOSS Meetup",
-                "event_start_date": datetime.today(),
-                "event_end_date": datetime.today() + timedelta(1),
-                "event_description": "testing",
-            }
-        )
-        event.insert()
-
-        rsvp = frappe.get_doc(
-            {
-                "doctype": "FOSS Event RSVP",
-                "max_rsvp_count": 5,
-                "is_published": False,
-                "event": event.name,
-            }
-        )
-        rsvp.insert()
-
-        # When a submission is made for this RSVP
-        # Then it should throw an error
-
-        fake = Faker()
-        with self.assertRaises(frappe.exceptions.ValidationError):
-            submission = frappe.get_doc(
-                {
-                    "doctype": "FOSS Event RSVP Submission",
-                    "linked_rsvp": rsvp.name,
-                    "name1": fake.name(),
-                    "email": fake.email(),
-                    "im_a": "Professional",
-                }
-            )
-            submission.insert()
-
     def test_unpublish_on_max_count(self):
         # Given an RSVP with max count of 5
         event = frappe.get_doc(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🍕Feature

## Description
<!-- Briefly describe the changes introduced by this pull request -->
- Until now, the `max_rsvp_count` was present just for statistics, and was not doing much. 
- Added a method in `after_save` controller of RSVP Submission doctype, such that, after every submission, the max count is checked with the count of rsvp submissions for that particular event. If `submission_count >= max_rsvp_count` the RSVP form is unpublished.
- ~Also added a function that validates if the rsvp form is published. If not, the user is not allowed to create a submission and an error gets thrown.~
- Added test for testing form unpublish when max submission count is hit.

## Related Issues & Docs
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

closes #482 
