### PR TITLE
fix(dashboard): broken chapter member & event volunteer addition workflow

### DIFF
--- a/dashboard/src/components/chapter/AddMember.vue
+++ b/dashboard/src/components/chapter/AddMember.vue
@@ -1,0 +1,82 @@
+<template>
+  <Dialog
+    :options="{
+      title: 'Add New Member',
+    }"
+  >
+    <template #body-content>
+      <div class="flex flex-col gap-2">
+        <div class="text-p-base text-gray-700">
+          Enter the username of the new member you want to add to the team.
+        </div>
+        <Autocomplete
+          :options="memberOptions.data"
+          v-model="newMembers"
+          placeholder="Search for a user"
+          :multiple="true"
+        >
+          <template #item-prefix="{ option }">
+            <Avatar
+              shape="circle"
+              :image="option.avatar"
+              :label="option.label"
+              size="lg"
+            />
+          </template>
+        </Autocomplete>
+      </div>
+    </template>
+    <template #actions>
+      <div class="grid grid-cols-2 gap-3">
+        <Button label="Cancel" @click="$emit('close-dialog')" />
+        <Button
+          label="Add"
+          variant="solid"
+          @click="$emit('update:add-member', newMembers)"
+        />
+      </div>
+    </template>
+  </Dialog>
+</template>
+<script setup>
+import { Dialog, Autocomplete, createResource, Avatar } from 'frappe-ui'
+import { ref, defineProps, defineEmits } from 'vue'
+
+const props = defineProps({
+  chapter: Object,
+})
+
+const emits = defineEmits(['update:add-member', 'close-dialog'])
+
+const memberOptions = createResource({
+  url: 'fossunited.api.dashboard.get_user_profile_list',
+  makeParams() {
+    return {
+      filters: {
+        name: [
+          'not in',
+          props.chapter.doc.chapter_members
+            .map((member) => member.chapter_member)
+            .join(','),
+        ],
+      },
+    }
+  },
+  auto: true,
+  realtime: true,
+  transform(data) {
+    return data.map((user) => {
+      return {
+        value: user.name,
+        label: user.username,
+        description: user.full_name,
+        avatar: user.profile_photo
+          ? user.profile_photo
+          : '/assets/fossunited/images/defaults/user_profile_image.png',
+      }
+    })
+  },
+})
+
+const newMembers = ref([])
+</script>

--- a/dashboard/src/components/chapter/AddMember.vue
+++ b/dashboard/src/components/chapter/AddMember.vue
@@ -40,11 +40,24 @@
 </template>
 <script setup>
 import { Dialog, Autocomplete, createResource, Avatar } from 'frappe-ui'
-import { ref, defineProps, defineEmits } from 'vue'
+import { ref, defineProps, defineEmits, computed } from 'vue'
 
 const props = defineProps({
   chapter: Object,
+  event: Object,
 })
+
+const existingMembers = computed(() => {
+  if (props.chapter) {
+    return props.chapter.doc.chapter_members.map((member) => member.chapter_member).join(',')
+  }
+  else if (props.event) {
+    return props.event.doc.event_members.map((member) => member.member).join(',')
+  }
+
+  return []
+})
+
 
 const emits = defineEmits(['update:add-member', 'close-dialog'])
 
@@ -55,9 +68,7 @@ const memberOptions = createResource({
       filters: {
         name: [
           'not in',
-          props.chapter.doc.chapter_members
-            .map((member) => member.chapter_member)
-            .join(','),
+          existingMembers.value
         ],
       },
     }

--- a/dashboard/src/pages/ChapterDetails.vue
+++ b/dashboard/src/pages/ChapterDetails.vue
@@ -82,6 +82,7 @@
         />
         <div class="col-span-2">
           <TextEditor
+            label="About Chapter"
             placeholder="Write a description about the chapter"
             :modelValue="chapter.doc.about_chapter"
             @update:modelValue="

--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -1,0 +1,38 @@
+import frappe
+
+from fossunited.doctype_ids import USER_PROFILE
+
+
+@frappe.whitelist()
+def check_if_chapter_member(
+    chapter: str, user: str = frappe.session.user
+) -> bool:
+    """
+    Check if the user is a member of the chapter.
+
+    Args:
+        chapter (str): Chapter id
+        user (str): User email. Default is current user.
+
+    Returns:
+        bool: True if the user is a member of the chapter, False otherwise.
+    """
+    profile = frappe.db.get_value(
+        USER_PROFILE, {"user": user}, ["name"]
+    )
+
+    if not profile:
+        return False
+
+    is_member = bool(
+        frappe.db.exists(
+            "FOSS Chapter Lead Team Member",
+            {
+                "parent": chapter,
+                "parenttype": "FOSS Chapter",
+                "chapter_member": profile,
+            },
+        )
+    )
+
+    return is_member

--- a/fossunited/api/dashboard.py
+++ b/fossunited/api/dashboard.py
@@ -155,3 +155,27 @@ def get_profile_data(username: str = None, email: str = None) -> dict:
     )
 
     return user
