### PR TITLE
[CHORE] Add chapter-related doctype ids

### DIFF
--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -1,6 +1,6 @@
 import frappe
 
-from fossunited.doctype_ids import USER_PROFILE
+from fossunited.doctype_ids import CHAPTER, USER_PROFILE
 
 
 @frappe.whitelist()
@@ -25,7 +25,7 @@ def check_if_chapter_member(chapter: str, user: str = frappe.session.user) -> bo
             "FOSS Chapter Lead Team Member",
             {
                 "parent": chapter,
-                "parenttype": "FOSS Chapter",
+                "parenttype": CHAPTER,
                 "chapter_member": profile,
             },
         )

--- a/fossunited/api/dashboard.py
+++ b/fossunited/api/dashboard.py
@@ -1,6 +1,6 @@
 import frappe
 
-from fossunited.doctype_ids import USER_PROFILE
+from fossunited.doctype_ids import EVENT, USER_PROFILE
 from fossunited.utils.payments import (
     get_in_razorpay_money,
     get_razorpay_client,
@@ -9,14 +9,12 @@ from fossunited.utils.payments import (
 
 @frappe.whitelist(allow_guest=True)
 def get_event(name: str) -> dict:
-    return frappe.get_doc("FOSS Chapter Event", name)
+    return frappe.get_doc(EVENT, name)
 
 
 @frappe.whitelist(allow_guest=True)
 def get_event_from_permalink(permalink: str, fields: list) -> dict:
-    return frappe.db.get_value(
-        "FOSS Chapter Event", {"event_permalink": permalink}, fields, as_dict=1
-    )
+    return frappe.db.get_value(EVENT, {"event_permalink": permalink}, fields, as_dict=1)
 
 
 @frappe.whitelist(allow_guest=True)
@@ -134,7 +132,7 @@ def get_profile_data(username: str = None, email: str = None) -> dict:
         frappe.throw("Username or email is required")
 
     user = frappe.db.get_value(
-        "FOSS User Profile",
+        USER_PROFILE,
         {"user": username, "email": email or ""},
         [
             "full_name",
@@ -157,7 +155,7 @@ def get_user_profile_list(filters: dict = None) -> list:
         filters = {}
 
     profiles = frappe.db.get_all(
-        "FOSS User Profile",
+        USER_PROFILE,
         filters=filters,
         fields=[
             "full_name",

--- a/fossunited/api/pages.py
+++ b/fossunited/api/pages.py
@@ -1,17 +1,19 @@
 import frappe
 
+from fossunited.doctype_ids import CHAPTER, STUDENT_CLUB
+
 
 @frappe.whitelist(allow_guest=True)
 def search_foss_club(query):
     club_list = frappe.get_all(
-        "FOSS Chapter",
+        CHAPTER,
         fields=[
             "chapter_name",
             "route",
             "city",
         ],
         filters={
-            "chapter_type": "FOSS Club",
+            "chapter_type": STUDENT_CLUB,
         },
         or_filters=[
             ["city", "like", "%" + query + "%"],

--- a/fossunited/api/profile.py
+++ b/fossunited/api/profile.py
@@ -1,7 +1,7 @@
 import frappe
 
 from fossunited.api.dashboard import get_session_user_profile
-from fossunited.doctype_ids import RESTRICTED_USERNAME, USER_PROFILE
+from fossunited.doctype_ids import CHAPTER, RESTRICTED_USERNAME, USER_PROFILE
 
 
 @frappe.whitelist()
@@ -110,7 +110,7 @@ def is_valid_username(username: str, id: str) -> bool:
         bool: True if username is unique and not a restricted username
     """
     if (
-        frappe.db.exists("FOSS Chapter", {"route": username})
+        frappe.db.exists(CHAPTER, {"route": username})
         or frappe.db.exists(
             USER_PROFILE,
             {"route": username, "name": ["!=", id]},

--- a/fossunited/api/reviewer.py
+++ b/fossunited/api/reviewer.py
@@ -1,7 +1,14 @@
 import frappe
 
 from fossunited.api.dashboard import get_profile_data
-from fossunited.doctype_ids import EVENT_CFP, PROPOSAL, PROPOSAL_REVIEW
+from fossunited.doctype_ids import (
+    CHAPTER,
+    EVENT,
+    EVENT_CFP,
+    PROPOSAL,
+    PROPOSAL_REVIEW,
+    USER_PROFILE,
+)
 
 
 def get_event_cfp_submissions(event: str) -> list:
@@ -69,7 +76,7 @@ def get_cfp_submissions_by_reviewer_status(
 
     submissions = get_event_cfp_submissions(event)
 
-    reviewer = frappe.db.get_value("FOSS User Profile", {"user": frappe.session.user}, "name")
+    reviewer = frappe.db.get_value(USER_PROFILE, {"user": frappe.session.user}, "name")
 
     for submission in submissions:
         if not frappe.db.exists(
@@ -128,7 +135,7 @@ def get_events_by_open_cfp() -> list:
     cfps_to_review = []
 
     events = frappe.db.get_list(
-        "FOSS Chapter Event",
+        EVENT,
         filters={
             "status": ["in", ["Approved", "Live"]],
             "is_published": 1,
@@ -157,7 +164,7 @@ def get_events_by_open_cfp() -> list:
             as_dict=1,
         )
         chapter = frappe.db.get_value(
-            "FOSS Chapter",
+            CHAPTER,
             event.chapter,
             ["name", "chapter_name", "chapter_type"],
             as_dict=1,
@@ -193,7 +200,7 @@ def has_cfp_review(submission_id: str, reviewer: str = frappe.session.user) -> b
         bool: True if the reviewer has reviewed the submission, False otherwise
     """
 
-    reviewer_profile = frappe.db.get_value("FOSS User Profile", {"email": reviewer}, "name")
+    reviewer_profile = frappe.db.get_value(USER_PROFILE, {"email": reviewer}, "name")
 
     return bool(
         frappe.db.exists(
@@ -222,7 +229,7 @@ def get_review(submission_id: str, reviewer: str = frappe.session.user) -> dict:
     if not has_cfp_review(submission_id, reviewer):
         frappe.throw("No review found")
 
-    reviewer_profile = frappe.db.get_value("FOSS User Profile", {"email": reviewer}, "name")
+    reviewer_profile = frappe.db.get_value(USER_PROFILE, {"email": reviewer}, "name")
 
     review = frappe.db.get_value(
         PROPOSAL_REVIEW,
@@ -260,7 +267,7 @@ def submit_review(
     if has_cfp_review(submission_id, reviewer):
         frappe.throw("Review already exists")
 
-    reviewer_profile = frappe.db.get_value("FOSS User Profile", {"email": reviewer}, "name")
+    reviewer_profile = frappe.db.get_value(USER_PROFILE, {"email": reviewer}, "name")
 
     submission_doc = frappe.get_doc(PROPOSAL, submission_id)
 

--- a/fossunited/api/schedule.py
+++ b/fossunited/api/schedule.py
@@ -2,6 +2,8 @@ from datetime import datetime
 
 import frappe
 
+from fossunited.doctype_ids import EVENT
+
 
 @frappe.whitelist(allow_guest=True)
 def get_event_schedule(event_id: str) -> dict:
@@ -17,7 +19,7 @@ def get_event_schedule(event_id: str) -> dict:
 
     schedule = frappe.db.get_all(
         "FOSS Event Schedule",
-        {"parent": event_id, "parenttype": "FOSS Chapter Event"},
+        {"parent": event_id, "parenttype": EVENT},
         ["*"],
         order_by="start_time",
     )

--- a/fossunited/api/tickets.py
+++ b/fossunited/api/tickets.py
@@ -5,7 +5,7 @@ APIs for Tickets and Transfer Tickets
 import frappe
 
 from fossunited.api.chapter import check_if_chapter_member
-from fossunited.doctype_ids import EVENT_TICKET, TICKET_TRANSFER
+from fossunited.doctype_ids import EVENT, EVENT_TICKET, TICKET_TRANSFER
 
 
 @frappe.whitelist(allow_guest=True)
@@ -297,7 +297,7 @@ def has_valid_permission(event_id: str, session_user: str = frappe.session.user)
     ):
         return False
 
-    chapter_id = frappe.db.get_value("FOSS Chapter Event", event_id, ["chapter"])
+    chapter_id = frappe.db.get_value(EVENT, event_id, ["chapter"])
     if not check_if_chapter_member(chapter_id, session_user):
         return False
 
@@ -334,6 +334,6 @@ def is_ticket_live(event_id: str) -> bool:
     Returns:
         bool: True if ticketing is live, False otherwise
     """
-    ticket_status = frappe.db.get_value("FOSS Chapter Event", event_id, "tickets_status")
+    ticket_status = frappe.db.get_value(EVENT, event_id, "tickets_status")
 
     return ticket_status == "Live"

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
@@ -4,7 +4,7 @@
 import frappe
 from frappe.website.website_generator import WebsiteGenerator
 
-from fossunited.doctype_ids import USER_PROFILE
+from fossunited.doctype_ids import EVENT, STUDENT_CLUB, USER_PROFILE
 
 
 class FOSSChapter(WebsiteGenerator):
@@ -125,7 +125,7 @@ class FOSSChapter(WebsiteGenerator):
                 break
 
     def set_route(self):
-        if self.chapter_type == "FOSS Club":
+        if self.chapter_type == STUDENT_CLUB:
             self.route = f"clubs/{self.chapter_name.lower().replace(' ', '-')}"
         else:
             self.route = f"{self.chapter_name.lower().replace(' ', '-')}"
@@ -134,7 +134,7 @@ class FOSSChapter(WebsiteGenerator):
         if self.chapter_type == "City Community":
             context.profile_img_src = "/assets/fossunited/images/chapter/city_profile.svg"
             context.default_banner = "/assets/fossunited/images/chapter/city_community_banner.png"
-        elif self.chapter_type == "FOSS Club":
+        elif self.chapter_type == STUDENT_CLUB:
             context.profile_img_src = "/assets/fossunited/images/chapter/foss_club_profile.svg"
             context.default_banner = "/assets/fossunited/images/chapter/foss_club_banner.png"
         else:
@@ -152,7 +152,7 @@ class FOSSChapter(WebsiteGenerator):
 
     def get_upcoming_events(self):
         return frappe.get_all(
-            "FOSS Chapter Event",
+            EVENT,
             filters={
                 "chapter": self.name,
                 "event_end_date": (">=", frappe.utils.now()),
@@ -174,7 +174,7 @@ class FOSSChapter(WebsiteGenerator):
 
     def get_past_events(self):
         return frappe.get_all(
-            "FOSS Chapter Event",
+            EVENT,
             filters={
                 "chapter": self.name,
                 "event_end_date": ("<", frappe.utils.now()),

--- a/fossunited/chapters/doctype/foss_chapter/test_foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/test_foss_chapter.py
@@ -5,6 +5,8 @@ import frappe
 from faker import Faker
 from frappe.tests.utils import FrappeTestCase
 
+from fossunited.doctype_ids import CHAPTER, STUDENT_CLUB, USER_PROFILE
+
 
 class TestFOSSChapter(FrappeTestCase):
     def setUp(self):
@@ -12,9 +14,9 @@ class TestFOSSChapter(FrappeTestCase):
 
         chapter = frappe.get_doc(
             {
-                "doctype": "FOSS Chapter",
+                "doctype": CHAPTER,
                 "chapter_name": fake.text(max_nb_chars=40),
-                "chapter_type": "FOSS Club",
+                "chapter_type": STUDENT_CLUB,
                 "city": "Pune",
                 "country": "India",
                 "email": fake.email(),
@@ -38,14 +40,14 @@ class TestFOSSChapter(FrappeTestCase):
                 ignore_permissions=True
             )
 
-        lead_profile = frappe.get_doc("FOSS User Profile", {"user": "test@example.com"})
+        lead_profile = frappe.get_doc(USER_PROFILE, {"user": "test@example.com"})
         chapter.append("chapter_members", {"chapter_member": lead_profile.name, "role": "Lead"})
         chapter.save()
 
         self.chapter = chapter
 
     def tearDown(self):
-        frappe.delete_doc("FOSS Chapter", self.chapter.name)
+        frappe.delete_doc(CHAPTER, self.chapter.name)
 
     def test_role_assignment_on_create(self):
         # Given a chapter
@@ -53,18 +55,16 @@ class TestFOSSChapter(FrappeTestCase):
 
         # When the chapter was created, a lead was assigned to it.
         # Then the lead should have the role of 'Chapter Lead' and 'Chapter Team Member'
-        user = frappe.db.get_value(
-            "FOSS User Profile", chapter.chapter_members[0].chapter_member, "user"
-        )
+        user = frappe.db.get_value(USER_PROFILE, chapter.chapter_members[0].chapter_member, "user")
         has_role = frappe.db.exists("Has Role", {"role": "Chapter Team Member", "parent": user})
         self.assertTrue(has_role)
 
     def test_role_assignment_on_member_addition(self):
         # Given a chapter: self.chapter
-        chapter = frappe.get_doc("FOSS Chapter", self.chapter.name)
+        chapter = frappe.get_doc(CHAPTER, self.chapter.name)
 
         # When a new member is added to the chapter
-        new_member = frappe.get_doc("FOSS User Profile", {"user": "test1@example.com"})
+        new_member = frappe.get_doc(USER_PROFILE, {"user": "test1@example.com"})
 
         chapter.append(
             "chapter_members", {"chapter_member": new_member.name, "role": "Core Team Member"}
@@ -72,16 +72,16 @@ class TestFOSSChapter(FrappeTestCase):
         chapter.save()
 
         # Then the new member should have the role of 'Chapter Team Member'
-        user = frappe.db.get_value("FOSS User Profile", new_member.name, "user")
+        user = frappe.db.get_value(USER_PROFILE, new_member.name, "user")
         has_role = frappe.db.exists("Has Role", {"role": "Chapter Team Member", "parent": user})
         self.assertTrue(has_role)
 
     def test_role_deassignment_on_member_removal(self):
         # Given a chapter: self.chapter
-        chapter = frappe.get_doc("FOSS Chapter", self.chapter.name)
+        chapter = frappe.get_doc(CHAPTER, self.chapter.name)
 
         new_members = frappe.get_all(
-            "FOSS User Profile",
+            USER_PROFILE,
             filters=[
                 ["user", "like", "%test%"],
                 ["name", "not in", [m.chapter_member for m in chapter.chapter_members]],
@@ -101,12 +101,12 @@ class TestFOSSChapter(FrappeTestCase):
         chapter.save()
 
         # Then the removed member should not have the role of 'Chapter Team Member'
-        user = frappe.db.get_value("FOSS User Profile", removed_member.chapter_member, "user")
+        user = frappe.db.get_value(USER_PROFILE, removed_member.chapter_member, "user")
         has_role = frappe.db.exists("Has Role", {"role": "Chapter Team Member", "parent": user})
 
         # check other members retain the role
         for member in chapter.chapter_members:
-            user = frappe.db.get_value("FOSS User Profile", member.chapter_member, "user")
+            user = frappe.db.get_value(USER_PROFILE, member.chapter_member, "user")
             if not bool(
                 frappe.db.exists("Has Role", {"role": "Chapter Team Member", "parent": user})
             ):

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -6,7 +6,14 @@ from datetime import datetime
 import frappe
 from frappe.website.website_generator import WebsiteGenerator
 
-from fossunited.doctype_ids import EVENT_CFP, EVENT_RSVP, PROPOSAL, RSVP_RESPONSE, USER_PROFILE
+from fossunited.doctype_ids import (
+    CHAPTER,
+    EVENT_CFP,
+    EVENT_RSVP,
+    PROPOSAL,
+    RSVP_RESPONSE,
+    USER_PROFILE,
+)
 from fossunited.fossunited.utils import is_user_team_member
 
 BASE_DATE = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
@@ -88,7 +95,7 @@ class FOSSChapterEvent(WebsiteGenerator):
         if not self.chapter:
             return
 
-        chapter_team_members = frappe.get_doc("FOSS Chapter", self.chapter).chapter_members
+        chapter_team_members = frappe.get_doc(CHAPTER, self.chapter).chapter_members
 
         for member in chapter_team_members:
             self.append(
@@ -155,7 +162,7 @@ class FOSSChapterEvent(WebsiteGenerator):
         self.route = f"events/{self.event_permalink}"
 
     def get_context(self, context):
-        context.chapter = frappe.get_doc("FOSS Chapter", self.chapter)
+        context.chapter = frappe.get_doc(CHAPTER, self.chapter)
         context.nav_items = self.get_navbar_items()
         context.sponsors_dict = self.get_sponsors()
         context.volunteers = self.get_volunteers()

--- a/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.py
@@ -5,7 +5,7 @@ import json
 import frappe
 from frappe.website.website_generator import WebsiteGenerator
 
-from fossunited.doctype_ids import EVENT_RSVP, RSVP_RESPONSE
+from fossunited.doctype_ids import EVENT, EVENT_RSVP, RSVP_RESPONSE
 
 
 class FOSSEventRSVP(WebsiteGenerator):
@@ -42,7 +42,7 @@ class FOSSEventRSVP(WebsiteGenerator):
             self.is_published = 0
 
     def get_context(self, context):
-        context.event = frappe.get_doc("FOSS Chapter Event", self.event)
+        context.event = frappe.get_doc(EVENT, self.event)
         context.event_name = self.event_name
         context.event_date = context.event.event_start_date.strftime("%B %d, %Y")
 
@@ -87,11 +87,11 @@ class FOSSEventRSVP(WebsiteGenerator):
         context.no_cache = 1
 
     def set_route(self):
-        event_route = frappe.db.get_value("FOSS Chapter Event", self.event, "route")
+        event_route = frappe.db.get_value(EVENT, self.event, "route")
         self.route = f"{event_route}/rsvp"
 
     def enable_rsvp_tab(self):
-        frappe.db.set_value("FOSS Chapter Event", self.event, "show_rsvp", 1)
+        frappe.db.set_value(EVENT, self.event, "show_rsvp", 1)
 
     def get_custom_questions(self):
         custom_questions = []

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
@@ -7,7 +7,7 @@ import frappe
 from faker import Faker
 from frappe.tests.utils import FrappeTestCase
 
-from fossunited.doctype_ids import EVENT_RSVP, RSVP_RESPONSE
+from fossunited.doctype_ids import EVENT, EVENT_RSVP, RSVP_RESPONSE
 
 
 class TestFOSSEventRSVPSubmission(FrappeTestCase):
@@ -15,7 +15,7 @@ class TestFOSSEventRSVPSubmission(FrappeTestCase):
         # Given an RSVP with max count of 5
         event = frappe.get_doc(
             {
-                "doctype": "FOSS Chapter Event",
+                "doctype": EVENT,
                 "event_name": "_Test_Event",
                 "event_permalink": "test-event-12345",
                 "status": "Live",

--- a/fossunited/doctype_ids.py
+++ b/fossunited/doctype_ids.py
@@ -14,10 +14,17 @@ HACKATHON_PROJECT = "FOSS Hackathon Project"
 HACKATHON_TEAM = "FOSS Hackathon Team"
 HACKATHON_TEAM_MEMBER = "FOSS Hackathon Team Member"
 
+# Chapter-related identifiers
+CHAPTER = "FOSS Chapter"
+EVENT = "FOSS Chapter Event"
+STUDENT_CLUB = "FOSS Club"
+CONFERENCE = "Conference"
+
 # Event proposal-related identifiers
 EVENT_CFP = "FOSS Event CFP"
 PROPOSAL = "FOSS Event CFP Submission"
 PROPOSAL_REVIEW = "FOSS Event CFP Review"
+GLOBAL_REVIEW_SETTINGS = "FOSS Global CFP Review Settings"
 
 # Event RSVP-related identifiers
 EVENT_RSVP = "FOSS Event RSVP"

--- a/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import frappe
 from frappe.website.website_generator import WebsiteGenerator
 
-from fossunited.doctype_ids import HACKATHON_PROJECT, PROPOSAL, USER_PROFILE
+from fossunited.doctype_ids import CHAPTER, HACKATHON_PROJECT, PROPOSAL, USER_PROFILE
 
 no_cache = 1
 
@@ -75,7 +75,7 @@ class FOSSHackathon(WebsiteGenerator):
 
     def get_context(self, context):
         if self.organizing_chapter:
-            context.chapter = frappe.get_doc("FOSS Chapter", self.organizing_chapter)
+            context.chapter = frappe.get_doc(CHAPTER, self.organizing_chapter)
 
         context.nav_items = self.get_nav_items()
         context.sponsors_dict = self.get_sponsors()

--- a/fossunited/fossunited/doctype/foss_event_cfp/foss_event_cfp.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp/foss_event_cfp.py
@@ -4,7 +4,7 @@
 import frappe
 from frappe.website.website_generator import WebsiteGenerator
 
-from fossunited.doctype_ids import EVENT_CFP, PROPOSAL
+from fossunited.doctype_ids import EVENT, EVENT_CFP, GLOBAL_REVIEW_SETTINGS, PROPOSAL
 
 
 class FOSSEventCFP(WebsiteGenerator):
@@ -42,7 +42,7 @@ class FOSSEventCFP(WebsiteGenerator):
         self.assign_reviewers()
 
     def assign_reviewers(self):
-        reviewers = frappe.get_single("FOSS Global CFP Review Settings").members
+        reviewers = frappe.get_single(GLOBAL_REVIEW_SETTINGS).members
         for reviewer in reviewers:
             self.append(
                 "cfp_reviewers",
@@ -58,19 +58,19 @@ class FOSSEventCFP(WebsiteGenerator):
         self.enable_cfp_tab()
 
     def set_route(self):
-        event_route = frappe.db.get_value("FOSS Chapter Event", self.event, "route")
+        event_route = frappe.db.get_value(EVENT, self.event, "route")
         self.route = f"{event_route}/cfp"
 
     def enable_cfp_tab(self):
-        frappe.db.set_value("FOSS Chapter Event", self.event, "show_cfp", 1)
+        frappe.db.set_value(EVENT, self.event, "show_cfp", 1)
 
     def get_context(self, context):
         context.submissions = get_cfp_submissions(self.name)
-        context.event = frappe.get_doc("FOSS Chapter Event", self.event)
+        context.event = frappe.get_doc(EVENT, self.event)
         context.event_name = self.event_name
-        context.event_date = frappe.db.get_value(
-            "FOSS Chapter Event", self.event, "event_start_date"
-        ).strftime("%B %d, %Y")
+        context.event_date = frappe.db.get_value(EVENT, self.event, "event_start_date").strftime(
+            "%B %d, %Y"
+        )
         context.submission_doctype = PROPOSAL
         context.already_submitted = True if self.check_if_already_submitted() else False
 

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -3,7 +3,7 @@
 import frappe
 from frappe.website.website_generator import WebsiteGenerator
 
-from fossunited.doctype_ids import EVENT_CFP, USER_PROFILE
+from fossunited.doctype_ids import EVENT, EVENT_CFP, USER_PROFILE
 from fossunited.fossunited.utils import (
     get_doc_likes,
     get_event_volunteers,
@@ -70,7 +70,7 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         self.last_name = " ".join(self.full_name.split(" ")[1:])
 
     def set_route(self):
-        event_route = frappe.db.get_value("FOSS Chapter Event", self.event, "route")
+        event_route = frappe.db.get_value(EVENT, self.event, "route")
         self.route = f"{event_route}/cfp/{self.name}"
 
     def set_scores(self):
@@ -90,7 +90,7 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
 
     def get_context(self, context):
         context.cfp = frappe.get_doc(EVENT_CFP, self.linked_cfp)
-        context.event = frappe.get_doc("FOSS Chapter Event", self.event)
+        context.event = frappe.get_doc(EVENT, self.event)
         context.likes = get_doc_likes(self.doctype, self.name)
         context.liked_by_user = frappe.session.user in context.likes
         context.reviewers = self.get_reviewers(context.cfp)

--- a/fossunited/fossunited/doctype/foss_global_cfp_review_settings/test_foss_global_cfp_review_settings.py
+++ b/fossunited/fossunited/doctype/foss_global_cfp_review_settings/test_foss_global_cfp_review_settings.py
@@ -3,7 +3,7 @@
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from fossunited.doctype_ids import USER_PROFILE
+from fossunited.doctype_ids import GLOBAL_REVIEW_SETTINGS, USER_PROFILE
 
 
 class TestFOSSGlobalCFPReviewSettings(FrappeTestCase):
@@ -12,7 +12,7 @@ class TestFOSSGlobalCFPReviewSettings(FrappeTestCase):
         # When the document is inserted without any members
         settings = frappe.get_doc(
             {
-                "doctype": "FOSS Global CFP Review Settings",
+                "doctype": GLOBAL_REVIEW_SETTINGS,
                 "members": [],
             }
         )
@@ -24,7 +24,7 @@ class TestFOSSGlobalCFPReviewSettings(FrappeTestCase):
         # Given a new FOSS Global CFP Review Settings document
         settings = frappe.get_doc(
             {
-                "doctype": "FOSS Global CFP Review Settings",
+                "doctype": GLOBAL_REVIEW_SETTINGS,
                 "members": [],
             }
         )
@@ -49,7 +49,7 @@ class TestFOSSGlobalCFPReviewSettings(FrappeTestCase):
         # Given a new FOSS Global CFP Review Settings document
         settings = frappe.get_doc(
             {
-                "doctype": "FOSS Global CFP Review Settings",
+                "doctype": GLOBAL_REVIEW_SETTINGS,
                 "members": [],
             }
         )

--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import frappe
 from frappe.utils.data import now_datetime
 
-from fossunited.doctype_ids import HACKATHON, USER_PROFILE
+from fossunited.doctype_ids import CHAPTER, EVENT, HACKATHON, USER_PROFILE
 
 
 # Jinja Filter
@@ -15,12 +15,12 @@ def get_profile_image(email):
 
 
 def get_event_volunteers(event):
-    volunteers = frappe.get_doc("FOSS Chapter Event", event).event_members
+    volunteers = frappe.get_doc(EVENT, event).event_members
     return volunteers
 
 
 def is_user_team_member(chapter, user):
-    members = frappe.get_doc("FOSS Chapter", chapter).chapter_members
+    members = frappe.get_doc(CHAPTER, chapter).chapter_members
     for member in members:
         if member.email == user:
             return True
@@ -197,7 +197,7 @@ def get_grouped_events():
     upcoming and past events.
     """
     events = frappe.get_all(
-        "FOSS Chapter Event",
+        EVENT,
         fields=["*"],
         filters={
             "status": ["in", ["Approved", "Live", "Concluded"]],

--- a/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import frappe
 from frappe.model.document import Document
 
-from fossunited.doctype_ids import EVENT_TICKET
+from fossunited.doctype_ids import EVENT, EVENT_TICKET
 
 if TYPE_CHECKING:
     from fossunited.payments.doctype.razorpay_payment.razorpay_payment import (
@@ -80,7 +80,7 @@ class FOSSEventTicket(Document):
         self.check_max_tickets()
 
     def check_max_tickets(self):
-        event = frappe.get_doc("FOSS Chapter Event", self.event)
+        event = frappe.get_doc(EVENT, self.event)
         tickets_count = frappe.db.count(
             EVENT_TICKET,
             {"event": self.event, "tier": self.tier},
@@ -120,7 +120,7 @@ def validate_payment_before_insert(doc: "RazorpayPayment", event: str):
     tier = payment_meta_data.get("tier", {}).get("name")
     price, event_name = frappe.db.get_value("FOSS Ticket Tier", tier, ["price", "parent"])
 
-    tshirt_price = frappe.db.get_value("FOSS Chapter Event", event_name, "t_shirt_price")
+    tshirt_price = frappe.db.get_value(EVENT, event_name, "t_shirt_price")
 
     for attendee in attendees:
         wants_tshirt = attendee.get("wants_tshirt", 0)
@@ -136,7 +136,7 @@ def validate_payment_before_insert(doc: "RazorpayPayment", event: str):
 
 
 def is_foss_event(doc: "RazorpayPayment"):
-    return doc.document_type == "FOSS Chapter Event"
+    return doc.document_type == EVENT
 
 
 def tickets_already_created(doc: "RazorpayPayment"):

--- a/fossunited/ticketing/doctype/foss_event_ticket/test_foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/test_foss_event_ticket.py
@@ -8,16 +8,14 @@ from faker import Faker
 from frappe.tests.utils import FrappeTestCase
 
 from fossunited.api.checkins import checkin_attendee
-from fossunited.doctype_ids import EVENT_TICKET
+from fossunited.doctype_ids import CHAPTER, CONFERENCE, EVENT, EVENT_TICKET, USER_PROFILE
 
 
 class TestFOSSEventTicket(FrappeTestCase):
     def setUp(self):
         fake = Faker()
 
-        chapter_member = frappe.db.get_value(
-            "FOSS User Profile", {"user": "test1@example.com"}, ["name"]
-        )
+        chapter_member = frappe.db.get_value(USER_PROFILE, {"user": "test1@example.com"}, ["name"])
         self.member_email = "test1@example.com"
         self.member_profile = chapter_member
 
@@ -32,8 +30,8 @@ class TestFOSSEventTicket(FrappeTestCase):
 
         chapter = frappe.get_doc(
             {
-                "doctype": "FOSS Chapter",
-                "chapter_type": "Conference",
+                "doctype": CHAPTER,
+                "chapter_type": CONFERENCE,
                 "chapter_name": fake.name(),
                 "email": fake.email(),
                 "about_chapter": fake.text(),
@@ -44,12 +42,12 @@ class TestFOSSEventTicket(FrappeTestCase):
 
         event = frappe.get_doc(
             {
-                "doctype": "FOSS Chapter Event",
+                "doctype": EVENT,
                 "chapter": chapter.name,
                 "event_name": fake.name(),
                 "event_permalink": fake.slug().replace("-", "_"),
                 "status": "Live",
-                "event_type": "Conference",
+                "event_type": CONFERENCE,
                 "event_start_date": datetime.today(),
                 "event_end_date": datetime.today() + timedelta(1),
                 "event_description": fake.text(),
@@ -70,7 +68,7 @@ class TestFOSSEventTicket(FrappeTestCase):
 
     def tearDown(self):
         frappe.set_user("Administrator")
-        frappe.delete_doc("FOSS Chapter Event", self.event.name, force=True)
+        frappe.delete_doc(EVENT, self.event.name, force=True)
 
     def test_checkin(self):
         fake = Faker()

--- a/fossunited/ticketing/doctype/foss_event_ticket_transfer/test_foss_event_ticket_transfer.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket_transfer/test_foss_event_ticket_transfer.py
@@ -7,7 +7,7 @@ import frappe
 from faker import Faker
 from frappe.tests.utils import FrappeTestCase
 
-from fossunited.doctype_ids import EVENT_TICKET, TICKET_TRANSFER
+from fossunited.doctype_ids import CONFERENCE, EVENT, EVENT_TICKET, TICKET_TRANSFER
 
 
 class TestFOSSEventTicketTransfer(FrappeTestCase):
@@ -16,11 +16,11 @@ class TestFOSSEventTicketTransfer(FrappeTestCase):
 
         event = frappe.get_doc(
             {
-                "doctype": "FOSS Chapter Event",
+                "doctype": EVENT,
                 "event_name": fake.text(max_nb_chars=20),
                 "event_permalink": fake.slug(3).replace("-", "_"),
                 "status": "Approved",
-                "event_type": "Conference",
+                "event_type": CONFERENCE,
                 "event_start_date": datetime.today(),
                 "event_end_date": datetime.today() + timedelta(1),
                 "event_description": "testing",
@@ -31,7 +31,7 @@ class TestFOSSEventTicketTransfer(FrappeTestCase):
         self.event = event
 
     def tearDown(self):
-        frappe.delete_doc("FOSS Chapter Event", self.event.name, force=True)
+        frappe.delete_doc(EVENT, self.event.name, force=True)
 
     def test_ticket_transfer(self):
         fake = Faker()

--- a/fossunited/www/cfp/submission/edit.py
+++ b/fossunited/www/cfp/submission/edit.py
@@ -1,13 +1,13 @@
 import frappe
 
-from fossunited.doctype_ids import EVENT_CFP, PROPOSAL
+from fossunited.doctype_ids import EVENT, EVENT_CFP, PROPOSAL
 from fossunited.fossunited.utils import filter_field_values
 
 
 def get_context(context):
     context.submission = frappe.get_doc(PROPOSAL, frappe.form_dict["submission"])
     context.cfp = frappe.get_doc(EVENT_CFP, context.submission.linked_cfp)
-    context.event = frappe.get_doc("FOSS Chapter Event", context.submission.event)
+    context.event = frappe.get_doc(EVENT, context.submission.event)
 
     frappe.form_dict["doctype"] = PROPOSAL
     frappe.form_dict["cfp"] = frappe.form_dict.submission

--- a/fossunited/www/rsvp/submission/edit.py
+++ b/fossunited/www/rsvp/submission/edit.py
@@ -1,12 +1,12 @@
 import frappe
 
-from fossunited.doctype_ids import EVENT_RSVP, RSVP_RESPONSE
+from fossunited.doctype_ids import EVENT, EVENT_RSVP, RSVP_RESPONSE
 from fossunited.fossunited.utils import filter_field_values
 
 
 def get_context(context):
     context.submission = frappe.get_doc(RSVP_RESPONSE, frappe.form_dict.submission)
-    context.event = frappe.get_doc("FOSS Chapter Event", context.submission.event)
+    context.event = frappe.get_doc(EVENT, context.submission.event)
     frappe.form_dict["rsvp"] = frappe.form_dict.submission
     frappe.form_dict["doctype"] = RSVP_RESPONSE
     context.form_fields = get_form_fields(context.submission.doctype, context.submission)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] ⚙️Chore

## Description
closes #485 

This PR introduces doctype identifiers for the following doctypes

- `FOSS Chapter"`
- `FOSS Chapter Event"`
- `FOSS Club"`
- `Conference"`
- `"FOSS Global CFP Review Settings"`

In addition, this PR also replaces a few missed `"FOSS User Profile"` strings with the existing `USER_PROFILE` constant. It's unclear how these were missed in the earlier PR that introduced `USER_PROFILE`.

With this, most of the remaining `"FOSS ...` strings are one-time only use and can be ignored for now. I would recommend closing #485 with this PR and moving on to other tasks.

## Checklist
- [x] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [ ] I have tested these changes locally.
- [ ] ~I have updated the documentation (If applicable).~
- [x] The code follows the project's coding standards.
- [ ] ~I have added/updated tests, if applicable.~