### PR TITLE
feat: ticket management pages for chapters

### DIFF
--- a/dashboard/src/components/EventHeader.vue
+++ b/dashboard/src/components/EventHeader.vue
@@ -9,7 +9,7 @@
       }}</CityCommunityBranding>
     </div>
     <div class="flex gap-3">
-      <div class="text-3xl font-semibold">{{ event.doc.event_name }}</div>
+      <div class="text-3xl font-semibold">{{ event.event_name }}</div>
       <Badge
         v-if="form_exists && form.data"
         :theme="form.data.is_published ? 'green' : 'gray'"
@@ -40,7 +40,7 @@
     </div>
     <div class="flex gap-2 items-center text-base text-gray-700">
       <div>
-        {{ event.doc.event_type }}
+        {{ event.event_type }}
       </div>
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -57,10 +57,10 @@
       </svg>
       <div>
         <span>
-          {{ getFormattedDate(event.doc.event_start_date) }}
+          {{ getFormattedDate(event.event_start_date) }}
         </span>
-        <span v-if="event.doc.event_start_date != event.doc.event_end_date">
-          - {{ getFormattedDate(event.doc.event_end_date) }}
+        <span v-if="event.event_start_date != event.event_end_date">
+          - {{ getFormattedDate(event.event_end_date) }}
         </span>
       </div>
     </div>
@@ -98,7 +98,7 @@ function getFormattedDate(date) {
 
 const chapter = createDocumentResource({
   doctype: 'FOSS Chapter',
-  name: props.event.doc.chapter,
+  name: props.event.chapter,
   fields: ['*'],
   auto: true,
 })

--- a/dashboard/src/components/EventHeader.vue
+++ b/dashboard/src/components/EventHeader.vue
@@ -8,8 +8,10 @@
         chapter.doc.chapter_name
       }}</CityCommunityBranding>
     </div>
-    <div class="flex gap-3">
-      <div class="text-3xl font-semibold">{{ event.event_name }}</div>
+    <div class="flex gap-3 items-center">
+      <div class="prose">
+        <h1>{{ event.event_name }}</h1>
+      </div>
       <Badge
         v-if="form_exists && form.data"
         :theme="form.data.is_published ? 'green' : 'gray'"

--- a/dashboard/src/components/Input.vue
+++ b/dashboard/src/components/Input.vue
@@ -1,0 +1,60 @@
+<template>
+  <div
+    class="border-b pb-1 flex flex-col gap-1 group focus-within:border-gray-800 transition-colors"
+  >
+    <div class="flex gap-1">
+      <slot name="label-prefix"></slot>
+      <div class="text-sm text-gray-600" v-if="label">
+        <span>
+        {{ label }}
+        </span>
+        <span v-if="required">*</span>
+      </div>
+    </div>
+    <div class="flex gap-1 items-center">
+      <slot name="input-prefix"></slot>
+      <input
+        :placeholder="placeholder"
+        class="focus:border-none focus:ring-0 border-none p-0 uppercase w-full"
+        :type="type"
+        v-model="model"
+        :class="inputClasses"
+      />
+    </div>
+    <small class="text-gray-600" v-if="description">
+      {{ description }}
+    </small>
+  </div>
+</template>
+<script setup>
+import { defineModel, defineProps } from 'vue'
+
+const model = defineModel()
+
+const props = defineProps({
+  type: {
+    type: String,
+    default: 'text',
+  },
+  label: {
+    type: String,
+    default: '',
+  },
+  description: {
+    type: String,
+    default: '',
+  },
+  placeholder: {
+    type: String,
+    default: '',
+  },
+  inputClasses: {
+    type: String,
+    default: '',
+  },
+  required: {
+    type: Boolean,
+    default: false,
+  },
+})
+</script>

--- a/dashboard/src/components/animation/LivePing.vue
+++ b/dashboard/src/components/animation/LivePing.vue
@@ -1,0 +1,9 @@
+<template>
+  <span class="relative flex h-3 w-3">
+    <span
+      class="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"
+    ></span>
+    <span class="relative inline-flex rounded-full h-3 w-3 bg-green-500"></span>
+  </span>
+</template>
+<script setup></script>

--- a/dashboard/src/components/event/ManageTicketTierDialog.vue
+++ b/dashboard/src/components/event/ManageTicketTierDialog.vue
@@ -1,0 +1,290 @@
+<template>
+  <Dialog
+    v-model="showDialog"
+    class="z-50"
+    :options="{
+      title: inCreateMode ? 'Create Ticket Tier' : 'Manage Ticket Tier',
+    }"
+  >
+    <template #body-content>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div
+          class="col-span-2 flex items-end justify-between border border-gray-600 p-3 border-dashed rounded-sm"
+          v-if="!inCreateMode"
+        >
+          <div class="flex flex-col gap-2">
+            <div class="text-sm text-gray-600">Status</div>
+            <div
+              class="font-medium text-sm uppercase flex items-center gap-2"
+              :class="tier.enabled ? 'text-green-600' : ''"
+            >
+              <LivePing v-if="tier.enabled" />
+              <span>
+                {{ tier.enabled ? 'Active' : 'Disabled' }}
+              </span>
+            </div>
+          </div>
+          <Button
+            :label="tier.enabled ? 'Disable' : 'Enable'"
+            :variant="tier.enabled ? 'subtle' : 'solid'"
+            class="w-fit"
+            @click="toggleTierStatus.fetch()"
+          />
+        </div>
+        <FormControl
+          v-if="inCreateMode"
+          v-model="modifyTier.enabled"
+          label="Enable?"
+          type="checkbox"
+          class="col-span-2 mb-1"
+        />
+        <Input
+          v-model="modifyTier.title"
+          label="Title"
+          class="w-full"
+          required
+        />
+        <Input
+          v-model="modifyTier.price"
+          label="Price"
+          class="w-full"
+          placeholder="0.00"
+          required
+        >
+          <template #input-prefix>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="#000000"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="icon icon-tabler w-5 h-5 icons-tabler-outline icon-tabler-currency-rupee"
+            >
+              <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+              <path d="M18 5h-11h3a4 4 0 0 1 0 8h-3l6 6" />
+              <path d="M7 9l11 0" />
+            </svg>
+          </template>
+        </Input>
+        <div>
+          <div class="text-sm text-gray-600 mb-1">Closes On</div>
+          <DatePicker
+            v-model="modifyTier.valid_till"
+            variant="subtle"
+            input-class="bg-white border-none hover:bg-white px-0"
+            label="Open Till"
+          />
+        </div>
+        <Input
+          v-model="modifyTier.maximum_tickets"
+          label="Maximum Tickets"
+          class="w-full"
+          placeholder="0"
+          required
+        />
+        <div class="col-span-2">
+          <div class="text-sm text-gray-600 mb-1">Description</div>
+          <textarea
+            v-model="modifyTier.description"
+            class="w-full border border-gray-300 rounded-sm p-2 text-base"
+            rows="4"
+            placeholder="Add a description"
+          ></textarea>
+          <small class="text-gray-700"
+            >You can use <code>Markdown</code>.</small
+          >
+        </div>
+      </div>
+      <ErrorMessage class="mt-2" :message="errorMessages" />
+    </template>
+    <template #actions>
+      <div class="grid grid-cols-2 gap-2">
+        <Button label="Cancel" size="sm" @click="showDialog = false" />
+        <Button
+          v-if="inCreateMode"
+          label="Create"
+          variant="solid"
+          size="sm"
+          @click="handleCreate"
+        />
+        <Button
+          v-else
+          label="Update"
+          variant="solid"
+          size="sm"
+          @click="handleSubmit"
+        />
+      </div>
+    </template>
+  </Dialog>
+</template>
+<script setup>
+import {
+  createResource,
+  Dialog,
+  DatePicker,
+  ErrorMessage,
+  FormControl,
+} from 'frappe-ui'
+import {
+  defineProps,
+  defineModel,
+  defineEmits,
+  onMounted,
+  reactive,
+  ref,
+} from 'vue'
+import { useRoute } from 'vue-router'
+import Input from '@/components/Input.vue'
+import LivePing from '@/components/animation/LivePing.vue'
+
+const props = defineProps({
+  tier: {
+    type: Object,
+    default: {},
+  },
+  inCreateMode: {
+    type: Boolean,
+    default: false,
+  },
+})
+const emit = defineEmits(['update-tier'])
+
+const route = useRoute()
+
+const showDialog = defineModel()
+
+const modifyTier = reactive({
+  enabled: false,
+  title: '',
+  price: 0,
+  currency: 'INR',
+  valid_till: '',
+  maximum_tickets: 0,
+  description: '',
+})
+
+onMounted(() => {
+  if (props.tier && !props.inCreateMode) {
+    Object.assign(modifyTier, props.tier)
+  }
+})
+
+const updateTier = createResource({
+  url: 'frappe.client.set_value',
+  makeParams() {
+    return {
+      doctype: 'FOSS Ticket Tier',
+      name: props.tier.name,
+      fieldname: {
+        title: modifyTier.title,
+        price: modifyTier.price,
+        currency: modifyTier.currency,
+        valid_till: modifyTier.valid_till,
+        maximum_tickets: modifyTier.maximum_tickets,
+        description: modifyTier.description,
+      },
+    }
+  },
+  onSuccess() {
+    emit('update-tier')
+    showDialog.value = false
+  },
+})
+
+const errorMessages = ref('')
+
+const validateTierFields = () => {
+  const errors = []
+  if (!modifyTier.title) {
+    errors.push('Title is required')
+  }
+  if (!modifyTier.price) {
+    errors.push('Price is required')
+  }
+  if (modifyTier.price <= 0) {
+    errors.push('Price should be greater than 0')
+  }
+  if (!modifyTier.valid_till) {
+    errors.push('Closing Date is required')
+  }
+  if (
+    props.tier.valid_till != modifyTier.valid_till &&
+    new Date(modifyTier.valid_till) < new Date()
+  ) {
+    errors.push('Valid till should be a future date')
+  }
+  if (!modifyTier.maximum_tickets) {
+    errors.push('Maximum tickets is required')
+  }
+  if (modifyTier.maximum_tickets <= 0) {
+    errors.push('Maximum tickets should be greater than 0')
+  }
+
+  return errors
+}
+
+const handleSubmit = () => {
+  const errors = validateTierFields()
+  if (errors.length) {
+    errorMessages.value = errors.join(', ')
+    return
+  }
+
+  updateTier.fetch()
+}
+
+const toggleTierStatus = createResource({
+  url: 'frappe.client.set_value',
+  makeParams() {
+    return {
+      doctype: 'FOSS Ticket Tier',
+      name: props.tier.name,
+      fieldname: 'enabled',
+      value: Boolean(!props.tier.enabled),
+    }
+  },
+  onSuccess() {
+    emit('update-tier')
+  },
+})
+
+const createTier = createResource({
+  url: 'frappe.client.insert',
+  makeParams() {
+    return {
+      doc: {
+        doctype: 'FOSS Ticket Tier',
+        title: modifyTier.title,
+        price: modifyTier.price,
+        currency: modifyTier.currency,
+        valid_till: modifyTier.valid_till,
+        maximum_tickets: modifyTier.maximum_tickets,
+        description: modifyTier.description,
+        enabled: modifyTier.enabled,
+        parent: route.params.id,
+        parentfield: 'tiers',
+        parenttype: 'FOSS Chapter Event',
+      },
+    }
+  },
+  onSuccess() {
+    emit('update-tier')
+    showDialog.value = false
+  },
+})
+
+const handleCreate = () => {
+  const errors = validateTierFields()
+  if (errors.length) {
+    errorMessages.value = errors.join(', ')
+    return
+  }
+
+  createTier.fetch()
+}
+</script>

