### PR TITLE
feat: automate event conclusions

### DIFF
--- a/fossunited/hooks.py
+++ b/fossunited/hooks.py
@@ -100,3 +100,11 @@ override_doctype_class = {
 # Migration
 # ----------------
 after_migrate = "fossunited.migrate.after_migrate"
+
+# Scheduler Events
+# ----------------
+scheduler_events = {
+    "daily_long": [
+        "fossunited.scheduled_tasks.conclude_events",
+    ],
+}

--- a/fossunited/scheduled_tasks.py
+++ b/fossunited/scheduled_tasks.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+
+import frappe
+
+from fossunited.doctype_ids import EVENT
+
+
+def conclude_events():
+    """
+    Get all the events which have ended (end_date < today) and set their status to concluded
+    """
+    events = frappe.db.get_all(
+        EVENT,
+        {"status": "Live", "event_end_date": ["<", datetime.today()]},
+        ["name", "status", "event_end_date", "event_start_date"],
+        page_length=999,
+    )
+
+    for event in events:
+        doc = frappe.get_doc(EVENT, event.name)
+        doc.status = "Concluded"
+        try:
+            doc.save(ignore_permissions=True)
+        except Exception as e:
+            frappe.log_error(
+                frappe.get_traceback(),
+                f"Error while concluding events through scheduler- ID:{doc.name}\nError:{str(e)}",
+            )
+            continue

--- a/fossunited/tests/test_scheduled_tasks.py
+++ b/fossunited/tests/test_scheduled_tasks.py
@@ -1,0 +1,71 @@
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from fossunited.doctype_ids import CHAPTER, EVENT
+from fossunited.scheduled_tasks import conclude_events
+
+from .utils import insert_test_chapter, insert_test_event
+
+
+class TestScheduledTasks(IntegrationTestCase):
+    def setUp(self):
+        today = datetime.today()
+        self.chapter = insert_test_chapter()
+
+        # Event 1 is live and is to end tomorrow
+        self.event1 = insert_test_event(
+            chapter=self.chapter,
+            start_date=today.replace(hour=9, minute=00),
+            end_date=today.replace(hour=15, minute=30),
+        )
+
+        # Event 2 is cancelled, and was supposed to end tomorrow
+        self.event2 = insert_test_event(
+            chapter=self.chapter,
+            status="Cancelled",
+            start_date=today.replace(hour=9, minute=00),
+            end_date=today.replace(hour=15, minute=30),
+        )
+
+        # Event 3 starts tomorrow, and ends the day-after tomorrow
+        self.event3 = insert_test_event(
+            chapter=self.chapter,
+            start_date=today.replace(hour=9, minute=00) + timedelta(days=1),
+            end_date=today.replace(hour=14, minute=00) + timedelta(days=2),
+        )
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+        frappe.delete_doc(CHAPTER, self.chapter.name, force=True)
+        frappe.delete_doc(EVENT, self.event1.name, force=True)
+        frappe.delete_doc(EVENT, self.event2.name, force=True)
+        frappe.delete_doc(EVENT, self.event3.name, force=True)
+
+    # Only patching the datetime within the `scheduled_tasks` module
+    @patch("fossunited.scheduled_tasks.datetime")
+    def test_concluded_events(self, mock_datetime):
+        # Set the mock datetime to return a specific date
+        mock_datetime.today.return_value = datetime.today().replace(hour=00, minute=1) + timedelta(
+            days=1
+        )
+        mock_datetime.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+
+        # Call the function to test
+        conclude_events()
+
+        # Fetch events to check their status
+        self.event1.reload()
+        self.event2.reload()
+        self.event3.reload()
+
+        # First event should change the status to concluded
+        self.assertEqual(self.event1.status, "Concluded")
+
+        # Second event should not change it's status, since it was cancelled
+        self.assertEqual(self.event2.status, "Cancelled")
+
+        # Third event is still live, since its end_date > mock date set here
+        self.assertEqual(self.event3.status, "Live")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕Feature

## Description

<!-- Briefly describe the changes introduced by this pull request -->

This PR automates the process of event conclusion at the end of the day / start of new day, when event_end_date < now date.

This uses the [Background Jobs](https://docs.frappe.io/framework/user/en/api/background_jobs) functionality of frappe. Specifically the [Scheduler events](https://docs.frappe.io/framework/user/en/api/background_jobs#scheduler-events).

Added a test for testing the functionality of the method involved. Used the `mock` and `patch` methods by Python's `unittest` library to mock the now_dates to a different dates in future.

## Related Issues & Docs
closes #711 
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
