### PR TITLE
fix(cfp): breadcrumb route in submission page

### DIFF
--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
@@ -6,7 +6,7 @@
         <span>{{ event.event_name }}</span>
       </a>
       <i class="ti ti-chevron-right"></i>
-      <a href="/dashboard/cfp/{{ event.event_permalink }}">
+      <a href="/dashboard/cfp/{{ event.route }}">
         <span>All Proposals</span>
       </a>
       <i class="ti ti-chevron-right"></i>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛Bug Fix

## Description

<!-- Briefly describe the changes introduced by this pull request -->
Breadcrumb route to `All Proposals` was broken. This PR fixes that.

Rather than `event_permalink`, `event_route` should be passed to the CFP listing page as params.

## Related Issues & Docs

closes #668 

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
