### PR TITLE
fix(ticket-transfer): emails not being sent automatically on transfer

### DIFF
--- a/fossunited/ticketing/doctype/foss_event_ticket_transfer/foss_event_ticket_transfer.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket_transfer/foss_event_ticket_transfer.py
@@ -58,13 +58,7 @@ class FOSSEventTicketTransfer(Document):
 
     def transfer_ticket(self):
         self.validate_ticket_exists()
-
-        current_user = frappe.session.user
-        current_session_data = frappe.session.data
-
         try:
-            frappe.set_user("Administrator")
-
             ticket = frappe.get_doc("FOSS Event Ticket", self.ticket)
             ticket.full_name = self.receiver_name
             ticket.email = self.receiver_email
@@ -73,9 +67,6 @@ class FOSSEventTicketTransfer(Document):
             ticket.wants_tshirt = self.wants_tshirt
             ticket.tshirt_size = self.tshirt_size
             ticket.is_transfer_ticket = 1
-            ticket.save()
+            ticket.save(ignore_permissions=True)
         except Exception as e:
             frappe.throw(str(e), frappe.ValidationError)
-        finally:
-            frappe.set_user(current_user)
-            frappe.session.data = current_session_data

--- a/fossunited/ticketing/doctype/foss_event_ticket_transfer/foss_event_ticket_transfer.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket_transfer/foss_event_ticket_transfer.py
@@ -58,19 +58,24 @@ class FOSSEventTicketTransfer(Document):
 
     def transfer_ticket(self):
         self.validate_ticket_exists()
+
+        current_user = frappe.session.user
+        current_session_data = frappe.session.data
+
         try:
-            frappe.db.set_value(
-                "FOSS Event Ticket",
-                self.ticket,
-                {
-                    "full_name": self.receiver_name,
-                    "email": self.receiver_email,
-                    "designation": self.designation,
-                    "organization": self.organization,
-                    "wants_tshirt": self.wants_tshirt,
-                    "tshirt_size": self.tshirt_size,
-                    "is_transfer_ticket": 1,
-                },
-            )
+            frappe.set_user("Administrator")
+
+            ticket = frappe.get_doc("FOSS Event Ticket", self.ticket)
+            ticket.full_name = self.receiver_name
+            ticket.email = self.receiver_email
+            ticket.designation = self.designation
+            ticket.organization = self.organization
+            ticket.wants_tshirt = self.wants_tshirt
+            ticket.tshirt_size = self.tshirt_size
+            ticket.is_transfer_ticket = 1
+            ticket.save()
         except Exception as e:
             frappe.throw(str(e), frappe.ValidationError)
+        finally:
+            frappe.set_user(current_user)
+            frappe.session.data = current_session_data


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🐛Bug Fix
- [x] 🧑‍💻Refactor

## Description
<!-- Briefly describe the changes introduced by this pull request -->
- Replaced the database methods with documents methods. Reason: database methods don't run controller methods attached to the doctype. Hence, the notifications set up on the desk were also not being sent when the value of `is_transfer_ticket` checkbox was changing for Ticket DocType.
- To bypass permissions set on ticket doctype, the user is temporarily switched to `Administrator` to make changes to ticket and save it. This is achieved using `frappe.set_user`.

## Related Issues & Docs
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
closes #521 
