### PR TITLE
feat(profile): `My Proposals` page in dashboard

### DIFF
--- a/dashboard/src/components/NewAppSidebar.vue
+++ b/dashboard/src/components/NewAppSidebar.vue
@@ -36,7 +36,7 @@
               >
                 {{ group.parent_label }}
               </div>
-              <div class="flex flex-col my-1 gap-2 text-gray-700">
+              <div class="flex flex-col my-1 gap-1 text-gray-700">
                 <router-link
                   v-for="(item, index) in group.items"
                   :key="item.label"

--- a/dashboard/src/components/profile/SubmissionListItem.vue
+++ b/dashboard/src/components/profile/SubmissionListItem.vue
@@ -1,0 +1,51 @@
+<template>
+  <div
+    class="p-4 border-b first:border-t border-gray-500 w-full flex flex-col gap-3 hover:cursor-pointer hover:bg-gray-50"
+    @click="redirectRoute(proposal.route)"
+  >
+    <h4 class="text-base font-medium">{{ proposal.talk_title }}</h4>
+    <div class="flex flex-col md:flex-row md:items-center justify-between gap-2">
+      <div class="flex flex-wrap gap-2 items-center divide-x-2 text-gray-800">
+        <Badge class="!rounded-sm" :theme="getTheme[proposal.status]">{{ proposal.status }}</Badge>
+        <span class="text-sm uppercase pl-2">{{ proposal.event_name }}</span>
+        <span class="text-sm uppercase pl-2">{{ proposal.chapter }}</span>
+      </div>
+      <span class="text-xs text-gray-600">{{ getFormattedModified(proposal.modified) }}</span>
+    </div>
+  </div>
+</template>
+<script setup>
+import { Badge } from 'frappe-ui'
+import { redirectRoute } from '@/helpers/utils'
+import dayjs from 'dayjs'
+import relativeTime from 'dayjs/plugin/relativeTime'
+dayjs.extend(relativeTime)
+
+const props = defineProps({
+  proposal: {
+    type: Object,
+    required: true,
+  },
+})
+
+const getTheme = {
+  'Review Pending': 'orange',
+  Approved: 'green',
+  Rejected: 'red',
+  Screening: 'blue',
+}
+
+const getFormattedModified = (date) => {
+  let fromNow = dayjs(date).fromNow()
+
+  // Extract the number and first letter of the time unit
+  const match = fromNow.match(/(\d+)\s*(\w)/)
+
+  if (match) {
+    const [, number, unit] = match
+    return `${number}${unit.charAt(0)}`
+  }
+
+  return 'now'
+}
+</script>

--- a/dashboard/src/pages/profile/MyProposals.vue
+++ b/dashboard/src/pages/profile/MyProposals.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="space-y-3">
+    <div class="prose p-4 pb-0">
+      <h2 class="mb-1">My Proposals</h2>
+      <p class="text-sm mb-4">Overview of all the talks you have ever proposed</p>
+    </div>
+    <div v-if="proposals.loading" class="px-4">
+      <LoadingText />
+    </div>
+    <div v-if="proposals.data" class="px-4">
+      <p v-if="!proposals.data.length" class="text-sm text-gray-600">No submissions yet.</p>
+      <SubmissionListItem
+        v-for="(proposal, key) in proposals.data"
+        :key="key"
+        :proposal="proposal"
+      />
+    </div>
+  </div>
+</template>
+<script setup>
+import { createResource } from 'frappe-ui'
+import LoadingText from 'frappe-ui/src/components/LoadingText.vue'
+import { inject } from 'vue'
+import SubmissionListItem from '@/components/profile/SubmissionListItem.vue'
+
+const session = inject('$session')
+
+const proposals = createResource({
+  url: 'frappe.client.get_list',
+  makeParams() {
+    return {
+      doctype: 'FOSS Event CFP Submission',
+      fields: [
+        'status',
+        'event_name',
+        'session_type',
+        'talk_title',
+        'route',
+        'creation',
+        'modified',
+      ],
+      order_by: 'creation',
+      limit_page_length: 999,
+      or_filters: { email: session.user, submitted_by: session.user },
+    }
+  },
+  auto: true,
+  loading: true,
+})
+</script>

--- a/dashboard/src/router.js
+++ b/dashboard/src/router.js
@@ -15,6 +15,11 @@ const routes = [
         component: () => import('@/pages/MyProfile.vue'),
       },
       {
+        path: '/my-proposals',
+        name: 'My Proposals',
+        component: () => import('@/pages/profile/MyProposals.vue'),
+      },
+      {
         path: '/my-hackathons',
         name: 'MyHackathons',
         component: () => import('@/pages/hackathon/MyHackathons.vue'),

--- a/fossunited/api/sidebar.py
+++ b/fossunited/api/sidebar.py
@@ -8,9 +8,10 @@ def get_sidebar_items(user: str = frappe.session.user):
             "parent_label": "Profile",
             "items": [
                 {
-                    "label": "My Profile",
+                    "label": "Details",
                     "route": "/me",
-                }
+                },
+                {"label": "My Proposals", "route": "/my-proposals"},
             ],
         },
         {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕Feature

## Description

<!-- Briefly describe the changes introduced by this pull request -->

- Add `My Proposals` page in dashboard, where a user can see all their proposals at a single place.
closes #682 

## Screenshots/GIFs/Screen Recordings (if applicable)

<!-- Visually demonstrate the changes, if applicable -->

![image](https://github.com/user-attachments/assets/7c35c1fd-f2ce-49c1-8c3d-dcfd0c1b3cd2)


