### PR TITLE
fix(chapter): fix chapter members comparison bug

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
@@ -25,7 +25,7 @@ class FOSSChapter(WebsiteGenerator):
         chapter_lead: DF.Link | None
         chapter_members: DF.Table[FOSSChapterLeadTeamMember]
         chapter_name: DF.Data
-        chapter_type: DF.Literal["City Community", "FOSS Club", "Conference"]  # type: ignore
+        chapter_type: DF.Literal["City Community", "FOSS Club", "Conference"]
         city: DF.Link | None
         country: DF.Link | None
         email: DF.Data
@@ -44,7 +44,7 @@ class FOSSChapter(WebsiteGenerator):
 
     # end: auto-generated types
     def before_insert(self):
-        self.set_member_roles()
+        self.handle_member_addition()
 
     def validate(self):
         self.make_city_name_upper()

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
@@ -25,7 +25,7 @@ class FOSSChapter(WebsiteGenerator):
         chapter_lead: DF.Link | None
         chapter_members: DF.Table[FOSSChapterLeadTeamMember]
         chapter_name: DF.Data
-        chapter_type: DF.Literal["City Community", "FOSS Club", "Conference"]
+        chapter_type: DF.Literal["City Community", "FOSS Club", "Conference"]  # type: ignore
         city: DF.Link | None
         country: DF.Link | None
         email: DF.Data
@@ -79,7 +79,7 @@ class FOSSChapter(WebsiteGenerator):
         if not prev_doc:
             return
         for member in prev_doc.chapter_members:
-            if member not in self.chapter_members:
+            if member.chapter_member not in [d.chapter_member for d in self.chapter_members]:
                 if self.member_of_other_chapter(member):
                     continue
                 user = frappe.db.get_value(USER_PROFILE, member.chapter_member, "user")

--- a/fossunited/chapters/doctype/foss_chapter/test_foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/test_foss_chapter.py
@@ -29,6 +29,11 @@ class TestFOSSChapter(FrappeTestCase):
         )
         chapter.insert()
 
+        if not frappe.db.exists("Role", "Chapter Team Member"):
+            frappe.get_doc({"doctype": "Role", "role_name": "Chapter Team Member"}).insert(ignore_permissions=True)
+        if not frappe.db.exists("Role", "Chapter Lead"):
+            frappe.get_doc({"doctype": "Role", "role_name": "Chapter Lead"}).insert(ignore_permissions=True)
+
         lead_profile = frappe.get_doc("FOSS User Profile", {"user": "test@example.com"})
         chapter.append("chapter_members", {"chapter_member": lead_profile.name, "role": "Lead"})
         chapter.save()

--- a/fossunited/chapters/doctype/foss_chapter/test_foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/test_foss_chapter.py
@@ -1,8 +1,49 @@
 # Copyright (c) 2023, Frappe x FOSSUnited and Contributors
 # See license.txt
 
+import frappe
+from faker import Faker
 from frappe.tests.utils import FrappeTestCase
 
 
 class TestFOSSChapter(FrappeTestCase):
-    pass
+    def setUp(self):
+        fake = Faker()
+
+        chapter = frappe.get_doc(
+            {
+                "doctype": "FOSS Chapter",
+                "chapter_name": "Pune",
+                "chapter_type": "City Community",
+                "city": "Pune",
+                "country": "India",
+                "email": fake.email(),
+                "facebook": fake.url(),
+                "instagram": fake.url(),
+                "linkedin": fake.url(),
+                "mastodon": fake.url(),
+                "public_chat_group_url": fake.url(),
+                "state": "Maharashtra",
+                "x": fake.url(),
+            }
+        )
+        chapter.insert()
+
+        lead_profile = frappe.get_doc("FOSS User Profile", {"user": "test@example.com"})
+        chapter.append("chapter_members", {"chapter_member": lead_profile.name, "role": "Lead"})
+        chapter.save()
+
+        self.chapter = chapter
+
+    def tearDown(self):
+        frappe.delete_doc("FOSS Chapter", self.chapter.name)
+
+    def test_role_assignment_on_create(self):
+        # Given a chapter
+        chapter = self.chapter
+
+        # When the chapter was created, a lead was assigned to it.
+        # Then the lead should have the role of 'Chapter Lead' and 'Chapter Team Member'
+        user = frappe.db.get_value("FOSS User Profile", chapter.chapter_members[0].chapter_member, "user")
+        has_role = frappe.db.exists("Has Role", {"role": "Chapter Team Member", "parent": user})
+        self.assertTrue(has_role)

--- a/fossunited/chapters/doctype/foss_chapter/test_foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/test_foss_chapter.py
@@ -13,8 +13,8 @@ class TestFOSSChapter(FrappeTestCase):
         chapter = frappe.get_doc(
             {
                 "doctype": "FOSS Chapter",
-                "chapter_name": "Pune",
-                "chapter_type": "City Community",
+                "chapter_name": fake.text(max_nb_chars=40),
+                "chapter_type": "FOSS Club",
                 "city": "Pune",
                 "country": "India",
                 "email": fake.email(),

--- a/fossunited/chapters/doctype/foss_chapter/test_foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/test_foss_chapter.py
@@ -47,3 +47,18 @@ class TestFOSSChapter(FrappeTestCase):
         user = frappe.db.get_value("FOSS User Profile", chapter.chapter_members[0].chapter_member, "user")
         has_role = frappe.db.exists("Has Role", {"role": "Chapter Team Member", "parent": user})
         self.assertTrue(has_role)
+
+    def test_role_assignment_on_member_addition(self):
+        # Given a chapter: self.chapter
+        chapter = frappe.get_doc("FOSS Chapter", self.chapter.name)
+
+        # When a new member is added to the chapter
+        new_member = frappe.get_doc("FOSS User Profile", {"user": "test1@example.com"})
+
+        chapter.append("chapter_members", {"chapter_member": new_member.name, "role": "Core Team Member"})
+        chapter.save()
+
+        # Then the new member should have the role of 'Chapter Team Member'
+        user = frappe.db.get_value("FOSS User Profile", new_member.name, "user")
+        has_role = frappe.db.exists("Has Role", {"role": "Chapter Team Member", "parent": user})
+        self.assertTrue(has_role)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dynamic = ["version"]
 dependencies = [
     "razorpay~=1.4.2",
     "PyGithub~=2.3.0",
+    "Faker~=27.0.0",
 ]
 
 [build-system]


### PR DESCRIPTION
Fix a bug in the `FOSS Chapter` doctype where the comparison of chapter members was not done correctly. This bug caused issues when checking if a member was already a team member or not; resulting in role removal of all the members of chapter. Now, the comparison is done using the `chapter_member` attribute of each member (which maps to profile id), ensuring accurate results.

## What type of PR is this? (check all applicable)
- [x] 🐛Bug Fix

## Related Issues & Docs
closes #546 
