### PR TITLE
feat(checkins): Participant Check-in Dashboard

### DIFF
--- a/dashboard/src/components/event/CheckinAttendeeList.vue
+++ b/dashboard/src/components/event/CheckinAttendeeList.vue
@@ -17,7 +17,7 @@
         { label: 'Name', key: 'full_name' },
         { label: 'Ticket ID', key: 'name' },
         { label: 'Bought Tshirt?', key: 'wants_tshirt', width: '150px' },
-        { label: 'Tshirt Provided?', key: 'tshirt_assigned', width: '150px' },
+        { label: 'Tshirt Delivered?', key: 'tshirt_delivered', width: '150px' },
         { label: 'Check-in Status', key: 'checkin_status', width: 1.5 },
         { label: 'Actions', key: 'action' },
       ]"
@@ -60,7 +60,7 @@
         </template>
         <template
           v-else-if="
-            column.key === 'wants_tshirt' || column.key === 'tshirt_assigned'
+            column.key === 'wants_tshirt' || column.key === 'tshirt_delivered'
           "
         >
           <Checkbox

--- a/dashboard/src/components/event/CheckinAttendeeList.vue
+++ b/dashboard/src/components/event/CheckinAttendeeList.vue
@@ -1,0 +1,180 @@
+<template>
+  <CheckinConfirmationDialog
+    v-model="showConfirmDialog"
+    :selectedAttendee="selectedAttendee"
+    :attendees="attendees"
+  />
+  <CheckinManageDialog
+    v-model="showManageDialog"
+    :selectedAttendee="selectedAttendee"
+    :attendees="attendees"
+  />
+
+  <!-- Attendee List -->
+  <div v-if="attendees.data">
+    <ListView
+      :columns="[
+        { label: 'Name', key: 'full_name' },
+        { label: 'Ticket ID', key: 'name' },
+        { label: 'Has Tshirt?', key: 'wants_tshirt', width: '100px' },
+        { label: 'Tshirt Provided?', key: 'tshirt_assigned', width: '150px' },
+        { label: 'Check-in Status', key: 'checkin_status', width: 1.5 },
+        { label: 'Actions', key: 'action' },
+      ]"
+      :rows="attendees.data"
+      :options="{
+        selectable: false,
+        showTooltip: false,
+        resizeColumn: true,
+        emptyState: {
+          title: 'No attendees found',
+        },
+      }"
+      row-key="name"
+    >
+      <template #cell="{ item, row, column }">
+        <template v-if="column.key === 'action'">
+          <Button
+            v-if="!isCheckedInToday(row)"
+            class="w-fit"
+            label="Check-in"
+            variant="solid"
+            @click="
+              () => {
+                selectedAttendee = row
+                showConfirmDialog = true
+              }
+            "
+          />
+          <Button
+            v-else
+            class="w-fit"
+            label="Manage"
+            @click="
+              () => {
+                selectedAttendee = row
+                showManageDialog = true
+              }
+            "
+          />
+        </template>
+        <template
+          v-else-if="
+            column.key === 'wants_tshirt' || column.key === 'tshirt_assigned'
+          "
+        >
+          <Checkbox
+            :model-value="Boolean(item)"
+            :disabled="true"
+            class="w-4 h-4"
+          />
+        </template>
+        <template v-else-if="column.key === 'name'">
+          <span class="font-mono text-sm font-semibold text-gray-800">{{
+            item
+          }}</span>
+        </template>
+        <template v-else-if="column.key === 'checkin_status'">
+          <div
+            class="flex items-center overflow-hidden overflow-x-visible flex-wrap"
+          >
+            <span
+              v-for="data in row.checkin_data"
+              class="flex items-center p-1 rounded-sm"
+            >
+              <Tooltip
+                arrow-class="fill-black"
+                :placement="'top'"
+                :hoverDelay="0.5"
+              >
+                <template #body>
+                  <span
+                    class="text-xs bg-gray-900 text-white px-2 py-1 rounded-full"
+                  >
+                    {{ getFormattedDateTime(data.check_in_time) }}
+                  </span>
+                </template>
+                <Badge
+                  :theme="
+                    getRelativeTime(data.check_in_time) == 'Today'
+                      ? 'green'
+                      : 'gray'
+                  "
+                  class="flex gap-1 items-center"
+                >
+                  <DoubleChecksIcon class="w-4 h-4" />
+                  <span>{{ getRelativeTime(data.check_in_time) }}</span>
+                </Badge>
+              </Tooltip>
+            </span>
+          </div>
+        </template>
+        <template v-else class="text-base">
+          {{ item }}
+        </template>
+      </template>
+    </ListView>
+  </div>
+  <div v-else>
+    <LoadingText />
+  </div>
+</template>
+<script setup>
+import { ref, defineProps, provide } from 'vue'
+import {
+  LoadingText,
+  ListView,
+  Badge,
+  Tooltip,
+  Checkbox,
+} from 'frappe-ui'
+import CheckinManageDialog from '@/components/event/CheckinManageDialog.vue'
+import CheckinConfirmationDialog from '@/components/event/CheckinConfirmationDialog.vue'
+import DoubleChecksIcon from '@/components/icons/DoubleChecks.vue'
+import dayjs from 'dayjs'
+import relativeTime from 'dayjs/plugin/relativeTime'
+import isToday from 'dayjs/plugin/isToday'
+import isYesterday from 'dayjs/plugin/isYesterday'
+
+dayjs.extend(relativeTime)
+dayjs.extend(isToday)
+dayjs.extend(isYesterday)
+
+const props = defineProps({
+  event: {
+    type: Object,
+    required: true,
+  },
+  attendees: {
+    type: Object,
+    required: true,
+  },
+})
+
+const selectedAttendee = ref(null)
+const showConfirmDialog = ref(false)
+const showManageDialog = ref(false)
+
+const isCheckedInToday = (attendee) => {
+  return attendee.checkin_data.some((data) =>
+    dayjs(data.check_in_time).isToday(),
+  )
+}
+
+provide('isCheckedInToday', isCheckedInToday)
+
+const getFormattedDateTime = (datetime) => {
+  return dayjs(datetime).format('DD MMM, hh:mm A')
+}
+
+const getRelativeTime = (datetime) => {
+  const date = dayjs(datetime)
+  if (date.isToday()) {
+    return 'Today'
+  } else if (date.isYesterday()) {
+    return 'Yesterday'
+  } else {
+    return date.fromNow()
+  }
+}
+</script>

--- a/dashboard/src/components/event/CheckinAttendeeList.vue
+++ b/dashboard/src/components/event/CheckinAttendeeList.vue
@@ -16,7 +16,7 @@
       :columns="[
         { label: 'Name', key: 'full_name' },
         { label: 'Ticket ID', key: 'name' },
-        { label: 'Has Tshirt?', key: 'wants_tshirt', width: '100px' },
+        { label: 'Bought Tshirt?', key: 'wants_tshirt', width: '150px' },
         { label: 'Tshirt Provided?', key: 'tshirt_assigned', width: '150px' },
         { label: 'Check-in Status', key: 'checkin_status', width: 1.5 },
         { label: 'Actions', key: 'action' },