+
+
+@frappe.whitelist()
+def get_user_profile_list(filters: dict = None) -> list:
+    """
+    Returns the list of user profiles based on the given filters.
+    """
+    if not filters:
+        filters = {}
+
+    profiles = frappe.db.get_all(
+        "FOSS User Profile",
+        filters=filters,
+        fields=[
+            "full_name",
+            "profile_photo",
+            "route",
+            "username",
+            "name",
+        ],
+        page_length=9999,
+    )
+
+    return profiles

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
@@ -57,13 +57,73 @@ class FOSSChapter(WebsiteGenerator):
 
     def on_update(self):
         self.set_member_roles()
+        self.handle_member_removal()
 
     def set_member_roles(self):
-        for member in self.chapter_members:
-            user = frappe.get_doc("User", member.email)
-            user.add_roles("Chapter Team Member")
-            if member.role == "Lead":
-                user.add_roles("Chapter Lead")
+        current_user = frappe.session.user
+        current_session_data = frappe.session.data
+        frappe.set_user("Administrator")
+
+        try:
+            for member in self.chapter_members:
+                user = frappe.db.get_value(
+                    USER_PROFILE, member.chapter_member, "user"
+                )
+
+                if frappe.db.exists(
+                    "Has Role",
+                    {"role": "Chapter Team Member", "parent": user},
+                ):
+                    continue
+                user_doc = frappe.get_doc("User", user)
+
+                user_doc.add_roles("Chapter Team Member")
+                if member.role == "Lead":
+                    user_doc.add_roles("Chapter Lead")
+
+        except Exception as e:
+            frappe.throw(f"Error: {e}")
+        finally:
+            frappe.set_user(current_user)
+            frappe.session.data = current_session_data
+
+    def handle_member_removal(self):
+        prev_doc = self.get_doc_before_save()
+        if not prev_doc:
+            return
+
+        current_user = frappe.session.user
+        current_session_data = frappe.session.data
+        frappe.set_user("Administrator")
+
+        try:
+            for member in prev_doc.chapter_members:
+                if member not in self.chapter_members:
+                    if self.member_of_other_chapter(member):
+                        continue
+                    user = frappe.db.get_value(
+                        USER_PROFILE, member.chapter_member, "user"
+                    )
+                    user_doc = frappe.get_doc("User", user)
+                    user_doc.remove_roles("Chapter Team Member")
+                    if member.role == "Lead":
+                        user_doc.remove_roles("Chapter Lead")
+        except Exception as e:
+            frappe.throw(f"Error: {e}")
+        finally:
+            frappe.set_user(current_user)
+            frappe.session.data = current_session_data
+
+    def member_of_other_chapter(self, member):
+        return bool(
+            frappe.db.exists(
+                "FOSS Chapter Lead Team Member",
+                {
+                    "chapter_member": member.chapter_member,
+                    "parent": ["!=", self.name],
+                },
+            )
+        )
 
     def set_chapter_lead(self):
         for member in self.chapter_members:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🐛Bug Fix
- [x] 🧑‍💻Refactor

## Description
<!-- Briefly describe the changes introduced by this pull request -->
- Member addition and volunteer addition workflow were broken for organizer dashboard due to the changes in permissions.
- This PR fixes the workflow to be usable again.
- Added a new vue component `AddMember.vue` which is essentially a dialog box used for adding members for chapter and event both.
- Refactored document controller methods for chapters, which were used to assign and de-assign `Chapter Team Member` and `Chapter Lead` roles to members of the chapter. Refactored the code to use `set_user`, so that the user is switched with Administrator at the time of any save to the chapter document. This is necessary, because Role addition works directly on the `User` doctype which can only be changed by the Administrator.
- Also, added a validation on the dashboard which checks whether the session user is the member of the chapter whose dashboard page is being accessed. If not, it throws an error dialog and redirects the user to dashboard. 

