### PR TITLE
fix(cfp): user nonetype error in cfp pages

### DIFF
--- a/fossunited/fossunited/doctype/foss_event_cfp_review/foss_event_cfp_review.json
+++ b/fossunited/fossunited/doctype/foss_event_cfp_review/foss_event_cfp_review.json
@@ -25,6 +25,7 @@
    "label": "Remarks"
   },
   {
+   "fetch_from": "reviewer_profile.email",
    "fieldname": "email",
    "fieldtype": "Data",
    "label": "Email"
@@ -48,7 +49,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-07-31 14:20:03.666303",
+ "modified": "2024-08-12 11:40:57.701384",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "FOSS Event CFP Review",

--- a/fossunited/fossunited/forms.py
+++ b/fossunited/fossunited/forms.py
@@ -78,7 +78,7 @@ def post_review(submission, to_approve, remarks):
         "reviews",
         {
             "reviewer": reviewer.username,
-            "email": frappe.session.user,
+            "reviewer_profile": reviewer.name,
             "to_approve": to_approve,
             "remarks": remarks,
         },

--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -11,6 +11,7 @@ from fossunited.doctype_ids import HACKATHON, USER_PROFILE
 # Jinja Filter
 def get_profile_image(email):
     profile = get_foss_profile(email)
+    print(profile)
     return (
         profile.profile_photo
         or "/assets/fossunited/images/defaults/user_profile_image.png"
@@ -297,4 +298,20 @@ def get_foss_profile(email):
     if email in ["guest@example.com", "admin@example.com"]:
         return None
 
-    return frappe.get_doc(USER_PROFILE, {"user": email})
+    profile = frappe.db.get_value(
+        USER_PROFILE,
+        {"user": email},
+        [
+            "name",
+            "full_name",
+            "user",
+            "profile_photo",
+            "username",
+            "route",
+            "github",
+            "email",
+            "gitlab",
+        ],
+        as_dict=1,
+    )
+    return profile

--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -11,7 +11,6 @@ from fossunited.doctype_ids import HACKATHON, USER_PROFILE
 # Jinja Filter
 def get_profile_image(email):
     profile = get_foss_profile(email)
-    print(profile)
     return (
         profile.profile_photo
         or "/assets/fossunited/images/defaults/user_profile_image.png"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🐛Bug Fix

## Description
<!-- Briefly describe the changes introduced by this pull request -->
- Reviews made through the dashboard were not capturing the 'email' field for FOSS Event CFP Review child doc. This field was used to render the picture of the Reviewer. With a blank email, the `User Nonetype` error was being thrown.
- Fixed it so emails are autofetched from the User Profile link field in CFP Review child doc.
- Will run a script on console via desk so that all other reviews are fixed.
