### PR TITLE
feat: cfp reviewer dashboard

### DIFF
--- a/dashboard/src/components/Breadcrumb.vue
+++ b/dashboard/src/components/Breadcrumb.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="flex gap-1 items-center">
+    <div
+      v-for="(item, index) in items"
+      class="text-base flex gap-1 items-center my-2"
+      :class="index == items.length - 1 ? 'font-medium text-gray-800' : 'text-gray-600 '"
+    >
+      <router-link v-if="item.route" class="hover:text-gray-700 transition-colors" :to="item.route">
+        {{ item.label }}
+      </router-link>
+      <span v-else>
+        {{ item.label }}
+      </span>
+      <span v-if="index !== items.length - 1">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          class="icon icon-tabler h-4 w-4 icons-tabler-outline icon-tabler-chevron-right"
+        >
+          <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+          <path d="M9 6l6 6l-6 6" />
+        </svg>
+      </span>
+    </div>
+  </div>
+</template>
+<script setup>
+import { defineProps, ref } from 'vue'
+
+const props = defineProps({
+  items: {
+    type: Array,
+    required: true,
+  },
+})
+</script>

--- a/dashboard/src/components/RefreshButton.vue
+++ b/dashboard/src/components/RefreshButton.vue
@@ -1,0 +1,28 @@
+<template>
+  <Button>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      class="icon icon-tabler w-4 h-4 icons-tabler-outline icon-tabler-refresh"
+      :class="inSpin ? 'animate-spin' : ''"
+    >
+      <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+      <path d="M20 11a8.1 8.1 0 0 0 -15.5 -2m-.5 -4v4h4" />
+      <path d="M4 13a8.1 8.1 0 0 0 15.5 2m.5 4v-4h-4" />
+    </svg>
+  </Button>
+</template>
+<script setup>
+import { defineProps } from 'vue';
+
+defineProps({
+  inSpin: Boolean,
+});
+</script>

--- a/dashboard/src/components/reviewers/ProposalsList.vue
+++ b/dashboard/src/components/reviewers/ProposalsList.vue
@@ -2,35 +2,41 @@
   <div v-if="cfp_submissions.data">
     <div class="flex flex-col gap-2">
       <div class="text-base font-medium">Filters</div>
-      <div class="flex gap-4 mb-5">
-        <div class="flex gap-2 items-center">
-          <label class="text-sm">Status:</label>
-          <select
-            class="border-none text-sm px-4 rounded w-44 h-fit items-center flex flex-col bg-gray-100 border-2"
-            v-model="selectedStatusFilter"
-          >
-            <option
-              v-for="(filter, index) in statusFilters"
-              @click="filterByStatus(filter)"
+      <div class="flex justify-between">
+        <div class="flex gap-4 mb-5">
+          <div class="flex gap-2 items-center">
+            <label class="text-sm">Status:</label>
+            <select
+              class="border-none text-sm px-4 rounded w-44 h-fit items-center flex flex-col bg-gray-100 border-2"
+              v-model="selectedStatusFilter"
             >
-              {{ filter.label }}
-            </option>
-          </select>
-        </div>
-        <div v-if="selectedStatusFilter=='Reviewed'" class="flex gap-2 items-center">
-          <label class="text-sm">Review Filter:</label>
-          <select
-            class="border-none text-sm px-4 rounded w-44 h-fit items-center flex flex-col bg-gray-100 border-2"
-            v-model="selectedToApproveFilter"
-          >
-            <option
-              v-for="(filter, index) in toApproveFilter"
-              @click="filterByToApprove(filter)"
+              <option
+                v-for="(filter, index) in statusFilters"
+                @click="filterByStatus(filter)"
+              >
+                {{ filter.label }}
+              </option>
+            </select>
+          </div>
+          <div v-if="selectedStatusFilter=='Reviewed'" class="flex gap-2 items-center">
+            <label class="text-sm">Review Filter:</label>
+            <select
+              class="border-none text-sm px-4 rounded w-44 h-fit items-center flex flex-col bg-gray-100 border-2"
+              v-model="selectedToApproveFilter"
             >
-              {{ filter.label }}
-            </option>
-          </select>
+              <option
+                v-for="(filter, index) in toApproveFilter"
+                @click="filterByToApprove(filter)"
+              >
+                {{ filter.label }}
+              </option>
+            </select>
+          </div>
         </div>
+        <RefreshButton
+          @click="cfp_submissions.fetch"
+          :inSpin="cfp_submissions.loading"
+        />
       </div>
     </div>
     <ListView
@@ -103,6 +109,7 @@
 import { defineProps, ref } from 'vue'
 import { createResource, ListView, Badge } from 'frappe-ui'
 import { useRouter } from 'vue-router'
+import RefreshButton from '@/components/RefreshButton.vue'
 
 const router = useRouter()
 

--- a/dashboard/src/components/reviewers/ProposalsList.vue
+++ b/dashboard/src/components/reviewers/ProposalsList.vue
@@ -60,14 +60,7 @@
         selectable: false,
         showTooltip: true,
         resizeColumn: true,
