### PR TITLE
chore: minor tweaks for reviewer dashboard

### DIFF
--- a/dashboard/src/components/reviewers/ProposalsList.vue
+++ b/dashboard/src/components/reviewers/ProposalsList.vue
@@ -166,6 +166,34 @@ const cfpSubmissions = createResource({
     event: props.event,
   },
   auto: true,
+  transform(data) {
+    let groups = [
+      {
+        group: 'Open for reviews',
+        rows: [],
+      },
+      {
+        group: 'Selected Talks',
+        rows: [],
+      },
+      {
+        group: 'Rejected Talks',
+        collapsed: true,
+        rows: [],
+      },
+    ]
+    data.forEach((item) => {
+      if (item.status === 'Review Pending') {
+        groups[0]['rows'].push(item)
+      } else if (item.status === 'Rejected') {
+        groups[2]['rows'].push(item)
+      } else {
+        groups[1]['rows'].push(item)
+      }
+    })
+
+    return groups
+  },
 })
 
 const filterByStatus = (filter) => {

--- a/dashboard/src/components/reviewers/ReviewListItem.vue
+++ b/dashboard/src/components/reviewers/ReviewListItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="p-4 border-t border-b border-gray-500 w-full flex flex-col gap-2 hover:cursor-pointer hover:bg-gray-50"
+    class="p-4 border-b first:border-t border-gray-500 w-full flex flex-col gap-2 hover:cursor-pointer hover:bg-gray-50"
     @click="router.push({ name: 'ReviewPage', params: { id: event.event } })"
   >
     <div class="flex flex-col gap-1 mb-2">

--- a/dashboard/src/components/reviewers/ReviewListItem.vue
+++ b/dashboard/src/components/reviewers/ReviewListItem.vue
@@ -1,0 +1,35 @@
+<template>
+  <div
+    class="p-4 border-t border-b border-gray-500 w-full flex flex-col gap-2 hover:cursor-pointer hover:bg-gray-50"
+    @click="router.push({ name: 'ReviewPage', params: { id: event.event } })"
+  >
+    <div class="flex flex-col gap-1 mb-2">
+      <div class="flex gap-2 text-sm uppercase">
+        <span>{{ event.chapter_name }}</span>
+        <span> - {{ dayjs(event.start_date).format('D MMM YYYY') }}</span>
+      </div>
+      <h4 class="text-lg font-semibold">{{ event.event_name }}</h4>
+    </div>
+    <div class="flex flex-col md:flex-row gap-2 justify-between">
+      <div class="flex flex-col md:flex-row gap-2 font-medium md:divide-x-2 divide-gray-300">
+        <span class="text-sm text-gray-800">Submissions: {{ event.submission_count }}</span>
+        <span class="text-sm md:pl-2 text-green-800">Reviewed: {{ event.reviewed_count }}</span>
+        <span class="text-sm md:pl-2 text-orange-800"
+          >Pending Review: {{ event.reviewed_count }}</span
+        >
+      </div>
+    </div>
+  </div>
+</template>
+<script setup>
+import { useRouter } from 'vue-router'
+import dayjs from 'dayjs'
+const router = useRouter()
+
+defineProps({
+  event: {
+    type: Object,
+    required: true,
+  },
+})
+</script>

--- a/dashboard/src/pages/reviewers/MyReviews.vue
+++ b/dashboard/src/pages/reviewers/MyReviews.vue
@@ -6,31 +6,8 @@
         <p class="text-sm mb-4">List of all upcoming events with proposal forms.</p>
       </div>
     </div>
-    <div v-if="events.data.length > 0" class="mt-6 grid grid-cols-1 md:grid-cols-3 gap-4">
-      <Card
-        v-for="event in events.data"
-        :key="event.name"
-        :title="event.event_name"
-        class="border-2 border-transparent !rounded-[8px] hover:border-gray-500 transition-colors hover:cursor-pointer"
-        @click="$router.push('/review/' + event.event)"
-      >
-        <template #actions>
-          <Tooltip text="Total Submissions">
-            <div class="text-base px-3 py-1 bg-gray-100 rounded-sm">
-              <span>{{ event.submission_count }}</span>
-            </div>
-          </Tooltip>
-        </template>
-        <div class="flex justify-between items-end">
-          <span class="text-sm">{{ event.chapter_name }}</span>
-          <div class="text-sm text-gray-600">
-            <span>{{ formatDate(event.start_date) }}</span>
-            <span v-if="formatDate(event.start_date) != formatDate(event.end_date)">
-              - {{ formatDate(event.end_date) }}</span
-            >
-          </div>
-        </div>
-      </Card>
+    <div v-if="events.data.length > 0" class="mt-5 flex flex-col">
+      <ReviewListItem v-for="event in events.data" :key="event.name" :event="event" />
     </div>
     <div v-else class="flex flex-col gap-2 rounded-sm p-4 border bg-gray-50">
       <div class="text-sm font-medium uppercase text-gray-800">No Call For Proposals</div>
@@ -42,16 +19,10 @@
 </template>
 <script setup>
 import { createResource, Tooltip } from 'frappe-ui'
+import ReviewListItem from '@/components/reviewers/ReviewListItem.vue'
 
 const events = createResource({
   url: 'fossunited.api.reviewer.get_events_by_open_cfp',
   auto: true,
 })
-
-const formatDate = (date) => {
-  return new Date(date).toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-  })
-}
 </script>