--- a/dashboard/src/components/event/CheckinConfirmationDialog.vue
+++ b/dashboard/src/components/event/CheckinConfirmationDialog.vue
@@ -1,0 +1,113 @@
+<template>
+  <Dialog
+    class="z-50"
+    v-model="showDialog"
+    :options="{
+      title: 'Confirm Attendee Check In?',
+    }"
+  >
+    <template #body-content v-if="selectedAttendee">
+      <div class="flex flex-col py-2">
+        <p class="text-base">
+          Are you sure you want to check in
+          <span class="font-semibold">{{ selectedAttendee.full_name }}</span
+          >?
+        </p>
+        <div class="bg-gray-50 text-sm p-2 my-2 rounded-sm font-mono">
+          <p class="leading-5">
+            Name: {{ selectedAttendee.full_name }}
+            <br />
+            Ticket ID: {{ selectedAttendee.name }}
+            <br />
+            Has Tshirt Add-on:
+            {{ selectedAttendee.wants_tshirt ? 'Yes' : 'No' }}
+            <br />
+            <span v-if="selectedAttendee.wants_tshirt"
+              >Tshirt Size: {{ selectedAttendee.tshirt_size }}</span
+            >
+          </p>
+        </div>
+        <div
+          v-if="
+            selectedAttendee.wants_tshirt && !selectedAttendee.tshirt_assigned
+          "
+        >
+          <hr class="my-4" />
+          <div class="text-sm uppercase font-medium mb-2">Assign T-shirt</div>
+          <Checkbox
+          v-model="assignTshirt"
+          label="Confirm Tshirt Assignment"
+          />
+          <p class="text-sm leading-5 mt-1 text-gray-600">
+            Only check this if you are providing the T-shirt to the attendee at the time of check-in.
+          </p>
+        </div>
+      </div>
+    </template>
+    <template #actions>
+      <div class="grid grid-cols-2 gap-2">
+        <Button
+          label="Cancel"
+          @click="
+            () => {
+              showDialog = false
+              selectedAttendee = null
+            }
+          "
+        />
+        <Button
+          label="Check In"
+          variant="solid"
+          theme="green"
+          @click="checkinAttendee.fetch()"
+          :loading="checkinAttendee.loading"
+          loadingText="Checking in..."
+        />
+      </div>
+    </template>
+  </Dialog>
+</template>
+<script setup>
+import { defineProps, defineModel, inject, ref } from 'vue'
+import { createResource, Dialog, Checkbox } from 'frappe-ui'
+
+const props = defineProps({
+  selectedAttendee: Object,
+  attendees: Object,
+})
+
+const session = inject('$session')
+const route = inject('route')
+const assignTshirt = ref(false)
+
+const showDialog = defineModel()
+
+const checkinAttendee = createResource({
+  url: 'fossunited.api.checkins.checkin_attendee',
+  makeParams() {
+    return {
+      event_id: route.params.id,
+      attendee: props.selectedAttendee,
+      user: session.user,
+      assign_tshirt: assignTshirt.value,
+    }
+  },
+  onSuccess() {
+    makeChangesToAttendeeDict(props.selectedAttendee)
+    props.selectedAttendee = null
+    showDialog.value = false
+  },
+})
+
+const makeChangesToAttendeeDict = (attendee) => {
+  const index = props.attendees.data.findIndex(
+    (data) => data.name === attendee.name,
+  )
+  props.attendees.data[index].checkin_data.unshift({
+    check_in_time: new Date(),
+  })
+  if (assignTshirt.value) {
+    props.attendees.data[index].tshirt_assigned = true
+  }
+}
+</script>

--- a/dashboard/src/components/event/CheckinConfirmationDialog.vue
+++ b/dashboard/src/components/event/CheckinConfirmationDialog.vue
@@ -19,6 +19,8 @@
             <br />
             Ticket ID: {{ selectedAttendee.name }}
             <br />
+            Tier: {{ selectedAttendee.tier }}
+            <br />
             Has Tshirt Add-on:
             {{ selectedAttendee.wants_tshirt ? 'Yes' : 'No' }}
             <br />
@@ -34,12 +36,10 @@
         >
           <hr class="my-4" />
           <div class="text-sm uppercase font-medium mb-2">Assign T-shirt</div>
-          <Checkbox
-          v-model="assignTshirt"
-          label="Confirm Tshirt Assignment"
-          />
+          <Checkbox v-model="assignTshirt" label="Confirm Tshirt Assignment" />
           <p class="text-sm leading-5 mt-1 text-gray-600">
-            Only check this if you are providing the T-shirt to the attendee at the time of check-in.
+            Only check this if you are providing the T-shirt to the attendee at
+            the time of check-in.
           </p>
         </div>
       </div>

--- a/dashboard/src/components/event/CheckinConfirmationDialog.vue
+++ b/dashboard/src/components/event/CheckinConfirmationDialog.vue
@@ -95,6 +95,7 @@ const checkinAttendee = createResource({
   onSuccess() {
     makeChangesToAttendeeDict(props.selectedAttendee)
     props.selectedAttendee = null
+    assignTshirt.value = false
     showDialog.value = false
   },
 })

--- a/dashboard/src/components/event/CheckinConfirmationDialog.vue
+++ b/dashboard/src/components/event/CheckinConfirmationDialog.vue
@@ -31,7 +31,7 @@
         </div>
         <div
           v-if="
-            selectedAttendee.wants_tshirt && !selectedAttendee.tshirt_assigned
+            selectedAttendee.wants_tshirt && !selectedAttendee.tshirt_delivered
           "
         >
           <hr class="my-4" />
@@ -104,11 +104,11 @@ const makeChangesToAttendeeDict = (attendee) => {
   const index = props.attendees.data.findIndex(
     (data) => data.name === attendee.name,
   )
-  props.attendees.data[index].checkin_data.unshift({
+  props.attendees.data[index].checkin_data.push({
     check_in_time: new Date(),
   })
   if (assignTshirt.value) {
-    props.attendees.data[index].tshirt_assigned = true
+    props.attendees.data[index].tshirt_delivered = true
   }
 }
 </script>

--- a/dashboard/src/components/event/CheckinConfirmationDialog.vue
+++ b/dashboard/src/components/event/CheckinConfirmationDialog.vue
@@ -68,6 +68,7 @@
   </Dialog>
 </template>
 <script setup>
+import { toast } from 'vue-sonner'
 import { defineProps, defineModel, inject, ref } from 'vue'
 import { createResource, Dialog, Checkbox } from 'frappe-ui'
 
@@ -97,6 +98,9 @@ const checkinAttendee = createResource({
     props.selectedAttendee = null
     assignTshirt.value = false
     showDialog.value = false
+  },
+  onError(error) {
+    toast.error('Failed to check in attendee')
   },
 })
 

--- a/dashboard/src/components/event/CheckinManageDialog.vue
+++ b/dashboard/src/components/event/CheckinManageDialog.vue
@@ -1,0 +1,141 @@
+<template>
+  <Dialog
+    v-model="showDialog"
+    class="z-50"
+    :options="{
+      title: 'Manage Attendee',
+    }"
+  >
+    <template #body-content v-if="selectedAttendee">
+      <div class="flex flex-col gap-4">
+        <div class="space-y-2">
+          <div class="text-sm uppercase font-medium">Details</div>
+          <div class="bg-gray-50 text-sm p-2 rounded-sm font-mono">
+            <p class="leading-5">
+              Name: {{ selectedAttendee.full_name }}
+              <br />
+              Ticket ID: {{ selectedAttendee.name }}
+              <br />
+              Has Tshirt Add-on:
+              {{ selectedAttendee.wants_tshirt ? 'Yes' : 'No' }}
+              <br />
+            </p>
+            <p v-if="selectedAttendee.wants_tshirt" class="leading-5">
+              <span>Tshirt Size: {{ selectedAttendee.tshirt_size }}</span>
+              <br />
+              <span
+                >Tshirt Assigned:
+                <span
+                  :class="
+                    selectedAttendee.tshirt_assigned
+                      ? 'text-green-600'
+                      : 'text-red-600'
+                  "
+                >
+                  {{ selectedAttendee.tshirt_assigned ? 'Yes' : 'No' }}
+                </span>
+              </span>
+            </p>
+            <div class="border-b-2 border-dashed border-gray-600 my-3"></div>
+            <div class="flex flex-col gap-2">
+              <div class="text-sm uppercase font-medium">Check-ins</div>
+              <div
+                v-for="data in selectedAttendee.checkin_data"
+                class="flex gap-2"
+              >
+                <span>-></span>
+                <span>
+                  {{ dayjs(data.checkin_time).format('DD MMM YYYY, h:mm A') }}
+                </span>
+              </div>
+            </div>
+          </div>
+          <Button
+            v-if="isCheckedInToday(selectedAttendee)"
+            @click="undoAttendeeCheckin.fetch()"
+            class="!text-sm border-orange-600 hover:border-orange-400 text-orange-600"
+            iconLeft="alert-triangle"
+            label="Undo Check-In for Today"
+            size="sm"
+            variant="outline"
+          />
+        </div>
+        <div
+          v-if="
+            selectedAttendee.wants_tshirt && !selectedAttendee.tshirt_assigned
+          "
+        >
+          <hr class="mb-4" />
+          <div class="text-sm uppercase font-medium">Assign T-shirt</div>
+          <p class="text-sm leading-5 mt-1">
+            <span class="text-orange-600">Pending</span> T-shirt assignment.
+            <br />
+            Click the button below when you have assigned a T-shirt to the
+            attendee.
+          </p>
+          <Button
+            class="mt-2"
+            label="Mark as Assigned"
+            size="sm"
+            variant="solid"
+            :loading="assignTshirt.loading"
+            loadingText="Assigning..."
+            @click="assignTshirt.fetch()"
+          />
+        </div>
+      </div>
+    </template>
+  </Dialog>
+</template>
+<script setup>
+import { defineProps, defineModel, inject } from 'vue'
+import { Dialog, createResource } from 'frappe-ui'
+import dayjs from 'dayjs'
+
+const props = defineProps({
+  attendees: Object,
+  selectedAttendee: Object,
+})
+
+const session = inject('$session')
+const route = inject('route')
+const isCheckedInToday = inject('isCheckedInToday')
+
+const showDialog = defineModel()
+
+const assignTshirt = createResource({
+    url: 'fossunited.api.checkins.assign_tshirt',
+    makeParams(){
+        return {
+            event_id: route.params.id,
+            attendee: props.selectedAttendee,
+            user: session.user,
+        }
+    },
+    onSuccess(){
+        const index = props.attendees.data.findIndex(
+            (data) => data.name === props.selectedAttendee.name
+        )
+        props.attendees.data[index].tshirt_assigned = true
+    }
+})
+
+const undoAttendeeCheckin = createResource({
+  url: 'fossunited.api.checkins.undo_attendee_checkin',
+  makeParams() {
+    return {
+      event_id: route.params.id,
+      attendee: props.selectedAttendee,
+      user: session.user,
+    }
+  },
+  onSuccess() {
+    const index = props.attendees.data.findIndex(
+      (data) => data.name === props.selectedAttendee.name,
+    )
+    props.attendees.data[index].checkin_data.shift()
+    props.selectedAttendee = null
+    showDialog.value = false
+  },
+})
+</script>

