### PR TITLE
FEAT: Use and display Matrix public chat URL on city chapter page

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.json
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.json
@@ -31,7 +31,7 @@
     "email",
     "x",
     "linkedin",
-    "public_chat_group_url",
+    "matrix",
     "column_break_fifp",
     "facebook",
     "instagram",
@@ -216,9 +216,9 @@
       "label": "Representing Image"
     },
     {
-      "fieldname": "public_chat_group_url",
+      "fieldname": "matrix",
       "fieldtype": "Data",
-      "label": "Public Chat Group URL",
+      "label": "Matrix Chat Group URL",
       "options": "URL"
     },
     {

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
@@ -36,7 +36,7 @@ class FOSSChapter(WebsiteGenerator):
         is_published: DF.Check
         linkedin: DF.Data | None
         mastodon: DF.Data | None
-        public_chat_group_url: DF.Data | None
+        matrix: DF.Data | None
         represent_image: DF.AttachImage | None
         route: DF.Data | None
         slug: DF.Data | None

--- a/fossunited/chapters/doctype/foss_chapter/test_foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/test_foss_chapter.py
@@ -25,7 +25,7 @@ class TestFOSSChapter(IntegrationTestCase):
                 "instagram": fake.url(),
                 "linkedin": fake.url(),
                 "mastodon": fake.url(),
-                "public_chat_group_url": fake.url(),
+                "matrix": fake.url(),
                 "state": "Maharashtra",
                 "x": fake.url(),
             }
@@ -133,7 +133,7 @@ class TestFOSSChapter(IntegrationTestCase):
                 "instagram": fake.url(),
                 "linkedin": fake.url(),
                 "mastodon": fake.url(),
-                "public_chat_group_url": fake.url(),
+                "matrix": fake.url(),
                 "state": "Maharashtra",
                 "x": fake.url(),
             }

--- a/fossunited/chapters/doctype/foss_chapter_event/test_foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/test_foss_chapter_event.py
@@ -33,7 +33,7 @@ class TestFOSSChapterEvent(IntegrationTestCase):
                 "instagram": fake.url(),
                 "linkedin": fake.url(),
                 "mastodon": fake.url(),
-                "public_chat_group_url": fake.url(),
+                "matrix": fake.url(),
                 "state": "Maharashtra",
                 "x": fake.url(),
             }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕Feature

## Description

This PR updates the `public_chat_group_url` field in the social links to `matrix`. This way, the existing field can be used via the dashboard to provide a `"Matrix Chat Group URL"` for a city chapter. On the dashboard, the matrix link can now be provided, which should automatically show up on the city page.

The changes in this PR were performed manually i.e. I updated the parameter/attribute on the `DocType` manually via the editor. I'm not sure if there is a way to make this change via the app.

## Related Issues & Docs

fixes #663 

## Checklist

- [x] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [ ] I have tested these changes locally.
- [ ] I have updated the documentation (If applicable).
- [x] The code follows the project's coding standards.
- [x] I have added/updated tests, if applicable.

## Screenshots/GIFs/Screen Recordings

N/A