--- a/dashboard/src/components/event/TicketCustomFieldDialog.vue
+++ b/dashboard/src/components/event/TicketCustomFieldDialog.vue
@@ -1,0 +1,203 @@
+<template>
+  <Dialog
+    class="z-50"
+    v-model="showDialog"
+    :options="{
+      title: inCreateMode ? 'Create Custom Field' : 'Edit Custom Field',
+      width: 'md',
+    }"
+  >
+    <template #body-content>
+      <div class="flex flex-col gap-4">
+        <FormControl v-model="question.label" label="Question &ast;" />
+        <FormControl
+          v-model="question.field_type"
+          label="Field Type &ast;"
+          type="select"
+          :options="[
+            { label: 'Data', value: 'Data' },
+            { label: 'Select', value: 'Select' },
+            { label: 'Int', value: 'Int' },
+          ]"
+        />
+        <div class="my-1 flex flex-col gap-1">
+          <FormControl
+            v-model="question.mandatory"
+            label="Is Mandatory"
+            type="checkbox"
+          />
+          <small class="text-gray-600"
+            >Whether the question is mandatory or not.</small
+          >
+        </div>
+        <FormControl
+          v-model="question.field_name"
+          label="Field Name &ast;"
+          description="The name of the field."
+        />
+        <FormControl
+          v-if="question.field_type === 'Select'"
+          type="textarea"
+          v-model="question.options"
+          label="Options"
+          description="Options for the select field. Enter each option on a new line."
+        />
+      </div>
+      <ErrorMessage :message="errorMessages" />
+    </template>
+    <template #actions>
+      <div class="flex gap-2 items-center">
+        <Button class="w-full" label="Cancel" @click="showDialog = false" />
+        <Button
+          v-if="inCreateMode"
+          class="w-full"
+          variant="solid"
+          label="Create"
+          @click="handleCreate"
+        />
+        <Button
+          v-else
+          class="w-full"
+          variant="solid"
+          label="Save"
+          @click="handleSave"
+        />
+      </div>
+    </template>
+  </Dialog>
+</template>
+<script setup>
+import { defineProps, defineModel, watch, reactive, ref } from 'vue'
+import { Dialog, FormControl, ErrorMessage, createResource } from 'frappe-ui'
+import { toast } from 'vue-sonner'
+
+const props = defineProps({
+  event: {
+    type: Object,
+    default: null,
+  },
+  inCreateMode: {
+    type: Boolean,
+    default: false,
+  },
+  row: {
+    type: Object,
+    default: {},
+  },
+})
+
+const showDialog = defineModel()
+
+const question = reactive({
+  label: '',
+  field_type: '',
+  mandatory: false,
+  field_name: '',
+  options: '',
+})
+
+watch(
+  () => props.row,
+  (row) => {
+    question.label = row.label
+    question.field_type = row.field_type
+    question.mandatory = row.mandatory
+    question.field_name = row.field_name
+    question.options = row.options
+  },
+  { immediate: true },
+)
+
+const errorMessages = ref('')
+
+const validateFields = () => {
+  const errors = []
+
+  if (!question.label) {
+    errors.push('Question is required.')
+  }
+  if (!question.field_type) {
+    errors.push('Field Type is required.')
+  }
+  if (!question.field_name) {
+    errors.push('Field Name is required.')
+  }
+  if (question.field_type === 'Select' && !question.options) {
+    errors.push('Options are required for Select field type.')
+  }
+
+  return errors
+}
+
+const createCustomField = createResource({
+  url: 'frappe.client.insert',
+  makeParams() {
+    return {
+      doc: {
+        doctype: 'FOSS Event Field',
+        label: question.label,
+        field_type: question.field_type,
+        mandatory: question.mandatory,
+        field_name: question.field_name,
+        options: question.options,
+        parent: props.event.data.name,
+        parenttype: 'FOSS Chapter Event',
+        parentfield: 'custom_fields',
+      },
+    }
+  },
+  onSuccess() {
+    props.event.fetch()
+    toast.success('Custom field created successfully')
+    showDialog.value = false
+  },
+  onError(error) {
+    errorMessages.value = error.message
+  },
+})
+
+const updateCustomField = createResource({
+    url: 'frappe.client.set_value',
+    makeParams() {
+      return {
+        doctype: 'FOSS Event Field',
+        name: props.row.name,
+        fieldname: {
+            label: question.label,
+            field_type: question.field_type,
+            mandatory: question.mandatory,
+            field_name: question.field_name,
+            options: question.options,
+        }
+      }
+    },
+    onSuccess() {
+      props.event.fetch()
+      toast.success('Custom field updated successfully')
+      showDialog.value = false
+    },
+    onError(error) {
+      errorMessages.value = error.message
+    },
+})
+
+const handleCreate = () => {
+  const errors = validateFields()
+  if (errors.length) {
+    errorMessages.value = errors.join(' ')
+    return
+  }
+  errorMessages.value = ''
+  createCustomField.fetch()
+}
+
+const handleSave = () => {
+  const errors = validateFields()
+  if (errors.length) {
+    errorMessages.value = errors.join(' ')
+    return
+  }
+  errorMessages.value = ''
+    updateCustomField.fetch()
+}
+</script>

--- a/dashboard/src/components/event/TicketCustomFieldDialog.vue
+++ b/dashboard/src/components/event/TicketCustomFieldDialog.vue
@@ -47,6 +47,13 @@
     </template>
     <template #actions>
       <div class="flex gap-2 items-center">
