### PR TITLE
fix: already transferred ticket not sending emails on re-transfer

### DIFF
--- a/fossunited/ticketing/doctype/foss_event_ticket_transfer/test_foss_event_ticket_transfer.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket_transfer/test_foss_event_ticket_transfer.py
@@ -32,13 +32,25 @@ class TestFOSSEventTicketTransfer(FrappeTestCase):
         frappe.delete_doc("FOSS Chapter Event", self.event.name, force=True)
 
     def test_ticket_transfer(self):
+        fake = Faker()
+
+        sender = {
+            "full_name": fake.name(),
+            "email": fake.email(),
+        }
+
+        recipient = {
+            "full_name": fake.name(),
+            "email": fake.email(),
+        }
+
         # Given for an event, a ticket is created. For that ticket, a transfer is generated.
         ticket = frappe.get_doc(
             {
                 "doctype": "FOSS Event Ticket",
                 "event": self.event.name,
-                "full_name": "Harsh Tandiya",
-                "email": "harsh@test.xyz",
+                "full_name": sender["full_name"],
+                "email": sender["email"],
             }
         )
         ticket.insert()
@@ -47,8 +59,8 @@ class TestFOSSEventTicketTransfer(FrappeTestCase):
             {
                 "doctype": "FOSS Event Ticket Transfer",
                 "ticket": ticket.name,
-                "receiver_name": "Rahul",
-                "receiver_email": "rahul@test.xyz",
+                "receiver_name": recipient["full_name"],
+                "receiver_email": recipient["email"],
             }
         )
         transfer.insert()
@@ -65,8 +77,8 @@ class TestFOSSEventTicketTransfer(FrappeTestCase):
         old_ticket_exists = frappe.db.exists(
             "FOSS Event Ticket",
             {
-                "email": "harsh@test.xyz",
-                "full_name": "Harsh Tandiya",
+                "email": sender["email"],
+                "full_name": sender["full_name"],
                 "event": self.event.name,
             },
         )
@@ -75,22 +87,23 @@ class TestFOSSEventTicketTransfer(FrappeTestCase):
         new_ticket_exists = frappe.db.exists(
             "FOSS Event Ticket",
             {
-                "email": "rahul@test.xyz",
-                "full_name": "Rahul",
+                "email": recipient["email"],
+                "full_name": recipient["full_name"],
                 "event": self.event.name,
             },
         )
         self.assertTrue(new_ticket_exists)
 
     def test_status_pending_on_create(self):
+        fake = Faker()
         # Given an event and a ticket linked to the event
         # With a ticket created for a user, try to transfer this ticket to another user while passing "Completed" as the status
         ticket = frappe.get_doc(
             {
                 "doctype": "FOSS Event Ticket",
                 "event": self.event.name,
-                "full_name": "Harsh Tandiya",
-                "email": "harsh2@test.xyz",
+                "full_name": fake.name(),
+                "email": fake.email(),
             }
         )
         ticket.insert()
@@ -101,8 +114,8 @@ class TestFOSSEventTicketTransfer(FrappeTestCase):
                 {
                     "doctype": "FOSS Event Ticket Transfer",
                     "ticket": ticket.name,
-                    "receiver_name": "Rahul",
-                    "receiver_email": "rahul2@test.xyz",
+                    "receiver_name": fake.name(),
+                    "receiver_email": fake.email(),
                     "status": "Completed",
                 }
             )


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🐛Bug Fix

## Description
<!-- Briefly describe the changes introduced by this pull request -->
Bug: Emails were not being sent when an already transferred ticket was being transferred again.

This happened because the notification trigger for the transfer ticket were such that, when `is_transfer_ticket` checkbox value changed from 0 to 1, then the notification was sent. 

Fixed it in this PR with `handle_already_transferred_ticket` method. The method runs when the `is_transfer_ticket` checkbox is already ticked, and it unchecks the checkbox and saves the document.

Then the other operations run as they were before.

---

Also refactored tests to use `setUp` and `tearDown` methods . And added a test to check this particular new method.

## Related Issues & Docs
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
closes #588 