-        onRowClick: (row) => {
-          $router.push({
-            name: 'SubmissionPage',
-            params: {
-              talk_id: row.name,
-            },
-          })
-        },
+        onRowClick: (row) => (openSubmission(row)),
         emptyState: {
           title: 'No Submissions',
           description: 'No submissions found.',
@@ -76,7 +69,7 @@
     >
       <template #cell="{ item, row, column }">
         <div v-if="column.label == 'Status'">
-          <Badge :theme="item == 'Reviewed' ? 'green' : 'gray'" :label="item" />
+          <Badge :theme="item == 'Reviewed' ? 'blue' : 'gray'" :label="item" />
         </div>
         <div v-else-if="column.label == 'Review'">
           <Badge
@@ -109,6 +102,9 @@
 <script setup>
 import { defineProps, ref } from 'vue'
 import { createResource, ListView, Badge } from 'frappe-ui'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
 
 const props = defineProps({
   event: {
@@ -150,6 +146,16 @@ const toApproveFilter = [
     value: ['Maybe'],
   },
 ]
+
+const openSubmission = (row) => {
+  let routeData =  router.resolve({
+    name: 'SubmissionPage',
+    params: {
+      talk_id: row.name,
+    },
+  })
+  window.open(routeData.href, '_blank')
+}
 
 const selectedStatusFilter = ref(statusFilters[0].label)
 const selectedToApproveFilter = ref(toApproveFilter[0].label)

--- a/dashboard/src/components/reviewers/ProposalsList.vue
+++ b/dashboard/src/components/reviewers/ProposalsList.vue
@@ -1,0 +1,186 @@
+<template>
+  <div v-if="cfp_submissions.data">
+    <div class="flex flex-col gap-2">
+      <div class="text-base font-medium">Filters</div>
+      <div class="flex gap-4 mb-5">
+        <div class="flex gap-2 items-center">
+          <label class="text-sm">Status:</label>
+          <select
+            class="border-none text-sm px-4 rounded w-44 h-fit items-center flex flex-col bg-gray-100 border-2"
+            v-model="selectedStatusFilter"
+          >
+            <option
+              v-for="(filter, index) in statusFilters"
+              @click="filterByStatus(filter)"
+            >
+              {{ filter.label }}
+            </option>
+          </select>
+        </div>
+        <div v-if="selectedStatusFilter=='Reviewed'" class="flex gap-2 items-center">
+          <label class="text-sm">Review Filter:</label>
+          <select
+            class="border-none text-sm px-4 rounded w-44 h-fit items-center flex flex-col bg-gray-100 border-2"
+            v-model="selectedToApproveFilter"
+          >
+            <option
+              v-for="(filter, index) in toApproveFilter"
+              @click="filterByToApprove(filter)"
+            >
+              {{ filter.label }}
+            </option>
+          </select>
+        </div>
+      </div>
+    </div>
+    <ListView
+      class="h-[480px]"
+      :columns="[
+        {
+          label: 'Talk Title',
+          key: 'talk_title',
+        },
+        {
+          label: 'Status',
+          key: 'review_status',
+          width: 1 / 2,
+        },
+        {
+          label: 'Review',
+          key: 'reviewer_status',
+        },
+        {
+          label: 'Remarks',
+          key: 'reviewer_remarks',
+        },
+      ]"
+      :rows="cfp_submissions.data"
+      row-key="name"
+      :options="{
+        selectable: false,
+        showTooltip: true,
+        resizeColumn: true,
+        onRowClick: (row) => {
+          $router.push({
+            name: 'SubmissionPage',
+            params: {
+              talk_id: row.name,
+            },
+          })
+        },
+        emptyState: {
+          title: 'No Submissions',
+          description: 'No submissions found.',
+        }
+      }"
+    >
+      <template #cell="{ item, row, column }">
+        <div v-if="column.label == 'Status'">
+          <Badge :theme="item == 'Reviewed' ? 'green' : 'gray'" :label="item" />
+        </div>
+        <div v-else-if="column.label == 'Review'">
+          <Badge
+            v-if="item"
+            :theme="
+              item == 'Yes'
+                ? 'green'
+                : item == 'Maybe'
+                  ? 'orange'
+                  : item == 'No'
+                    ? 'red'
+                    : 'gray'
+            "
+          >
+            {{ { Yes: 'Approved', No: 'Reject', Maybe: 'Not Sure' }[item] }}
+          </Badge>
+          <div v-else class="text-sm text-gray-500">-</div>
+        </div>
+        <div v-else-if="column.label == 'Remarks'">
+          <div v-if="item" class="text-sm truncate">{{ item }}</div>
+          <div v-else class="text-sm text-gray-500">-</div>
+        </div>
+        <div v-else class="text-base truncate">
+          {{ item }}
+        </div>
+      </template>
+    </ListView>
+  </div>
+</template>
+<script setup>
+import { defineProps, ref } from 'vue'
+import { createResource, ListView, Badge } from 'frappe-ui'
+
+const props = defineProps({
+  event: {
+    type: String,
+    required: true,
+  },
+})
+
+const statusFilters = [
+  {
+    label: 'All',
+    value: ['Reviewed', 'Not Reviewed'],
+  },
+  {
+    label: 'Reviewed',
+    value: ['Reviewed'],
+  },
+  {
+    label: 'Not Reviewed',
+    value: ['Not Reviewed'],
+  },
+]
+
+const toApproveFilter = [
+  {
+    label: 'All',
+    value: ['Yes', 'No', 'Maybe'],
+  },
+  {
+    label: 'Approved',
+    value: ['Yes'],
+  },
+  {
+    label: 'Rejected',
+    value: ['No'],
+  },
+  {
+    label: 'Not Sure',
+    value: ['Maybe'],
+  },
+]
+
+const selectedStatusFilter = ref(statusFilters[0].label)
+const selectedToApproveFilter = ref(toApproveFilter[0].label)
+
+const cfp_submissions = createResource({
+  url: 'fossunited.api.reviewer.get_cfp_submissions_by_reviewer_status',
+  params: {
+    event: props.event,
+  },
+  auto: true,
+})
+
+const filterByStatus = (filter) => {
+  selectedToApproveFilter.value = toApproveFilter[0].label
+  cfp_submissions.update({
+    params: {
+      event: props.event,
+      status_filter: filter.value,
+    }
+  })
+  cfp_submissions.fetch()
+}
+
+const filterByToApprove = (filter) => {
+  cfp_submissions.update({
+    params: {
+      event: props.event,
+      status_filter: ['Reviewed'],
+      to_approve_filter: filter.value,
+    }
+  })
+  cfp_submissions.fetch()
+}
+</script>

--- a/dashboard/src/components/reviewers/ProposalsList.vue
+++ b/dashboard/src/components/reviewers/ProposalsList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="cfp_submissions.data">
+  <div v-if="cfpSubmissions.data">
     <div class="flex flex-col gap-2">
       <div class="text-base font-medium">Filters</div>
       <div class="flex justify-between">
@@ -34,8 +34,8 @@
           </div>
         </div>
         <RefreshButton
-          @click="cfp_submissions.fetch"
-          :inSpin="cfp_submissions.loading"
+          @click="cfpSubmissions.fetch"
+          :inSpin="cfpSubmissions.loading"
         />
       </div>
     </div>
@@ -60,7 +60,7 @@
           key: 'reviewer_remarks',
         },
       ]"