+        <Button
+            v-if="!inCreateMode"
+            class="w-fit px-2"
+            icon="trash"
+            theme="red"
+            @click="handleDelete"
+        />
         <Button class="w-full" label="Cancel" @click="showDialog = false" />
         <Button
           v-if="inCreateMode"
@@ -181,6 +188,24 @@ const updateCustomField = createResource({
     },
 })
 
+const deleteCustomField = createResource({
+  url: 'frappe.client.delete',
+  makeParams() {
+    return {
+      doctype: 'FOSS Event Field',
+      name: props.row.name,
+    }
+  },
+  onSuccess() {
+    props.event.fetch()
+    toast.info('Custom field deleted successfully')
+    showDialog.value = false
+  },
+  onError(error) {
+    errorMessages.value = error.message
+  },
+})
+
 const handleCreate = () => {
   const errors = validateFields()
   if (errors.length) {
@@ -199,5 +224,9 @@ const handleSave = () => {
   }
   errorMessages.value = ''
     updateCustomField.fetch()
+}
+
+const handleDelete = () => {
+  deleteCustomField.fetch()
 }
 </script>

--- a/dashboard/src/components/event/TicketCustomFieldsSection.vue
+++ b/dashboard/src/components/event/TicketCustomFieldsSection.vue
@@ -1,0 +1,110 @@
+<template>
+  <TicketCustomFieldDialog
+    :event="event"
+    :inCreateMode="inCreateMode"
+    :row="selectedRow"
+    v-model="showDialog"
+  />
+  <div>
+    <div class="prose">
+      <h2 class="mb-1">Custom Fields</h2>
+      <p class="text-sm">
+        Any custom fields you want to collect while ticket booking
+      </p>
+      <Button
+        variant="solid"
+        label="Add Field"
+        icon-left="plus"
+        @click="handleCustomRowCreate"
+      />
+    </div>
+    <ListView
+      class="mt-4 min-h-[300px]"
+      :columns="[
+        {
+          label: 'Field Label',
+          key: 'label',
+        },
+        {
+          label: 'Field Type',
+          key: 'field_type',
+        },
+        {
+          label: 'Is Mandatory?',
+          key: 'mandatory',
+        },
+        {
+          label: 'Fieldname',
+          key: 'field_name',
+        },
+        {
+          label: 'options',
+          key: 'options',
+        },
+      ]"
+      :rows="event.data.custom_fields"
+      row-key="id"
+      :options="{
+        emptyState: {
+          title: 'No Custom Fields',
+          description: 'No custom fields have been added yet.',
+        },
+        selectable: false,
+        showTooltip: true,
+        resizeColumn: true,
+        onRowClick: (row) => handleCustomRowEdit(row),
+      }"
+    >
+      <template #cell="{ item, row, column }">
+        <div v-if="column.key === 'mandatory'">
+          <Checkbox :model-value="item" :disabled="true" />
+        </div>
+        <div v-else-if="column.key === 'field_name'">
+          <span class="font-mono text-base">{{ item }}</span>
+        </div>
+        <div v-else-if="column.key === 'options' && key != null">
+          <span class="text-sm">
+            <span v-for="option in item.split('\n')" :key="option">
+              <span class="px-1 py-0.5 bg-gray-200 rounded-sm mr-1">
+                {{ option }}
+              </span>
+            </span>
+          </span>
+        </div>
+        <div v-else>
+          <span class="text-base">
+            {{ item }}
+          </span>
+        </div>
+      </template>
+    </ListView>
+  </div>
+</template>
+<script setup>
+import { defineProps, ref } from 'vue'
+import { createResource, ListView, Checkbox } from 'frappe-ui'
+import TicketCustomFieldDialog from '@/components/event/TicketCustomFieldDialog.vue'
+
+const props = defineProps({
+  event: {
+    type: Object,
+    default: null,
+  },
+})
+
+const showDialog = ref(false)
+const inCreateMode = ref(false)
+const selectedRow = ref({})
+
+const handleCustomRowEdit = (row) => {
+  inCreateMode.value = false
+  selectedRow.value = row
+  showDialog.value = true
+}
+
+const handleCustomRowCreate = () => {
+  selectedRow.value = {}
+  inCreateMode.value = true
+  showDialog.value = true
+}
+</script>

--- a/dashboard/src/components/event/TicketList.vue
+++ b/dashboard/src/components/event/TicketList.vue
@@ -1,0 +1,156 @@
+<template>
+  <div class="prose">
+    <h3 class="mb-1">Attendee List</h3>
+    <p class="text-sm">List of attendees for this event.</p>
+  </div>
+  <div class="flex flex-col flex-wrap md:flex-row gap-5 my-2 md:items-end">
+    <FormControl
+      type="search"
+      label="Search"
+      placeholder="Search by Name"
+      class="md:w-1/4"
+      v-model="filters.search_text"
+      @input="attendeesList.fetch()"
+    />
+    <FormControl
+        type="select"
+        label="Tier"
+        class="md:w-1/6"
+        v-if="tiers.data"
+        :options="tierOptions"
+        v-model="filters.tier"
+        @change="attendeesList.fetch()"
+    />
+  </div>
+  <ListView
+    v-if="attendeesList.data"
+    class="h-[540px]"
+    :columns="[
+      {
+        label: 'Name',
+        key: 'full_name',
+      },
+      {
+        label: 'Designation',
+        key: 'designation',
+      },
+      {
+        label: 'Organization',
+        key: 'organization',
+      },
+      {
+        label: 'Tier',
+        key: 'tier',
+      },
+      {
+        label: 'T-shirt Addon',
+        key: 'wants_tshirt',
+        width: 1 / 4,
+      },
+      {
+        label: 'Tshirt Size',
+        key: 'tshirt_size',
+        width: 1 / 4,
+      },
+    ]"
+    :rows="attendeesList.data"
+    :options="{
+      selectable: false,
+      showTooltip: false,
+      resizeColumn: false,
+      emptyState: {
+        title: 'No attendees for this event',
+        description: 'Attendees will be listed here once they buy tickets.',
+      },
+    }"
+  >
+    <template #cell="{ item, row, column }" class="even:bg-gray-50">
+      <div v-if="column.key === 'wants_tshirt'">
+        <Checkbox :model-value="item" :disabled="true" />
+      </div>
+      <div v-else-if="column.key === 'tshirt_size'">
+        <div v-if="!row['wants_tshirt']">
+          <div class="text-base">-</div>
+        </div>
+        <div v-else class="text-base">{{ item }}</div>
+      </div>
+      <div v-else class="text-base">{{ item }}</div>
+    </template>
+  </ListView>
+  <div
+    v-if="attendeesList.loading"
+    class="w-full h-[220px] flex items-center justify-center"
+  >
+    <LoadingIndicator class="w-5 h-5" />
+  </div>
+</template>
+<script setup>
+import {
+  createResource,
+  ListView,
+  LoadingIndicator,
+  Checkbox,
+  FormControl,
+} from 'frappe-ui'
+import { toast } from 'vue-sonner'
+import { defineProps, reactive, ref } from 'vue'
+
+const props = defineProps({
+  event: {
+    type: Object,
+    required: true,
+  },
+})
+
+const filters = reactive({
+  search_text: '',
+  wants_tshirt: false,
+})
+
+const tierOptions = ref([])
+
+const tiers = createResource({
+    url: 'fossunited.api.tickets.get_ticket_tiers',
+    makeParams() {
+        return {
+        event_id: props.event.data.name,
+        }
+    },
+    auto: true,
+    onSuccess(data){
+        let options = []
+        options.push({
+            label: 'All',
+            value: data.map(tier => tier.title),
+        })
+
+        data.forEach(tier => {
+            options.push({
+                label: tier.title,
+                value: tier.title,
+            })
+        })
+        tierOptions.value = options
+        filters.tier = options[0].value
+    }
+})
+
+const attendeesList = createResource({
+  url: 'fossunited.api.tickets.get_sold_tickets',
+  makeParams() {
+    return {
+      event_id: props.event.data.name,
+      filters: {
+        full_name : ['like', `%${filters.search_text}%`],
+        tier: ['in', filters.tier],
+      },
+    }
+  },
+  loading: true,
+  debounce: 500,
+  auto: true,
+  onError(error) {
+    toast.error(error.message)
+  },
+})
+</script>

