### PR TITLE
fix: oauth signup errors

### DIFF
--- a/fossunited/fossunited/user_utils.py
+++ b/fossunited/fossunited/user_utils.py
@@ -33,7 +33,7 @@ def create_profile_on_user_create(doc, method):
         profile.insert(ignore_permissions=True)
 
     try:
-        frappe.db.set_value("User", profile.user, "username", profile.username)
+        frappe.db.set_value("User", profile.user, "username", profile.username, update_modified=False)
     except Exception:
         frappe.throw("Error updating username")
 

--- a/fossunited/fossunited/user_utils.py
+++ b/fossunited/fossunited/user_utils.py
@@ -34,8 +34,8 @@ def create_profile_on_user_create(doc, method):
 
     try:
         frappe.db.set_value("User", profile.user, "username", profile.username, update_modified=False)
-    except Exception:
-        frappe.throw("Error updating username")
+    except Exception as e:
+        frappe.throw("Error updating username. Error: " + str(e))
 
 
 def generate_username(username, count=1):


### PR DESCRIPTION
## Description

In the method `create_profile_on_user_create`, after the profile is created at the time of signup, the username for `User` doctype is changed. This throws a TimestampMismatchError:Document has been modified after you have opened it.

This can be simply fixed if we pass an additional parameter of `update_modified=False` in set_value function,

Reference:
https://frappeframework.com/docs/user/en/api/database#frappedbset_value

https://discuss.frappe.io/t/document-has-been-modified-after-you-have-opened-it/34584/3

## What type of PR is this? (check all applicable)
- [x] 🐛Bug Fix

## Related Issues & Docs
closes #557
closes #558


