### PR TITLE
REFACTOR!: chapter & event routes

### DIFF
--- a/dashboard/src/components/CopyToClipboardButton.vue
+++ b/dashboard/src/components/CopyToClipboardButton.vue
@@ -1,0 +1,27 @@
+<template>
+  <Tooltip :text="tooltipText">
+    <Button icon="copy" class="w-4" variant="ghost" @click="handleCopy" />
+  </Tooltip>
+</template>
+<script setup>
+import { Tooltip } from 'frappe-ui'
+import { copyToClipboard } from '@/helpers/utils'
+import { ref } from 'vue'
+
+const tooltipText = ref('Copy to clipboard')
+
+const props = defineProps({
+  value: {
+    type: String,
+    required: true,
+  },
+})
+
+const handleCopy = () => {
+  copyToClipboard(props.value)
+  tooltipText.value = 'Copied!'
+  setTimeout(() => {
+    tooltipText.value = 'Copy to clipboard'
+  }, 1000)
+}
+</script>

--- a/dashboard/src/helpers/utils.js
+++ b/dashboard/src/helpers/utils.js
@@ -9,3 +9,7 @@ export const redirectRoute = (route) => {
 export const createAbsoluteUrlFromRoute = (route) => {
   return window.location.origin + '/' + route
 }
+
+export const copyToClipboard = (text) => {
+  navigator.clipboard.writeText(text)
+}

--- a/dashboard/src/pages/Event.vue
+++ b/dashboard/src/pages/Event.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, provide } from 'vue'
 import { createResource, usePageMeta } from 'frappe-ui'
 import { RouterView, useRoute } from 'vue-router'
 import SideNavbar from '@/components/NewAppSidebar.vue'