--- a/dashboard/src/components/event/TicketTierCard.vue
+++ b/dashboard/src/components/event/TicketTierCard.vue
@@ -1,0 +1,59 @@
+<template>
+  <ManageTicketTierDialog
+    v-model="showDialog"
+    :tier="tier"
+    @update-tier="updateTier"
+  />
+  <div class="rounded border p-4">
+    <div class="flex w-full justify-between items-center">
+      <div class="flex flex-wrap items-center">
+        <div class="prose">
+          <h3 class="uppercase">{{ tier.title }}</h3>
+        </div>
+        <Badge :theme="tier.enabled ? 'green' : 'gray'" class="ml-2">
+          {{ tier.enabled ? 'Active' : 'Inactive' }}
+        </Badge>
+      </div>
+      <Button label="Manage" @click="manageTicketTier" />
+    </div>
+    <div class="mt-6 flex flex-col gap-1">
+      <div class="prose">
+        <h3 class="font-medium">
+          {{ tier.price }} <span class="text-lg">{{ tier.currency }}</span>
+        </h3>
+      </div>
+      <div class="text-xs text-gray-600" v-if="tier.valid_till">
+        Closes: {{ new Date(tier.valid_till).toDateString() }}
+      </div>
+      <div class="text-xs text-gray-600" v-if="tier.maximum_tickets">
+        Max Tickets: {{ tier.maximum_tickets }}
+      </div>
+    </div>
+  </div>
+</template>
+<script setup>
+import { toast } from 'vue-sonner'
+import { Badge } from 'frappe-ui'
+import { defineProps, defineEmits, ref } from 'vue'
+import ManageTicketTierDialog from '@/components/event/ManageTicketTierDialog.vue'
+
+const showDialog = ref(false)
+
+const props = defineProps({
+  tier: {
+    type: Object,
+    required: true,
+  },
+})
+
+const emit = defineEmits(['update-tier'])
+
+const updateTier = () => {
+  toast.success('Ticket tier updated successfully')
+  emit('update-tier')
+}
+
+const manageTicketTier = () => {
+  showDialog.value = true
+}
+</script>

--- a/dashboard/src/components/event/TicketTierInsightCard.vue
+++ b/dashboard/src/components/event/TicketTierInsightCard.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="flex flex-col w-full border rounded-sm p-4">
+    <div class="text-sm uppercase font-semibold ">{{ tier.title }}</div>
+    <div class="flex gap-2 items-end justify-between mt-6">
+      <div>
+        <div class="prose">
+          <h2 class="">{{ tier.total_sold }}</h2>
+        </div>
+        <span v-if="tier.tier_capacity" class="text-sm text-gray-600 mb-1"
+          >out of {{ tier.tier_capacity }}</span
+        >
+      </div>
+      <div
+        class="flex items-center gap-1 text-sm mt-1 font-medium p-1 w-fit rounded-sm px-2"
+        :class="
+          tier.tickets_sold_today === 0
+            ? 'bg-gray-100 text-gray-600'
+            : 'bg-green-100 text-green-600'
+        "
+      >
+        <svg
+          v-if="tier.tickets_sold_today"
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          class="icon icon-tabler w-4 h-4 -mx-1 icons-tabler-outline icon-tabler-arrow-narrow-up"
+        >
+          <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+          <path d="M12 5l0 14" />
+          <path d="M16 9l-4 -4" />
+          <path d="M8 9l4 -4" />
+        </svg>
+        <span>{{ tier.tickets_sold_today }}</span>
+        <span>sold today</span>
+      </div>
+    </div>
+  </div>
+</template>
+<script setup>
+import { defineProps } from 'vue'
+
+const props = defineProps({
+  tier: {
+    type: Object,
+    required: true,
+  },
+})
+</script>

--- a/dashboard/src/components/event/TicketTierSection.vue
+++ b/dashboard/src/components/event/TicketTierSection.vue
@@ -1,0 +1,32 @@
+<template>
+  <ManageTicketTierDialog v-model="showDialog" :inCreateMode="true" @update-tier="event.fetch()"/>
+  <div>
+    <div class="prose">
+      <h2 class="mb-1">Ticket Tiers</h2>
+      <p class="text-sm">Manage the ticket tiers for this event here.</p>
+      <Button variant="solid" label="Add Tier" @click="showDialog = true" icon-left="plus" />
+    </div>
+    <div class="grid grid-cols-1 md:grid-cols-3 my-4 gap-4">
+      <TicketTierCard
+        @update-tier="event.fetch()"
+        v-for="tier in event.data.tiers"
+        :key="tier.name"
+        :tier="tier"
+      />
+    </div>
+  </div>
+</template>
+<script setup>
+import TicketTierCard from '@/components/event/TicketTierCard.vue'
+import ManageTicketTierDialog from '@/components/event/ManageTicketTierDialog.vue'
+import { defineProps, ref } from 'vue'
+
+const props = defineProps({
+  event: {
+    type: Object,
+    default: null,
+  },
+})
+
+const showDialog = ref(false)
+</script>

--- a/dashboard/src/components/event/TicketTshirtInsightCard.vue
+++ b/dashboard/src/components/event/TicketTshirtInsightCard.vue
@@ -1,0 +1,70 @@
+<template>
+  <Dialog
+    class="z-50"
+    v-model="showDialog"
+    :options="{
+      title: 'Sold T-shirt Details',
+    }"
+  >
+    <template #body-content>
+        <div class="text-sm">
+            <p class="mb-2">T-shirts sold for this event.</p>
+        </div>
+        <table class="w-3/4 table-fixed text-center">
+            <thead class="text-xs text-gray-700 uppercase bg-gray-50">
+                <tr>
+                    <th class="p-2 border">Size</th>
+                    <th class="p-2 border">Quantity</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr v-for="(quantity, size) in insight.tshirt_size_count">
+                    <td class="p-2 text-base border">{{ size }}</td>
+                    <td class="p-2 text-base border">{{ quantity }}</td>
+                </tr>
+                <tr>
+                    <td class="p-2 text-base font-semibold">Total</td>
+                    <td class="p-2 text-base font-semibold">{{ insight.tshirts_sold }}</td>
+                </tr>
+            </tbody>
+        </table>
+    </template>
+  </Dialog>
+  <div class="flex flex-col w-full border rounded-sm p-4">
+    <div class="text-sm flex gap-2 items-center uppercase font-semibold">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        class="icon icon-tabler icons-tabler-filled w-5 h-5 icon-tabler-shirt"
+      >
+        <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+        <path
+          d="M14.883 3.007l.095 -.007l.112 .004l.113 .017l.113 .03l6 2a1 1 0 0 1 .677 .833l.007 .116v5a1 1 0 0 1 -.883 .993l-.117 .007h-2v7a2 2 0 0 1 -1.85 1.995l-.15 .005h-10a2 2 0 0 1 -1.995 -1.85l-.005 -.15v-7h-2a1 1 0 0 1 -.993 -.883l-.007 -.117v-5a1 1 0 0 1 .576 -.906l.108 -.043l6 -2a1 1 0 0 1 1.316 .949a2 2 0 0 0 3.995 .15l.009 -.24l.017 -.113l.037 -.134l.044 -.103l.05 -.092l.068 -.093l.069 -.08c.056 -.054 .113 -.1 .175 -.14l.096 -.053l.103 -.044l.108 -.032l.112 -.02z"
+        />
+      </svg>
+      <span> T-shirts Sold </span>
+    </div>
+    <div class="flex gap-2 items-end justify-between mt-6">
+      <div class="prose">
+        <h2 class="">{{ insight.tshirts_sold }}</h2>
+      </div>
+      <Button class="w-fit" label="View Details" @click="showDialog = true" />
+    </div>
+  </div>
+</template>
+<script setup>
+import { Dialog } from 'frappe-ui'
+import { defineProps, ref } from 'vue'
+
+const showDialog = ref(false)
+
+const props = defineProps({
+  insight: {
+    type: Object,
+    required: true,
+  },
+})
+</script>