--- a/dashboard/src/components/event/CheckinManageDialog.vue
+++ b/dashboard/src/components/event/CheckinManageDialog.vue
@@ -47,7 +47,7 @@
               >
                 <span>-></span>
                 <span>
-                  {{ dayjs(data.checkin_time).format('DD MMM YYYY, h:mm A') }}
+                  {{ dayjs(data.check_in_time).format('DD MMM YYYY, h:mm A') }}
                 </span>
               </div>
             </div>

--- a/dashboard/src/components/event/CheckinManageDialog.vue
+++ b/dashboard/src/components/event/CheckinManageDialog.vue
@@ -16,6 +16,8 @@
               <br />
               Ticket ID: {{ selectedAttendee.name }}
               <br />
+              Tier: {{ selectedAttendee.tier }}
+              <br />
               Has Tshirt Add-on:
               {{ selectedAttendee.wants_tshirt ? 'Yes' : 'No' }}
               <br />
@@ -104,20 +106,20 @@ const isCheckedInToday = inject('isCheckedInToday')
 const showDialog = defineModel()
 
 const assignTshirt = createResource({
-    url: 'fossunited.api.checkins.assign_tshirt',
-    makeParams(){
-        return {
-            event_id: route.params.id,
-            attendee: props.selectedAttendee,
-            user: session.user,
-        }
-    },
-    onSuccess(){
-        const index = props.attendees.data.findIndex(
-            (data) => data.name === props.selectedAttendee.name
-        )
-        props.attendees.data[index].tshirt_assigned = true
+  url: 'fossunited.api.checkins.assign_tshirt',
+  makeParams() {
+    return {
+      event_id: route.params.id,
+      attendee: props.selectedAttendee,
+      user: session.user,
     }
+  },
+  onSuccess() {
+    const index = props.attendees.data.findIndex(
+      (data) => data.name === props.selectedAttendee.name,
+    )
+    props.attendees.data[index].tshirt_assigned = true
+  },
 })
 
 const undoAttendeeCheckin = createResource({

--- a/dashboard/src/components/event/CheckinManageDialog.vue
+++ b/dashboard/src/components/event/CheckinManageDialog.vue
@@ -29,12 +29,12 @@
                 >Tshirt Assigned:
                 <span
                   :class="
-                    selectedAttendee.tshirt_assigned
+                    selectedAttendee.tshirt_delivered
                       ? 'text-green-600'
                       : 'text-red-600'
                   "
                 >
-                  {{ selectedAttendee.tshirt_assigned ? 'Yes' : 'No' }}
+                  {{ selectedAttendee.tshirt_delivered ? 'Yes' : 'No' }}
                 </span>
               </span>
             </p>
@@ -64,7 +64,7 @@
         </div>
         <div
           v-if="
-            selectedAttendee.wants_tshirt && !selectedAttendee.tshirt_assigned
+            selectedAttendee.wants_tshirt && !selectedAttendee.tshirt_delivered
           "
         >
           <hr class="mb-4" />
@@ -118,7 +118,7 @@ const assignTshirt = createResource({
     const index = props.attendees.data.findIndex(
       (data) => data.name === props.selectedAttendee.name,
     )
-    props.attendees.data[index].tshirt_assigned = true
+    props.attendees.data[index].tshirt_delivered = true
   },
 })
 
@@ -135,7 +135,7 @@ const undoAttendeeCheckin = createResource({
     const index = props.attendees.data.findIndex(
       (data) => data.name === props.selectedAttendee.name,
     )
-    props.attendees.data[index].checkin_data.shift()
+    props.attendees.data[index].checkin_data.pop()
     props.selectedAttendee = null
     showDialog.value = false
   },

--- a/dashboard/src/components/icons/DoubleChecks.vue
+++ b/dashboard/src/components/icons/DoubleChecks.vue
@@ -1,0 +1,23 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="icon icon-tabler icons-tabler-outline icon-tabler-checks"
+  >
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+    <path d="M7 12l5 5l10 -10" />
+    <path d="M2 12l5 5m5 -5l5 -5" />
+  </svg>
+</template>
+<!--
+  Icons from Tabler
+  Website: https://tabler.io/icons
+  Github: https://github.com/tabler/tabler?tab=MIT-1-ov-file
+ -->

--- a/dashboard/src/pages/Event.vue
+++ b/dashboard/src/pages/Event.vue
@@ -70,6 +70,10 @@ const event = createResource({
         label: 'Tickets',
         route: `/event/${route.params.id}/tickets`,
       })
+      sidebar_items.items.push({
+        label: 'Check-Ins',
+        route: `/event/${route.params.id}/checkins`,
+      })
     }
 
     sidebarMenuItems.value.push(sidebar_items)

--- a/dashboard/src/pages/EventCheckins.vue
+++ b/dashboard/src/pages/EventCheckins.vue
@@ -1,0 +1,207 @@
+<template>
+  <div v-if="event.data" class="w-full">
+    <EventHeader :event="event.data" class="p-4 md:p-8" />
+    <hr />
+    <div class="p-4 md:px-8 md:py-6">
+      <div class="prose">
+        <h2 class="mb-1">Attendee Check-Ins</h2>
+        <p class="text-sm">Check in attendees as they arrive at the event.</p>
+      </div>
+      <div class="flex flex-col my-4 justify-center">
+        <div v-if="attendees.data">
+          <ListView
+            :columns="[
+              { label: 'Ticket ID', key: 'name', width: 1 / 5 },
+              { label: 'Name', key: 'full_name', width: 1 / 5 },
+              { label: 'Check-in Status', key: 'checkin_status', width: 2 / 5 },
+              { label: 'Actions', key: 'action', width: 1 / 5 },
+            ]"
+            :rows="attendees.data"
+            :options="{
+              selectable: false,
+              showTooltip: false,
+              resizeColumn: true,
+              emptyState: {
+                title: 'No attendees found',
+              },
+            }"
+            row-key="name"
+          >
+            <template #cell="{ item, row, column }">
+              <template v-if="column.key === 'action'">
+                <Button
+                  v-if="!isCheckedInToday(row)"
+                  class="w-fit"
+                  label="Check-in"
+                  variant="solid"
+                  @click="() => {
+                    selectedAttendee = row
+                    checkinAttendee.fetch()
+                  }"
+                  :loading="checkinAttendee.loading && selectedAttendee.name === row.name"
+                  loadingText="Checking in..."
+                />
+                <Button
+                  v-else
+                  class="w-fit"
+                  label="Undo"
+                  @click="() => {
+                    selectedAttendee = row
+                    undoAttendeeCheckin.fetch()
+                  }"
+                />
+              </template>
+              <template v-else-if="column.key ==='name'">
+                <span class="font-mono text-sm font-semibold text-gray-800">{{ item }}</span>
+              </template>
+              <template v-else-if="column.key === 'checkin_status'">
+                <div class="flex items-center overflow-scroll flex-wrap">
+                  <span
+                    v-for="data in row.checkin_data"
+                    class="flex items-center p-1 rounded-sm"
+                  >
+                    <Tooltip
+                      arrow-class="fill-black"
+                      :placement="'top'"
+                      :hoverDelay="0.5"
+                    >
+                      <template #body>
+                        <span class="text-xs bg-gray-900 text-white px-2 py-1 rounded-full">
+                          {{ getFormattedDateTime(data.check_in_time) }}
+                        </span>
+                      </template>
+                      <Badge :theme="getRelativeTime(data.check_in_time) == 'Today' ? 'green' : 'gray'" class="flex gap-1 items-center">
+                        <DoubleChecksIcon class="w-4 h-4" />
+                        <span>{{ getRelativeTime(data.check_in_time) }}</span>
+                      </Badge>
+                    </Tooltip>
+                  </span>
+                </div>
+              </template>
+              <template v-else class="text-base">
+                {{ item }}
+              </template>
+            </template>
+          </ListView>
+        </div>
+        <div v-else>
+          <LoadingText />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+<script setup>
+import DoubleChecksIcon from '@/components/icons/DoubleChecks.vue'
+import EventHeader from '@/components/EventHeader.vue'
+import {
+  createResource,
+  usePageMeta,
+  LoadingText,
+  ListView,
+  Badge,
+  Tooltip,
+} from 'frappe-ui'
+import { useRoute } from 'vue-router'
+import { inject, ref } from 'vue'
+import dayjs from 'dayjs'
+import relativeTime from 'dayjs/plugin/relativeTime'
+import isToday from 'dayjs/plugin/isToday'
+import isYesterday from 'dayjs/plugin/isYesterday'
+
+dayjs.extend(relativeTime)
+dayjs.extend(isToday)
+dayjs.extend(isYesterday)
+
+const session = inject('$session')
+
+const route = useRoute()
+
+const event = createResource({
+  url: 'frappe.client.get',
+  makeParams() {
+    return {
+      doctype: 'FOSS Chapter Event',
+      name: route.params.id,
+      fields: ['*'],
+    }
+  },
+  auto: true,
+})
+
+usePageMeta(() => {
+  return {
+    title: `Check-ins | ${event.data?.event_name}`,
+  }
+})
+
+const attendees = createResource({
+  url: 'fossunited.api.checkins.get_attendee_with_checkin_data',
+  makeParams() {
+    return {
+      event_id: route.params.id,
+      user: session.user,
+    }
+  },
+  auto: true,
+})
+
+const selectedAttendee = ref(null)
+
+const checkinAttendee = createResource({
+  url: 'fossunited.api.checkins.checkin_attendee',
+  makeParams() {
+    return {
+      event_id: route.params.id,
+      attendee: selectedAttendee.value,
+      user: session.user,
+    }
+  },
+  onSuccess() {
+    makeChangesToAttendeeDict(selectedAttendee.value)
+    selectedAttendee.value = null
+  },
+})
+
+const undoAttendeeCheckin = createResource({
+  url: 'fossunited.api.checkins.undo_attendee_checkin',
+  makeParams() {
+    return {
+      event_id: route.params.id,
+      attendee: selectedAttendee.value,
+      user: session.user,
+    }
+  },
+  onSuccess() {
+    const index = attendees.data.findIndex((data) => data.name === selectedAttendee.value.name)
+    attendees.data[index].checkin_data.shift()
+    selectedAttendee.value = null
+  },
+})
+
+const makeChangesToAttendeeDict = (attendee) => {
+  const index = attendees.data.findIndex((data) => data.name === attendee.name)
+  attendees.data[index].checkin_data.unshift({
+    check_in_time: new Date(),
+  })
+}
+
+const isCheckedInToday = (attendee) => {
+  return attendee.checkin_data.some((data) => dayjs(data.check_in_time).isToday())
+}
+
+const getFormattedDateTime = (datetime) => {
+  return dayjs(datetime).format('DD MMM, hh:mm A')
+}
+
+const getRelativeTime = (datetime) => {
+  const date = dayjs(datetime)
+  if (date.isToday()) {
+    return 'Today'
+  } else if (date.isYesterday()) {
+    return 'Yesterday'
+  } else {
+    return date.fromNow()
+  }
+}
+</script>

