### PR TITLE
[HOTFIX] fixing typo in HACKATHON_TEAM constant

### DIFF
--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -112,7 +112,7 @@ def create_team(hackathon: str, team: dict) -> dict:
     """
     team_doc = frappe.get_doc(
         {
-            "doctype": HACAKTHON_TEAM,
+            "doctype": HACKATHON_TEAM,
             "team_name": team.get("team_name"),
             "hackathon": hackathon,
             "team_lead": team.get("team_lead"),
@@ -139,7 +139,7 @@ def get_team_by_member_email(hackathon: str, email: str) -> dict:
 
     try:
         team = frappe.get_doc(
-            HACAKTHON_TEAM,
+            HACKATHON_TEAM,
             [
                 [
                     HACKATHON_TEAM_MEMBER,
@@ -170,7 +170,7 @@ def get_team_from_participant_id(hackathon: str, id: str) -> dict:
     """
     try:
         team = frappe.get_doc(
-            HACAKTHON_TEAM,
+            HACKATHON_TEAM,
             [
                 [
                     HACKATHON_TEAM_MEMBER,
@@ -361,7 +361,7 @@ def join_team_via_code(team_code: str, user: str):
         dict: Team document as a dictionary
     """
     try:
-        team = frappe.get_doc(HACAKTHON_TEAM, team_code)
+        team = frappe.get_doc(HACKATHON_TEAM, team_code)
     except frappe.exceptions.DoesNotExistError:
         frappe.throw("Team not found")
         return "Invalid Code. Team with this code does not exist."
@@ -470,7 +470,7 @@ def delete_project(hackathon: str, team: str):
         hackathon (str): Hackathon ID
         team (str): Team ID
     """
-    team_doc = frappe.get_doc(HACAKTHON_TEAM, team)
+    team_doc = frappe.get_doc(HACKATHON_TEAM, team)
     if frappe.session.user not in [
         member.email for member in team_doc.members
     ]:
@@ -479,7 +479,7 @@ def delete_project(hackathon: str, team: str):
     project = get_project_by_team(hackathon, team)
 
     try:
-        frappe.db.set_value(HACAKTHON_TEAM, team, "project", None)
+        frappe.db.set_value(HACKATHON_TEAM, team, "project", None)
         frappe.db.delete(HACKATHON_PROJECT, project.name)
         return True
     except Exception as e:

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/foss_hackathon_join_team_request.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/foss_hackathon_join_team_request.py
@@ -52,7 +52,7 @@ class FOSSHackathonJoinTeamRequest(Document):
             frappe.throw("Participant not found")
             return
 
-        team_doc = frappe.get_doc(HACAKTHON_TEAM, self.team)
+        team_doc = frappe.get_doc(HACKATHON_TEAM, self.team)
         team_doc.append("members", {"member": participant_doc.name})
         team_doc.save()
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_project/foss_hackathon_project.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_project/foss_hackathon_project.py
@@ -58,7 +58,7 @@ class FOSSHackathonProject(WebsiteGenerator):
             "team_members",
         ]
 
-        context.team = frappe.get_doc(HACAKTHON_TEAM, self.team)
+        context.team = frappe.get_doc(HACKATHON_TEAM, self.team)
         context.team_members = get_team_members(context.team)
         context.likes = get_doc_likes(self.doctype, self.name)
         context.liked_by_user = frappe.session.user in context.likes


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] ⚙️Chore
- [x] 🐛Bug Fix
- [x] 🧑‍💻Refactor

## Description 
This is a Hotfix PR to fix the typo in the FOSS Hackathon Team constant `HACKATHON_TEAM` which was set to `HACAKTHON_TEAM` and which lead to breaking the FOSS hackathon Projects page. 

## Error (before) 

![Screenshot 2024-08-07 at 10 18 31 PM](https://github.com/user-attachments/assets/c1e4ab75-b631-47cf-b806-8f6b4ac9878a)

## Test Project 

![image](https://github.com/user-attachments/assets/e12df797-2656-4239-959e-8649e2d26d98)
