### PR TITLE
fix: weird tab behaviour in RSVP and CFP sections

### DIFF
--- a/dashboard/src/components/AppSidebar.vue
+++ b/dashboard/src/components/AppSidebar.vue
@@ -15,7 +15,7 @@
     </div>
     <div class="my-4">
       <router-link
-        to="/"
+        to="/chapter"
         class="p-2 flex font-medium gap-2 text-base rounded-sm text-gray-800 hover:underline hover:text-gray-900"
       >
         <FeatherIcon name="arrow-left" class="h-4" />

--- a/dashboard/src/components/EventCard.vue
+++ b/dashboard/src/components/EventCard.vue
@@ -2,7 +2,7 @@
   <Card
     :title="event.event_name"
     class="border-2 border-transparent hover:border-gray-500 transition-colors hover:cursor-pointer"
-    @click="() => $router.replace(`/event/${event.name}`)"
+    @click="() => $router.push(`/event/${event.name}`)"
   >
     <div class="flex justify-between">
       <div class="text-sm font-medium">

--- a/dashboard/src/components/NewAppSidebar.vue
+++ b/dashboard/src/components/NewAppSidebar.vue
@@ -1,36 +1,37 @@
 <template>
   <div
-    v-if="nav_items.data"
     class="relative block min-h-0 flex-shrink-0 overflow-hidden hover:overflow-auto"
   >
     <div class="fixed flex min-h-screen w-[220px] flex-col border-r bg-gray-50">
       <div class="p-4">
-        <!-- <FOSSUnitedLogo class="w-16 h-12" fill="black"></FOSSUnitedLogo> -->
         <div class="font-fff text-gray-900 uppercase">FOSS United</div>
         <div class="text-sm mt-2 tracking-wider text-gray-700 uppercase">
           Dashboard
         </div>
       </div>
-      <div class="flex flex-col gap-2 px-4 my-2" v-if="nav_items.data">
-        <div v-for="group in nav_items.data" class="my-1">
+      <div class="text-lg font-semibold uppercase px-4 mt-4" v-if="title">{{ title }}</div>
+      <div class="flex flex-col gap-2 px-4 my-2" v-if="menuItems.length > 0">
+        <div v-for="group in menuItems" class="my-1">
           <div
             class="text-xs text-gray-600 font-medium uppercase tracking-wide"
+            v-if="group.parent_label"
           >
             {{ group.parent_label }}
           </div>
-          <div class="flex flex-col my-1 text-gray-600">
+          <div class="flex flex-col my-1 gap-2 text-gray-700">
             <router-link
               v-for="(item, index) in group.items"
               :key="item.label"
               :to="item.route"
-              class="w-full text-sm rounded-sm p-2 hover:bg-gray-100"
+              class="w-full text-sm flex items-center gap-1 rounded-sm p-2 hover:bg-gray-100 transition-colors "
               :class="
                 isMenuItemActive(item.route, index)
                   ? 'font-medium text-gray-900 bg-gray-100'
                   : ''
               "
             >
-              {{ item.label }}
+              <FeatherIcon class="w-4 h-4" v-if="item.icon" :name="item.icon"/>
+              <span>{{ item.label }}</span>
             </router-link>
           </div>
         </div>
@@ -39,15 +40,21 @@
   </div>
 </template>
 <script setup>
-import FOSSUnitedLogo from '@/components/FossUnitedLogo.vue'
-import { createResource } from 'frappe-ui'
+import { createResource, FeatherIcon } from 'frappe-ui'
 import { useRoute } from 'vue-router'
+import { defineProps } from 'vue'
 
 const route = useRoute()
 