--- a/dashboard/src/pages/EventCheckins.vue
+++ b/dashboard/src/pages/EventCheckins.vue
@@ -1,58 +1,4 @@
 <template>
-  <!-- Checkin Dialog -->
-  <Dialog
-    class="z-50"
-    v-model="showDialog"
-    :options="{
-      title: 'Confirm Attendee Check In?',
-    }"
-  >
-    <template #body-content v-if="selectedAttendee">
-      <div class="flex flex-col py-2">
-        <p class="text-base">
-          Are you sure you want to check in
-          <span class="font-semibold">{{ selectedAttendee.full_name }}</span
-          >?
-        </p>
-        <div class="bg-gray-50 text-sm p-2 my-2 rounded-sm font-mono">
-          <p class="leading-5">
-            Name: {{ selectedAttendee.full_name }}
-            <br />
-            Ticket ID: {{ selectedAttendee.name }}
-            <br />
-            Has Tshirt Add-on:
-            {{ selectedAttendee.wants_tshirt ? 'Yes' : 'No' }}
-            <br />
-            <span v-if="selectedAttendee.wants_tshirt"
-              >Tshirt Size: {{ selectedAttendee.tshirt_size }}</span
-            >
-          </p>
-        </div>
-      </div>
-    </template>
-    <template #actions>
-      <div class="grid grid-cols-2 gap-2">
-        <Button
-          label="Cancel"
-          @click="
-            () => {
-              showDialog = false
-              selectedAttendee = null
-            }
-          "
-        />
-        <Button
-          label="Check In"
-          variant="solid"
-          theme="green"
-          @click="checkinAttendee.fetch()"
-          :loading="checkinAttendee.loading"
-          loadingText="Checking in..."
-        />
-      </div>
-    </template>
-  </Dialog>
-
   <!-- Main Section -->
   <div v-if="event.data" class="w-full">
     <EventHeader :event="event.data" class="p-4 md:p-8" />
@@ -63,9 +9,8 @@
         <p class="text-sm">Check in attendees as they arrive at the event.</p>
       </div>
       <div class="flex flex-col my-4 justify-center">
+        <!-- Search Fields -->
         <div class="flex flex-col gap-2 mb-4 mt-2">
-
-          <!-- Search Fields -->
           <div
             class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-2 items-center"
           >
@@ -90,161 +35,25 @@
               @input="attendees.fetch()"
             />
           </div>
-          <Button
-            class="w-fit"
-            label="Search"
-            variant="solid"
-            @click="attendees.fetch()"
-            :loading="attendees.loading"
-            loadingText="Searching..."
-          />
         </div>
-
 
         <!-- Attendee List -->
