### PR TITLE
fix: add custom fields on migration

### DIFF
--- a/fossunited/hooks.py
+++ b/fossunited/hooks.py
@@ -96,3 +96,7 @@ before_uninstall = "fossunited.uninstall.before_uninstall"
 override_doctype_class = {
     "Newsletter": "fossunited.overrides.newsletter_extend.NewsletterExtend",
 }
+
+# Migration
+# ----------------
+after_migrate = "fossunited.migrate.after_migrate"

--- a/fossunited/migrate.py
+++ b/fossunited/migrate.py
@@ -1,0 +1,51 @@
+import click
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+from fossunited.setup import get_custom_fields
+
+
+def after_migrate():
+    try:
+        missing_custom_fields = has_custom_fields()
+        if not missing_custom_fields:
+            click.secho("All custom fields are already added.", fg="blue")
+            return
+
+        # Add missing custom fields
+        click.secho("Adding custom fields...", fg="blue")
+        create_custom_fields(missing_custom_fields, ignore_validate=True)
+        click.secho("Custom fields added!", fg="green")
+    except Exception as e:
+        BUG_REPORT_URL = "https://github.com/fossunited/fossunited/issues/new"
+        click.secho("After migration failed for app: fossunited :(", fg="bright_red")
+        click.secho(f"Please try reinstalling the app or report the bug at {BUG_REPORT_URL}")
+        raise e
+
+
+def has_custom_fields():
+    """
+    Check which custom fields from get_custom_fields() are not yet in the database.
+
+    :return: A dictionary of doctype:fields that are missing from the database
+    """
+    custom_fields = get_custom_fields()
+    missing_fields = {}
+
+    for doctype, fields in custom_fields.items():
+        # Check each field for this doctype
+        doctype_missing_fields = []
+        for field in fields:
+            # Check if the field already exists in the database
+            exists = frappe.db.exists(
+                "Custom Field", {"dt": doctype, "fieldname": field["fieldname"]}
+            )
+
+            if not exists:
+                doctype_missing_fields.append(field)
+
+        # If there are missing fields for this doctype, add to the result
+        if doctype_missing_fields:
+            missing_fields[doctype] = doctype_missing_fields
+
+    return missing_fields


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛Bug Fix

## Description

<!-- Briefly describe the changes introduced by this pull request -->

In the last PR, we introduces after_install hook, which did a bunch of stuff at the time of install. What we missed was that `after_install` only runs once at the time of installation of app.

 So, right now, the CFP and RSVP submissions are broken because the custom fields were not added to the newsletter and email group doctypes. The absence of these fields break the workflow that adds a user's email to these email groups.

Hence, using the `after_migrate` hooks would be better in this case. This PR introduces the same. 

Now, after installation and migration, the app checks whether the required custom fields defined in the [setup.py](https://github.com/fossunited/fossunited/blob/develop/fossunited/setup.py) file are already added to the required doctypes. Any missing custom fields are then added at the time of migration.

## Related Issues & Docs
closes #704 
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
