### PR TITLE
[CHORE] Remove "Mark as must attend" boolean flag from UI

### DIFF
--- a/dashboard/src/pages/EventDetails.vue
+++ b/dashboard/src/pages/EventDetails.vue
@@ -109,17 +109,6 @@
           v-model="event.doc.event_type"
           label="Event Type"
         />
-        <div class="flex flex-col gap-1">
-          <FormControl
-            :type="'checkbox'"
-            size="md"
-            label="Mark as Must Attend"
-            v-model="event.doc.must_attend"
-          />
-          <span class="text-sm text-gray-600"
-            >Mark this event as a must-attend for the audience.</span
-          >
-        </div>
         <FormControl
           :type="'text'"
           size="md"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] ⚙️Chore

## Description

This PR removes the `"Mark as must attend"` boolean option from the UI when an event is being created. As mentioned in the issue, this option should be set by folks at the Foundation and not the city volunteers.

## Related Issues & Docs

fixes #623 

## Checklist

- [x] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [ ] I have tested these changes locally.
- [ ] ~I have updated the documentation (If applicable).~
- [x] The code follows the project's coding standards.
- [ ] ~I have added/updated tests, if applicable.~

## Screenshots/GIFs/Screen Recordings (if applicable)

I do not have the dev setup locally to actually test the changes sadly.