### PR TITLE
refactor: move profiles under `/u/` subroute

### DIFF
--- a/fossunited/api/profile.py
+++ b/fossunited/api/profile.py
@@ -85,7 +85,13 @@ def update_profile(fields_dict):
 
         user_updates = {}
         if fields_dict.get("full_name") != user_doc.full_name:
-            user_updates["first_name"] = fields_dict.get("full_name").split(" ")[0]
+            name_parts = fields_dict.get("full_name").split()
+            if len(name_parts) > 1:
+                user_updates["first_name"] = name_parts[0]
+                user_updates["last_name"] = "".join(name_parts[1:])
+            else:
+                user_updates["first_name"] = name_parts[0]
+                user_updates["last_name"] = ""
 
         if fields_dict.get("username") != user_doc.username:
             user_updates["username"] = fields_dict.get("username")
@@ -94,6 +100,8 @@ def update_profile(fields_dict):
             user = frappe.get_doc("User", user_doc.user)
             for field, value in user_updates.items():
                 setattr(user, field, value)
+
+            user.save(ignore_permissions=True)
 
         return True
 

--- a/fossunited/api/profile.py
+++ b/fossunited/api/profile.py
@@ -62,7 +62,6 @@ def update_profile(fields_dict):
         updated_fields = {
             "full_name": fields_dict.get("full_name"),
             "username": fields_dict.get("username"),
-            "route": fields_dict.get("username"),
             "bio": fields_dict.get("bio"),
             "current_city": fields_dict.get("current_city"),
             "about": fields_dict.get("about"),
@@ -78,17 +77,23 @@ def update_profile(fields_dict):
             "mastodon": fields_dict.get("mastodon"),
         }
 
-        frappe.db.set_value(USER_PROFILE, user_doc.name, updated_fields)
+        profile = frappe.get_doc(USER_PROFILE, user_doc.name)
+        for field, value in updated_fields.items():
+            if hasattr(profile, field):
+                setattr(profile, field, value)
+        profile.save(ignore_permissions=True)
 
         user_updates = {}
         if fields_dict.get("full_name") != user_doc.full_name:
-            user_updates["full_name"] = fields_dict.get("full_name")
+            user_updates["first_name"] = fields_dict.get("full_name").split(" ")[0]
 
         if fields_dict.get("username") != user_doc.username:
             user_updates["username"] = fields_dict.get("username")
 
         if user_updates:
-            frappe.db.set_value("User", user_doc.user, user_updates)
+            user = frappe.get_doc("User", user_doc.user)
+            for field, value in user_updates.items():
+                setattr(user, field, value)
 
         return True
 

--- a/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.py
@@ -114,7 +114,7 @@ class FOSSUserProfile(WebsiteGenerator):
             frappe.throw("Username is already taken or restricted.")
 
     def set_route(self):
-        self.route = self.username
+        self.route = f"u/{self.username}"
 
     def get_context(self, context):
         if self.is_private and frappe.session.user not in (

--- a/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
@@ -192,7 +192,7 @@
     <div class="header-section">
       <img
         class="header-cover-image"
-        src="{{ doc.cover_image or 'assets/fossunited/images/defaults/user_profile_banner.png' }}"
+        src="{{ doc.cover_image or '/assets/fossunited/images/defaults/user_profile_banner.png' }}"
         alt="cover-image"
       />
       <div class="profile-detail-section">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] ⚙️Chore
- [x] 🐛Bug Fix
- [x] 🧑‍💻Refactor

## Description

<!-- Briefly describe the changes introduced by this pull request -->

- Changed the logic for `update_profile` method in `fossunited.api.profiles`. New approach uses the document api `get_doc` to make changes to the profile details. This enables us to use the document controllers such as `before_save`, `on_update` etc, to be run every time the profile is updated. This helps in robust validations.

- Minor fix: the path for default user cover images was incorrect.

- Major: refactored the `before_save` controller to change the user routes to prefix with `u/` followed by `<username>`

#### For existing users:
There will be a need to do a mass update of routes for all the existing users. Since this route rule is written in the `before_save` controller, a simple `unpublish -> publish` should rewrite the route for a user. 



## Related Issues & Docs
Closes #424 
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
