### PR TITLE
fix(test): change `throw` -> `raise` for event checkin method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,6 @@ jobs:
         working-directory: /home/runner/frappe-bench
         run: |
           bench --site test_site set-config allow_tests true
-          bench --site test_site run-tests --app fossunited
+          bench --site test_site run-parallel-tests --app fossunited
         env:
           TYPE: server

--- a/fossunited/api/checkins.py
+++ b/fossunited/api/checkins.py
@@ -80,10 +80,10 @@ def checkin_attendee(
         user (str): The user who is checking in the attendee
     """
     if not has_valid_permission(event_id, user):
-        frappe.throw("You do not have permission to access this resource", frappe.PermissionError)
+        raise frappe.PermissionError("You do not have permission to access this resource")
 
     if check_if_already_checked_in(attendee["name"]):
-        frappe.throw("Attendee is already checked in", frappe.ValidationError)
+        raise frappe.ValidationError("Attendee already checked in!")
 
     ticket = frappe.get_doc(EVENT_TICKET, attendee["name"])
     ticket.append("check_ins", {"check_in_time": frappe.utils.now()})


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛Bug Fix

## Description
- Attempts to fix the failing test for attendee checkin. The test should raise a `ValidationError` when an already checked-in attendee is tried to be checked in again. 
- However, CI is failing for some days now, because the ValidationError is not being raised.
- Problem ? This tests pass on local setup, perhaps something wrong with CI then?

<!-- Briefly describe the changes introduced by this pull request -->