### PR TITLE
chore(event): Add validation for event permalink

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -134,6 +134,12 @@ class FOSSChapterEvent(WebsiteGenerator):
                 "Event Permalink cannot contain / character. Please use a different permalink."
             )
 
+        # ensure permalink is only alphanumeric with exception of -
+        if not self.event_permalink.replace("-", "").isalnum():
+            frappe.throw(
+                "Event Permalink can only contain alphabets, numbers and hyphens."
+            )
+
     def update_published_status(self):
         if self.status == "Draft" or self.status == "Cancelled":
             self.is_published = 0

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -111,6 +111,25 @@ class FOSSChapterEvent(WebsiteGenerator):
             self.update_published_status()
         self.set_route()
 
+    def validate(self):
+        self.validate_permalink()
+
+    def validate_permalink(self):
+        if self.is_external_event:
+            return
+
+        if frappe.db.exists(
+            self.doctype, {"event_permalink": self.event_permalink}
+        ):
+            frappe.throw(
+                f"Event Permalink {self.event_permalink} already exists!"
+            )
+
+        if "/" in self.event_permalink:
+            frappe.throw(
+                "Event Permalink cannot contain / character. Please use a different permalink."
+            )
+
     def update_published_status(self):
         if self.status == "Draft" or self.status == "Cancelled":
             self.is_published = 0

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -134,10 +134,13 @@ class FOSSChapterEvent(WebsiteGenerator):
                 "Event Permalink cannot contain / character. Please use a different permalink."
             )
 
-        # ensure permalink is only alphanumeric with exception of -
-        if not self.event_permalink.replace("-", "").isalnum():
+        if (
+            not self.event_permalink.replace("-", "")
+            .replace("_", "")
+            .isalnum()
+        ):
             frappe.throw(
-                "Event Permalink can only contain alphabets, numbers and hyphens."
+                "Event Permalink can only contain alphabets, numbers, - and _ characters."
             )
 
     def update_published_status(self):

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -119,7 +119,11 @@ class FOSSChapterEvent(WebsiteGenerator):
             return
 
         if frappe.db.exists(
-            self.doctype, {"event_permalink": self.event_permalink}
+            self.doctype,
+            {
+                "event_permalink": self.event_permalink,
+                "name": ("!=", self.name),
+            },
         ):
             frappe.throw(
                 f"Event Permalink {self.event_permalink} already exists!"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] ⚙️Chore

## Description
<!-- Briefly describe the changes introduced by this pull request -->
- Added a validation which does not let people create events with a permalink having the `/` character

## Related Issues & Docs
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

closes #509 