-        <div v-if="attendees.data">
-          <ListView
-            :columns="[
-              { label: 'Name', key: 'full_name' },
-              { label: 'Ticket ID', key: 'name'},
-              { label: 'Has Tshirt?', key: 'wants_tshirt', width: '100px' },
-              { label: 'Tshirt Provided?', key: 'tshirt_assigned',  width: '150px' },
-              { label: 'Check-in Status', key: 'checkin_status', width: 1.5 },
-              { label: 'Actions', key: 'action'},
-            ]"
-            :rows="attendees.data"
-            :options="{
-              selectable: false,
-              showTooltip: false,
-              resizeColumn: true,
-              emptyState: {
-                title: 'No attendees found',
-              },
-            }"
-            row-key="name"
-          >
-            <template #cell="{ item, row, column }">
-              <template v-if="column.key === 'action'">
-                <Button
-                  v-if="!isCheckedInToday(row)"
-                  class="w-fit"
-                  label="Check-in"
-                  variant="solid"
-                  @click="
-                    () => {
-                      selectedAttendee = row
-                      showDialog = true
-                    }
-                  "
-                  :loading="
-                    checkinAttendee.loading &&
-                    selectedAttendee.name === row.name
-                  "
-                  loadingText="Checking in..."
-                />
-                <Button
-                  v-else
-                  class="w-fit"
-                  label="Undo"
-                  @click="
-                    () => {
-                      selectedAttendee = row
-                      undoAttendeeCheckin.fetch()
-                    }
-                  "
-                />
-              </template>
-              <template v-else-if="column.key === 'wants_tshirt' || column.key === 'tshirt_assigned'">
-                <Checkbox
-                  :model-value="item"
-                  :disabled="true"
-                  class="w-4 h-4"
-                />
-              </template>
-              <template v-else-if="column.key === 'name'">
-                <span class="font-mono text-sm font-semibold text-gray-800">{{
-                  item
-                }}</span>
-              </template>
-              <template v-else-if="column.key === 'checkin_status'">
-                <div
-                  class="flex items-center overflow-hidden overflow-x-visible flex-wrap"
-                >
-                  <span
-                    v-for="data in row.checkin_data"
-                    class="flex items-center p-1 rounded-sm"
-                  >
-                    <Tooltip
-                      arrow-class="fill-black"
-                      :placement="'top'"
-                      :hoverDelay="0.5"
-                    >
-                      <template #body>
-                        <span
-                          class="text-xs bg-gray-900 text-white px-2 py-1 rounded-full"
-                        >
-                          {{ getFormattedDateTime(data.check_in_time) }}
-                        </span>
-                      </template>
-                      <Badge
-                        :theme="
-                          getRelativeTime(data.check_in_time) == 'Today'
-                            ? 'green'
-                            : 'gray'
-                        "
-                        class="flex gap-1 items-center"
-                      >
-                        <DoubleChecksIcon class="w-4 h-4" />
-                        <span>{{ getRelativeTime(data.check_in_time) }}</span>
-                      </Badge>
-                    </Tooltip>
-                  </span>
-                </div>
-              </template>
-              <template v-else class="text-base">
-                {{ item }}
-              </template>
-            </template>
-          </ListView>
-        </div>
-        <div v-else>
-          <LoadingText />
-        </div>
-
+        <CheckinAttendeeList :event="event.data" :attendees="attendees" />
       </div>
     </div>
   </div>
 </template>
 <script setup>
-import DoubleChecksIcon from '@/components/icons/DoubleChecks.vue'
 import EventHeader from '@/components/EventHeader.vue'
-import {
-  FormControl,
-  createResource,
-  usePageMeta,
-  LoadingText,
-  ListView,
-  Badge,
-  Tooltip,
-  Dialog,
-  Checkbox,
-} from 'frappe-ui'
+import CheckinAttendeeList from '@/components/event/CheckinAttendeeList.vue'
+import { createResource, usePageMeta, FormControl } from 'frappe-ui'
 import { useRoute } from 'vue-router'
-import { inject, ref, reactive } from 'vue'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
-import isToday from 'dayjs/plugin/isToday'
-import isYesterday from 'dayjs/plugin/isYesterday'
-
-dayjs.extend(relativeTime)
-dayjs.extend(isToday)
-dayjs.extend(isYesterday)
+import { inject, reactive, provide } from 'vue'
 
 const session = inject('$session')
 
-const showDialog = ref(false)
-
 const route = useRoute()