-const nav_items = createResource({
-  url: 'fossunited.api.sidebar.get_sidebar_items',
-  auto: true,
+const props = defineProps({
+  title: {
+    type: String,
+  },
+  menuItems: {
+    type: Array,
+    required: true,
+    default: () => [],
+  },
 })
 
 const isMenuItemActive = (menuRoute, index) => {

--- a/dashboard/src/pages/Chapter.vue
+++ b/dashboard/src/pages/Chapter.vue
@@ -1,33 +1,58 @@
 <template>
-  <Header />
   <div class="flex">
-    <AppSideBar
-      title="MANAGE CHAPTER"
+    <SideNavbar
+      title="Manage Chapter"
       :menuItems="sidebarMenuItems"
-    ></AppSideBar>
-    <RouterView />
+      :class="showNav ? 'z-50 block mt-[55px]' : 'hidden md:block'"
+    />
+    <div class="w-full md:ml-[220px]">
+      <HeaderWithNav @toggleSidebar="($event) => (showNav = $event)" />
+      <RouterView />
+    </div>
   </div>
 </template>
 
 <script setup>
-import AppSideBar from '@/components/AppSidebar.vue'
-import Header from '@/components/Header.vue'
+import { ref } from 'vue'
+import { usePageMeta } from 'frappe-ui'
 import { useRoute, RouterView } from 'vue-router'
+import SideNavbar from '@/components/NewAppSidebar.vue'
+import HeaderWithNav from '@/components/HeaderWithNav.vue'
 
 const route = useRoute()
+const showNav = ref(false)
 
 const sidebarMenuItems = [
   {
-    label: 'Details',
-    route: `/chapter/${route.params.id}`,
+    items: [
+      {
+        icon: 'arrow-left',
+        label: 'Go Home',
+        route: '/chapter',
+      },
+    ],
   },
   {
-    label: 'Events',
-    route: `/chapter/${route.params.id}/events`,
-  },
-  {
-    label: 'Members',
-    route: `/chapter/${route.params.id}/members`,
+    items: [
+      {
+        label: 'Details',
+        route: `/chapter/${route.params.id}`,
+      },
+      {
+        label: 'Events',
+        route: `/chapter/${route.params.id}/events`,
+      },
+      {
+        label: 'Members',
+        route: `/chapter/${route.params.id}/members`,
+      },
+    ],
   },
 ]
+
+usePageMeta(() => {
+  return {
+    title: 'Manage Chapter',
+  }
+})
 </script>

--- a/dashboard/src/pages/Event.vue
+++ b/dashboard/src/pages/Event.vue
@@ -28,7 +28,7 @@ const sidebarMenuItems = [
     items: [
       {
         icon: 'arrow-left',
-        label: 'Go to Dashboard',
+        label: 'Go Home',
         route: '/chapter'
       }
     ]

--- a/dashboard/src/pages/Event.vue
+++ b/dashboard/src/pages/Event.vue
@@ -1,35 +1,57 @@
 <template>
-  <Header />
   <div class="flex">
-    <AppSidebar title="MANAGE EVENT" :menuItems="sidebarMenuItems" />
-    <RouterView />
+    <SideNavbar
+      title="Manage Event"
+      :menuItems="sidebarMenuItems"
+      :class="showNav ? 'z-50 block mt-[55px]' : 'hidden md:block'"
+    />
+    <div class="w-full md:ml-[220px]">
+      <HeaderWithNav @toggleSidebar="($event) => (showNav = $event)" />
+      <RouterView />
+    </div>
   </div>
 </template>
 
 <script setup>
-import { RouterView, useRoute } from 'vue-router'
-import Header from '@/components/Header.vue'
-import AppSidebar from '@/components/AppSidebar.vue'
+import { ref } from 'vue'
 import { usePageMeta } from 'frappe-ui'
+import { RouterView, useRoute } from 'vue-router'
+import SideNavbar from '@/components/NewAppSidebar.vue'
+import HeaderWithNav from '@/components/HeaderWithNav.vue'
 
 const route = useRoute()
 
+const showNav = ref(false)
+
 const sidebarMenuItems = [
   {
-    label: 'Details',
-    route: `/event/${route.params.id}`,
+    items: [
+      {
+        icon: 'arrow-left',
+        label: 'Go to Dashboard',
+        route: '/chapter'
+      }
+    ]
   },
   {
-    label: 'RSVP',
-    route: `/event/${route.params.id}/rsvp`,
-  },
-  {
-    label: 'CFP',
-    route: `/event/${route.params.id}/cfp`,
-  },
-  {
-    label: 'Volunteers',
-    route: `/event/${route.params.id}/volunteers`,
+    items: [
+      {
+        label: 'Details',
+        route: `/event/${route.params.id}`,
+      },
+      {
+        label: 'RSVP',
+        route: `/event/${route.params.id}/rsvp`,
+      },
+      {
+        label: 'CFP',
+        route: `/event/${route.params.id}/cfp`,
+      },
+      {
+        label: 'Volunteers',
+        route: `/event/${route.params.id}/volunteers`,
+      },
+    ],
   },
 ]
 

--- a/dashboard/src/pages/EventCfp.vue
+++ b/dashboard/src/pages/EventCfp.vue
@@ -4,12 +4,12 @@
       <EventHeader
         class=""
         :event="event"
-        :form_exists="new Boolean(has_cfp.data)"
-        :form="event_cfp"
+        :form_exists="Boolean(hasCfp.data)"
+        :form="eventCfp"
       />
     </div>
     <TabsWithRoute :tabs="tabs.options" />
-    <RouterView @cfp-created="cfpCreated" :event_cfp="event_cfp" />
+    <RouterView @cfp-created="cfpCreated" :eventCfp="eventCfp" />
   </div>
 </template>
 <script setup>
@@ -37,7 +37,7 @@ const tabs = reactive({
   ],
 })
 
-const has_cfp = createResource({
+const hasCfp = createResource({
   url: 'frappe.client.get_count',
   makeParams() {
     return {
@@ -51,7 +51,7 @@ const has_cfp = createResource({
   onSuccess(data) {
     resetTabs()
     if (data > 0) {
-      event_cfp.fetch()
+      eventCfp.fetch()
       tabs.options.push(...[
         {
           label: 'Web Form',
@@ -71,7 +71,7 @@ const has_cfp = createResource({
   },
 })
 
-const event_cfp = createResource({
+const eventCfp = createResource({
   url: 'frappe.client.get',
   params: {
     doctype: 'FOSS Event CFP',
@@ -91,7 +91,7 @@ const resetTabs = () => {
 }
 
 const cfpCreated = () => {
-  has_cfp.fetch()
+  hasCfp.fetch()
   router.replace(`/event/${route.params.id}/cfp`)
 }
 </script>

--- a/dashboard/src/pages/EventRsvp.vue
+++ b/dashboard/src/pages/EventRsvp.vue
@@ -3,23 +3,26 @@
     <EventHeader
       class="px-4 py-8 md:p-8"
       :event="event"
-      :form_exists="rsvp_exists"
+      :form_exists="new Boolean(has_rsvp.data)"
       :form="event_rsvp"
     />
     <TabsWithRoute :tabs="tabs.options" />
-    <RouterView @rsvp-created="rsvpCreated" :event_rsvp="event_rsvp" />
+    <RouterView
+      :event_rsvp="event_rsvp"
+      @rsvp-created="rsvpCreated"
+    />
   </div>
 </template>
-Show
 <script setup>
+import TabsWithRoute from '@/components/TabsWithRoute.vue'
 import EventHeader from '@/components/EventHeader.vue'
 import { createDocumentResource, createResource } from 'frappe-ui'
 import { useRoute, useRouter } from 'vue-router'
-import TabsWithRoute from '@/components/TabsWithRoute.vue'
 import { reactive, ref, watch } from 'vue'
 
 const route = useRoute()
 const router = useRouter()
+
 const event = createDocumentResource({
   doctype: 'FOSS Chapter Event',
   name: route.params.id,
@@ -27,67 +30,70 @@ const event = createDocumentResource({
   auto: true,
 })
 
-let tabs = reactive({
+const tabs = reactive({
   options: [
     {
       label: 'Overview',
       route: `/event/${route.params.id}/rsvp`,
     },
-    {
-      label: 'Web Form',
-      route: `/event/${route.params.id}/rsvp/create`,
-    },
   ],
 })
 
-const replaceCreateOption = () => {
-  // TODO: simplify this
-  tabs.options = tabs.options.filter((d) => d.label !== 'Web Form')
-
-  if (!tabs.options.find((d) => d.label === 'Web Form')) {
-    tabs.options.push({
-      label: 'Web Form',
-      route: `/event/${route.params.id}/rsvp/edit`,
-    })
-  }
-
-  if (!tabs.options.find((d) => d.label === 'Insights')) {
-    tabs.options.push({
-      label: 'Insights',
-      route: `/event/${route.params.id}/rsvp/insights`,
-    })
-  }
-}
-
-let rsvp_exists = ref(false)
-let event_rsvp = reactive({})
-
-watch(event, (newEvent) => {
-  event_rsvp = createResource({
-    url: 'frappe.client.get',
-    params: {
+const has_rsvp = createResource({
+  url: 'frappe.client.get_count',
+  makeParams() {
+    return {
       doctype: 'FOSS Event RSVP',
       filters: {
-        event: newEvent.doc.name,
+        event: route.params.id,
       },
-    },
-    auto: true,
-    onError(error) {
-      if (error.response.status === 404) {
-        rsvp_exists.value = false
-      }
-    },
-    onSuccess(response) {
-      rsvp_exists.value = true
-    },
-  })
-  if (rsvp_exists.value) {
-    replaceCreateOption()
-  }
+    }
+  },
+  auto: true,
+  onSuccess(data) {
+    resetTabs()
+    if (data > 0) {
+      event_rsvp.fetch()
+      tabs.options.push({
+        label: 'Web Form',
+        route: `/event/${route.params.id}/rsvp/edit`,
+      })
+      tabs.options.push({
+        label: 'Insights',
+        route: `/event/${route.params.id}/rsvp/insights`,
+      })
+      return
+    }
+    tabs.options.push({
+      label: 'Web Form',
+      route: `/event/${route.params.id}/rsvp/create`,
+    })
+  },
 })
 
+const event_rsvp = createResource({
+  url: 'frappe.client.get',
+  makeParams() {
+    return {
+      doctype: 'FOSS Event RSVP',
+      filters: {
+        event: route.params.id,
+      },
+    }
+  },
+})
+
+const resetTabs = () => {
+  tabs.options = [
+    {
+      label: 'Overview',
+      route: `/event/${route.params.id}/rsvp`,
+    },
+  ]
+}
+
 const rsvpCreated = () => {
-  replaceCreateOption()
-  router.replace(`/event/${route.params.id}/rsvp/edit`)
+  has_rsvp.fetch()
+  router.replace(`/event/${route.params.id}/rsvp`)
 }
 </script>

--- a/dashboard/src/pages/EventRsvp.vue
+++ b/dashboard/src/pages/EventRsvp.vue
@@ -3,7 +3,7 @@
     <EventHeader
       class="px-4 py-8 md:p-8"
       :event="event"
-      :form_exists="new Boolean(has_rsvp.data)"
+      :form_exists="Boolean(has_rsvp.data)"
       :form="event_rsvp"
     />
     <TabsWithRoute :tabs="tabs.options" />

--- a/dashboard/src/pages/Home.vue
+++ b/dashboard/src/pages/Home.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex">
-    <SideNavbar v-if="nav_items.data" :menuItems="nav_items.data" :class="showNav ? 'z-50 block mt-[55px]' : 'hidden md:block'" />
+    <SideNavbar v-if="navItems.data" :menuItems="navItems.data" :class="showNav ? 'z-50 block mt-[55px]' : 'hidden md:block'" />
     <div class="w-full md:ml-[220px]">
       <HeaderWithNav @toggleSidebar="($event) => (showNav = $event)" />
       <RouterView />
@@ -17,7 +17,7 @@ import HeaderWithNav from '@/components/HeaderWithNav.vue'
 const session = inject('$session')
 const showNav = ref(false)
 
-const nav_items = createResource({
+const navItems = createResource({
   url: 'fossunited.api.sidebar.get_sidebar_items',
   auto: true,
 })

--- a/dashboard/src/pages/Home.vue
+++ b/dashboard/src/pages/Home.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex">
-    <SideNavbar :class="showNav ? 'z-50 block mt-[55px]' : 'hidden md:block'" />
+    <SideNavbar v-if="nav_items.data" :menuItems="nav_items.data" :class="showNav ? 'z-50 block mt-[55px]' : 'hidden md:block'" />
     <div class="w-full md:ml-[220px]">
       <HeaderWithNav @toggleSidebar="($event) => (showNav = $event)" />
       <RouterView />
@@ -10,12 +10,17 @@
 
 <script setup>
 import { inject, watch, ref } from 'vue'
-import { usePageMeta } from 'frappe-ui'
+import { usePageMeta, createResource } from 'frappe-ui'
 import SideNavbar from '@/components/NewAppSidebar.vue'
 import HeaderWithNav from '@/components/HeaderWithNav.vue'
 
 const session = inject('$session')
 const showNav = ref(false)
+
+const nav_items = createResource({
+  url: 'fossunited.api.sidebar.get_sidebar_items',
+  auto: true,
+})
 
 usePageMeta(() => {
   return {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🐛Bug Fix
- [x] 🧑‍💻Refactor

## Description
<!-- Briefly describe the changes introduced by this pull request -->
- Fixed the weird tab behavior bug, due to which the tabs in RSVP & CFP sections in dashboard were hallucinating before rendering. See #481 

## Related Issues & Docs
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
closes #481 
