### PR TITLE
Refactor CFP Pages & Review section

### DIFF
--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -6,7 +6,6 @@ from frappe.website.website_generator import WebsiteGenerator
 from fossunited.doctype_ids import EVENT, EVENT_CFP, USER_PROFILE
 from fossunited.fossunited.utils import (
     get_doc_likes,
-    get_event_volunteers,
 )
 
 
@@ -123,16 +122,8 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
             "proposal_reviews",
         ]
 
-        volunteers = get_event_volunteers(self.event)
         if context.cfp.anonymise_proposals and not self.status == "Approved":
             nav_items.remove("about_speaker")
-
-        if (
-            not context.is_reviewer
-            and frappe.session.user not in [volunteer.email for volunteer in volunteers]
-            and not frappe.session.user == self.submitted_by
-        ):
-            nav_items.remove("proposal_reviews")
 
         return nav_items
 

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
@@ -65,6 +65,9 @@
         {% if frappe.session.user == doc.submitted_by %}
           <button onclick="window.location.href='/{{ doc.route }}/edit'">Edit CFP</button>
         {% endif %}
+        {% if is_reviewer %}
+          <button onclick="window.location.href= '/dashboard/review/{{ doc.event }}/talk/{{ doc.name }}'">Review Talk</button>
+        {% endif %}
       </div>
     </div>
   </div>
@@ -96,7 +99,7 @@
 {% macro render_proposal_reviews() %}
   <div class="proposal-reviews-container cfp-content-div content-div" id="proposal_reviews">
     <div class="proposal-overview-section">
-      <h5>{{ _("Proposal Overview") }}</h5>
+      <h5>{{ _("Reviews Overview") }}</h5>
     </div>
     <div class="review-statistics-grid">
       {% for statistic in review_statistics %}
@@ -119,61 +122,11 @@
         </div>
       {% endfor %}
     </div>
-    {% if is_reviewer and not already_reviewed %}
-      <form class="submit-reviews-section">
-        <h5>{{ _("Submit Your Review") }}</h5>
-        <fieldset class="select-review-status">
-          <h6>Select your review status:</h6>
-          <div class="review-status-options-flex">
-            <input
-              type="radio"
-              id="review-status-accepted"
-              name="review-status"
-              class="review-status"
-              value="Yes"
-            />
-            <label class="m-0 review-status-option" for="review-status-accepted">Accepted</label>
-            <input
-              type="radio"
-              id="review-status-rejected"
-              name="review-status"
-              class="review-status"
-              value="No"
-            />
-            <label class="m-0 review-status-option" for="review-status-rejected">Rejected</label>
-            <input
-              type="radio"
-              id="review-status-pending"
-              name="review-status"
-              class="review-status"
-              value="Maybe"
-            />
-            <label class="m-0 review-status-option" for="review-status-pending">Not Sure</label>
-          </div>
-        </fieldset>
-        <!-- ToDo: Drop Down of Review Templates -->
-        <div>
-          <h6>Additional Comments</h6>
-          <div class="d-flex mt-5 mb-2">
-            <img
-              class="user-img-sm mr-2 rounded"
-              src="{{ frappe.session.user | get_profile_image }}"
-              alt=""
-            />
-            <textarea
-              class="form-control additional-comments"
-              placeholder="Add your comments here"
-              id="remarks"
-            ></textarea>
-          </div>
-        </div>
-        <div class="d-flex flex-row-reverse">
-          <button class="primary-button text-sm" id="submit-cfp-review">Post your Review</button>
-        </div>
-      </form>
-    {% endif %}
     <div class="form-divider my-5"></div>
     <div class="review-comments-section">
+      {% if reviews | len == 0 %}
+        <span>No reviews yet</span>
+      {% endif %}
       {% for review in reviews %}
         <div class="review-comment-container">
           <div class="d-flex">

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
@@ -65,9 +65,6 @@
         {% if frappe.session.user == doc.submitted_by %}
           <button onclick="window.location.href='/{{ doc.route }}/edit'">Edit CFP</button>
         {% endif %}
-        {% if is_reviewer %}
-          <button onclick="window.location.href= '/dashboard/review/{{ doc.event }}/talk/{{ doc.name }}'">Review Talk</button>
-        {% endif %}
       </div>
     </div>
   </div>
@@ -124,32 +121,30 @@
     </div>
     <div class="form-divider my-5"></div>
     <div class="review-comments-section">
+      <h6>Reviews</h6>
       {% if reviews | len == 0 %}
         <span>No reviews yet</span>
       {% endif %}
       {% for review in reviews %}
         <div class="review-comment-container">
           <div class="d-flex">
-            <img class="user-img-sm rounded" src="{{ review.email | get_profile_image }}" alt="" />
             <div class="review-comment-username-remarks ml-3">
               <div class="review-comment-remarks" data-name="{{ review.name }}">
                 {{ review.remarks }}
               </div>
               <div class="d-flex align-items-baseline">
-                <span class="text-sm mr-1">{{ remark_val[review.to_approve] }}</span>
+                <span class="text-sm mr-1">Reviewer #{{loop.index}}</span>
                 <span class="mx-1">•</span>
-                <a href="/{{ review.reviewer }}" class="review-comment-username"
-                  >{{ review.reviewer }}</a
-                >
+                <span class="text-sm mr-1">{{ remark_val[review.to_approve] }}</span>
                 <span class="mx-1">•</span>
                 <span class="text-sm"> {{ frappe.utils.pretty_date(review.modified) }} </span>
               </div>
             </div>
           </div>
-          <button class="text-sm" data-name="{{ review.name }}" onClick="handleCommentEdit(this)">
-            Edit
-          </button>
         </div>
+        {% if not loop.last %}
+        <div class="form-divider"></div>
+        {% endif %}
       {% endfor %}
     </div>
   </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] ⚙️Chore
- [x] 🧑‍💻Refactor

## Description

<!-- Briefly describe the changes introduced by this pull request -->

- Proposals section in the submission pages will now be visible to everyone, not just reviewers.
- Removed the Review section from the submission pages. This is in compliance with #507 . All the review stuff will be done only from the dashboard.
- Made the reviews to be anonymous. This is done because a lot of people were editing their proposals and pinging the reviewers directly for re-review of the talk.

## Related Issues & Docs

closes #604 

## Screenshots/GIFs/Screen Recordings (if applicable)

<!-- Visually demonstrate the changes, if applicable -->

#### Before
![image](https://github.com/user-attachments/assets/4fbbc00d-eea3-445a-a01a-200921e5e59f)

#### After
![image](https://github.com/user-attachments/assets/cf1f3e01-f002-4167-a013-2fb8215e9010)