+provide('route', route)
 
 const event = createResource({
   url: 'frappe.client.get',
@@ -282,68 +91,4 @@ const attendees = createResource({
   auto: true,
   debounce: 500,
 })
-
-const selectedAttendee = ref(null)
-
-const checkinAttendee = createResource({
-  url: 'fossunited.api.checkins.checkin_attendee',
-  makeParams() {
-    return {
-      event_id: route.params.id,
-      attendee: selectedAttendee.value,
-      user: session.user,
-    }
-  },
-  onSuccess() {
-    makeChangesToAttendeeDict(selectedAttendee.value)
-    showDialog.value = false
-    selectedAttendee.value = null
-  },
-})
-
-const undoAttendeeCheckin = createResource({
-  url: 'fossunited.api.checkins.undo_attendee_checkin',
-  makeParams() {
-    return {
-      event_id: route.params.id,
-      attendee: selectedAttendee.value,
-      user: session.user,
-    }
-  },
-  onSuccess() {
-    const index = attendees.data.findIndex(
-      (data) => data.name === selectedAttendee.value.name,
-    )
-    attendees.data[index].checkin_data.shift()
-    selectedAttendee.value = null
-  },
-})
-
-const makeChangesToAttendeeDict = (attendee) => {
-  const index = attendees.data.findIndex((data) => data.name === attendee.name)
-  attendees.data[index].checkin_data.unshift({
-    check_in_time: new Date(),
-  })
-}
-
-const isCheckedInToday = (attendee) => {
-  return attendee.checkin_data.some((data) =>
-    dayjs(data.check_in_time).isToday(),
-  )
-}
-
-const getFormattedDateTime = (datetime) => {
-  return dayjs(datetime).format('DD MMM, hh:mm A')
-}
-
-const getRelativeTime = (datetime) => {
-  const date = dayjs(datetime)
-  if (date.isToday()) {
-    return 'Today'
-  } else if (date.isYesterday()) {
-    return 'Yesterday'
-  } else {
-    return date.fromNow()
-  }
-}
 </script>

--- a/dashboard/src/pages/EventCheckins.vue
+++ b/dashboard/src/pages/EventCheckins.vue
@@ -8,6 +8,38 @@
         <p class="text-sm">Check in attendees as they arrive at the event.</p>
       </div>
       <div class="flex flex-col my-4 justify-center">
+        <div class="flex flex-col gap-2 mb-4 mt-2">
+          <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-2 items-center">
+            <FormControl
+              v-model="filters.name"
+              label="Ticket ID"
+              placeholder="Search by Ticket ID"
+              @input="attendees.fetch()"
+            />
+            <FormControl
+              v-model="filters.full_name"
+              label="Name"
+              type="text"
+              placeholder="Search by Name"
+              @input="attendees.fetch()"
+            />
+            <FormControl
+              v-model="filters.email"
+              label="Email"
+              type="text"
+              placeholder="Search by Email"
+              @input="attendees.fetch()"
+            />
+          </div>
+          <Button
+            class="w-fit"
+            label="Search"
+            variant="solid"
+            @click="attendees.fetch()"
+            :loading="attendees.loading"
+            loadingText="Searching..."
+          />
+        </div>
         <div v-if="attendees.data">
           <ListView
             :columns="[
@@ -55,7 +87,7 @@
                 <span class="font-mono text-sm font-semibold text-gray-800">{{ item }}</span>
               </template>
               <template v-else-if="column.key === 'checkin_status'">
-                <div class="flex items-center overflow-scroll flex-wrap">
+                <div class="flex items-center overflow-hidden overflow-x-visible flex-wrap">
                   <span
                     v-for="data in row.checkin_data"
                     class="flex items-center p-1 rounded-sm"
@@ -95,6 +127,7 @@
 import DoubleChecksIcon from '@/components/icons/DoubleChecks.vue'
 import EventHeader from '@/components/EventHeader.vue'
 import {
+  FormControl,
   createResource,
   usePageMeta,
   LoadingText,
@@ -103,7 +136,7 @@ import {
   Tooltip,
 } from 'frappe-ui'
 import { useRoute } from 'vue-router'
-import { inject, ref } from 'vue'
+import { inject, ref, reactive } from 'vue'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import isToday from 'dayjs/plugin/isToday'
@@ -135,15 +168,23 @@ usePageMeta(() => {
   }
 })
 
+const filters = reactive({
+  name: '',
+  full_name: '',
+  email: '',
+})
+
 const attendees = createResource({
   url: 'fossunited.api.checkins.get_attendee_with_checkin_data',
   makeParams() {
     return {
       event_id: route.params.id,
       user: session.user,
+      filters: filters,
     }
   },
   auto: true,
+  debounce: 500,
 })
 
 const selectedAttendee = ref(null)

--- a/dashboard/src/router.js
+++ b/dashboard/src/router.js
@@ -165,6 +165,11 @@ const routes = [
         name: 'EventVolunteers',
         component: () => import('@/pages/EventVolunteers.vue'),
       },
+      {
+        path: 'checkins',
+        name: 'EventCheckins',
+        component: () => import('@/pages/EventCheckins.vue'),
+      }
     ],
   },
   {

--- a/fossunited/api/checkins.py
+++ b/fossunited/api/checkins.py
@@ -23,7 +23,7 @@ def get_attendee_with_checkin_data(event_id: str, user: str = frappe.session.use
     _filters.update({key: ["like", f"%{value}%"] for key, value in filters.items()})
     print(_filters)
 
-    tickets = frappe.db.get_all("FOSS Event Ticket", _filters, ["name", "full_name", "designation", "organization", "wants_tshirt", "tshirt_size"])
+    tickets = frappe.db.get_all("FOSS Event Ticket", _filters, ["name", "full_name", "designation", "organization", "wants_tshirt", "tshirt_assigned", "tshirt_size"])
 
     for ticket in tickets:
         ticket["checkin_data"] = get_checkin_data(ticket["name"])

--- a/fossunited/api/checkins.py
+++ b/fossunited/api/checkins.py
@@ -16,7 +16,7 @@ def get_attendee_with_checkin_data(event_id: str, user: str = frappe.session.use
         dict: The attendees of the event with their checkin details
     """
     if not has_valid_permission(event_id, user):
-        frappe.throw("You do not have permission to access this resource")
+        frappe.throw("You do not have permission to access this resource", frappe.PermissionError)
 
     _filters = {"event": event_id}
     # Map the items in filters to be like "key": ["like", value]
@@ -56,7 +56,7 @@ def checkin_attendee(event_id: str, attendee: dict, user: str = frappe.session.u
         user (str): The user who is checking in the attendee
     """
     if not has_valid_permission(event_id, user):
-        frappe.throw("You do not have permission to access this resource")
+        frappe.throw("You do not have permission to access this resource", frappe.PermissionError)
 
     ticket = frappe.get_doc("FOSS Event Ticket", attendee["name"])
     ticket.append("check_ins", {"check_in_time": frappe.utils.now()})
@@ -75,7 +75,7 @@ def undo_attendee_checkin(event_id: str, attendee: dict, user: str = frappe.sess
         user (str): The user who is undoing the check-in
     """
     if not has_valid_permission(event_id, user):
-        frappe.throw("You do not have permission to access this resource")
+        frappe.throw("You do not have permission to access this resource", frappe.PermissionError)
 
     ticket = frappe.get_doc("FOSS Event Ticket", attendee["name"])
     ticket.check_ins.pop()
@@ -93,7 +93,7 @@ def assign_tshirt(event_id: str, attendee: dict, user: str = frappe.session.user
         user (str): The user who is assigning the Tshirt
     """
     if not has_valid_permission(event_id, user):
-        frappe.throw("You do not have permission to access this resource")
+        frappe.throw("You do not have permission to access this resource", frappe.PermissionError)
 
     ticket = frappe.get_doc("FOSS Event Ticket", attendee["name"])
     ticket.tshirt_assigned = True

--- a/fossunited/api/checkins.py
+++ b/fossunited/api/checkins.py
@@ -1,0 +1,76 @@
+import frappe
+
+from fossunited.api.tickets import has_valid_permission
+
+
+@frappe.whitelist()
+def get_attendee_with_checkin_data(event_id: str, user: str = frappe.session.user) -> dict:
+    """
+    Get the attendees of the event with their checkin details
+
+    Args:
+        event_id (str): The event id
+        user (str): The user who is requesting the data
+
+    Returns:
+        dict: The attendees of the event with their checkin details
+    """
+    if not has_valid_permission(event_id, user):
+        frappe.throw("You do not have permission to access this resource")
+
+    tickets = frappe.db.get_all("FOSS Event Ticket", {"event": event_id}, ["name", "full_name", "designation", "organization", "wants_tshirt", "tshirt_size"])
+
+    for ticket in tickets:
+        ticket["checkin_data"] = get_checkin_data(ticket["name"])
+
+    return tickets
+
+
+def get_checkin_data(attendee_id: str) -> dict:
+    """
+    Get the checkin data for the attendee
+
+    Args:
+        attendee_id (str): The attendee / ticket id
+
+    Returns:
+        dict: The checkin data for the attendee
+    """
+
+    checkin_data = frappe.db.get_all("Event Check In", {"parent": attendee_id, "parenttype": "FOSS Event Ticket", "parentfield": "check_ins"}, ["check_in_time"])
+
+    return checkin_data
+
+
+@frappe.whitelist()
+def checkin_attendee(event_id: str, attendee: dict, user: str = frappe.session.user):
+    """
+    Check-in the attendee for the event.
+
+    Args:
+        attendee (dict): The attendee details / ticket details
+        user (str): The user who is checking in the attendee
+    """
+    if not has_valid_permission(event_id, user):
+        frappe.throw("You do not have permission to access this resource")
+
+    ticket = frappe.get_doc("FOSS Event Ticket", attendee["name"])
+    ticket.append("check_ins", {"check_in_time": frappe.utils.now()})
+    ticket.save(ignore_permissions=True)
+
+
+@frappe.whitelist()
+def undo_attendee_checkin(event_id: str, attendee: dict, user: str = frappe.session.user):
+    """
+    Undo the check-in for the attendee
+
+    Args:
+        attendee (dict): The attendee details / ticket details
+        user (str): The user who is undoing the check-in
+    """
+    if not has_valid_permission(event_id, user):
+        frappe.throw("You do not have permission to access this resource")
+
+    ticket = frappe.get_doc("FOSS Event Ticket", attendee["name"])
+    ticket.check_ins.pop()
+    ticket.save(ignore_permissions=True)

--- a/fossunited/api/checkins.py
+++ b/fossunited/api/checkins.py
@@ -22,7 +22,7 @@ def get_attendee_with_checkin_data(event_id: str, user: str = frappe.session.use
     # Map the items in filters to be like "key": ["like", value]
     _filters.update({key: ["like", f"%{value}%"] for key, value in filters.items()})
 
-    tickets = frappe.db.get_all("FOSS Event Ticket", _filters, ["name", "full_name", "designation", "organization", "wants_tshirt", "tshirt_assigned", "tshirt_size"])
+    tickets = frappe.db.get_all("FOSS Event Ticket", _filters, ["name", "full_name", "designation", "organization", "wants_tshirt", "tier", "tshirt_assigned", "tshirt_size"])
 
     for ticket in tickets:
         ticket["checkin_data"] = get_checkin_data(ticket["name"])

--- a/fossunited/api/checkins.py
+++ b/fossunited/api/checkins.py
@@ -4,7 +4,7 @@ from fossunited.api.tickets import has_valid_permission
 
 
 @frappe.whitelist()
-def get_attendee_with_checkin_data(event_id: str, user: str = frappe.session.user) -> dict:
+def get_attendee_with_checkin_data(event_id: str, user: str = frappe.session.user, filters: dict = {}) -> dict:
     """
     Get the attendees of the event with their checkin details
 
@@ -18,7 +18,12 @@ def get_attendee_with_checkin_data(event_id: str, user: str = frappe.session.use
     if not has_valid_permission(event_id, user):
         frappe.throw("You do not have permission to access this resource")
 
-    tickets = frappe.db.get_all("FOSS Event Ticket", {"event": event_id}, ["name", "full_name", "designation", "organization", "wants_tshirt", "tshirt_size"])
+    _filters = {"event": event_id}
+    # Map the items in filters to be like "key": ["like", value]
+    _filters.update({key: ["like", f"%{value}%"] for key, value in filters.items()})
+    print(_filters)
+
+    tickets = frappe.db.get_all("FOSS Event Ticket", _filters, ["name", "full_name", "designation", "organization", "wants_tshirt", "tshirt_size"])
 
     for ticket in tickets:
         ticket["checkin_data"] = get_checkin_data(ticket["name"])

--- a/fossunited/api/checkins.py
+++ b/fossunited/api/checkins.py
@@ -22,7 +22,7 @@ def get_attendee_with_checkin_data(event_id: str, user: str = frappe.session.use
     # Map the items in filters to be like "key": ["like", value]
     _filters.update({key: ["like", f"%{value}%"] for key, value in filters.items()})
 
-    tickets = frappe.db.get_all("FOSS Event Ticket", _filters, ["name", "full_name", "designation", "organization", "wants_tshirt", "tier", "tshirt_assigned", "tshirt_size"])
+    tickets = frappe.db.get_all("FOSS Event Ticket", _filters, ["name", "full_name", "designation", "organization", "wants_tshirt", "tier", "tshirt_delivered", "tshirt_size"])
 
     for ticket in tickets:
         ticket["checkin_data"] = get_checkin_data(ticket["name"])
@@ -61,7 +61,7 @@ def checkin_attendee(event_id: str, attendee: dict, user: str = frappe.session.u
     ticket = frappe.get_doc("FOSS Event Ticket", attendee["name"])
     ticket.append("check_ins", {"check_in_time": frappe.utils.now()})
     if assign_tshirt:
-        ticket.tshirt_assigned = True
+        ticket.tshirt_delivered = True
     ticket.save(ignore_permissions=True)
 
 
@@ -96,5 +96,5 @@ def assign_tshirt(event_id: str, attendee: dict, user: str = frappe.session.user
         frappe.throw("You do not have permission to access this resource", frappe.PermissionError)
 
     ticket = frappe.get_doc("FOSS Event Ticket", attendee["name"])
-    ticket.tshirt_assigned = True
+    ticket.tshirt_delivered = True
     ticket.save(ignore_permissions=True)

--- a/fossunited/api/tickets.py
+++ b/fossunited/api/tickets.py
@@ -242,7 +242,7 @@ def get_sold_tickets(event_id: str, filters: dict = {}, user: str = frappe.sessi
 
     if not has_valid_permission(event_id, user):
         frappe.throw("You are not authorized to view the tickets for this event")
-    print("Filters: ", filters)
+
     tickets = frappe.db.get_all(
         "FOSS Event Ticket",
         filters={"event": event_id, **filters},
@@ -278,6 +278,15 @@ def has_valid_permission(event_id: str, session_user: str = frappe.session.user)
                 "Has Role",
                 {
                     "role": "Chapter Lead",
+                    "parent": session_user,
+                },
+            )
+        )
+        or bool(
+            frappe.db.exists(
+                "Has Role",
+                {
+                    "role": "Chapter Team Member",
                     "parent": session_user,
                 },
             )

--- a/fossunited/fossunited/doctype/event_check_in/event_check_in.json
+++ b/fossunited/fossunited/doctype/event_check_in/event_check_in.json
@@ -1,0 +1,30 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-09-02 12:07:52.297533",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "check_in_time"
+ ],
+ "fields": [
+  {
+   "fieldname": "check_in_time",
+   "fieldtype": "Datetime",
+   "label": "Check In Time"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2024-09-02 12:08:37.894519",
+ "modified_by": "Administrator",
+ "module": "FOSSUnited",
+ "name": "Event Check In",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/fossunited/fossunited/doctype/event_check_in/event_check_in.json
+++ b/fossunited/fossunited/doctype/event_check_in/event_check_in.json
@@ -12,13 +12,14 @@
   {
    "fieldname": "check_in_time",
    "fieldtype": "Datetime",
+   "in_list_view": 1,
    "label": "Check In Time"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-09-02 12:08:37.894519",
+ "modified": "2024-09-02 14:38:02.294172",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "Event Check In",

--- a/fossunited/fossunited/doctype/event_check_in/event_check_in.py
+++ b/fossunited/fossunited/doctype/event_check_in/event_check_in.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2024, Frappe x FOSSUnited and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class EventCheckIn(Document):
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        check_in_time: DF.Datetime | None
+        parent: DF.Data
+        parentfield: DF.Data
+        parenttype: DF.Data
+    # end: auto-generated types
+    pass

--- a/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.json
+++ b/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.json
@@ -21,6 +21,7 @@
   "customer",
   "additional_details_section",
   "wants_tshirt",
+  "tshirt_assigned",
   "column_break_qbfj",
   "tshirt_size",
   "section_break_tzsu",
@@ -149,10 +150,16 @@
    "fieldtype": "Table",
    "label": "Check Ins",
    "options": "Event Check In"
+  },
+  {
+   "default": "0",
+   "fieldname": "tshirt_assigned",
+   "fieldtype": "Check",
+   "label": "Tshirt Assigned?"
   }
  ],
  "links": [],
- "modified": "2024-09-02 14:37:49.073913",
+ "modified": "2024-09-03 14:40:26.541234",
  "modified_by": "Administrator",
  "module": "Ticketing",
  "name": "FOSS Event Ticket",

--- a/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.json
+++ b/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.json
@@ -24,7 +24,9 @@
   "column_break_qbfj",
   "tshirt_size",
   "section_break_tzsu",
-  "custom_fields"
+  "custom_fields",
+  "section_break_ueio",
+  "check_ins"
  ],
  "fields": [
   {
@@ -137,10 +139,20 @@
   {
    "fieldname": "section_break_ogof",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "section_break_ueio",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "check_ins",
+   "fieldtype": "Table",
+   "label": "Check Ins",
+   "options": "Event Check In"
   }
  ],
  "links": [],
- "modified": "2024-07-03 14:45:28.719114",
+ "modified": "2024-09-02 14:37:49.073913",
  "modified_by": "Administrator",
  "module": "Ticketing",
  "name": "FOSS Event Ticket",
@@ -157,6 +169,12 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "export": 1,
+   "read": 1,
+   "role": "Chapter Lead",
+   "select": 1
   }
  ],
  "sort_field": "creation",

--- a/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.json
+++ b/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.json
@@ -159,7 +159,7 @@
   }
  ],
  "links": [],
- "modified": "2024-09-03 14:40:26.541234",
+ "modified": "2024-09-05 16:01:32.717661",
  "modified_by": "Administrator",
  "module": "Ticketing",
  "name": "FOSS Event Ticket",
@@ -176,12 +176,6 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
-  },
-  {
-   "export": 1,
-   "read": 1,
-   "role": "Chapter Lead",
-   "select": 1
   }
  ],
  "sort_field": "creation",

--- a/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.json
+++ b/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.json
@@ -21,7 +21,7 @@
   "customer",
   "additional_details_section",
   "wants_tshirt",
-  "tshirt_assigned",
+  "tshirt_delivered",
   "column_break_qbfj",
   "tshirt_size",
   "section_break_tzsu",
@@ -153,13 +153,13 @@
   },
   {
    "default": "0",
-   "fieldname": "tshirt_assigned",
+   "fieldname": "tshirt_delivered",
    "fieldtype": "Check",
-   "label": "Tshirt Assigned?"
+   "label": "Tshirt Delivered?"
   }
  ],
  "links": [],
- "modified": "2024-09-05 16:01:32.717661",
+ "modified": "2024-09-05 16:13:42.830490",
  "modified_by": "Administrator",
  "module": "Ticketing",
  "name": "FOSS Event Ticket",

--- a/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
@@ -35,7 +35,7 @@ class FOSSEventTicket(Document):
         organization: DF.Data | None
         razorpay_payment: DF.Link | None
         tier: DF.Data | None
-        tshirt_assigned: DF.Check
+        tshirt_delivered: DF.Check
         tshirt_size: DF.Data | None
         wants_tshirt: DF.Check
     # end: auto-generated types

--- a/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
@@ -35,6 +35,7 @@ class FOSSEventTicket(Document):
         organization: DF.Data | None
         razorpay_payment: DF.Link | None
         tier: DF.Data | None
+        tshirt_assigned: DF.Check
         tshirt_size: DF.Data | None
         wants_tshirt: DF.Check
     # end: auto-generated types

--- a/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
@@ -21,10 +21,10 @@ class FOSSEventTicket(Document):
     if TYPE_CHECKING:
         from frappe.types import DF
 
-        from fossunited.ticketing.doctype.foss_ticket_custom_field.foss_ticket_custom_field import (
-            FOSSTicketCustomField,
-        )
+        from fossunited.fossunited.doctype.event_check_in.event_check_in import EventCheckIn
+        from fossunited.ticketing.doctype.foss_ticket_custom_field.foss_ticket_custom_field import FOSSTicketCustomField
 
+        check_ins: DF.Table[EventCheckIn]
         custom_fields: DF.Table[FOSSTicketCustomField]
         customer: DF.Data | None
         designation: DF.Data | None

--- a/fossunited/ticketing/doctype/foss_event_ticket/test_foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/test_foss_event_ticket.py
@@ -1,8 +1,88 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and Contributors
 # See license.txt
 
+from datetime import datetime, timedelta
+
+import frappe
+from faker import Faker
 from frappe.tests.utils import FrappeTestCase
+
+from fossunited.api.checkins import checkin_attendee
 
 
 class TestFOSSEventTicket(FrappeTestCase):
-    pass
+    def setUp(self):
+        fake = Faker()
+
+        chapter_member = frappe.db.get_value("FOSS User Profile", {"user": "test1@example.com"}, ["name"])
+        self.member_email = "test1@example.com"
+        self.member_profile = chapter_member
+
+        chapter = frappe.get_doc(
+            {
+                "doctype": "FOSS Chapter",
+                "chapter_type": "Conference",
+                "chapter_name": fake.name(),
+                "email": fake.email(),
+                "about_chapter": fake.text(),
+                "chapter_members": [{"chapter_member": chapter_member}],
+            }
+        )
+        chapter.insert(ignore_permissions=True)
+
+        event = frappe.get_doc(
+            {
+                "doctype": "FOSS Chapter Event",
+                "chapter": chapter.name,
+                "event_name": fake.name(),
+                "event_permalink": fake.slug().replace("-", "_"),
+                "status": "Live",
+                "event_type": "Conference",
+                "event_start_date": datetime.today(),
+                "event_end_date": datetime.today() + timedelta(1),
+                "event_description": fake.text(),
+                "is_paid_event": 1,
+                "tickets_status": "Live",
+                "tiers": [
+                    {
+                        "enabled": 1,
+                        "title": "General",
+                        "price": 100,
+                    }
+                ],
+            }
+        )
+        event.insert(ignore_permissions=True)
+
+        self.event = event
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+        frappe.delete_doc("FOSS Chapter Event", self.event.name, force=True)
+
+    def test_checkin(self):
+        fake = Faker()
+
+        # Given that a ticket is created for an event
+        ticket = frappe.get_doc(
+            {
+                "doctype": "FOSS Event Ticket",
+                "event": self.event.name,
+                "full_name": fake.name(),
+                "email": fake.email(),
+                "tier": "General",
+            }
+        )
+        ticket.insert(ignore_permissions=True)
+        ticket.reload()
+
+        self.assertFalse(ticket.check_ins)
+        # Set the user as a chapter member
+        frappe.set_user(self.member_email)
+
+        # When the user checks in the attendee
+        checkin_attendee(self.event.name, ticket.as_dict(), self.member_email)
+
+        # Then the check-in data should be saved
+        ticket.reload()
+        self.assertTrue(ticket.check_ins)

--- a/fossunited/ticketing/doctype/foss_event_ticket/test_foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/test_foss_event_ticket.py
@@ -86,3 +86,28 @@ class TestFOSSEventTicket(FrappeTestCase):
         # Then the check-in data should be saved
         ticket.reload()
         self.assertTrue(ticket.check_ins)
+
+    def test_checkin_as_non_chapter_member(self):
+        fake = Faker()
+
+        # Given that a ticket is created for an event
+        ticket = frappe.get_doc(
+            {
+                "doctype": "FOSS Event Ticket",
+                "event": self.event.name,
+                "full_name": fake.name(),
+                "email": fake.email(),
+                "tier": "General",
+            }
+        )
+        ticket.insert(ignore_permissions=True)
+        ticket.reload()
+
+        self.assertFalse(ticket.check_ins)
+        # Set the user as a random user
+        frappe.set_user("test2@example.com")
+
+        # When the user checks in the attendee
+        # Then the user should not have permission to check-in the attendee
+        with self.assertRaises(frappe.PermissionError):
+            checkin_attendee(self.event.name, ticket.as_dict(), "test2@example.com")

--- a/fossunited/ticketing/doctype/foss_event_ticket/test_foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/test_foss_event_ticket.py
@@ -18,6 +18,11 @@ class TestFOSSEventTicket(FrappeTestCase):
         self.member_email = "test1@example.com"
         self.member_profile = chapter_member
 
+        if not frappe.db.exists("Role", "Chapter Team Member"):
+            frappe.get_doc({"doctype": "Role", "role_name": "Chapter Team Member"}).insert(ignore_permissions=True)
+        if not frappe.db.exists("Role", "Chapter Lead"):
+            frappe.get_doc({"doctype": "Role", "role_name": "Chapter Lead"}).insert(ignore_permissions=True)
+
         chapter = frappe.get_doc(
             {
                 "doctype": "FOSS Chapter",

--- a/fossunited/ticketing/doctype/foss_event_ticket/test_foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/test_foss_event_ticket.py
@@ -87,6 +87,11 @@ class TestFOSSEventTicket(FrappeTestCase):
         ticket.reload()
         self.assertTrue(ticket.check_ins)
 
+        # When the user tries to check-in the attendee again on the same day
+        # Then the user should not be able to check-in the attendee again
+        with self.assertRaises(frappe.ValidationError):
+            checkin_attendee(self.event.name, ticket.as_dict(), self.member_email)
+
     def test_checkin_as_non_chapter_member(self):
         fake = Faker()
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🍕Feature

## Description
<!-- Briefly describe the changes introduced by this pull request -->
- Created a dashboard page, which can be used by the chapter members to check-in any participant.

It consists of a list of attendees with details such as "Name", "Ticket ID", "Bought Tshirt" (checkbox which tells whether the person has bought a tshirt along with their ticket, and "Tshirt Provided" (a checkbox which tells whether the tshirt was delivered to the person).

There is a `Checkin Status` column which tells the times (multiple) when a person has been checked in.

There is also a column called `Actions` which has CTAs "Manage" and "Check-In", which open respective dialog boxes as shown in the gif below.

Tshirts can also be marked as "assigned" at the time of checkin or at any later time.

Currently, the check-in system is only feasible for paid events, but we can plan it to move for unpaid events too.

The list can be searched by `Full Name`, `Email` and `Ticket ID` of the attendee.

This dashboard can only be accessed by the Chapter members of the event.

- Added a new doctype `Event Check Ins`. 
This is done because multi-day events require multi-day check-ins. Hence, rather than having a date-time field in the ticket doctype itself, it is more feasible to go with a child table where multiple datetimes can be filled for the same ticket.

- `tshirt_assigned` field is added to the Ticket doctype. If the ticket had a tshirt addon to it, this field marks whether the tshirt was assigned to teh respective person.

- Added a couple of tests for the checkin methods.

## Related Issues & Docs
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
closes #596 

## Screenshots/GIFs/Screen Recordings (if applicable)
<!-- Visually demonstrate the changes, if applicable -->
[Screencast from 2024-09-05 15-50-44.webm](https://github.com/user-attachments/assets/c6c7e029-e585-4366-a6ac-84215172428c)