@@ -39,11 +39,12 @@ const event = createResource({
   url: 'frappe.client.get_value',
   params: {
     doctype: 'FOSS Chapter Event',
-    fieldname: ['name', 'event_name', 'is_paid_event'],
+    fieldname: ['name', 'event_name', 'is_paid_event', 'chapter'],
     filters: { name: route.params.id },
   },
   auto: true,
   onSuccess(data) {
+    chapter.fetch()
     let sidebar_items = {
       items: [
         {
@@ -79,6 +80,19 @@ const event = createResource({
     sidebarMenuItems.value.push(sidebar_items)
   },
 })
+
+const chapter = createResource({
+  url: 'frappe.client.get_value',
+  makeParams() {
+    return {
+      doctype: 'FOSS Chapter',
+      fieldname: ['name', 'chapter_name', 'route'],
+      filters: { name: event.data.chapter },
+    }
+  },
+})
+
+provide('chapter', chapter)
 
 usePageMeta(() => {
   return {

--- a/dashboard/src/pages/EventDetails.vue
+++ b/dashboard/src/pages/EventDetails.vue
@@ -65,14 +65,32 @@
     <div class="flex flex-col my-6">
       <div class="font-semibold text-gray-800 border-b-2 pb-2">Event Details</div>
       <div class="p-2 my-1 grid sm:grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-6">
-        <FormControl v-model="event.doc.event_name" :type="'text'" size="md" label="Event Name" />
         <FormControl
           v-model="event.doc.event_permalink"
           :type="'text'"
           size="md"
           label="Event Permalink"
-          description="Only enter the event endpoint. Events will be rendered at event/<event_permalink>"
         />
+        <div class="flex flex-col gap-2">
+          <FormControl
+            :disabled="true"
+            :value="getEventLink()"
+            type="url"
+            size="md"
+            label="Event Link"
+          >
+            <template #suffix>
+              <CopyToClipboardButton :value="getEventLink()" />
+            </template>
+          </FormControl>
+          <Button
+            label="See on Website"
+            class="w-fit"
+            icon-right="external-link"
+            :link="createAbsoluteUrlFromRoute(event.doc.route)"
+          />
+        </div>
+        <FormControl v-model="event.doc.event_name" :type="'text'" size="md" label="Event Name" />
         <FormControl
           v-model="event.doc.status"
           :type="'select'"
@@ -158,9 +176,12 @@
 <script setup>
 import EventHeader from '@/components/EventHeader.vue'
 import TextEditor from '@/components/TextEditor.vue'
+import CopyToClipboardButton from '@/components/CopyToClipboardButton.vue'
 import { createDocumentResource, createListResource, FileUploader, FormControl } from 'frappe-ui'
 import { useRoute } from 'vue-router'
 import { toast } from 'vue-sonner'
+import { createAbsoluteUrlFromRoute } from '@/helpers/utils'
+import { inject } from 'vue'
 
 const route = useRoute()
 const event = createDocumentResource({
@@ -169,6 +190,7 @@ const event = createDocumentResource({
   fields: ['*'],
   auto: true,
 })
+const chapter = inject('chapter')
 
 const validateFile = (file) => {
   let extn = file.name.split('.').pop().toLowerCase()
@@ -217,5 +239,12 @@ const updateDetails = () => {
         description: error.message,
       })
     })
+}
+
+const getEventLink = () => {
+  let event_route = createAbsoluteUrlFromRoute(
+    chapter.data?.route + '/' + event.doc.event_permalink,
+  )
+  return event_route.replace(/(^\w+:|^)\/\//, '')
 }
 </script>

--- a/dashboard/src/pages/events/AllProposals.vue
+++ b/dashboard/src/pages/events/AllProposals.vue
@@ -67,27 +67,28 @@ import EventHeader from '@/components/schedule/EventHeader.vue'
 import ThemedSelectBlack from '@/components/common/ThemedSelectBlack.vue'
 
 const route = useRoute()
-const eventPermalink = route.params.permalink
 
 const event = createResource({
-  url: 'fossunited.api.dashboard.get_event_from_permalink',
-  params: {
-    permalink: eventPermalink,
-    fields: [
-      'name',
-      'chapter',
-      'chapter_name',
-      'event_name',
-      'event_start_date',
-      'event_end_date',
-      'event_location',
-      'event_bio',
-      'is_external_event',
-      'external_event_url',
-      'event_logo',
-      'proposal_page_description',
-      'route',
-    ],
+  url: 'fossunited.api.dashboard.get_event_from_route',
+  makeParams() {
+    return {
+      route: route.params.route,
+      fields: [
+        'name',
+        'chapter',
+        'chapter_name',
+        'event_name',
+        'event_start_date',
+        'event_end_date',
+        'event_location',
+        'event_bio',
+        'is_external_event',
+        'external_event_url',
+        'event_logo',
+        'proposal_page_description',
+        'route',
+      ],
+    }
   },
   auto: true,
   onSuccess(data) {
@@ -105,9 +106,11 @@ const proposals = createResource({
   auto: false,
 })
 
-usePageMeta(() => ({
-  title: event.data ? `${event.data.event_name} | Proposals` : 'Loading Proposals...',
-}))
+usePageMeta(() => {
+  return {
+    title: 'Proposals | ' + event.data?.event_name,
+  }
+})
 
 const breadcrumb_items = computed(() => {
   if (!event.data) return []

--- a/dashboard/src/pages/schedule/Schedule.vue
+++ b/dashboard/src/pages/schedule/Schedule.vue
@@ -38,10 +38,10 @@ const selectedSchedule = ref(null)
 const selectedScheduleView = ref('vertical')
 
 const event = createResource({
-  url: 'fossunited.api.dashboard.get_event_from_permalink',
+  url: 'fossunited.api.dashboard.get_event_from_route',
   makeParams() {
     return {
-      permalink: route.params.permalink,
+      route: route.params.route,
       fields: ['*'],
     }
   },

--- a/dashboard/src/router.js
+++ b/dashboard/src/router.js
@@ -206,7 +206,7 @@ const routes = [
   },
   {
     name: 'SchedulePage',
-    path: '/schedule/:permalink',
+    path: '/schedule/:route(.*)',
     component: () => import('@/pages/schedule/Schedule.vue'),
     meta: { isPublicPage: true },
   },
@@ -258,7 +258,7 @@ const routes = [
   },
   {
     name: 'AllProposalsPage',
-    path: '/cfp/:permalink',
+    path: '/cfp/:route(.*)',
     component: () => import('@/pages/events/AllProposals.vue'),
     meta: { isPublicPage: true },
   },

--- a/fossunited/api/dashboard.py
+++ b/fossunited/api/dashboard.py
@@ -18,6 +18,14 @@ def get_event_from_permalink(permalink: str, fields: list) -> dict:
 
 
 @frappe.whitelist(allow_guest=True)
+def get_event_from_route(route: str, fields: list) -> dict:
+    # if route does not start with c/, add it
+    if not route.startswith("c/"):
+        route = f"c/{route}"
+    return frappe.db.get_value(EVENT, {"route": route}, fields, as_dict=1)
+
+
+@frappe.whitelist(allow_guest=True)
 def get_states():
     return frappe.get_all("State", fields=["name"], page_length=1000, order_by="name")
 

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.js
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.js
@@ -1,0 +1,15 @@
+// Copyright (c) 2024, Frappe x FOSSUnited and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('FOSS Chapter', {
+  chapter_name(frm) {
+    if (frm.doc.chapter_name) {
+      frm.doc.slug = frm.doc.chapter_name
+        .toLowerCase()
+        .replace(/[^\w\s-]/g, '') // Remove special characters
+        .replace(/\s+/g, '-') // Replace spaces with hyphens
+        .replace(/-+/g, '-') // Replace multiple hyphens with single hyphen
+      frm.refresh_field('slug')
+    }
+  },
+})

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.json
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.json
@@ -1,278 +1,278 @@
 {
- "actions": [],
- "allow_guest_to_view": 1,
- "allow_rename": 1,
- "autoname": "format:{chapter_name}-{chapter_type}",
- "creation": "2023-06-30 01:25:06.245665",
- "doctype": "DocType",
- "engine": "InnoDB",
- "field_order": [
-  "meta_info_section",
-  "is_published",
-  "slug",
-  "column_break_pmbj",
-  "route",
-  "represent_image",
-  "basic_information_section",
-  "banner_image",
-  "column_break_3gye",
-  "chapter_type",
-  "chapter_name",
-  "institution_name",
-  "about_chapter_section",
-  "about_chapter",
-  "location_section",
-  "city",
-  "state",
-  "column_break_uljz",
-  "country",
-  "google_map_link",
-  "socials_section",
-  "email",
-  "x",
-  "linkedin",
-  "public_chat_group_url",
-  "column_break_fifp",
-  "facebook",
-  "instagram",
-  "mastodon",
-  "chapter_members_section",
-  "chapter_members",
-  "chapter_lead"
- ],
- "fields": [
-  {
-   "fieldname": "chapter_name",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Chapter Name",
-   "reqd": 1
-  },
-  {
-   "fieldname": "chapter_type",
-   "fieldtype": "Select",
-   "in_list_view": 1,
-   "label": "Chapter Type",
-   "options": "City Community\nFOSS Club\nConference",
-   "reqd": 1
-  },
-  {
-   "fieldname": "city",
-   "fieldtype": "Link",
-   "label": "City",
-   "options": "City"
-  },
-  {
-   "fieldname": "state",
-   "fieldtype": "Link",
-   "label": "State",
-   "mandatory_depends_on": "eval:doc.chapter_type!='Conference'",
-   "options": "State"
-  },
-  {
-   "default": "India",
-   "fieldname": "country",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Country",
-   "options": "Country"
-  },
-  {
-   "fieldname": "chapter_lead",
-   "fieldtype": "Link",
-   "label": "Chapter Lead",
-   "options": "FOSS User Profile",
-   "read_only": 1
-  },
-  {
-   "fieldname": "basic_information_section",
-   "fieldtype": "Section Break",
-   "label": "Basic Information"
-  },
-  {
-   "depends_on": "eval:doc.chapter_type!='Conference' ",
-   "fieldname": "location_section",
-   "fieldtype": "Section Break",
-   "label": "Location"
-  },
-  {
-   "fieldname": "column_break_uljz",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "chapter_members_section",
-   "fieldtype": "Section Break",
-   "label": "Member Information"
-  },
-  {
-   "fieldname": "column_break_3gye",
-   "fieldtype": "Column Break"
-  },
-  {
-   "depends_on": "eval: doc.chapter_type==='FOSS Club'",
-   "fieldname": "institution_name",
-   "fieldtype": "Link",
-   "label": "Institution Name",
-   "options": "Institute"
-  },
-  {
-   "fieldname": "about_chapter",
-   "fieldtype": "Text Editor",
-   "label": "About Chapter"
-  },
-  {
-   "fieldname": "google_map_link",
-   "fieldtype": "Data",
-   "label": "Google Map Link",
-   "options": "URL"
-  },
-  {
-   "fieldname": "route",
-   "fieldtype": "Data",
-   "label": "Route"
-  },
-  {
-   "default": "1",
-   "fieldname": "is_published",
-   "fieldtype": "Check",
-   "label": "Is Published?",
-   "reqd": 1
-  },
-  {
-   "fieldname": "socials_section",
-   "fieldtype": "Section Break",
-   "label": "Socials"
-  },
-  {
-   "fieldname": "email",
-   "fieldtype": "Data",
-   "label": "Email",
-   "options": "Email",
-   "reqd": 1
-  },
-  {
-   "fieldname": "linkedin",
-   "fieldtype": "Data",
-   "label": "LinkedIn",
-   "options": "URL"
-  },
-  {
-   "fieldname": "column_break_fifp",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "facebook",
-   "fieldtype": "Data",
-   "label": "Facebook",
-   "options": "URL"
-  },
-  {
-   "fieldname": "instagram",
-   "fieldtype": "Data",
-   "label": "Instagram",
-   "options": "URL"
-  },
-  {
-   "fieldname": "mastodon",
-   "fieldtype": "Data",
-   "label": "Mastodon",
-   "options": "URL"
-  },
-  {
-   "fieldname": "chapter_members",
-   "fieldtype": "Table",
-   "label": "Chapter Members",
-   "options": "FOSS Chapter Lead Team Member"
-  },
-  {
-   "fieldname": "meta_info_section",
-   "fieldtype": "Section Break",
-   "label": "Meta Info"
-  },
-  {
-   "fieldname": "column_break_pmbj",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "banner_image",
-   "fieldtype": "Attach Image",
-   "label": "Banner Image"
-  },
-  {
-   "fieldname": "about_chapter_section",
-   "fieldtype": "Section Break",
-   "label": "About Chapter"
-  },
-  {
-   "fieldname": "x",
-   "fieldtype": "Data",
-   "label": "X",
-   "options": "URL"
-  },
-  {
-   "default": "/files/City_Illustration.svg",
-   "fieldname": "represent_image",
-   "fieldtype": "Attach Image",
-   "label": "Representing Image"
-  },
-  {
-   "fieldname": "public_chat_group_url",
-   "fieldtype": "Data",
-   "label": "Public Chat Group URL",
-   "options": "URL"
-  },
-  {
-   "fieldname": "slug",
-   "fieldtype": "Data",
-   "label": "Slug",
-   "unique": 1
-  }
- ],
- "has_web_view": 1,
- "index_web_pages_for_search": 1,
- "is_published_field": "is_published",
- "links": [
-  {
-   "link_doctype": "FOSS Chapter Event",
-   "link_fieldname": "chapter"
-  }
- ],
- "modified": "2024-09-24 14:07:16.754531",
- "modified_by": "Administrator",
- "module": "Chapters",
- "name": "FOSS Chapter",
- "naming_rule": "Expression",
- "owner": "Administrator",
- "permissions": [
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "System Manager",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "read": 1,
-   "role": "Chapter Team Member",
-   "write": 1
-  },
-  {
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "All",
-   "share": 1
-  }
- ],
- "route": "c",
- "sort_field": "modified",
- "sort_order": "DESC",
- "states": []
+  "actions": [],
+  "allow_guest_to_view": 1,
+  "allow_rename": 1,
+  "autoname": "format:{chapter_name}-{chapter_type}",
+  "creation": "2023-06-30 01:25:06.245665",
+  "doctype": "DocType",
+  "engine": "InnoDB",
+  "field_order": [
+    "meta_info_section",
+    "is_published",
+    "slug",
+    "column_break_pmbj",
+    "route",
+    "represent_image",
+    "basic_information_section",
+    "banner_image",
+    "column_break_3gye",
+    "chapter_type",
+    "chapter_name",
+    "institution_name",
+    "about_chapter_section",
+    "about_chapter",
+    "location_section",
+    "city",
+    "state",
+    "column_break_uljz",
+    "country",
+    "google_map_link",
+    "socials_section",
+    "email",
+    "x",
+    "linkedin",
+    "public_chat_group_url",
+    "column_break_fifp",
+    "facebook",
+    "instagram",
+    "mastodon",
+    "chapter_members_section",
+    "chapter_members",
+    "chapter_lead"
+  ],
+  "fields": [
+    {
+      "fieldname": "chapter_name",
+      "fieldtype": "Data",
+      "in_list_view": 1,
+      "label": "Chapter Name",
+      "reqd": 1
+    },
+    {
+      "fieldname": "chapter_type",
+      "fieldtype": "Select",
+      "in_list_view": 1,
+      "label": "Chapter Type",
+      "options": "City Community\nFOSS Club\nConference",
+      "reqd": 1
+    },
+    {
+      "fieldname": "city",
+      "fieldtype": "Link",
+      "label": "City",
+      "options": "City"
+    },
+    {
+      "fieldname": "state",
+      "fieldtype": "Link",
+      "label": "State",
+      "mandatory_depends_on": "eval:doc.chapter_type!='Conference'",
+      "options": "State"
+    },
+    {
+      "default": "India",
+      "fieldname": "country",
+      "fieldtype": "Link",
+      "in_list_view": 1,
+      "label": "Country",
+      "options": "Country"
+    },
+    {
+      "fieldname": "chapter_lead",
+      "fieldtype": "Link",
+      "label": "Chapter Lead",
+      "options": "FOSS User Profile",
+      "read_only": 1
+    },
+    {
+      "fieldname": "basic_information_section",
+      "fieldtype": "Section Break",
+      "label": "Basic Information"
+    },
+    {
+      "depends_on": "eval:doc.chapter_type!='Conference' ",
+      "fieldname": "location_section",
+      "fieldtype": "Section Break",
+      "label": "Location"
+    },
+    {
+      "fieldname": "column_break_uljz",
+      "fieldtype": "Column Break"
+    },
+    {
+      "fieldname": "chapter_members_section",
+      "fieldtype": "Section Break",
+      "label": "Member Information"
+    },
+    {
+      "fieldname": "column_break_3gye",
+      "fieldtype": "Column Break"
+    },
+    {
+      "depends_on": "eval: doc.chapter_type==='FOSS Club'",
+      "fieldname": "institution_name",
+      "fieldtype": "Link",
+      "label": "Institution Name",
+      "options": "Institute"
+    },
+    {
+      "fieldname": "about_chapter",
+      "fieldtype": "Text Editor",
+      "label": "About Chapter"
+    },
+    {
+      "fieldname": "google_map_link",
+      "fieldtype": "Data",
+      "label": "Google Map Link",
+      "options": "URL"
+    },
+    {
+      "fieldname": "route",
+      "fieldtype": "Data",
+      "label": "Route"
+    },
+    {
+      "default": "1",
+      "fieldname": "is_published",
+      "fieldtype": "Check",
+      "label": "Is Published?",
+      "reqd": 1
+    },
+    {
+      "fieldname": "socials_section",
+      "fieldtype": "Section Break",
+      "label": "Socials"
+    },
+    {
+      "fieldname": "email",
+      "fieldtype": "Data",
+      "label": "Email",
+      "options": "Email",
+      "reqd": 1
+    },
+    {
+      "fieldname": "linkedin",
+      "fieldtype": "Data",
+      "label": "LinkedIn",
+      "options": "URL"
+    },
+    {
+      "fieldname": "column_break_fifp",
+      "fieldtype": "Column Break"
+    },
+    {
+      "fieldname": "facebook",
+      "fieldtype": "Data",
+      "label": "Facebook",
+      "options": "URL"
+    },
+    {
+      "fieldname": "instagram",
+      "fieldtype": "Data",
+      "label": "Instagram",
+      "options": "URL"
+    },
+    {
+      "fieldname": "mastodon",
+      "fieldtype": "Data",
+      "label": "Mastodon",
+      "options": "URL"
+    },
+    {
+      "fieldname": "chapter_members",
+      "fieldtype": "Table",
+      "label": "Chapter Members",
+      "options": "FOSS Chapter Lead Team Member"
+    },
+    {
+      "fieldname": "meta_info_section",
+      "fieldtype": "Section Break",
+      "label": "Meta Info"
+    },
+    {
+      "fieldname": "column_break_pmbj",
+      "fieldtype": "Column Break"
+    },
+    {
+      "fieldname": "banner_image",
+      "fieldtype": "Attach Image",
+      "label": "Banner Image"
+    },
+    {
+      "fieldname": "about_chapter_section",
+      "fieldtype": "Section Break",
+      "label": "About Chapter"
+    },
+    {
+      "fieldname": "x",
+      "fieldtype": "Data",
+      "label": "X",
+      "options": "URL"
+    },
+    {
+      "default": "/files/City_Illustration.svg",
+      "fieldname": "represent_image",
+      "fieldtype": "Attach Image",
+      "label": "Representing Image"
+    },
+    {
+      "fieldname": "public_chat_group_url",
+      "fieldtype": "Data",
+      "label": "Public Chat Group URL",
+      "options": "URL"
+    },
+    {
+      "fieldname": "slug",
+      "fieldtype": "Data",
+      "label": "Slug",
+      "unique": 1
+    }
+  ],
+  "has_web_view": 1,
+  "index_web_pages_for_search": 1,
+  "is_published_field": "is_published",
+  "links": [
+    {
+      "link_doctype": "FOSS Chapter Event",
+      "link_fieldname": "chapter"
+    }
+  ],
+  "modified": "2024-09-24 14:07:16.754531",
+  "modified_by": "Administrator",
+  "module": "Chapters",
+  "name": "FOSS Chapter",
+  "naming_rule": "Expression",
+  "owner": "Administrator",
+  "permissions": [
+    {
+      "create": 1,
+      "delete": 1,
+      "email": 1,
+      "export": 1,
+      "print": 1,
+      "read": 1,
+      "report": 1,
+      "role": "System Manager",
+      "share": 1,
+      "write": 1
+    },
+    {
+      "read": 1,
+      "role": "Chapter Team Member",
+      "write": 1
+    },
+    {
+      "email": 1,
+      "export": 1,
+      "print": 1,
+      "read": 1,
+      "report": 1,
+      "role": "All",
+      "share": 1
+    }
+  ],
+  "route": "c",
+  "sort_field": "modified",
+  "sort_order": "DESC",
+  "states": []
 }

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.json
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.json
@@ -1,271 +1,278 @@
 {
-  "actions": [],
-  "allow_guest_to_view": 1,
-  "allow_rename": 1,
-  "autoname": "format:{chapter_name}-{chapter_type}",
-  "creation": "2023-06-30 01:25:06.245665",
-  "doctype": "DocType",
-  "engine": "InnoDB",
-  "field_order": [
-    "meta_info_section",
-    "is_published",
-    "column_break_pmbj",
-    "route",
-    "represent_image",
-    "basic_information_section",
-    "banner_image",
-    "column_break_3gye",
-    "chapter_type",
-    "chapter_name",
-    "institution_name",
-    "about_chapter_section",
-    "about_chapter",
-    "location_section",
-    "city",
-    "state",
-    "column_break_uljz",
-    "country",
-    "google_map_link",
-    "socials_section",
-    "email",
-    "x",
-    "linkedin",
-    "public_chat_group_url",
-    "column_break_fifp",
-    "facebook",
-    "instagram",
-    "mastodon",
-    "chapter_members_section",
-    "chapter_members",
-    "chapter_lead"
-  ],
-  "fields": [
-    {
-      "fieldname": "chapter_name",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "label": "Chapter Name",
-      "reqd": 1
-    },
-    {
-      "fieldname": "chapter_type",
-      "fieldtype": "Select",
-      "in_list_view": 1,
-      "label": "Chapter Type",
-      "options": "City Community\nFOSS Club\nConference",
-      "reqd": 1
-    },
-    {
-      "fieldname": "city",
-      "fieldtype": "Link",
-      "label": "City",
-      "options": "City"
-    },
-    {
-      "fieldname": "state",
-      "fieldtype": "Link",
-      "label": "State",
-      "mandatory_depends_on": "eval:doc.chapter_type!='Conference'",
-      "options": "State"
-    },
-    {
-      "default": "India",
-      "fieldname": "country",
-      "fieldtype": "Link",
-      "in_list_view": 1,
-      "label": "Country",
-      "options": "Country"
-    },
-    {
-      "fieldname": "chapter_lead",
-      "fieldtype": "Link",
-      "label": "Chapter Lead",
-      "options": "FOSS User Profile",
-      "read_only": 1
-    },
-    {
-      "fieldname": "basic_information_section",
-      "fieldtype": "Section Break",
-      "label": "Basic Information"
-    },
-    {
-      "depends_on": "eval:doc.chapter_type!='Conference' ",
-      "fieldname": "location_section",
-      "fieldtype": "Section Break",
-      "label": "Location"
-    },
-    {
-      "fieldname": "column_break_uljz",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "chapter_members_section",
-      "fieldtype": "Section Break",
-      "label": "Member Information"
-    },
-    {
-      "fieldname": "column_break_3gye",
-      "fieldtype": "Column Break"
-    },
-    {
-      "depends_on": "eval: doc.chapter_type==='FOSS Club'",
-      "fieldname": "institution_name",
-      "fieldtype": "Link",
-      "label": "Institution Name",
-      "options": "Institute"
-    },
-    {
-      "fieldname": "about_chapter",
-      "fieldtype": "Text Editor",
-      "label": "About Chapter"
-    },
-    {
-      "fieldname": "google_map_link",
-      "fieldtype": "Data",
-      "label": "Google Map Link",
-      "options": "URL"
-    },
-    {
-      "fieldname": "route",
-      "fieldtype": "Data",
-      "label": "Route"
-    },
-    {
-      "default": "1",
-      "fieldname": "is_published",
-      "fieldtype": "Check",
-      "label": "Is Published?",
-      "reqd": 1
-    },
-    {
-      "fieldname": "socials_section",
-      "fieldtype": "Section Break",
-      "label": "Socials"
-    },
-    {
-      "fieldname": "email",
-      "fieldtype": "Data",
-      "label": "Email",
-      "options": "Email",
-      "reqd": 1
-    },
-    {
-      "fieldname": "linkedin",
-      "fieldtype": "Data",
-      "label": "LinkedIn",
-      "options": "URL"
-    },
-    {
-      "fieldname": "column_break_fifp",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "facebook",
-      "fieldtype": "Data",
-      "label": "Facebook",
-      "options": "URL"
-    },
-    {
-      "fieldname": "instagram",
-      "fieldtype": "Data",
-      "label": "Instagram",
-      "options": "URL"
-    },
-    {
-      "fieldname": "mastodon",
-      "fieldtype": "Data",
-      "label": "Mastodon",
-      "options": "URL"
-    },
-    {
-      "fieldname": "chapter_members",
-      "fieldtype": "Table",
-      "label": "Chapter Members",
-      "options": "FOSS Chapter Lead Team Member"
-    },
-    {
-      "fieldname": "meta_info_section",
-      "fieldtype": "Section Break",
-      "label": "Meta Info"
-    },
-    {
-      "fieldname": "column_break_pmbj",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "banner_image",
-      "fieldtype": "Attach Image",
-      "label": "Banner Image"
-    },
-    {
-      "fieldname": "about_chapter_section",
-      "fieldtype": "Section Break",
-      "label": "About Chapter"
-    },
-    {
-      "fieldname": "x",
-      "fieldtype": "Data",
-      "label": "X",
-      "options": "URL"
-    },
-    {
-      "default": "/files/City_Illustration.svg",
-      "fieldname": "represent_image",
-      "fieldtype": "Attach Image",
-      "label": "Representing Image"
-    },
-    {
-      "fieldname": "public_chat_group_url",
-      "fieldtype": "Data",
-      "label": "Public Chat Group URL",
-      "options": "URL"
-    }
-  ],
-  "has_web_view": 1,
-  "index_web_pages_for_search": 1,
-  "is_published_field": "is_published",
-  "links": [
-    {
-      "link_doctype": "FOSS Chapter Event",
-      "link_fieldname": "chapter"
-    }
-  ],
-  "modified": "2024-07-08 14:40:16.845746",
-  "modified_by": "Administrator",
-  "module": "Chapters",
-  "name": "FOSS Chapter",
-  "naming_rule": "Expression",
-  "owner": "Administrator",
-  "permissions": [
-    {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "System Manager",
-      "share": 1,
-      "write": 1
-    },
-    {
-      "read": 1,
-      "role": "Chapter Team Member",
-      "write": 1
-    },
-    {
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "All",
-      "share": 1
-    }
-  ],
-  "route": "chapters",
-  "sort_field": "modified",
-  "sort_order": "DESC",
-  "states": []
+ "actions": [],
+ "allow_guest_to_view": 1,
+ "allow_rename": 1,
+ "autoname": "format:{chapter_name}-{chapter_type}",
+ "creation": "2023-06-30 01:25:06.245665",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "meta_info_section",
+  "is_published",
+  "slug",
+  "column_break_pmbj",
+  "route",
+  "represent_image",
+  "basic_information_section",
+  "banner_image",
+  "column_break_3gye",
+  "chapter_type",
+  "chapter_name",
+  "institution_name",
+  "about_chapter_section",
+  "about_chapter",
+  "location_section",
+  "city",
+  "state",
+  "column_break_uljz",
+  "country",
+  "google_map_link",
+  "socials_section",
+  "email",
+  "x",
+  "linkedin",
+  "public_chat_group_url",
+  "column_break_fifp",
+  "facebook",
+  "instagram",
+  "mastodon",
+  "chapter_members_section",
+  "chapter_members",
+  "chapter_lead"
+ ],
+ "fields": [
+  {
+   "fieldname": "chapter_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Chapter Name",
+   "reqd": 1
+  },
+  {
+   "fieldname": "chapter_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Chapter Type",
+   "options": "City Community\nFOSS Club\nConference",
+   "reqd": 1
+  },
+  {
+   "fieldname": "city",
+   "fieldtype": "Link",
+   "label": "City",
+   "options": "City"
+  },
+  {
+   "fieldname": "state",
+   "fieldtype": "Link",
+   "label": "State",
+   "mandatory_depends_on": "eval:doc.chapter_type!='Conference'",
+   "options": "State"
+  },
+  {
+   "default": "India",
+   "fieldname": "country",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Country",
+   "options": "Country"
+  },
+  {
+   "fieldname": "chapter_lead",
+   "fieldtype": "Link",
+   "label": "Chapter Lead",
+   "options": "FOSS User Profile",
+   "read_only": 1
+  },
+  {
+   "fieldname": "basic_information_section",
+   "fieldtype": "Section Break",
+   "label": "Basic Information"
+  },
+  {
+   "depends_on": "eval:doc.chapter_type!='Conference' ",
+   "fieldname": "location_section",
+   "fieldtype": "Section Break",
+   "label": "Location"
+  },
+  {
+   "fieldname": "column_break_uljz",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "chapter_members_section",
+   "fieldtype": "Section Break",
+   "label": "Member Information"
+  },
+  {
+   "fieldname": "column_break_3gye",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval: doc.chapter_type==='FOSS Club'",
+   "fieldname": "institution_name",
+   "fieldtype": "Link",
+   "label": "Institution Name",
+   "options": "Institute"
+  },
+  {
+   "fieldname": "about_chapter",
+   "fieldtype": "Text Editor",
+   "label": "About Chapter"
+  },
+  {
+   "fieldname": "google_map_link",
+   "fieldtype": "Data",
+   "label": "Google Map Link",
+   "options": "URL"
+  },
+  {
+   "fieldname": "route",
+   "fieldtype": "Data",
+   "label": "Route"
+  },
+  {
+   "default": "1",
+   "fieldname": "is_published",
+   "fieldtype": "Check",
+   "label": "Is Published?",
+   "reqd": 1
+  },
+  {
+   "fieldname": "socials_section",
+   "fieldtype": "Section Break",
+   "label": "Socials"
+  },
+  {
+   "fieldname": "email",
+   "fieldtype": "Data",
+   "label": "Email",
+   "options": "Email",
+   "reqd": 1
+  },
+  {
+   "fieldname": "linkedin",
+   "fieldtype": "Data",
+   "label": "LinkedIn",
+   "options": "URL"
+  },
+  {
+   "fieldname": "column_break_fifp",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "facebook",
+   "fieldtype": "Data",
+   "label": "Facebook",
+   "options": "URL"
+  },
+  {
+   "fieldname": "instagram",
+   "fieldtype": "Data",
+   "label": "Instagram",
+   "options": "URL"
+  },
+  {
+   "fieldname": "mastodon",
+   "fieldtype": "Data",
+   "label": "Mastodon",
+   "options": "URL"
+  },
+  {
+   "fieldname": "chapter_members",
+   "fieldtype": "Table",
+   "label": "Chapter Members",
+   "options": "FOSS Chapter Lead Team Member"
+  },
+  {
+   "fieldname": "meta_info_section",
+   "fieldtype": "Section Break",
+   "label": "Meta Info"
+  },
+  {
+   "fieldname": "column_break_pmbj",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "banner_image",
+   "fieldtype": "Attach Image",
+   "label": "Banner Image"
+  },
+  {
+   "fieldname": "about_chapter_section",
+   "fieldtype": "Section Break",
+   "label": "About Chapter"
+  },
+  {
+   "fieldname": "x",
+   "fieldtype": "Data",
+   "label": "X",
+   "options": "URL"
+  },
+  {
+   "default": "/files/City_Illustration.svg",
+   "fieldname": "represent_image",
+   "fieldtype": "Attach Image",
+   "label": "Representing Image"
+  },
+  {
+   "fieldname": "public_chat_group_url",
+   "fieldtype": "Data",
+   "label": "Public Chat Group URL",
+   "options": "URL"
+  },
+  {
+   "fieldname": "slug",
+   "fieldtype": "Data",
+   "label": "Slug",
+   "unique": 1
+  }
+ ],
+ "has_web_view": 1,
+ "index_web_pages_for_search": 1,
+ "is_published_field": "is_published",
+ "links": [
+  {
+   "link_doctype": "FOSS Chapter Event",
+   "link_fieldname": "chapter"
+  }
+ ],
+ "modified": "2024-09-24 14:07:16.754531",
+ "modified_by": "Administrator",
+ "module": "Chapters",
+ "name": "FOSS Chapter",
+ "naming_rule": "Expression",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "read": 1,
+   "role": "Chapter Team Member",
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "All",
+   "share": 1
+  }
+ ],
+ "route": "c",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
 }

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
@@ -144,7 +144,9 @@ class FOSSChapter(WebsiteGenerator):
             self.set_slug()
 
         if frappe.db.exists("FOSS Chapter", {"slug": self.slug, "name": ["!=", self.name]}):
-            frappe.throw(f"Chapter with slug {self.slug} already exists")
+            frappe.throw(
+                f"Chapter with slug {self.slug} already exists", frappe.UniqueValidationError
+            )
 
         if " " in self.slug:
             frappe.throw("Slug cannot have spaces")

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
@@ -39,6 +39,7 @@ class FOSSChapter(WebsiteGenerator):
         public_chat_group_url: DF.Data | None
         represent_image: DF.AttachImage | None
         route: DF.Data | None
+        slug: DF.Data | None
         state: DF.Link | None
         x: DF.Data | None
 
@@ -48,6 +49,7 @@ class FOSSChapter(WebsiteGenerator):
 
     def validate(self):
         self.make_city_name_upper()
+        self.validate_slug()
 
     def before_save(self):
         self.set_chapter_lead()
@@ -125,10 +127,27 @@ class FOSSChapter(WebsiteGenerator):
                 break
 
     def set_route(self):
-        if self.chapter_type == STUDENT_CLUB:
-            self.route = f"clubs/{self.chapter_name.lower().replace(' ', '-')}"
-        else:
-            self.route = f"{self.chapter_name.lower().replace(' ', '-')}"
+        if not self.slug:
+            self.set_slug()
+
+        if self.route and not self.has_value_changed("slug"):
+            return
+
+        self.route = f"c/{self.slug}"
+
+    def set_slug(self):
+        if not self.slug:
+            self.slug = frappe.scrub(self.chapter_name).replace("_", "-")
+
+    def validate_slug(self):
+        if not self.slug:
+            self.set_slug()
+
+        if frappe.db.exists("FOSS Chapter", {"slug": self.slug, "name": ["!=", self.name]}):
+            frappe.throw(f"Chapter with slug {self.slug} already exists")
+
+        if " " in self.slug:
+            frappe.throw("Slug cannot have spaces")
 
     def get_context(self, context):
         if self.chapter_type == "City Community":

--- a/fossunited/chapters/doctype/foss_chapter/test_foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/test_foss_chapter.py
@@ -5,18 +5,19 @@ import frappe
 from faker import Faker
 from frappe.tests.utils import FrappeTestCase
 
-from fossunited.doctype_ids import CHAPTER, STUDENT_CLUB, USER_PROFILE
+from fossunited.doctype_ids import CHAPTER, CITY_COMMUNITY, USER_PROFILE
+
+fake = Faker()
 
 
 class TestFOSSChapter(FrappeTestCase):
     def setUp(self):
-        fake = Faker()
-
         chapter = frappe.get_doc(
             {
                 "doctype": CHAPTER,
                 "chapter_name": fake.text(max_nb_chars=40),
-                "chapter_type": STUDENT_CLUB,
+                "chapter_type": CITY_COMMUNITY,
+                "slug": fake.slug(),
                 "city": "Pune",
                 "country": "India",
                 "email": fake.email(),
@@ -113,3 +114,30 @@ class TestFOSSChapter(FrappeTestCase):
                 self.fail(f"Role not retained for {member}")
 
         self.assertFalse(has_role)
+
+    def test_unique_chapter_slug(self):
+        # Given a chapter: self.chapter
+        chapter = self.chapter
+
+        # When a new chapter is created with the same slug
+        new_chapter = frappe.get_doc(
+            {
+                "doctype": CHAPTER,
+                "chapter_name": "Test Chapter",
+                "chapter_type": CITY_COMMUNITY,
+                "slug": chapter.slug,
+                "city": "Mumbai",
+                "country": "India",
+                "email": fake.email(),
+                "facebook": fake.url(),
+                "instagram": fake.url(),
+                "linkedin": fake.url(),
+                "mastodon": fake.url(),
+                "public_chat_group_url": fake.url(),
+                "state": "Maharashtra",
+                "x": fake.url(),
+            }
+        )
+
+        with self.assertRaises(frappe.UniqueValidationError):
+            new_chapter.insert()

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -160,6 +160,7 @@ class FOSSChapterEvent(WebsiteGenerator):
         context.cfp_status_block = self.get_cfp_status_block()
         context.user_cfp_submissions = self.get_user_cfp_submissions()
         context.recent_cfp_submissions = self.get_recent_cfp_submissions()
+        context.all_cfp_link = f'/dashboard/cfp/{self.route.split("c/")[1]}'
         context.schedule_dict = self.get_schedule_dict()
         context.no_cache = 1
 

--- a/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
+++ b/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
@@ -250,7 +250,7 @@
         </div>
       {% endif %}
       <div class="d-flex justify-content-end align-items-baseline">
-        <a href="/dashboard/cfp/{{ doc.event_permalink }}" class="secondary-button">
+        <a href="{{ all_cfp_link }}" class="secondary-button">
           <span> View all Proposals </span>
           <i class="ti ti-arrow-right"></i>
         </a>

--- a/fossunited/chapters/doctype/foss_chapter_event/test_foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/test_foss_chapter_event.py
@@ -1,0 +1,126 @@
+from datetime import datetime, timedelta
+
+import frappe
+from faker import Faker
+from frappe.tests.utils import FrappeTestCase
+
+from fossunited.doctype_ids import (
+    CHAPTER,
+    CITY_COMMUNITY,
+    EVENT,
+    EVENT_VOLUNTEER,
+    USER_PROFILE,
+)
+
+fake = Faker()
+
+LEAD = "test1@example.com"
+MEMBER1 = "test2@example.com"
+
+
+class TestFOSSChapterEvent(FrappeTestCase):
+    def setUp(self):
+        chapter = frappe.get_doc(
+            {
+                "doctype": CHAPTER,
+                "chapter_name": fake.text(max_nb_chars=40),
+                "chapter_type": CITY_COMMUNITY,
+                "slug": fake.slug(),
+                "city": "Pune",
+                "country": "India",
+                "email": fake.email(),
+                "facebook": fake.url(),
+                "instagram": fake.url(),
+                "linkedin": fake.url(),
+                "mastodon": fake.url(),
+                "public_chat_group_url": fake.url(),
+                "state": "Maharashtra",
+                "x": fake.url(),
+            }
+        )
+        chapter.insert()
+        chapter.reload()
+
+        lead_profile = frappe.db.get_value(
+            USER_PROFILE,
+            {"user": LEAD},
+            "name",
+        )
+
+        chapter.append(
+            "chapter_members",
+            {
+                "chapter_member": lead_profile,
+                "role": "Lead",
+            },
+        )
+        chapter.save()
+
+        self.chapter = chapter
+
+        event = frappe.get_doc(
+            {
+                "doctype": EVENT,
+                "chapter": chapter.name,
+                "event_name": fake.text(max_nb_chars=40),
+                "event_type": "FOSS Meetup",
+                "event_permalink": fake.slug(),
+                "status": "Live",
+                "event_start_date": datetime.now() + timedelta(days=1),
+                "event_end_date": datetime.now() + timedelta(days=2),
+                "event_description": fake.text(max_nb_chars=200),
+            }
+        )
+        event.insert()
+        event.reload()
+        self.event = event
+
+    def tearDown(self):
+        frappe.delete_doc(CHAPTER, self.chapter.name, force=1)
+        frappe.delete_doc(EVENT, self.event.name, force=1)
+
+    def test_members_are_added_to_event(self):
+        # Given a chapter
+        chapter = self.chapter
+        # When an event is created for the chapter
+        event = self.event
+        # Then the existing members of the chapter should be added to the event
+
+        for member in chapter.chapter_members:
+            self.assertTrue(
+                frappe.db.exists(
+                    EVENT_VOLUNTEER,
+                    {
+                        "parent": event.name,
+                        "member": member.chapter_member,
+                    },
+                )
+            )
+
+    def test_unique_event_slug(self):
+        # Given a chapter and its event
+        chapter = self.chapter
+        event = self.event
+        # When a new event is created with the same slug
+        new_event = frappe.get_doc(
+            {
+                "doctype": EVENT,
+                "chapter": chapter.name,
+                "event_name": fake.text(max_nb_chars=40),
+                "event_type": "FOSS Meetup",
+                "event_permalink": event.event_permalink,
+                "status": "Live",
+                "event_start_date": datetime.now() + timedelta(days=4),
+                "event_end_date": datetime.now() + timedelta(days=5),
+                "event_description": fake.text(max_nb_chars=200),
+            }
+        )
+
+        # Then an error should be raised
+        with self.assertRaises(frappe.exceptions.ValidationError):
+            new_event.insert()
+
+        # however, if the event is created with a different slug
+        new_event.event_permalink = fake.slug()
+        # Then the event should be created successfully
+        new_event.insert()

--- a/fossunited/chapters/doctype/foss_chapter_event/test_foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/test_foss_chapter_event.py
@@ -41,6 +41,15 @@ class TestFOSSChapterEvent(FrappeTestCase):
         chapter.insert()
         chapter.reload()
 
+        if not frappe.db.exists("Role", "Chapter Team Member"):
+            frappe.get_doc({"doctype": "Role", "role_name": "Chapter Team Member"}).insert(
+                ignore_permissions=True
+            )
+        if not frappe.db.exists("Role", "Chapter Lead"):
+            frappe.get_doc({"doctype": "Role", "role_name": "Chapter Lead"}).insert(
+                ignore_permissions=True
+            )
+
         lead_profile = frappe.db.get_value(
             USER_PROFILE,
             {"user": LEAD},

--- a/fossunited/doctype_ids.py
+++ b/fossunited/doctype_ids.py
@@ -20,6 +20,10 @@ EVENT = "FOSS Chapter Event"
 CITY_COMMUNITY = "City Community"
 STUDENT_CLUB = "FOSS Club"
 CONFERENCE = "Conference"
+CHAPTER_MEMBER = "FOSS Chapter Lead Team Member"
+
+# Event-related identifiers
+EVENT_VOLUNTEER = "FOSS Chapter Event Member"
 
 # Event proposal-related identifiers
 EVENT_CFP = "FOSS Event CFP"

--- a/fossunited/doctype_ids.py
+++ b/fossunited/doctype_ids.py
@@ -17,6 +17,7 @@ HACKATHON_TEAM_MEMBER = "FOSS Hackathon Team Member"
 # Chapter-related identifiers
 CHAPTER = "FOSS Chapter"
 EVENT = "FOSS Chapter Event"
+CITY_COMMUNITY = "City Community"
 STUDENT_CLUB = "FOSS Club"
 CONFERENCE = "Conference"
 

--- a/fossunited/hooks.py
+++ b/fossunited/hooks.py
@@ -80,6 +80,6 @@ doc_events = {
 }
 
 website_redirects = [
-    {"source": r"events/(.+)/cfp/all", "target": r"/dashboard/cfp/\1"},
-    {"source": r"events/(.+)/schedule", "target": r"/dashboard/schedule/\1"},
+    {"source": r"c/(.+)/cfp/all", "target": r"/dashboard/cfp/\1"},
+    {"source": r"c/(.+)/schedule", "target": r"/dashboard/schedule/\1"},
 ]

--- a/fossunited/hooks.py
+++ b/fossunited/hooks.py
@@ -26,11 +26,11 @@ website_route_rules = [
         "to_route": "dashboard",
     },
     {
-        "from_route": "/events/<event_permalink>/cfp/<submission>/edit",
+        "from_route": "/<path:event_route>/cfp/<submission>/edit",
         "to_route": "/cfp/submission/edit",
     },
     {
-        "from_route": "/events/<event_permalink>/rsvp/<submission>/edit",
+        "from_route": "/<path:event_route>/rsvp/<submission>/edit",
         "to_route": "/rsvp/submission/edit",
     },
     {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] ⚙️Chore
- [x] 🧑‍💻Refactor

## Description

<!-- Briefly describe the changes introduced by this pull request -->
See: #332 & #424 

There have been discussions of refactoring the chapter routes to come under `/c/`.
This means that what previously would be something like `fossunited.org/hyderabad` would change to become `fossunited.org/c/hyderabad`. 
Similarly, refactoring the events routes from `/event` to come under the chapter's route made more sense. 
Currently, all events are named in such a way: `fossunited.org/event/hyd-sep-2024`. But this PR changes that to be something of this pattern: `fossunited.org/c/hyderabad/2024/sep`

These are the formats followed:
- For Chapter: `/c/<chapter_slug>`
- For Event: `/c/<chapter_slug>/<event_permalink>`

---

Additionally:
- Removed the validations which were stopping organizers from adding `/` in permalinks. This will enable a greater sense of freedom in cause of event routes.
- Added a couple of tests for the new routes. Which ensures that no two events in a chapter have same kind of routes
- Routing was breaking for CFP All & Schedule dashboard pages, this PR fixes that.
- CFP & RSVP submission page was breaking, fixed that too.


## Related Issues & Docs
#424 

## Screenshots/GIFs/Screen Recordings (if applicable)

![image](https://github.com/user-attachments/assets/cc5c6844-8c12-43ba-b9ad-461f70124771)

