### PR TITLE
hotfix: adding screening option to status field

### DIFF
--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.json
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.json
@@ -143,7 +143,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Status",
-   "options": "Review Pending\nApproved\nRejected",
+   "options": "Review Pending\nScreening\nApproved\nRejected",
    "permlevel": 2
   },
   {
@@ -290,7 +290,7 @@
  "has_web_view": 1,
  "is_published_field": "is_published",
  "links": [],
- "modified": "2024-07-31 14:06:54.643071",
+ "modified": "2024-08-07 11:58:39.087697",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "FOSS Event CFP Submission",

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -48,7 +48,9 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         reviews: DF.Table[FOSSEventCFPReview]
         route: DF.Data | None
         session_type: DF.Literal["Talk", "Lightning Talk", "Workshop"]
-        status: DF.Literal["Review Pending", "Approved", "Rejected"]
+        status: DF.Literal[
+            "Review Pending", "Screening", "Approved", "Rejected"
+        ]
         submitted_by: DF.Link | None
         talk_description: DF.TextEditor
         talk_reference: DF.Data | None


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🍕Feature
- [x] ⚙️Chore

## Description
This is a quick PR to add one more field "Screening" to the Event CFP Submissions Doctype.  The Screening field will be used to send notifications to schedule mock calls with potential speakers. 