--- a/dashboard/src/pages/reviewers/ReviewPage.vue
+++ b/dashboard/src/pages/reviewers/ReviewPage.vue
@@ -2,26 +2,7 @@
   <Header />
   <div v-if="event.doc" class="w-full flex flex-col items-center">
     <div class="max-w-screen-xl p-4 w-full">
-      <a href="/dashboard/review" class="text-base hover:underline flex items-center gap-1 my-4">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          class="icon icon-tabler w-5 h-5 icons-tabler-outline icon-tabler-arrow-left"
-        >
-          <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-          <path d="M5 12l14 0" />
-          <path d="M5 12l6 6" />
-          <path d="M5 12l6 -6" />
-        </svg>
-        <span> Go to Dashboard </span>
-      </a>
+      <Button label="Go Back" icon-left="arrow-left" variant="ghost" @click="router.back()" />
       <div class="prose my-5">
         <h1 class="m-0">CFP Review</h1>
         <p class="mt-1">Review the session proposals for this event.</p>
@@ -60,20 +41,14 @@
   </div>
 </template>
 <script setup>
-import {
-  createResource,
-  createDocumentResource,
-  createListResource,
-  usePageMeta,
-  ListView,
-} from 'frappe-ui'
-import { ref } from 'vue'
-import { useRoute } from 'vue-router'
+import { createDocumentResource, usePageMeta } from 'frappe-ui'
+import { useRoute, useRouter } from 'vue-router'
 import EventHeader from '@/components/EventHeader.vue'
 import Header from '@/components/Header.vue'
 import ProposalList from '@/components/reviewers/ProposalsList.vue'
 
 const route = useRoute()
+const router = useRouter()
 
 usePageMeta(() => {
   return {

--- a/dashboard/src/pages/reviewers/SubmissionPage.vue
+++ b/dashboard/src/pages/reviewers/SubmissionPage.vue
@@ -8,7 +8,10 @@
           <h1 class="text-[2rem]">{{ submission.data.talk_title }}</h1>
         </div>
         <div class="flex flex-wrap gap-2 md:gap-4 items-center mt-0 mb-2">
-          <Tooltip text="This is the first talk submitted by the speaker">
+          <Tooltip
+            v-if="submission.data.is_first_talk === 'Yes'"
+            text="This is the first talk submitted by the speaker"
+          >
             <Badge label="First Talk" variant="outline" size="lg" class="p-1">
               <template #prefix>
                 <svg
@@ -31,9 +34,10 @@
               </template>
             </Badge>
           </Tooltip>
-          <span class="text-sm uppercase">{{ submission.data.session_type }}</span>
+          <span class="text-sm uppercase font-medium">{{ submission.data.session_type }}</span>
         </div>
         <a
+          v-if="submission.data.talk_reference"
           class="text-sm uppercase text-green-700 cursor-pointer font-medium hover:underline flex items-center gap-1"
           :href="submission.data.talk_reference"
           target="_blank"
@@ -57,6 +61,9 @@
             <path d="M15 4h5v5" />
           </svg>
         </a>
+        <div v-else class="text-sm text-gray-500">
+          <span>Session reference not provided.</span>
+        </div>
       </div>
       <div class="my-6 flex flex-col gap-4">
         <div class="prose min-w-full">

--- a/fossunited/api/reviewer.py
+++ b/fossunited/api/reviewer.py
@@ -26,7 +26,6 @@ def get_event_cfp_submissions(event: str) -> list:
         "linked_cfp",
         "route",
         "is_published",
-        "title",
         "status",
         "event",
         "event_name",
@@ -35,7 +34,6 @@ def get_event_cfp_submissions(event: str) -> list:
         "talk_title",
         "talk_reference",
         "talk_description",
-        "custom_answers",
         "positive_reviews",
         "negative_reviews",
         "unsure_reviews",
@@ -53,11 +51,12 @@ def get_event_cfp_submissions(event: str) -> list:
             "bio",
         ]
 
-    submissions = frappe.db.get_list(
+    submissions = frappe.db.get_all(
         PROPOSAL,
-        filters={"event": event, "status": "Review Pending"},
+        filters={"event": event},
         fields=fields,
         order_by="creation desc",
+        page_length=9999,
     )
 
     return submissions
@@ -89,7 +88,6 @@ def get_cfp_submissions_by_reviewer_status(
         ):
             if "Not Reviewed" in status_filter:
                 submission["review_status"] = "Not Reviewed"
-                submission["status"] = "-"
                 submission["remarks"] = "-"
                 submissions_list.append(submission)
             continue


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] ⚙️Chore
- [x] 🧑‍💻Refactor

## Description
- Grouped talks by status:
Previously, only the talks that needed reviews were being rendered for the reviewers to see, and talks that were already `Accepted` or `Rejected` by the organizers were not rendered. 
This lead to confusion as there was a difference in the talks being shown in public page and talks being rendered for the reviewers.

Now, all the talks are rendered for the reviewers, and they are grouped in 3 : `Open For Reviews`, `Selected Talks` and `Rejected Talks`.

![image](https://github.com/user-attachments/assets/eb2e5cc0-925c-4106-8873-c568cd090668)


- Broken reference link : if no reference link was provided, it resulted in the reference link going no where in the Reviewer Page. Fixed this by including an empty state to handle no reference links. fixes #550 

- Better Review Cards:
In the `My Reviews` page, it was requested that the review cards be made more detailed as per #553 . Made changes likewise.

![image](https://github.com/user-attachments/assets/05d0645a-ac66-4cde-b9ca-12b5050d2610)


## Related Issues & Docs
closes #553 
closes #550 
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->