--- a/dashboard/src/components/event/TicketTshirtSection.vue
+++ b/dashboard/src/components/event/TicketTshirtSection.vue
@@ -1,0 +1,133 @@
+<template>
+  <div>
+    <div class="prose w-full">
+      <h2 class="mb-1">Manage T-Shirts</h2>
+      <p class="text-sm">You can manage the t-shirts for this event here.</p>
+    </div>
+    <div class="w-full md:w-1/3 mt-4 flex gap-2 flex-col rounded border p-4">
+      <div class="flex justify-between items-center">
+        <div class="text-base font-semibold mb-1">
+          T-Shirts add-on is
+          <span
+            :class="
+              event.data.paid_tshirts_available
+                ? 'text-green-600'
+                : 'text-gray-600'
+            "
+            >{{
+              event.data.paid_tshirts_available ? 'Available' : 'Unavailable'
+            }}</span
+          >
+        </div>
+        <div class="space-x-2">
+          <Button
+            class="w-fit mt-2"
+            :label="
+              event.data.paid_tshirts_available ? 'Deactivate' : 'Activate'
+            "
+            :theme="event.data.paid_tshirts_available ? 'red' : 'gray'"
+            @click="toggleTshirtStatus.fetch()"
+          />
+        </div>
+      </div>
+      <div class="mt-6 flex flex-col gap-1">
+        <div class="flex gap-2" v-if="inPriceEdit">
+          <Input
+            class="w-1/3"
+            v-model="newTshirtPrice"
+            inputClasses="text-2xl"
+            placeholder="0.00"
+          >
+          </Input>
+          <Button icon="x" @click="inPriceEdit = false" />
+          <Button icon="check" theme="green" @click="handleTshirtPriceUpdate" />
+        </div>
+        <div v-else class="prose flex items-center gap-2">
+          <h3 class="font-medium mb-0">
+            {{ event.data.t_shirt_price }} <span class="text-lg">INR</span>
+          </h3>
+          <Button icon="edit" @click="inPriceEdit = true" />
+        </div>
+      </div>
+      <ErrorMessage :message="errorMessages" />
+    </div>
+  </div>
+</template>
+<script setup>
+import { defineProps, ref } from 'vue'
+import { createResource, ErrorMessage } from 'frappe-ui'
+import { useRoute } from 'vue-router'
+import { toast } from 'vue-sonner'
+import Input from '@/components/Input.vue'
+
+const props = defineProps({
+  event: {
+    type: Object,
+    default: null,
+  },
+})
+
+const inPriceEdit = ref(false)
+const newTshirtPrice = ref(props.event.data.t_shirt_price)
+const route = useRoute()
+
+const toggleTshirtStatus = createResource({
+  url: 'frappe.client.set_value',
+  makeParams() {
+    return {
+      doctype: 'FOSS Chapter Event',
+      name: route.params.id,
+      fieldname: 'paid_tshirts_available',
+      value: !props.event.data.paid_tshirts_available,
+    }
+  },
+  onSuccess() {
+    props.event.fetch()
+  },
+})
+
+const errorMessages = ref('')
+const tshirtPriceUpdateErrors = () => {
+  const errors = []
+
+  if (!newTshirtPrice.value) {
+    errors.push('Price cannot be empty')
+  }
+  if (isNaN(newTshirtPrice.value)) {
+    errors.push('Price should be a number')
+  }
+  if (Number(newTshirtPrice.value) <= 0) {
+    errors.push('Price should be greater than 0')
+  }
+
+  return errors
+}
+
+const updateTshirtPrice = createResource({
+  url: 'frappe.client.set_value',
+  makeParams() {
+    return {
+      doctype: 'FOSS Chapter Event',
+      name: route.params.id,
+      fieldname: 't_shirt_price',
+      value: newTshirtPrice.value,
+    }
+  },
+  onSuccess() {
+    props.event.fetch()
+    toast.success('T-shirt price updated successfully')
+    inPriceEdit.value = false
+  },
+})
+
+const handleTshirtPriceUpdate = () => {
+  const errors = tshirtPriceUpdateErrors()
+  if (errors.length) {
+    errorMessages.value = errors.join(', ')
+    return
+  }
+  errorMessages.value = ''
+
+  updateTshirtPrice.fetch()
+}
+</script>

--- a/dashboard/src/pages/Event.vue
+++ b/dashboard/src/pages/Event.vue
@@ -14,7 +14,7 @@
 
 <script setup>
 import { ref } from 'vue'
-import { usePageMeta } from 'frappe-ui'
+import { createResource, usePageMeta } from 'frappe-ui'
 import { RouterView, useRoute } from 'vue-router'
 import SideNavbar from '@/components/NewAppSidebar.vue'
 import HeaderWithNav from '@/components/HeaderWithNav.vue'
@@ -23,37 +23,58 @@ const route = useRoute()
 
 const showNav = ref(false)
 