-      :rows="cfp_submissions.data"
+      :rows="cfpSubmissions.data"
       row-key="name"
       :options="{
         selectable: false,
@@ -167,7 +167,7 @@ const openSubmission = (row) => {
 const selectedStatusFilter = ref(statusFilters[0].label)
 const selectedToApproveFilter = ref(toApproveFilter[0].label)
 
-const cfp_submissions = createResource({
+const cfpSubmissions = createResource({
   url: 'fossunited.api.reviewer.get_cfp_submissions_by_reviewer_status',
   params: {
     event: props.event,
@@ -177,23 +177,23 @@ const cfp_submissions = createResource({
 
 const filterByStatus = (filter) => {
   selectedToApproveFilter.value = toApproveFilter[0].label
-  cfp_submissions.update({
+  cfpSubmissions.update({
     params: {
       event: props.event,
       status_filter: filter.value,
     }
   })
-  cfp_submissions.fetch()
+  cfpSubmissions.fetch()
 }
 
 const filterByToApprove = (filter) => {
-  cfp_submissions.update({
+  cfpSubmissions.update({
     params: {
       event: props.event,
       status_filter: ['Reviewed'],
       to_approve_filter: filter.value,
     }
   })
-  cfp_submissions.fetch()
+  cfpSubmissions.fetch()
 }
 </script>

--- a/dashboard/src/components/reviewers/ReviewSection.vue
+++ b/dashboard/src/components/reviewers/ReviewSection.vue
@@ -1,0 +1,176 @@
+<template>
+  <div class="prose min-w-full">
+    <h2 class="mb-2">Your Review</h2>
+    <div v-if="in_review_edit" class="flex flex-col gap-2">
+      <RadioGroup v-model="selectedReviewOption">
+        <RadioGroupLabel class="text-sm uppercase">Your Review</RadioGroupLabel>
+        <div class="flex gap-2 my-1">
+          <RadioGroupOption
+            v-slot="{ checked }"
+            v-for="option in reviewOptions"
+            :key="option.value"
+            :value="option"
+          >
+            <Button
+              :label="option.label"
+              :variant="checked ? 'solid' : 'outline'"
+              size="md"
+            />
+          </RadioGroupOption>
+        </div>
+      </RadioGroup>
+      <FormControl
+        label="Remarks"
+        v-model="newRemarks"
+        type="textarea"
+        placeholder="Enter your remarks here"
+      />
+      <ErrorMessage :message="errors" />
+      <Button
+        class="w-fit"
+        :label="reviewData.data ? 'Update Review' : 'Submit Review'"
+        @click="handleReviewSubmit"
+      />
+    </div>
+    <div v-else>
+      <div
+        v-if="hasReviewed.data && reviewData.data"
+        class="text-base flex flex-col gap-4"
+      >
+        <div>
+          <span>Your Review: </span>
+          <span
+            class="font-medium"
+            :class="
+              {
+                Yes: 'text-green-600',
+                No: 'text-red-600',
+                Maybe: 'text-orange-600',
+              }[selectedReviewOption.value]
+            "
+            >{{ selectedReviewOption.label }}</span
+          >
+        </div>
+        <div class="flex flex-col gap-2">
+          <div class="text-md font-semibold">Remarks</div>
+          <div>{{ reviewData.data.remarks }}</div>
+        </div>
+        <Button label="Edit Review" @click="in_review_edit = true" class="w-fit" size="sm"/>
+      </div>
+      <div v-else>
+        <LoadingIndicator class="w-6 h-6" />
+      </div>
+    </div>
+  </div>
+</template>
+<script setup>
+import { createResource, LoadingIndicator, FormControl, ErrorMessage } from 'frappe-ui'
+import { defineProps, inject, ref } from 'vue'
+import { useRoute } from 'vue-router'
+import { RadioGroup, RadioGroupLabel, RadioGroupOption } from '@headlessui/vue'
+
+const props = defineProps({
+  submission: Object,
+})
+const route = useRoute()
+const session = inject('$session')
+
+const in_review_edit = ref(false)
+const reviewOptions = ref([
+  { value: 'Yes', label: 'Approve' },
+  { value: 'No', label: 'Reject' },
+  { value: 'Maybe', label: 'Unsure' },
+])
+const newRemarks = ref('')
+const errors = ref('')
+
+const selectedReviewOption = ref(reviewOptions.value[0])
+
+const hasReviewed = createResource({
+  url: 'fossunited.api.reviewer.has_cfp_review',
+  makeParams() {
+    return {
+      submission_id: route.params.talk_id,
+    }
+  },
+  onSuccess(data) {
+    if (!data) {
+        in_review_edit.value = true
+      return
+    }
+    reviewData.fetch()
+  },
+  auto: true,
+})
+
+const reviewData = createResource({
+  url: 'fossunited.api.reviewer.get_review',
+  makeParams() {
+    return {
+      submission_id: route.params.talk_id,
+    }
+  },
+  onSuccess(data) {
+    newRemarks.value = data.remarks
+    selectedReviewOption.value = reviewOptions.value.find(
+      (option) => option.value == data.to_approve,
+    )
+  },
+})
+
+const handleReviewSubmit = () => {
+    if(!selectedReviewOption.value){
+        errors.value = 'Please select a review option'
+        return
+    }
+
+    if (reviewData.data){
+        updateReview()
+        return
+    }
+
+    submitReview()
+}
+
+const updateReview = () => {
+    createResource({
+        url: 'frappe.client.set_value',
+        makeParams() {
+            return {
+                doctype: 'FOSS Event CFP Review',
+                name: reviewData.data.name,
+                fieldname: {
+                    to_approve: selectedReviewOption.value.value,
+                    remarks: newRemarks.value,
+                },
+            }
+        },
+        auto: true,
+        onSuccess() {
+            in_review_edit.value = false
+            reviewData.fetch()
+        },
+        onError(error) {
+            errors.value = 'Failed to update review'
+        },
+    })
+}
+
+const submitReview = () => {
+    createResource({
+        url: 'fossunited.api.reviewer.submit_review',
+        makeParams(){
+            return {
+                submission_id: route.params.talk_id,
+                to_approve: selectedReviewOption.value.value,
+                remarks: newRemarks.value,
+            }
+        },
+        auto: true,
+        onSuccess() {
+            in_review_edit.value = false
+            hasReviewed.fetch()
+        },
+    })
+}
+</script>

--- a/dashboard/src/components/reviewers/ReviewSection.vue
+++ b/dashboard/src/components/reviewers/ReviewSection.vue
@@ -53,7 +53,7 @@
         </div>
         <div class="flex flex-col gap-2">
           <div class="text-md font-semibold">Remarks</div>
-          <div>{{ reviewData.data.remarks }}</div>
+          <div>{{ reviewData.data.remarks || 'No remarks.'}}</div>
         </div>
         <Button label="Edit Review" @click="in_review_edit = true" class="w-fit" size="sm"/>
       </div>

--- a/dashboard/src/pages/reviewers/MyReviews.vue
+++ b/dashboard/src/pages/reviewers/MyReviews.vue
@@ -2,8 +2,8 @@
   <div v-if="events.data" class="p-4">
     <div class="prose">
       <div class="prose pb-0">
-        <h2 class="mb-1">My LocalHosts</h2>
-        <p class="text-sm mb-4">Keep a track of localhosts you organize.</p>
+        <h2 class="mb-1">Review Talks</h2>
+        <p class="text-sm mb-4">List of all upcoming events with proposal forms.</p>
       </div>
     </div>
     <div

--- a/dashboard/src/pages/reviewers/MyReviews.vue
+++ b/dashboard/src/pages/reviewers/MyReviews.vue
@@ -1,0 +1,59 @@
+<template>
+  <div v-if="events.data" class="p-4">
+    <div class="prose">
+      <div class="prose pb-0">
+        <h2 class="mb-1">My LocalHosts</h2>
+        <p class="text-sm mb-4">Keep a track of localhosts you organize.</p>
+      </div>
+    </div>
+    <div
+      v-if="events.data.length > 0"
+      class="mt-6 grid grid-cols-1 md:grid-cols-3 gap-4"
+    >
+      <Card
+        v-for="event in events.data"
+        :title="event.event_name"
+        class="border-2 border-transparent !rounded-[8px] hover:border-gray-500 transition-colors hover:cursor-pointer"
+        @click="$router.push('/review/' + event.event)"
+      >
+        <template #actions>
+          <Tooltip text="Total Submissions">
+            <div class="text-base px-3 py-1 bg-gray-100 rounded-sm">
+              <span>{{ event.submission_count }}</span>
+            </div>
+          </Tooltip>
+        </template>
+        <div class="flex justify-between items-end">
+          <span class="text-sm">{{ event.chapter_name }}</span>
+          <div class="text-sm text-gray-600">
+            <span>{{ formatDate(event.start_date) }}</span>
+            <span v-if="formatDate(event.start_date) != formatDate(event.end_date)"> - {{ formatDate(event.end_date) }}</span>
+          </div>
+        </div>
+      </Card>
+    </div>
+    <div v-else class="flex flex-col gap-2 rounded-sm p-4 border bg-gray-50">
+      <div class="text-sm font-medium uppercase text-gray-800">
+        No Call For Proposals
+      </div>
+      <div class="text-xs text-gray-600">
+        There are no CFPs open right now. There are no talks to review.
+      </div>
+    </div>
+  </div>
+</template>
+<script setup>
+import { createResource, Tooltip } from 'frappe-ui'
+
+const events = createResource({
+  url: 'fossunited.api.reviewer.get_events_by_open_cfp',
+  auto: true,
+})
+
+const formatDate = (date) => {
+  return new Date(date).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  })
+}
+</script>

--- a/dashboard/src/pages/reviewers/ReviewPage.vue
+++ b/dashboard/src/pages/reviewers/ReviewPage.vue
@@ -1,0 +1,97 @@
+<template>
+  <Header />
+  <div class="w-full flex flex-col items-center" v-if="event.doc">
+    <div class="max-w-screen-xl p-4 w-full">
+      <a
+        href="/"
+        class="text-base hover:underline flex items-center gap-1 my-4"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          class="icon icon-tabler w-5 h-5 icons-tabler-outline icon-tabler-arrow-left"
+        >
+          <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+          <path d="M5 12l14 0" />
+          <path d="M5 12l6 6" />
+          <path d="M5 12l6 -6" />
+        </svg>
+        <span> Go to Dashboard </span>
+      </a>
+      <div class="prose my-5">
+        <h1 class="m-0">CFP Review</h1>
+        <p class="mt-1">Review the session proposals for this event.</p>
+      </div>
+      <hr class="mb-6" />
+      <div class="my-6">
+        <EventHeader :event="event" />
+        <a
+          class="text-sm flex gap-1 my-4 hover:underline"
+          target="_blank"
+          :href="redirectToRoute(event.doc.route)"
+        >
+          <span> Go to Event Page </span>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            class="icon icon-tabler w-4 h-4 icons-tabler-outline icon-tabler-arrow-up-right"
+          >
+            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+            <path d="M17 7l-10 10" />
+            <path d="M8 7l9 0l0 9" />
+          </svg>
+        </a>
+      </div>
+      <div class="my-2">
+        <ProposalList :event="event.doc.name" />
+      </div>
+    </div>
+  </div>
+</template>
+<script setup>
+import {
+  createResource,
+  createDocumentResource,
+  createListResource,
+  usePageMeta,
+  ListView,
+} from 'frappe-ui'
+import { ref } from 'vue'
+import { useRoute } from 'vue-router'
+import EventHeader from '@/components/EventHeader.vue'
+import Header from '@/components/Header.vue'
+import ProposalList from '@/components/reviewers/ProposalsList.vue'
+
+const route = useRoute()
+
+usePageMeta(() => {
+  return {
+    title: 'CFP Review',
+  }
+})
+
+const event = createDocumentResource({
+  doctype: 'FOSS Chapter Event',
+  name: route.params.id,
+  fields: ['*'],
+  auto: true,
+})
+
+const redirectToRoute = (route) => {
+  return `${window.location.origin}/${route}`
+}
+</script>

--- a/dashboard/src/pages/reviewers/ReviewPage.vue
+++ b/dashboard/src/pages/reviewers/ReviewPage.vue
@@ -3,7 +3,7 @@
   <div class="w-full flex flex-col items-center" v-if="event.doc">
     <div class="max-w-screen-xl p-4 w-full">
       <a
-        href="/"
+        href="/dashboard/review"
         class="text-base hover:underline flex items-center gap-1 my-4"
       >
         <svg

--- a/dashboard/src/pages/reviewers/SubmissionPage.vue
+++ b/dashboard/src/pages/reviewers/SubmissionPage.vue
@@ -213,7 +213,7 @@ const breadcrumb_items = computed(() => {
   return [
     {
       label: 'CFP Review',
-      route: '/',
+      route: '/review',
     },
     {
       label: submission.data.event_name,

--- a/dashboard/src/pages/reviewers/SubmissionPage.vue
+++ b/dashboard/src/pages/reviewers/SubmissionPage.vue
@@ -1,0 +1,227 @@
+<template>
+  <Header />
+  <div class="w-full flex flex-col items-center" v-if="submission.data">
+    <div class="max-w-screen-xl p-4 w-full">
+      <Breadcrumb class="mb-5" :items="breadcrumb_items" />
+      <div class="flex flex-col gap-2">
+        <div class="prose">
+          <h1 class="text-[2rem]">{{ submission.data.talk_title }}</h1>
+        </div>
+        <div class="flex flex-wrap gap-2 md:gap-4 items-center mt-0 mb-2">
+          <Tooltip text="This is the first talk submitted by the speaker">
+            <Badge label="First Talk" variant="outline" size="lg" class="p-1">
+              <template #prefix>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class="icon icon-tabler h-4 w-4 icons-tabler-outline icon-tabler-sparkles"
+                >
+                  <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                  <path
+                    d="M16 18a2 2 0 0 1 2 2a2 2 0 0 1 2 -2a2 2 0 0 1 -2 -2a2 2 0 0 1 -2 2zm0 -12a2 2 0 0 1 2 2a2 2 0 0 1 2 -2a2 2 0 0 1 -2 -2a2 2 0 0 1 -2 2zm-7 12a6 6 0 0 1 6 -6a6 6 0 0 1 -6 -6a6 6 0 0 1 -6 6a6 6 0 0 1 6 6z"
+                  />
+                </svg>
+              </template>
+            </Badge>
+          </Tooltip>
+          <span class="text-sm uppercase">{{
+            submission.data.session_type
+          }}</span>
+        </div>
+        <a
+          class="text-sm uppercase text-green-700 cursor-pointer font-medium hover:underline flex items-center gap-1"
+          :href="submission.data.talk_reference"
+          target="_blank"
+        >
+          <span>View Session Reference</span>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="#000000"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            class="icon icon-tabler stroke-green-700 h-4 w-4 icons-tabler-outline icon-tabler-external-link"
+          >
+            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+            <path
+              d="M12 6h-6a2 2 0 0 0 -2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-6"
+            />
+            <path d="M11 13l9 -9" />
+            <path d="M15 4h5v5" />
+          </svg>
+        </a>
+      </div>
+      <div class="my-6 flex flex-col gap-4">
+        <div class="prose min-w-full">
+          <h3 class="-mb-4">Description</h3>
+          <div class="my-2" v-html="submission.data.talk_description"></div>
+        </div>
+        <div
+          class="prose min-w-full"
+          v-if="!cfp_settings.data?.anonymise_proposals"
+        >
+          <h3>About Speaker</h3>
+          <div class="flex flex-col gap-2 items-start">
+            <div class="flex gap-4 -mb-2">
+              <img
+                :src="submission.data.picture_url"
+                class="w-12 h-12 rounded m-0"
+              />
+              <div class="flex flex-col gap-2">
+                <h5 class="text-lg font-medium">
+                  {{ submission.data.full_name }}
+                </h5>
+                <div
+                  class="flex flex-wrap items-center gap-2 divide-x-2 divide-gray-600"
+                >
+                  <span class="text-sm">{{ submission.data.designation }}</span>
+                  <span class="text-sm pl-2">{{
+                    submission.data.organization
+                  }}</span>
+                </div>
+              </div>
+            </div>
+            <div
+              v-html="submission.data.bio"
+              class="text-base text-gray-600"
+            ></div>
+          </div>
+        </div>
+        <ReviewSection :submission="submission" />
+      </div>
+    </div>
+  </div>
+  <div v-else class="w-full h-screen flex items-center justify-center">
+    <LoadingIndicator class="w-6 h-6" />
+  </div>
+</template>
+<script setup>
+import { useRoute } from 'vue-router'
+import {
+  createResource,
+  LoadingIndicator,
+  Badge,
+  usePageMeta,
+  Tooltip,
+} from 'frappe-ui'
+import { computed, ref } from 'vue'
+import { toast } from 'vue-sonner'
+import Header from '@/components/Header.vue'
+import Breadcrumb from '@/components/Breadcrumb.vue'
+import ReviewSection from '@/components/reviewers/ReviewSection.vue'
+
+const route = useRoute()
+
+const fields_to_fetch = ref([
+  'name',
+  'linked_cfp',
+  'route',
+  'is_published',
+  'status',
+  'event',
+  'event_name',
+  'is_first_talk',
+  'session_type',
+  'talk_title',
+  'talk_reference',
+  'talk_description',
+  'custom_answers',
+  'positive_reviews',
+  'negative_reviews',
+  'unsure_reviews',
+  'approvability',
+])
+
+const cfp_settings = createResource({
+  url: 'frappe.client.get_value',
+  makeParams() {
+    return {
+      doctype: 'FOSS Event CFP',
+      filters: { event: route.params.id },
+      fieldname: [
+        'allow_cfp_edit',
+        'anonymise_proposals',
+        'cfp_reviewers',
+        'only_talk_proposals',
+        'only_workshops',
+      ],
+    }
+  },
+  onSuccess(data) {
+    if (!data.anonymise_proposals) {
+      fields_to_fetch.value.push(
+        ...['full_name', 'bio', 'designation', 'organization', 'picture_url'],
+      )
+    }
+    submission.fetch()
+  },
+  auto: true,
+})
+
+const submission = createResource({
+  url: 'frappe.client.get_value',
+  makeParams() {
+    return {
+      doctype: 'FOSS Event CFP Submission',
+      filters: {
+        name: route.params.talk_id,
+      },
+      fieldname: fields_to_fetch.value,
+    }
+  },
+  onSuccess(data) {
+    let is_anonymous = new Boolean(cfp_settings.data.anonymise_proposals)
+    if (!is_anonymous) {
+      submitter_profile.fetch()
+    }
+  },
+  onError(error) {
+    toast.error('Failed to fetch submission details')
+  },
+})
+
+const submitter_profile = createResource({
+  url: 'fossunited.api.reviewer.get_submitter_profile',
+  makeParams() {
+    return {
+      submission_id: submission.data.name,
+    }
+  },
+  onError(error) {
+    toast.error('Failed to fetch submitter profile')
+  },
+})
+
+usePageMeta(() => {
+  return {
+    title: `Review - ${submission.data?.talk_title}`,
+  }
+})
+
+const breadcrumb_items = computed(() => {
+  return [
+    {
+      label: 'CFP Review',
+      route: '/',
+    },
+    {
+      label: submission.data.event_name,
+      route: { name: 'ReviewPage', params: { id: submission.data.event } },
+    },
+    {
+      label: submission.data.talk_title,
+    },
+  ]
+})
+</script>

--- a/dashboard/src/router.js
+++ b/dashboard/src/router.js
@@ -60,6 +60,21 @@ const routes = [
     ],
   },
   {
+    path: '/review/:id',
+    children: [
+      {
+        path: '',
+        name: 'ReviewPage',
+        component: () => import('@/pages/reviewers/ReviewPage.vue'),
+      },
+      {
+        path: 'talk/:talk_id',
+        name: 'SubmissionPage',
+        component: () => import('@/pages/reviewers/SubmissionPage.vue'),
+      }
+    ]
+  },
+  {
     name: 'Event',
     path: '/event/:id',
     component: () => import('@/pages/Event.vue'),

--- a/dashboard/src/router.js
+++ b/dashboard/src/router.js
@@ -29,6 +29,11 @@ const routes = [
         name: 'MyChapters',
         component: () => import('@/pages/MyChapters.vue'),
       },
+      {
+        path: '/review',
+        name: 'MyReviews',
+        component: () => import('@/pages/reviewers/MyReviews.vue'),
+      },
     ]
   },
   {

--- a/fossunited/api/dashboard.py
+++ b/fossunited/api/dashboard.py
@@ -131,3 +131,26 @@ def get_session_user_profile():
     )
 
     return user
+
+
+@frappe.whitelist()
+def get_profile_data(username: str = None, email: str = None) -> dict:
+    """
+    Returns the profile data of the given username.
+    """
+    if not username and not email:
+        frappe.throw("Username or email is required")
+
+    user = frappe.db.get_value(
+        "FOSS User Profile",
+        {"user": username, "email": email or ""},
+        [
+            "full_name",
+            "username",
+            "profile_photo",
+            "route",
+        ],
+        as_dict=1,
+    )
+
+    return user

--- a/fossunited/api/reviewer.py
+++ b/fossunited/api/reviewer.py
@@ -49,7 +49,7 @@ def get_event_cfp_submissions(event: str) -> list:
 
     submissions = frappe.db.get_list(
         "FOSS Event CFP Submission",
-        filters={"event": event},
+        filters={"event": event, "status": "Review Pending"},
         fields=fields,
         order_by="creation desc",
     )

--- a/fossunited/api/reviewer.py
+++ b/fossunited/api/reviewer.py
@@ -1,0 +1,72 @@
+import frappe
+
+
+def get_event_cfp_submissions(event: str):
+    submissions = frappe.db.get_list(
+        "FOSS Event CFP Submission",
+        filters={"event": event},
+        fields=["*"],
+        order_by="creation desc",
+    )
+
+    return submissions
+
+
+@frappe.whitelist()
+def get_cfp_submissions_by_reviewer_status(
+    event: str,
+    status_filter: list = ["Reviewed", "Not Reviewed"],
+    to_approve_filter: list = ["Yes", "No", "Maybe"],
+):
+    if not has_reviewer_role():
+        frappe.throw("Unauthorized Access")
+
+    submissions_list = []
+
+    submissions = get_event_cfp_submissions(event)
+
+    reviewer = frappe.db.get_value(
+        "FOSS User Profile", {"user": frappe.session.user}, "name"
+    )
+
+    for submission in submissions:
+        if not frappe.db.exists(
+            "FOSS Event CFP Review",
+            {
+                "parent": submission.name,
+                "reviewer": reviewer,
+                "parenttype": "FOSS Event CFP Submission",
+            },
+        ):
+            if "Not Reviewed" in status_filter:
+                submission["review_status"] = "Not Reviewed"
+                submission["status"] = "-"
+                submission["remarks"] = "-"
+                submissions_list.append(submission)
+            continue
+
+        if "Reviewed" in status_filter:
+            review = frappe.get_doc(
+                "FOSS Event CFP Review",
+                {
+                    "parent": submission.name,
+                    "reviewer": reviewer,
+                    "parenttype": "FOSS Event CFP Submission",
+                },
+            )
+            if review.to_approve in to_approve_filter:
+                submission["review_status"] = "Reviewed"
+                submission["reviewer_status"] = review.to_approve
+                submission["reviewer_remarks"] = review.remarks
+                submissions_list.append(submission)
+
+    return submissions_list
+
+
+def has_reviewer_role():
+    return bool(
+        frappe.db.exists(
+            "Has Role",
+            {"role": "CFP Reviewer", "parent": frappe.session.user},
+        )
+    )

--- a/fossunited/api/reviewer.py
+++ b/fossunited/api/reviewer.py
@@ -1,11 +1,56 @@
 import frappe
 
+from fossunited.api.dashboard import get_profile_data
 
-def get_event_cfp_submissions(event: str):
+
+def get_event_cfp_submissions(event: str) -> list:
+    """
+    Get all the submissions for the given event
+
+    Args:
+        event (str): The id of the event
+
+    Returns:
+        list: List of submissions for the given event
+    """
+    fields = [
+        "name",
+        "linked_cfp",
+        "route",
+        "is_published",
+        "title",
+        "status",
+        "event",
+        "event_name",
+        "is_first_talk",
+        "session_type",
+        "talk_title",
+        "talk_reference",
+        "talk_description",
+        "custom_answers",
+        "positive_reviews",
+        "negative_reviews",
+        "unsure_reviews",
+        "approvability",
+    ]
+
+    is_cfp_anonymous = frappe.db.get_value(
+        "FOSS Event CFP", {"event": event}, "anonymise_proposals"
+    )
+
+    if not is_cfp_anonymous:
+        fields += [
+            "full_name",
+            "picture_url",
+            "designation",
+            "organization",
+            "bio",
+        ]
+
     submissions = frappe.db.get_list(
         "FOSS Event CFP Submission",
         filters={"event": event},
-        fields=["*"],
+        fields=fields,
         order_by="creation desc",
     )
 
@@ -34,7 +79,7 @@ def get_cfp_submissions_by_reviewer_status(
             "FOSS Event CFP Review",
             {
                 "parent": submission.name,
-                "reviewer": reviewer,
+                "reviewer_profile": reviewer,
                 "parenttype": "FOSS Event CFP Submission",
             },
         ):
@@ -49,9 +94,9 @@ def get_cfp_submissions_by_reviewer_status(
             review = frappe.get_doc(
                 "FOSS Event CFP Review",
                 {
-                    "parent": submission.name,
-                    "reviewer": reviewer,
                     "parenttype": "FOSS Event CFP Submission",
+                    "parent": submission.name,
+                    "reviewer_profile": reviewer,
                 },
             )
             if review.to_approve in to_approve_filter:
@@ -70,3 +115,127 @@ def has_reviewer_role():
             {"role": "CFP Reviewer", "parent": frappe.session.user},
         )
     )
+
+
+@frappe.whitelist()
+def has_cfp_review(
+    submission_id: str, reviewer: str = frappe.session.user
+) -> bool:
+    """
+    Check if the reviewer has reviewed the submission
+
+    Args:
+        submission_id (str): The id of the submission
+        reviewer (str): The reviewer's email
+
+    Returns:
+        bool: True if the reviewer has reviewed the submission, False otherwise
+    """
+
+    reviewer_profile = frappe.db.get_value(
+        "FOSS User Profile", {"email": reviewer}, "name"
+    )
+
+    return bool(
+        frappe.db.exists(
+            "FOSS Event CFP Review",
+            {
+                "parent": submission_id,
+                "reviewer_profile": reviewer_profile,
+                "parenttype": "FOSS Event CFP Submission",
+            },
+        )
+    )
+
+
+@frappe.whitelist()
+def get_review(
+    submission_id: str, reviewer: str = frappe.session.user
+) -> dict:
+    """
+    Get the review of the submission by the reviewer
+
+    Args:
+        submission_id (str): The id of the submission
+        reviewer (str): The reviewer's email
+
+    Returns:
+        dict: The review of the submission by the reviewer
+    """
+    if not has_cfp_review(submission_id, reviewer):
+        frappe.throw("No review found")
+
+    reviewer_profile = frappe.db.get_value(
+        "FOSS User Profile", {"email": reviewer}, "name"
+    )
+
+    review = frappe.db.get_value(
+        "FOSS Event CFP Review",
+        {
+            "parent": submission_id,
+            "reviewer_profile": reviewer_profile,
+            "parenttype": "FOSS Event CFP Submission",
+        },
+        ["to_approve", "remarks", "name", "reviewer_profile"],
+        as_dict=1,
+    )
+
+    return review
+
+
+@frappe.whitelist()
+def submit_review(
+    submission_id: str,
+    remarks: str,
+    to_approve: str,
+    reviewer: str = frappe.session.user,
+) -> None:
+    """
+    Create a review for the submission
+
+    Args:
+        submission_id (str): The id of the submission
+        remarks (str): The reviewer's remarks
+        to_approve (str): The reviewer's decision
+        reviewer (str): The reviewer's email
+    """
+    if not has_reviewer_role():
+        frappe.throw("Unauthorized Access")
+
+    if has_cfp_review(submission_id, reviewer):
+        frappe.throw("Review already exists")
+
+    reviewer_profile = frappe.db.get_value(
+        "FOSS User Profile", {"email": reviewer}, "name"
+    )
+
+    submission_doc = frappe.get_doc(
+        "FOSS Event CFP Submission", submission_id
+    )
+
+    submission_doc.append(
+        "reviews",
+        {
+            "reviewer_profile": reviewer_profile,
+            "to_approve": to_approve,
+            "remarks": remarks,
+        },
+    )
+    submission_doc.save(ignore_permissions=True)
+
+
+@frappe.whitelist()
+def get_submitter_profile(submission_id: str) -> dict:
+    """
+    Returns the profile of the submitter of the CFP submission.
+    """
+    submitter_email = frappe.db.get_value(
+        "FOSS Event CFP Submission", submission_id, ["submitted_by"]
+    )
+
+    if not submitter_email:
+        frappe.throw("Submitter email not found")
+
+    user = get_profile_data(email=submitter_email)
+
+    return user

--- a/fossunited/api/sidebar.py
+++ b/fossunited/api/sidebar.py
@@ -3,6 +3,8 @@ import frappe
 
 @frappe.whitelist(allow_guest=True)
 def get_sidebar_items():
+    is_reviewer = user_is_cfp_reviewer()
+
     sidebar_items = [
         {
             "parent_label": "Profile",
@@ -45,6 +47,19 @@ def get_sidebar_items():
             }
         )
 
+    if is_reviewer:
+        sidebar_items.append(
+            {
+                "parent_label": "CFP Reviewer",
+                "items": [
+                    {
+                        "label": "Review Proposals",
+                        "route": "/review",
+                    },
+                ],
+            }
+        )
+
     return sidebar_items
 
 
@@ -62,5 +77,14 @@ def user_is_localhost_organizer(user: str = frappe.session.user):
         frappe.db.exists(
             "Has Role",
             {"role": "Localhost Organizer", "parent": user},
+        )
+    )
+
+
+def user_is_cfp_reviewer(user: str = frappe.session.user):
+    return bool(
+        frappe.db.exists(
+            "Has Role",
+            {"role": "CFP Reviewer", "parent": user},
         )
     )

--- a/fossunited/fossunited/doctype/foss_event_cfp_review/foss_event_cfp_review.json
+++ b/fossunited/fossunited/doctype/foss_event_cfp_review/foss_event_cfp_review.json
@@ -7,6 +7,7 @@
  "engine": "InnoDB",
  "field_order": [
   "reviewer",
+  "reviewer_profile",
   "email",
   "to_approve",
   "remarks"
@@ -15,7 +16,6 @@
   {
    "fieldname": "reviewer",
    "fieldtype": "Data",
-   "in_list_view": 1,
    "label": "Reviewer"
   },
   {
@@ -36,12 +36,19 @@
    "label": "To Approve?",
    "options": "\nYes\nNo\nMaybe",
    "reqd": 1
+  },
+  {
+   "fieldname": "reviewer_profile",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Reviewer Profile",
+   "options": "FOSS User Profile"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-08 00:23:40.587456",
+ "modified": "2024-07-31 14:20:03.666303",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "FOSS Event CFP Review",

--- a/fossunited/fossunited/doctype/foss_event_cfp_review/foss_event_cfp_review.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_review/foss_event_cfp_review.py
@@ -5,4 +5,21 @@ from frappe.model.document import Document
 
 
 class FOSSEventCFPReview(Document):
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        email: DF.Data | None
+        parent: DF.Data
+        parentfield: DF.Data
+        parenttype: DF.Data
+        remarks: DF.SmallText | None
+        reviewer: DF.Data | None
+        reviewer_profile: DF.Link | None
+        to_approve: DF.Literal["", "Yes", "No", "Maybe"]
+    # end: auto-generated types
     pass

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.json
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.json
@@ -181,8 +181,7 @@
    "fieldname": "reviews",
    "fieldtype": "Table",
    "label": "Reviews",
-   "options": "FOSS Event CFP Review",
-   "permlevel": 1
+   "options": "FOSS Event CFP Review"
   },
   {
    "fieldname": "route",
@@ -232,20 +231,17 @@
   {
    "fieldname": "positive_reviews",
    "fieldtype": "Data",
-   "label": "Positive Reviews %",
-   "permlevel": 1
+   "label": "Positive Reviews %"
   },
   {
    "fieldname": "negative_reviews",
    "fieldtype": "Data",
-   "label": "Negative Reviews  %",
-   "permlevel": 1
+   "label": "Negative Reviews  %"
   },
   {
    "fieldname": "unsure_reviews",
    "fieldtype": "Data",
-   "label": "Unsure Reviews  %",
-   "permlevel": 1
+   "label": "Unsure Reviews  %"
   },
   {
    "fieldname": "column_break_fnih",
@@ -254,8 +250,7 @@
   {
    "fieldname": "approvability",
    "fieldtype": "Data",
-   "label": "Approvability  %",
-   "permlevel": 1
+   "label": "Approvability  %"
   },
   {
    "columns": 2,
@@ -295,7 +290,7 @@
  "has_web_view": 1,
  "is_published_field": "is_published",
  "links": [],
- "modified": "2024-07-11 12:21:24.738519",
+ "modified": "2024-07-31 14:06:54.643071",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "FOSS Event CFP Submission",
@@ -335,15 +330,10 @@
    "write": 1
   },
   {
+   "create": 1,
    "read": 1,
    "role": "CFP Reviewer",
    "select": 1,
-   "write": 1
-  },
-  {
-   "permlevel": 1,
-   "read": 1,
-   "role": "CFP Reviewer",
    "write": 1
   }
  ],


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🍕Feature

## Description
<!-- Briefly describe the changes introduced by this pull request -->
- Added a CFP Reviewer Dashboard, so that the users having a `CFP Reviewer` role can find all the talks for an event at a central place.
- Better reactivity with Vue
- Edit / Create Review
- See talk details directly in the dashboard
- Filter using Status: whether reviewed or not & Status : Accept , Reject , Unsure


## Related Issues & Docs
#416 Related discussion

## Screenshots/GIFs/Screen Recordings (if applicable)

#### Dashboard Event CFP Page
![image](https://github.com/user-attachments/assets/2d32afa1-e99f-46af-8d31-d4f9dfd3c890)

#### Listing Page
![image](https://github.com/user-attachments/assets/1448a5ea-f6c9-4243-8e09-9a38e2bb6ee4)

#### Submission Page
![image](https://github.com/user-attachments/assets/e81645d9-d3ff-4ccf-a61b-de5b9dbff118)
![image](https://github.com/user-attachments/assets/15b23e72-9c68-4f79-b147-7eb186e1c349)

#### Render details when CFP not anonymous
![image](https://github.com/user-attachments/assets/6e7bb824-7205-4131-be0c-e10af20dc8ea)
