### PR TITLE
Custom PrivateProfile Exception when user access a private profile 

### DIFF
--- a/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.py
@@ -11,6 +11,8 @@ from fossunited.api.profile import is_valid_username
 
 
 class PrivateProfileError(PermissionError):
+    """Exception raised when trying to access a private profile."""
+
     pass
 
 

--- a/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.py
@@ -4,9 +4,14 @@
 import re
 
 import frappe
+from frappe.exceptions import PermissionError
 from frappe.website.website_generator import WebsiteGenerator
 
 from fossunited.api.profile import is_valid_username
+
+
+class PrivateProfileError(PermissionError):
+    pass
 
 
 class FOSSUserProfile(WebsiteGenerator):
@@ -114,7 +119,7 @@ class FOSSUserProfile(WebsiteGenerator):
             "Administrator",
             self.user,
         ):
-            frappe.throw("Profile Not Found", frappe.DoesNotExistError)
+            frappe.throw("Profile is Private", PrivateProfileError)
 
         experiences_dict = {}
         for experience in self.experience:

--- a/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
@@ -54,7 +54,12 @@ class TestFOSSUserProfile(IntegrationTestCase):
         ).insert()
 
         private_profile = frappe.get_doc(
-            {"doctype": USER_PROFILE, "user": test_user.name, "is_private": 1}
+            {
+                "doctype": USER_PROFILE,
+                "user": test_user.name,
+                "is_private": 1,
+                "username": fake.user_name(),
+            }
         ).insert()
 
         current_user = frappe.session.user

--- a/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
@@ -53,20 +53,19 @@ class TestFOSSUserProfile(IntegrationTestCase):
             },
         ).insert()
 
-        private_profile = frappe.get_doc(
-            {
-                "doctype": USER_PROFILE,
-                "user": test_user.name,
-                "is_private": 1,
-                "username": fake.user_name(),
-            }
-        ).insert()
+        # Given a private profile
+        private_profile = frappe.get_doc(USER_PROFILE, {"user": test_user.name})
+        frappe.db.set_value(USER_PROFILE, private_profile.name, "is_private", "1")
 
         current_user = frappe.session.user
         frappe.set_user("guest@example.com")
 
         with self.assertRaises(PrivateProfileError) as context:
-            private_profile.get_profile()
+            # When accessing the profile not as admin or user
+            # then an exception is raised
+            private_profile = frappe.get_doc(USER_PROFILE, {"user": test_user.name})
+            # Simulate loading the profile
+            private_profile.get_context({})
 
         self.assertTrue("Profile is Private" in str(context.exception))
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕Feature
- [ ] ⚙️Chore
- [x] 🐛Bug Fix
- [ ] 🎨Style
- [ ] 🧑‍💻Refactor
- [ ] 📕Documentation
- [ ] 🏎️Optimization

## Description

Added a custom expection class with a test

## Related Issues & Docs

Closes #666 

## Checklist

- [x] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [x] I have tested these changes locally.
- [x] I have updated the documentation (If applicable).
- [x] The code follows the project's coding standards.
- [x] I have added/updated tests, if applicable.

## Screenshots/GIFs/Screen Recordings (if applicable)

Yes, Now when accessing the private profile it shows this page - 
![image](https://github.com/user-attachments/assets/2df6fd2f-2684-4005-8497-31b3c08151d0)

## Additional context

N/A
