### PR TITLE
fix(dashboard): status badge on Event Header

### DIFF
--- a/dashboard/src/pages/EventCfp.vue
+++ b/dashboard/src/pages/EventCfp.vue
@@ -4,7 +4,7 @@
       <EventHeader
         class=""
         :event="event.doc"
-        :form_exists="Boolean(hasCfp.data)"
+        :form-exists="Boolean(hasCfp.data)"
         :form="eventCfp"
       />
     </div>

--- a/dashboard/src/pages/EventDetails.vue
+++ b/dashboard/src/pages/EventDetails.vue
@@ -3,7 +3,7 @@
     <div class="flex flex-col md:flex-row gap-2 justify-between">
       <EventHeader
         :event="event.doc"
-        :form_exists="true"
+        :form-exists="true"
         :form="{
           data: {
             is_published: event.doc.is_published,

--- a/dashboard/src/pages/EventRsvp.vue
+++ b/dashboard/src/pages/EventRsvp.vue
@@ -3,7 +3,7 @@
     <EventHeader
       class="px-4 py-8 md:p-8"
       :event="event.doc"
-      :form_exists="Boolean(has_rsvp.data)"
+      :form-exists="Boolean(has_rsvp.data)"
       :form="event_rsvp"
     />
     <TabsWithRoute :tabs="tabs.options" />


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🐛Bug Fix

## Description

<!-- Briefly describe the changes introduced by this pull request -->

The Status badge on the Event Header component was no longer working correctly. This happened most probably due to the recently made ESLint changes & error fixes. The prop name in `EventHeader.vue` was changed from `form_exists` to `formExists` but it was not changed in the places where the component was being used in.

Changed and fixed that here. Changed all the `form_exists` references to `form-exists`.

Helpful: https://vuejs.org/guide/components/props.html#prop-name-casing

> Technically, you can also use camelCase when passing props to a child component (except in [in-DOM templates](https://vuejs.org/guide/essentials/component-basics#in-dom-template-parsing-caveats)). However, the convention is using kebab-case in all cases to align with HTML attributes:
`<MyComponent greeting-message="hello" />`

<MyComponent greeting-message="hello" />

## Related Issues & Docs

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

closes #492 
