### PR TITLE
refactor(event timeline): Sort month_grouped_events in reverse order past events

### DIFF
--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -253,10 +253,17 @@ def get_month_grouped_events(events, hackathons):
             month_grouped_events[key][month_year] = list(month_year_events)
 
     for key in month_grouped_events:
-        sorted_month_years = sorted(
-            month_grouped_events[key].keys(),
-            key=lambda x: datetime.strptime(x, "%B %Y"),
-        )
+        if key == "Upcoming FOSS Events":
+            sorted_month_years = sorted(
+                month_grouped_events[key].keys(),
+                key=lambda x: datetime.strptime(x, "%B %Y"),
+            )
+        else:
+            sorted_month_years = sorted(
+                month_grouped_events[key].keys(),
+                key=lambda x: datetime.strptime(x, "%B %Y"),
+                reverse=True,
+            )
         month_grouped_events[key] = {
             month: month_grouped_events[key][month] for month in sorted_month_years
         }


### PR DESCRIPTION
The code changes in this commit refactor the sorting logic for the month_grouped_events dictionary. For past events, the dictionary is now sorted in reverse order based on the month and year. This ensures that the events are displayed in descending order of their occurrence. The sorting is done using the datetime.strptime function with the "%B %Y" format.

## What type of PR is this? (check all applicable)
- [x] 🧑‍💻Refactor

## Related Issues & Docs

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
closes #633 
closes #627 


## Screenshots/GIFs/Screen Recordings (if applicable)

<!-- Visually demonstrate the changes, if applicable -->

![image](https://github.com/user-attachments/assets/2c467869-cdd8-4bed-b7cf-166c0e017596)