-const sidebarMenuItems = [
+const sidebarMenuItems = ref([
   {
     items: [
       {
         icon: 'arrow-left',
         label: 'Go Home',
-        route: '/chapter'
-      }
-    ]
-  },
-  {
-    items: [
-      {
-        label: 'Details',
-        route: `/event/${route.params.id}`,
-      },
-      {
-        label: 'RSVP',
-        route: `/event/${route.params.id}/rsvp`,
-      },
-      {
-        label: 'CFP',
-        route: `/event/${route.params.id}/cfp`,
-      },
-      {
-        label: 'Volunteers',
-        route: `/event/${route.params.id}/volunteers`,
+        route: '/chapter',
       },
     ],
   },
-]
+])
+
+const event = createResource({
+  url: 'frappe.client.get_value',
+  params: {
+    doctype: 'FOSS Chapter Event',
+    fieldname: ['name', 'event_name', 'is_paid_event'],
+    filters: { name: route.params.id },
+  },
+  auto: true,
+  onSuccess(data) {
+    let sidebar_items = {
+      items: [
+        {
+          label: 'Details',
+          route: `/event/${route.params.id}`,
+        },
+        {
+          label: 'RSVP',
+          route: `/event/${route.params.id}/rsvp`,
+        },
+        {
+          label: 'CFP',
+          route: `/event/${route.params.id}/cfp`,
+        },
+        {
+          label: 'Volunteers',
+          route: `/event/${route.params.id}/volunteers`,
+        },
+      ],
+    }
+
+    if (data.is_paid_event) {
+      sidebar_items.items.splice(1, 1, {
+        label: 'Tickets',
+        route: `/event/${route.params.id}/tickets`,
+      })
+    }
+
+    sidebarMenuItems.value.push(sidebar_items)
+  },
+})
 
 usePageMeta(() => {
   return {

--- a/dashboard/src/pages/EventCfp.vue
+++ b/dashboard/src/pages/EventCfp.vue
@@ -3,7 +3,7 @@
     <div class="flex gap-3 items-end px-4 py-8 md:p-8">
       <EventHeader
         class=""
-        :event="event"
+        :event="event.doc"
         :form_exists="Boolean(hasCfp.data)"
         :form="eventCfp"
       />

--- a/dashboard/src/pages/EventDetails.vue
+++ b/dashboard/src/pages/EventDetails.vue
@@ -2,7 +2,7 @@
   <div v-if="event.doc" class="px-4 py-8 md:p-8 w-full z-0 min-h-screen">
     <div class="flex flex-col md:flex-row gap-2 justify-between">
       <EventHeader
-        :event="event"
+        :event="event.doc"
         :form_exists="true"
         :form="{
           data: {

--- a/dashboard/src/pages/EventRsvp.vue
+++ b/dashboard/src/pages/EventRsvp.vue
@@ -2,7 +2,7 @@
   <div v-if="event.doc" class="w-full z-0 min-h-screen">
     <EventHeader
       class="px-4 py-8 md:p-8"
-      :event="event"
+      :event="event.doc"
       :form_exists="Boolean(has_rsvp.data)"
       :form="event_rsvp"
     />

--- a/dashboard/src/pages/EventTicketInsights.vue
+++ b/dashboard/src/pages/EventTicketInsights.vue
@@ -19,6 +19,9 @@
           :tier="tier"
         />
       </div>
+      <div class="flex flex-col gap-4">
+        <TicketList :event="event" />
+      </div>
     </div>
   </div>
   <div v-else class="w-full h-[220px] flex items-center justify-center">
@@ -27,10 +30,11 @@
 </template>
 <script setup>
 import { defineProps, reactive } from 'vue'
-import { createResource, LoadingIndicator } from 'frappe-ui'
+import { createResource, LoadingIndicator, ListView } from 'frappe-ui'
 import { toast } from 'vue-sonner'
 import TicketTierInsightCard from '@/components/event/TicketTierInsightCard.vue'
 import TicketTshirtInsightCard from '@/components/event/TicketTshirtInsightCard.vue'
+import TicketList from '@/components/event/TicketList.vue'
 
 const props = defineProps({
   event: {

--- a/dashboard/src/pages/EventTicketInsights.vue
+++ b/dashboard/src/pages/EventTicketInsights.vue
@@ -1,0 +1,66 @@
+<template>
+  <div v-if="ticket_insights.data" class="flex flex-col gap-6">
+    <div class="flex flex-col gap-4">
+      <div class="prose">
+        <h2 class="mb-1">Insights</h2>
+        <p class="text-sm">Get insights about the tickets sold for this event.</p>
+      </div>
+      <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+          <TicketTierInsightCard :tier="today_stats" />
+          <TicketTshirtInsightCard :insight="ticket_insights.data.tshirt_insights" />
+      </div>
+      <div class="prose mt-4">
+        <h4>Tier Insights</h4>
+      </div>
+      <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+        <TicketTierInsightCard
+          v-for="tier in ticket_insights.data.tier_data"
+          :key="tier.title"
+          :tier="tier"
+        />
+      </div>
+    </div>
+  </div>
+  <div v-else class="w-full h-[220px] flex items-center justify-center">
+    <LoadingIndicator class="w-5 h-5" />
+  </div>
+</template>
+<script setup>
+import { defineProps, reactive } from 'vue'
+import { createResource, LoadingIndicator } from 'frappe-ui'
+import { toast } from 'vue-sonner'
+import TicketTierInsightCard from '@/components/event/TicketTierInsightCard.vue'
+import TicketTshirtInsightCard from '@/components/event/TicketTshirtInsightCard.vue'
+
+const props = defineProps({
+  event: {
+    type: Object,
+    required: true,
+  },
+})
+
+const today_stats = reactive({
+  title: 'Total Tickets Sold',
+  total_sold: 0,
+  tickets_sold_today: 0,
+  tier_capacity: false,
+})
+
+const ticket_insights = createResource({
+  url: 'fossunited.api.tickets.get_tickets_insights',
+  makeParams() {
+    return {
+      event_id: props.event.data.name,
+    }
+  },
+  loading: true,
+  auto: true,
+  onSuccess(data) {
+    today_stats.total_sold = data.total_sold
+    today_stats.tickets_sold_today = data.tickets_sold_today
+  },
+  onError(error) {
+    toast.error(error.message)
+  },
+})
+</script>

--- a/dashboard/src/pages/EventTicketManage.vue
+++ b/dashboard/src/pages/EventTicketManage.vue
@@ -1,0 +1,91 @@
+<template>
+  <div class="flex flex-col gap-6" v-if="event.data">
+    <!-- Manage Tickets -->
+    <div>
+      <div class="prose w-full">
+        <h2 class="mb-1">Manage Tickets</h2>
+        <p class="text-sm">You can manage the tickets for this event here.</p>
+      </div>
+      <div
+        class="w-full md:w-1/3 mt-4 flex gap-2 flex-col p-4 border rounded-sm border-gray-500 border-dashed"
+      >
+        <div>
+          <div class="text-base font-semibold mb-1">
+            Tickets are
+            <span
+              :class="
+                { Live: 'text-green-700', Closed: 'text-red-600' }[
+                  event.data.tickets_status
+                ]
+              "
+              >{{ event.data.tickets_status }}</span
+            >
+          </div>
+          <p class="text-sm text-gray-600">
+            {{ ticketSubtitle[event.data.tickets_status] }}
+          </p>
+        </div>
+        <Button
+          class="w-fit mt-2"
+          :label="
+            { Live: 'Deactivate', Closed: 'Activate' }[
+              event.data.tickets_status
+            ]
+          "
+          :theme="{ Live: 'red', Closed: 'gray' }[event.data.tickets_status]"
+          @click="toggleTicketStatus.fetch()"
+        />
+      </div>
+    </div>
+
+    <!-- Ticket Tier Section -->
+    <TicketTierSection :event="event" />
+
+    <!-- Tshirt Section -->
+    <TicketTshirtSection :event="event" />
+
+    <!-- Custom Fields -->
+    <TicketCustomFieldsSection :event="event" />
+  </div>
+</template>
+<script setup>
+import TicketTierSection from '@/components/event/TicketTierSection.vue'
+import TicketTshirtSection from '@/components/event/TicketTshirtSection.vue'
+import TicketCustomFieldsSection from '@/components/event/TicketCustomFieldsSection.vue'
+import { createResource } from 'frappe-ui'
+import { useRoute } from 'vue-router'
+
+const route = useRoute()
+
+const ticketSubtitle = {
+  Live: 'Tickets are currently available for purchase.',
+  Closed: 'Tickets are currently not available for purchase.',
+}
+
+const event = createResource({
+  url: 'frappe.client.get',
+  makeParams() {
+    return {
+      doctype: 'FOSS Chapter Event',
+      name: route.params.id,
+      fields: ['*'],
+    }
+  },
+  auto: true,
+})
+
+const toggleTicketStatus = createResource({
+  url: 'frappe.client.set_value',
+  makeParams() {
+    return {
+      doctype: 'FOSS Chapter Event',
+      name: route.params.id,
+      fieldname: 'tickets_status',
+      value: event.data.tickets_status === 'Live' ? 'Closed' : 'Live',
+    }
+  },
+  onSuccess() {
+    event.fetch()
+  },
+})
+</script>

--- a/dashboard/src/pages/EventTickets.vue
+++ b/dashboard/src/pages/EventTickets.vue
@@ -2,7 +2,7 @@
   <div v-if="event.data" class="w-full z-0 ">
     <EventHeader :event="event.doc" v-if="event.doc" class="p-4 md:p-8" />
     <TabsWithRoute :tabs="tabs" />
-    <RouterView class="p-4 md:p-8" />
+    <RouterView class="p-4 md:p-8" :event="event" />
   </div>
   <div v-else class="w-full h-[220px] flex items-center justify-center">
     <LoadingIndicator class="w-5 h-5" />

--- a/dashboard/src/pages/EventTickets.vue
+++ b/dashboard/src/pages/EventTickets.vue
@@ -1,0 +1,105 @@
+<template>
+  <div v-if="event.data" class="w-full z-0 px-4 py-4 md:p-8">
+    <EventHeader :event="event.doc" v-if="event.doc" />
+    <hr class="my-5" />
+
+    <div class="flex flex-col gap-4">
+      <!-- Manage Tickets -->
+      <div>
+        <div class="prose w-full">
+          <h2 class="mb-1">Manage Tickets</h2>
+          <p class="text-sm">You can manage the tickets for this event here.</p>
+        </div>
+        <div
+          class="w-full md:w-1/3 mt-4 flex gap-2 flex-col p-4 border rounded-sm border-gray-500 border-dashed"
+        >
+          <div>
+            <div class="text-base font-semibold mb-1">
+              Tickets are
+              <span
+                :class="
+                  { Live: 'text-green-700', Closed: 'text-red-600' }[
+                    event.data.tickets_status
+                  ]
+                "
+                >{{ event.data.tickets_status }}</span
+              >
+            </div>
+            <p class="text-sm text-gray-600">
+              {{ ticketSubtitle[event.data.tickets_status] }}
+            </p>
+          </div>
+          <Button
+            class="w-fit mt-2"
+            :label="
+              { Live: 'Deactivate', Closed: 'Activate' }[
+                event.data.tickets_status
+              ]
+            "
+            :theme="{ Live: 'red', Closed: 'gray' }[event.data.tickets_status]"
+            @click="toggleTicketStatus.fetch()"
+          />
+        </div>
+      </div>
+
+      <!-- Ticket Tier Section -->
+      <TicketTierSection :event="event"/>
+
+      <!-- Tshirt Section -->
+      <TicketTshirtSection :event="event"/>
+
+      <!-- Custom Fields -->
+      <TicketCustomFieldsSection :event="event" />
+    </div>
+  </div>
+  <div v-else class="w-full h-[220px] flex items-center justify-center">
+    <LoadingIndicator class="w-5 h-5" />
+  </div>
+</template>
+<script setup>
+import EventHeader from '@/components/EventHeader.vue'
+import TicketTierSection from '@/components/event/TicketTierSection.vue'
+import TicketTshirtSection from '@/components/event/TicketTshirtSection.vue'
+import TicketCustomFieldsSection from '@/components/event/TicketCustomFieldsSection.vue'
+import { createResource, LoadingIndicator } from 'frappe-ui'
+import { useRoute } from 'vue-router'
+
+const route = useRoute()
+
+const ticketSubtitle = {
+  Live: 'Tickets are currently available for purchase.',
+  Closed: 'Tickets are currently not available for purchase.',
+}
+
+const event = createResource({
+  url: 'frappe.client.get',
+  makeParams(){
+    return {
+      doctype: 'FOSS Chapter Event',
+      name: route.params.id,
+      fields: ['*'],
+    }
+  },
+  onSuccess(data){
+    event.doc = data
+  },
+  auto: true,
+})
+
+const toggleTicketStatus = createResource({
+  url: 'frappe.client.set_value',
+  makeParams(){
+    return {
+      doctype: 'FOSS Chapter Event',
+      name: route.params.id,
+      fieldname: 'tickets_status',
+      value: event.data.tickets_status === 'Live' ? 'Closed' : 'Live',
+    }
+  },
+  onSuccess(){
+    event.fetch()
+  }
+})
+
+
+</script>

--- a/dashboard/src/pages/EventTickets.vue
+++ b/dashboard/src/pages/EventTickets.vue
@@ -1,56 +1,8 @@
 <template>
-  <div v-if="event.data" class="w-full z-0 px-4 py-4 md:p-8">
-    <EventHeader :event="event.doc" v-if="event.doc" />
-    <hr class="my-5" />
-
-    <div class="flex flex-col gap-4">
-      <!-- Manage Tickets -->
-      <div>
-        <div class="prose w-full">
-          <h2 class="mb-1">Manage Tickets</h2>
-          <p class="text-sm">You can manage the tickets for this event here.</p>
-        </div>
-        <div
-          class="w-full md:w-1/3 mt-4 flex gap-2 flex-col p-4 border rounded-sm border-gray-500 border-dashed"
-        >
-          <div>
-            <div class="text-base font-semibold mb-1">
-              Tickets are
-              <span
-                :class="
-                  { Live: 'text-green-700', Closed: 'text-red-600' }[
-                    event.data.tickets_status
-                  ]
-                "
-                >{{ event.data.tickets_status }}</span
-              >
-            </div>
-            <p class="text-sm text-gray-600">
-              {{ ticketSubtitle[event.data.tickets_status] }}
-            </p>
-          </div>
-          <Button
-            class="w-fit mt-2"
-            :label="
-              { Live: 'Deactivate', Closed: 'Activate' }[
-                event.data.tickets_status
-              ]
-            "
-            :theme="{ Live: 'red', Closed: 'gray' }[event.data.tickets_status]"
-            @click="toggleTicketStatus.fetch()"
-          />
-        </div>
-      </div>
-
-      <!-- Ticket Tier Section -->
-      <TicketTierSection :event="event"/>
-
-      <!-- Tshirt Section -->
-      <TicketTshirtSection :event="event"/>
-
-      <!-- Custom Fields -->
-      <TicketCustomFieldsSection :event="event" />
-    </div>
+  <div v-if="event.data" class="w-full z-0 ">
+    <EventHeader :event="event.doc" v-if="event.doc" class="p-4 md:p-8" />
+    <TabsWithRoute :tabs="tabs" />
+    <RouterView class="p-4 md:p-8" />
   </div>
   <div v-else class="w-full h-[220px] flex items-center justify-center">
     <LoadingIndicator class="w-5 h-5" />
@@ -58,48 +10,35 @@
 </template>
 <script setup>
 import EventHeader from '@/components/EventHeader.vue'
-import TicketTierSection from '@/components/event/TicketTierSection.vue'
-import TicketTshirtSection from '@/components/event/TicketTshirtSection.vue'
-import TicketCustomFieldsSection from '@/components/event/TicketCustomFieldsSection.vue'
+import TabsWithRoute from '@/components/TabsWithRoute.vue'
 import { createResource, LoadingIndicator } from 'frappe-ui'
 import { useRoute } from 'vue-router'
 
 const route = useRoute()
 
-const ticketSubtitle = {
-  Live: 'Tickets are currently available for purchase.',
-  Closed: 'Tickets are currently not available for purchase.',
-}
-
 const event = createResource({
   url: 'frappe.client.get',
-  makeParams(){
+  makeParams() {
     return {
       doctype: 'FOSS Chapter Event',
       name: route.params.id,
       fields: ['*'],
     }
   },
-  onSuccess(data){
+  onSuccess(data) {
     event.doc = data
   },
   auto: true,
 })
 
-const toggleTicketStatus = createResource({
-  url: 'frappe.client.set_value',
-  makeParams(){
-    return {
-      doctype: 'FOSS Chapter Event',
-      name: route.params.id,
-      fieldname: 'tickets_status',
-      value: event.data.tickets_status === 'Live' ? 'Closed' : 'Live',
-    }
+const tabs = [
+  {
+    label: 'Manage',
+    route: `/event/${route.params.id}/tickets`,
   },
-  onSuccess(){
-    event.fetch()
-  }
-})
-
-
+  {
+    label: 'Insights',
+    route: `/event/${route.params.id}/tickets/insights`,
+  },
+]
 </script>

--- a/dashboard/src/pages/EventVolunteers.vue
+++ b/dashboard/src/pages/EventVolunteers.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="event.doc" class="px-4 py-8 md:p-8 w-full z-0 min-h-screen">
-    <EventHeader :event="event" />
+    <EventHeader :event="event.doc" />
 
     <div class="flex flex-col mt-4 gap-3 w-fit">
       <div class="text-base text-gray-600">Manage volunteers of the event.</div>

--- a/dashboard/src/pages/reviewers/ReviewPage.vue
+++ b/dashboard/src/pages/reviewers/ReviewPage.vue
@@ -31,7 +31,7 @@
       </div>
       <hr class="mb-6" />
       <div class="my-6">
-        <EventHeader :event="event" />
+        <EventHeader :event="event.doc" />
         <a
           class="text-sm flex gap-1 my-4 hover:underline"
           target="_blank"

--- a/dashboard/src/router.js
+++ b/dashboard/src/router.js
@@ -126,6 +126,11 @@ const routes = [
             name: 'EventTicketsManage',
             component: () => import('@/pages/EventTicketManage.vue'),
           },
+          {
+            path: 'insights',
+            name: 'EventTicketsInsights',
+            component: () => import('@/pages/EventTicketInsights.vue'),
+          },
         ],
       },
       {

--- a/dashboard/src/router.js
+++ b/dashboard/src/router.js
@@ -117,6 +117,11 @@ const routes = [
         ],
       },
       {
+        path: 'tickets',
+        name: 'EventTickets',
+        component: () => import('@/pages/EventTickets.vue'),
+      },
+      {
         path: 'cfp',
         name: 'EventCfp',
         component: () => import('@/pages/EventCfp.vue'),

--- a/dashboard/src/router.js
+++ b/dashboard/src/router.js
@@ -120,6 +120,13 @@ const routes = [
         path: 'tickets',
         name: 'EventTickets',
         component: () => import('@/pages/EventTickets.vue'),
+        children: [
+          {
+            path: '',
+            name: 'EventTicketsManage',
+            component: () => import('@/pages/EventTicketManage.vue'),
+          },
+        ],
       },
       {
         path: 'cfp',

--- a/fossunited/api/tickets.py
+++ b/fossunited/api/tickets.py
@@ -235,7 +235,7 @@ def get_percentage_change(today: float, yesterday: float) -> float:
 
 
 @frappe.whitelist()
-def get_sold_tickets(event_id: str) -> list:
+def get_sold_tickets(event_id: str, filters: dict = {}) -> list:
     """
     Get the list of all tickets sold for the event.
 
@@ -250,10 +250,10 @@ def get_sold_tickets(event_id: str) -> list:
         frappe.throw(
             "You are not authorized to view the tickets for this event"
         )
-
+    print("Filters: ", filters)
     tickets = frappe.db.get_all(
         "FOSS Event Ticket",
-        filters={"event": event_id},
+        filters={"event": event_id, **filters},
         fields=[
             "tier",
             "wants_tshirt",
@@ -263,10 +263,8 @@ def get_sold_tickets(event_id: str) -> list:
             "designation",
             "organization",
             "is_transfer_ticket",
-            "wants_tshirt",
-            "tshirt_size",
-            "custom_fields",
         ],
+        order_by="creation",
     )
     return tickets
 
@@ -303,3 +301,22 @@ def has_valid_permission(event_id: str) -> bool:
         return False
 
     return True
+
+
+@frappe.whitelist()
+def get_ticket_tiers(event_id: str) -> list:
+    """
+    Get the list of ticket tiers for the event
+
+    Args:
+        event_id (str): Event ID
+
+    Returns:
+        list: List of ticket tiers
+    """
+    tiers = frappe.db.get_all(
+        "FOSS Ticket Tier",
+        filters={"parent": event_id, "parentfield": "tiers"},
+        fields=["title", "maximum_tickets"],
+    )
+    return tiers

--- a/fossunited/api/tickets.py
+++ b/fossunited/api/tickets.py
@@ -4,6 +4,8 @@ APIs for Tickets and Transfer Tickets
 
 import frappe
 
+from fossunited.api.chapter import check_if_chapter_member
+
 
 @frappe.whitelist(allow_guest=True)
 def check_ticket_validity(ticket_id: str):
@@ -85,4 +87,219 @@ def change_transfer_status(transfer_id: str, status: str):
     doc = frappe.get_doc("FOSS Event Ticket Transfer", transfer_id)
     doc.status = status
     doc.save()
+    return True
+
+
+@frappe.whitelist()
+def get_tickets_insights(event_id: str) -> dict:
+    """
+    Get the insights of the tickets for the event
+
+    Returns:
+        dict: Insights of the tickets
+    """
+    total_sold = frappe.db.count(
+        "FOSS Event Ticket", filters={"event": event_id}
+    )
+
+    # Get the insights of the t-shirts
+    tshirt_insights = get_tshirt_insights(event_id)
+
+    # Get the percentage of increase or decrease in the tickets sold compared to till previous day
+    tickets_sold_today = frappe.db.count(
+        "FOSS Event Ticket",
+        filters={
+            "event": event_id,
+            "creation": ["like", f"{frappe.utils.nowdate()}%"],
+        },
+    )
+    tickets_sold_yesterday = frappe.db.count(
+        "FOSS Event Ticket",
+        filters={
+            "event": event_id,
+            "creation": [
+                "like",
+                f"{frappe.utils.add_days(frappe.utils.nowdate(), -1)}%",
+            ],
+        },
+    )
+
+    percentage_change = get_percentage_change(
+        float(tickets_sold_today), float(tickets_sold_yesterday)
+    )
+
+    tier_data = {}
+
+    # Get the tickets insights for each tier
+    tiers = frappe.db.get_all(
+        "FOSS Ticket Tier",
+        filters={"parent": event_id, "parentfield": "tiers"},
+        fields=["*"],
+    )
+    for tier in tiers:
+        tier_data[tier.title] = get_tier_insights(tier)
+
+    return {
+        "total_sold": total_sold,
+        "tshirt_insights": tshirt_insights,
+        "tickets_sold_today": tickets_sold_today,
+        "total_percentage_change": percentage_change,
+        "tier_data": tier_data,
+    }
+
+
+def get_tshirt_insights(event_id: str) -> dict:
+    """
+    Get the insights of the t-shirts for the event
+
+    Returns:
+        dict: Insights of the t-shirts
+    """
+    tshirts_sold = frappe.db.count(
+        "FOSS Event Ticket",
+        filters={"event": event_id, "wants_tshirt": 1},
+    )
+
+    # Group tshirts sold by size
+    tshirt_sizes = frappe.db.get_all(
+        "FOSS Event Ticket",
+        filters={"event": event_id, "wants_tshirt": 1},
+        fields=["tshirt_size"],
+    )
+    tshirt_sizes = [size.tshirt_size for size in tshirt_sizes]
+
+    tshirt_size_count = {}
+    for size in tshirt_sizes:
+        tshirt_size_count[size] = tshirt_size_count.get(size, 0) + 1
+
+    return {
+        "tshirts_sold": tshirts_sold,
+        "tshirt_size_count": tshirt_size_count,
+    }
+
+
+def get_tier_insights(tier: dict) -> dict:
+    """
+    Get the insights of the tickets for the tier
+    """
+    stats = {}
+    stats["title"] = tier.title
+    stats["total_sold"] = frappe.db.count(
+        "FOSS Event Ticket",
+        filters={"event": tier.parent, "tier": tier.title},
+    )
+    stats["tickets_sold_today"] = frappe.db.count(
+        "FOSS Event Ticket",
+        filters={
+            "event": tier.parent,
+            "tier": tier.title,
+            "creation": ["like", f"{frappe.utils.nowdate()}%"],
+        },
+    )
+    stats["tickets_sold_yesterday"] = frappe.db.count(
+        "FOSS Event Ticket",
+        filters={
+            "event": tier.parent,
+            "tier": tier.title,
+            "creation": [
+                "like",
+                f"{frappe.utils.add_days(frappe.utils.nowdate(), -1)}%",
+            ],
+        },
+    )
+
+    stats["percentage_change"] = get_percentage_change(
+        float(stats["tickets_sold_today"]),
+        float(stats["tickets_sold_yesterday"]),
+    )
+    stats["tier_capacity"] = tier.maximum_tickets
+
+    return stats
+
+
+def get_percentage_change(today: float, yesterday: float) -> float:
+    """
+    Get the percentage change between today and yesterday
+    """
+
+    if yesterday > 0:
+        percentage_change = ((today - yesterday) / yesterday) * 100
+    elif today > 0:
+        percentage_change = ((today - yesterday) / 1) * 100
+    else:
+        percentage_change = 0.0
+
+    percentage_change = max(percentage_change, 0.0)
+
+    return percentage_change
+
+
+@frappe.whitelist()
+def get_sold_tickets(event_id: str) -> list:
+    """
+    Get the list of all tickets sold for the event.
+
+    Args:
+        event_id (str): Event ID
+
+    Returns:
+        list: List of tickets sold for the event
+    """
+
+    if not has_valid_permission(event_id):
+        frappe.throw(
+            "You are not authorized to view the tickets for this event"
+        )
+
+    tickets = frappe.db.get_all(
+        "FOSS Event Ticket",
+        filters={"event": event_id},
+        fields=[
+            "tier",
+            "wants_tshirt",
+            "tshirt_size",
+            "event",
+            "full_name",
+            "designation",
+            "organization",
+            "is_transfer_ticket",
+            "wants_tshirt",
+            "tshirt_size",
+            "custom_fields",
+        ],
+    )
+    return tickets
+
+
+def has_valid_permission(event_id: str) -> bool:
+    """
+    Check if the user has valid permission to view the tickets for the event
+
+    Args:
+        event_id (str): Event ID
+
+    Returns:
+        bool: True if the user has valid permission, False otherwise
+    """
+    session_user = frappe.session.user
+
+    if not (
+        bool(
+            frappe.db.exists(
+                "Has Role",
+                {
+                    "role": "Chapter Lead",
+                    "parent": session_user,
+                },
+            )
+        )
+    ):
+        return False
+
+    chapter_id = frappe.db.get_value(
+        "FOSS Chapter Event", event_id, ["chapter"]
+    )
+    if not check_if_chapter_member(chapter_id, session_user):
+        return False
+
     return True

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
@@ -425,6 +425,7 @@
    "label": "External Event URL"
   },
   {
+   "default": "Live",
    "fieldname": "tickets_status",
    "fieldtype": "Select",
    "label": "Tickets Status",
@@ -450,7 +451,7 @@
    "link_fieldname": "event"
   }
  ],
- "modified": "2024-08-14 15:32:07.543451",
+ "modified": "2024-08-15 15:10:05.697637",
  "modified_by": "Administrator",
  "module": "Chapters",
  "name": "FOSS Chapter Event",

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
@@ -63,6 +63,7 @@
   "event_schedule",
   "tickets_tab",
   "is_paid_event",
+  "tickets_status",
   "tiers",
   "ticket_form_description",
   "section_break_idyt",
@@ -388,7 +389,8 @@
    "fieldname": "t_shirt_price",
    "fieldtype": "Currency",
    "label": "T Shirt Price",
-   "mandatory_depends_on": "eval:doc.paid_tshirts_available==1"
+   "mandatory_depends_on": "eval:doc.paid_tshirts_available==1",
+   "non_negative": 1
   },
   {
    "fieldname": "section_break_hjyr",
@@ -421,6 +423,12 @@
    "fieldname": "external_event_url",
    "fieldtype": "Data",
    "label": "External Event URL"
+  },
+  {
+   "fieldname": "tickets_status",
+   "fieldtype": "Select",
+   "label": "Tickets Status",
+   "options": "Live\nClosed"
   }
  ],
  "has_web_view": 1,
@@ -442,7 +450,7 @@
    "link_fieldname": "event"
   }
  ],
- "modified": "2024-07-08 14:42:21.932221",
+ "modified": "2024-08-14 15:32:07.543451",
  "modified_by": "Administrator",
  "module": "Chapters",
  "name": "FOSS Chapter Event",

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -81,6 +81,7 @@ class FOSSChapterEvent(WebsiteGenerator):
         ]
         t_shirt_price: DF.Currency
         ticket_form_description: DF.MarkdownEditor | None
+        tickets_status: DF.Literal["Live", "Closed"]
         tiers: DF.Table[FOSSTicketTier]
     # end: auto-generated types
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🍕Feature
- [x] ⚙️Chore

## Description
<!-- Briefly describe the changes introduced by this pull request -->
- Add a ticket management page for paid events
- Make ticket pages "Live" or "Closed"
- Create & Manage tiers of tickets
- Tshirt management for the event. See insights, set tshirt price.
- Add custom fields to be shown at the time of ticket purchase
- Insights for tickets. See total tickets sold, Tier based insights, Tshirt insights.
- See the list of attendees for the event.

## Related Issues & Docs
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
closes #499

## Screenshots/GIFs/Screen Recordings (if applicable)
<!-- Visually demonstrate the changes, if applicable -->
[Screencast from 2024-08-18 17-51-34.webm](https://github.com/user-attachments/assets/2e4571cb-c079-4215-bb8b-6aa5b351928a)

