### PR TITLE
chore: add additional fields and options in IP doctype

### DIFF
--- a/fossunited/fossunited/doctype/industry_partners/industry_partners.json
+++ b/fossunited/fossunited/doctype/industry_partners/industry_partners.json
@@ -15,7 +15,14 @@
   "joining_date",
   "is_current_partner",
   "tier",
-  "special_category"
+  "special_category",
+  "flagship_event_sponsorship_section",
+  "indiafoss_sponsorship_column",
+  "is_indiafoss_sponsor",
+  "indiafoss_sponsor_tier",
+  "foss_hack_sponsorship_column",
+  "is_fosshack_sponsor",
+  "fosshack_sponsor_tier"
  ],
  "fields": [
   {
@@ -59,7 +66,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Tier",
-   "options": "Patron\nPlatinum\nGold\nSilver\nBronze\nSpecial",
+   "options": "Patron\nPlatinum\nGold\nSilver\nBronze\nSpecial\nFlagship Event Sponsor",
    "reqd": 1
   },
   {
@@ -72,11 +79,50 @@
    "fieldname": "special_category",
    "fieldtype": "Data",
    "label": "Special Category"
+  },
+  {
+   "fieldname": "flagship_event_sponsorship_section",
+   "fieldtype": "Section Break",
+   "label": "Flagship Event Sponsorship"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_indiafoss_sponsor",
+   "fieldtype": "Check",
+   "label": "IndiaFOSS Sponsor"
+  },
+  {
+   "fieldname": "indiafoss_sponsorship_column",
+   "fieldtype": "Column Break",
+   "label": "IndiaFOSS Sponsorship"
+  },
+  {
+   "fieldname": "indiafoss_sponsor_tier",
+   "fieldtype": "Select",
+   "label": "Sponsorship Tier",
+   "options": "Platinum\nGold\nSilver\nBronze"
+  },
+  {
+   "fieldname": "foss_hack_sponsorship_column",
+   "fieldtype": "Column Break",
+   "label": "FOSS Hack Sponsorship"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_fosshack_sponsor",
+   "fieldtype": "Check",
+   "label": "FOSS Hack Sponsor"
+  },
+  {
+   "fieldname": "fosshack_sponsor_tier",
+   "fieldtype": "Select",
+   "label": "Sponsorship Tier",
+   "options": "Platinum\nGold\nSilver\nBronze"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-02-13 17:07:04.204042",
+ "modified": "2024-08-08 14:59:08.857648",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "Industry Partners",

--- a/fossunited/fossunited/doctype/industry_partners/industry_partners.py
+++ b/fossunited/fossunited/doctype/industry_partners/industry_partners.py
@@ -5,4 +5,37 @@ from frappe.model.document import Document
 
 
 class IndustryPartners(Document):
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        company: DF.Data
+        fosshack_sponsor_tier: DF.Literal[
+            "Platinum", "Gold", "Silver", "Bronze"
+        ]
+        indiafoss_sponsor_tier: DF.Literal[
+            "Platinum", "Gold", "Silver", "Bronze"
+        ]
+        is_current_partner: DF.Check
+        is_fosshack_sponsor: DF.Check
+        is_indiafoss_sponsor: DF.Check
+        joining_date: DF.Date | None
+        logo: DF.AttachImage
+        special_category: DF.Data | None
+        tier: DF.Literal[
+            "Patron",
+            "Platinum",
+            "Gold",
+            "Silver",
+            "Bronze",
+            "Special",
+            "Flagship Event Sponsor",
+        ]
+        website: DF.Data
+    # end: auto-generated types
+
     pass


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] ⚙️Chore

## Description

We have added custom fields in the IP doctype to handle sponsors for flagship events, This PR adds those fields and options in the app. 

Additionally added an option - Flagship Event Sponsor in `tier` field - so that active/inactive states of Flagship event sponsors does not interfere with that of Partners Page. Handles the state of an org - being a partner and a flagship event sponsor at a time.

## Related Issues & Docs

- Partially handles #533 

## Checklist
- [x] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [x] I have tested these changes locally.
- [x] I have updated the documentation (If applicable).
- [x] ~The code follows the project's coding standards.~
- [x] I have added/updated tests, if applicable.

