### PR TITLE
feat(event): add livestream field

### DIFF
--- a/dashboard/src/pages/EventDetails.vue
+++ b/dashboard/src/pages/EventDetails.vue
@@ -161,6 +161,17 @@
       </div>
     </div>
     <div class="flex flex-col my-6">
+      <div class="font-semibold text-gray-800 border-b-2 pb-2">Livestreaming</div>
+      <div class="p-2 my-1 grid sm:grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-6">
+        <FormControl
+          v-model="event.doc.livestream_link"
+          type="url"
+          label="Livestream Link"
+          size="md"
+        />
+      </div>
+    </div>
+    <div class="flex flex-col my-6">
       <div class="font-semibold text-gray-800 border-b-2 pb-2">Location Details</div>
       <div class="p-2 my-1 grid sm:grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-6">
         <FormControl

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
@@ -1,562 +1,562 @@
 {
- "actions": [],
- "allow_guest_to_view": 1,
- "allow_rename": 1,
- "autoname": "hash",
- "creation": "2023-07-01 23:55:20.934607",
- "default_view": "List",
- "doctype": "DocType",
- "editable_grid": 1,
- "engine": "InnoDB",
- "field_order": [
-  "is_external_event",
-  "column_break_okxh",
-  "external_event_url",
-  "meta_info_section",
-  "is_published",
-  "column_break_yozf",
-  "route",
-  "navbar_controls_section",
-  "show_speakers",
-  "show_rsvp",
-  "show_schedule",
-  "column_break_moaa",
-  "show_cfp",
-  "show_photos",
-  "chapter_information_section",
-  "chapter",
-  "column_break_tzza",
-  "chapter_name",
-  "event_infomation_section",
-  "must_attend",
-  "event_name",
-  "event_permalink",
-  "status",
-  "event_type",
-  "column_break_pua4",
-  "event_logo",
-  "banner_image",
-  "event_location",
-  "map_link",
-  "cta_section_section",
-  "primary_button_label",
-  "primary_button_url",
-  "column_break_hrox",
-  "secondary_button_label",
-  "secondary_button_url",
-  "event_timeline_section",
-  "event_start_date",
-  "column_break_ae9v",
-  "event_end_date",
-  "livestreaming_section",
-  "livestream_link",
-  "event_information_section",
-  "event_bio",
-  "event_description",
-  "proposal_page_description",
-  "event_sponsors_section",
-  "sponsor_list",
-  "deck_link",
-  "community_partners_section",
-  "community_partners",
-  "volunteers_tab",
-  "event_members_section",
-  "event_members",
-  "schedule_tab",
-  "schedule_section",
-  "event_schedule",
-  "section_break_vlwf",
-  "hall_options",
-  "column_break_wqtz",
-  "schedule_page_description",
-  "tickets_tab",
-  "is_paid_event",
-  "tickets_status",
-  "tiers",
-  "ticket_form_description",
-  "section_break_idyt",
-  "paid_tshirts_available",
-  "column_break_cntx",
-  "t_shirt_price",
-  "section_break_hjyr",
-  "custom_fields"
- ],
- "fields": [
-  {
-   "fieldname": "event_infomation_section",
-   "fieldtype": "Section Break",
-   "label": "Basic Information"
-  },
-  {
-   "fieldname": "event_name",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Event Name",
-   "reqd": 1
-  },
-  {
-   "fieldname": "column_break_pua4",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "event_type",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Event Type",
-   "mandatory_depends_on": "eval:doc.is_external_event == 0",
-   "options": "FOSS Event Type"
-  },
-  {
-   "fieldname": "chapter_information_section",
-   "fieldtype": "Section Break",
-   "label": "Organizing Chapter"
-  },
-  {
-   "fieldname": "chapter",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Chapter",
-   "options": "FOSS Chapter",
-   "search_index": 1
-  },
-  {
-   "default": "0",
-   "fieldname": "must_attend",
-   "fieldtype": "Check",
-   "label": "Must Attend"
-  },
-  {
-   "fieldname": "map_link",
-   "fieldtype": "Data",
-   "label": "Map Link",
-   "options": "URL"
-  },
-  {
-   "fieldname": "event_timeline_section",
-   "fieldtype": "Section Break",
-   "label": "Event Timeline"
-  },
-  {
-   "fieldname": "event_start_date",
-   "fieldtype": "Datetime",
-   "label": "Event Start Date & Time",
-   "mandatory_depends_on": "eval:doc.is_external_event == 0"
-  },
-  {
-   "fieldname": "event_end_date",
-   "fieldtype": "Datetime",
-   "label": "Event End Date & Time",
-   "mandatory_depends_on": "eval:doc.is_external_event == 0"
-  },
-  {
-   "fieldname": "column_break_ae9v",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "event_location",
-   "fieldtype": "Data",
-   "label": "Location"
-  },
-  {
-   "depends_on": "eval:doc.is_external_event == 0",
-   "fieldname": "event_description",
-   "fieldtype": "Text Editor",
-   "label": "Description",
-   "mandatory_depends_on": "eval:doc.is_external_event == 0"
-  },
-  {
-   "fieldname": "status",
-   "fieldtype": "Select",
-   "label": "Status",
-   "options": "\nDraft\nLive\nApproved\nConcluded\nCancelled",
-   "reqd": 1
-  },
-  {
-   "fieldname": "event_members_section",
-   "fieldtype": "Section Break",
-   "label": "Event Volunteers"
-  },
-  {
-   "fieldname": "event_members",
-   "fieldtype": "Table",
-   "label": "Event Team Members",
-   "options": "FOSS Chapter Event Member"
-  },
-  {
-   "fieldname": "column_break_tzza",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "event_information_section",
-   "fieldtype": "Section Break",
-   "label": "Event Information"
-  },
-  {
-   "fieldname": "event_sponsors_section",
-   "fieldtype": "Section Break",
-   "label": "Event Sponsors"
-  },
-  {
-   "fieldname": "sponsor_list",
-   "fieldtype": "Table",
-   "label": "Sponsors",
-   "options": "FOSS Event Sponsor"
-  },
-  {
-   "fieldname": "community_partners_section",
-   "fieldtype": "Section Break",
-   "label": "Community Partners"
-  },
-  {
-   "fieldname": "community_partners",
-   "fieldtype": "Table",
-   "label": "Community Partners",
-   "options": "FOSS Event Community Partner"
-  },
-  {
-   "fieldname": "deck_link",
-   "fieldtype": "Data",
-   "label": "Deck Link",
-   "options": "URL"
-  },
-  {
-   "fieldname": "cta_section_section",
-   "fieldtype": "Section Break",
-   "label": "CTA Section"
-  },
-  {
-   "fieldname": "primary_button_label",
-   "fieldtype": "Data",
-   "label": "Primary Button Label"
-  },
-  {
-   "fieldname": "primary_button_url",
-   "fieldtype": "Data",
-   "label": "Primary Button URL"
-  },
-  {
-   "fieldname": "column_break_hrox",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "secondary_button_label",
-   "fieldtype": "Data",
-   "label": "Secondary Button Label"
-  },
-  {
-   "fieldname": "secondary_button_url",
-   "fieldtype": "Data",
-   "label": "Secondary Button URL"
-  },
-  {
-   "fieldname": "volunteers_tab",
-   "fieldtype": "Tab Break",
-   "label": "Volunteers"
-  },
-  {
-   "fieldname": "schedule_tab",
-   "fieldtype": "Tab Break",
-   "label": "Schedule"
-  },
-  {
-   "fieldname": "event_schedule",
-   "fieldtype": "Table",
-   "label": "Event Schedule",
-   "options": "FOSS Event Schedule"
-  },
-  {
-   "fieldname": "route",
-   "fieldtype": "Data",
-   "label": "Route"
-  },
-  {
-   "fieldname": "column_break_yozf",
-   "fieldtype": "Column Break"
-  },
-  {
-   "default": "0",
-   "fieldname": "is_published",
-   "fieldtype": "Check",
-   "label": "Is Published?"
-  },
-  {
-   "fieldname": "event_bio",
-   "fieldtype": "Data",
-   "label": "Short Event Bio"
-  },
-  {
-   "fieldname": "navbar_controls_section",
-   "fieldtype": "Section Break",
-   "label": "Navbar Controls"
-  },
-  {
-   "default": "0",
-   "fieldname": "show_speakers",
-   "fieldtype": "Check",
-   "label": "Show Speakers"
-  },
-  {
-   "default": "0",
-   "fieldname": "show_rsvp",
-   "fieldtype": "Check",
-   "label": "Show RSVP"
-  },
-  {
-   "fieldname": "column_break_moaa",
-   "fieldtype": "Column Break"
-  },
-  {
-   "default": "0",
-   "fieldname": "show_cfp",
-   "fieldtype": "Check",
-   "label": "Show CFP"
-  },
-  {
-   "default": "0",
-   "fieldname": "show_photos",
-   "fieldtype": "Check",
-   "label": "Show Photos"
-  },
-  {
-   "depends_on": "eval:doc.is_external_event == 0",
-   "fieldname": "meta_info_section",
-   "fieldtype": "Section Break",
-   "label": "Meta Info"
-  },
-  {
-   "fetch_from": "chapter.banner_image",
-   "fetch_if_empty": 1,
-   "fieldname": "banner_image",
-   "fieldtype": "Attach Image",
-   "label": "Event Banner Image"
-  },
-  {
-   "fieldname": "schedule_section",
-   "fieldtype": "Section Break",
-   "label": "Schedule"
-  },
-  {
-   "fetch_from": "chapter.chapter_name",
-   "fieldname": "chapter_name",
-   "fieldtype": "Data",
-   "label": "Chapter Name"
-  },
-  {
-   "depends_on": "eval:doc.is_external_event == 0",
-   "description": "Only enter the permalink endpoint.\nRoute will be set as events/< event_permalink >",
-   "fieldname": "event_permalink",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "in_preview": 1,
-   "label": "Event Permalink",
-   "mandatory_depends_on": "eval:doc.is_external_event == 0"
-  },
-  {
-   "default": "0",
-   "fieldname": "show_schedule",
-   "fieldtype": "Check",
-   "label": "Show Schedule"
-  },
-  {
-   "fieldname": "tickets_tab",
-   "fieldtype": "Tab Break",
-   "label": "Tickets"
-  },
-  {
-   "default": "0",
-   "fieldname": "is_paid_event",
-   "fieldtype": "Check",
-   "label": "Is paid event?"
-  },
-  {
-   "depends_on": "eval:doc.is_paid_event==1",
-   "fieldname": "tiers",
-   "fieldtype": "Table",
-   "label": "Tiers",
-   "options": "FOSS Ticket Tier"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:doc.is_paid_event==1",
-   "fieldname": "paid_tshirts_available",
-   "fieldtype": "Check",
-   "label": "Paid T Shirts available?"
-  },
-  {
-   "fieldname": "section_break_idyt",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "column_break_cntx",
-   "fieldtype": "Column Break"
-  },
-  {
-   "depends_on": "eval:doc.paid_tshirts_available==1",
-   "description": "INR",
-   "fieldname": "t_shirt_price",
-   "fieldtype": "Currency",
-   "label": "T Shirt Price",
-   "mandatory_depends_on": "eval:doc.paid_tshirts_available==1",
-   "non_negative": 1
-  },
-  {
-   "fieldname": "section_break_hjyr",
-   "fieldtype": "Section Break"
-  },
-  {
-   "depends_on": "eval:doc.is_paid_event==1",
-   "description": "Any custom fields you want to collect while ticket booking",
-   "fieldname": "custom_fields",
-   "fieldtype": "Table",
-   "label": "Custom Fields",
-   "options": "FOSS Event Field"
-  },
-  {
-   "fieldname": "ticket_form_description",
-   "fieldtype": "Markdown Editor",
-   "label": "Ticket Form Description"
-  },
-  {
-   "default": "0",
-   "fieldname": "is_external_event",
-   "fieldtype": "Check",
-   "label": "Is External Event?"
-  },
-  {
-   "fieldname": "column_break_okxh",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "external_event_url",
-   "fieldtype": "Data",
-   "label": "External Event URL"
-  },
-  {
-   "default": "Live",
-   "fieldname": "tickets_status",
-   "fieldtype": "Select",
-   "label": "Tickets Status",
-   "options": "Live\nClosed"
-  },
-  {
-   "fieldname": "section_break_vlwf",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "hall_options",
-   "fieldtype": "Small Text",
-   "label": "Hall Options"
-  },
-  {
-   "fieldname": "column_break_wqtz",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "event_logo",
-   "fieldtype": "Attach Image",
-   "label": "Event logo"
-  },
-  {
-   "fieldname": "schedule_page_description",
-   "fieldtype": "Long Text",
-   "label": "Schedule Page Description"
-  },
-  {
-   "fieldname": "proposal_page_description",
-   "fieldtype": "Text",
-   "label": "Proposal page description"
-  },
-  {
-   "fieldname": "livestreaming_section",
-   "fieldtype": "Section Break",
-   "label": "Livestreaming"
-  },
-  {
-   "fieldname": "livestream_link",
-   "fieldtype": "Data",
-   "label": "Livestream Link",
-   "options": "URL"
-  }
- ],
- "has_web_view": 1,
- "index_web_pages_for_search": 1,
- "is_published_field": "is_published",
- "links": [
-  {
-   "group": "RSVP",
-   "link_doctype": "FOSS Event RSVP Submission",
-   "link_fieldname": "event"
-  },
-  {
-   "group": "Tickets",
-   "link_doctype": "FOSS Event Ticket",
-   "link_fieldname": "event"
-  },
-  {
-   "group": "Emailing",
-   "link_doctype": "Email Group",
-   "link_fieldname": "event"
-  }
- ],
- "modified": "2024-12-12 11:36:27.114146",
- "modified_by": "Administrator",
- "module": "Chapters",
- "name": "FOSS Chapter Event",
- "naming_rule": "Random",
- "owner": "Administrator",
- "permissions": [
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "System Manager",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "create": 1,
-   "delete": 1,
-   "read": 1,
-   "role": "Chapter Team Member",
-   "select": 1,
-   "write": 1
-  },
-  {
-   "read": 1,
-   "role": "All",
-   "select": 1
-  },
-  {
-   "read": 1,
-   "role": "Guest",
-   "select": 1
-  }
- ],
- "search_fields": "event_permalink, chapter",
- "show_title_field_in_link": 1,
- "sort_field": "modified",
- "sort_order": "DESC",
- "states": [
-  {
-   "color": "Orange",
-   "title": "Draft"
-  },
-  {
-   "color": "Green",
-   "title": "Live"
-  },
-  {
-   "color": "Gray",
-   "title": "Concluded"
-  },
-  {
-   "color": "Red",
-   "title": "Cancelled"
-  }
- ],
- "title_field": "event_name"
+  "actions": [],
+  "allow_guest_to_view": 1,
+  "allow_rename": 1,
+  "autoname": "hash",
+  "creation": "2023-07-01 23:55:20.934607",
+  "default_view": "List",
+  "doctype": "DocType",
+  "editable_grid": 1,
+  "engine": "InnoDB",
+  "field_order": [
+    "is_external_event",
+    "column_break_okxh",
+    "external_event_url",
+    "meta_info_section",
+    "is_published",
+    "column_break_yozf",
+    "route",
+    "navbar_controls_section",
+    "show_speakers",
+    "show_rsvp",
+    "show_schedule",
+    "column_break_moaa",
+    "show_cfp",
+    "show_photos",
+    "chapter_information_section",
+    "chapter",
+    "column_break_tzza",
+    "chapter_name",
+    "event_infomation_section",
+    "must_attend",
+    "event_name",
+    "event_permalink",
+    "status",
+    "event_type",
+    "column_break_pua4",
+    "event_logo",
+    "banner_image",
+    "event_location",
+    "map_link",
+    "cta_section_section",
+    "primary_button_label",
+    "primary_button_url",
+    "column_break_hrox",
+    "secondary_button_label",
+    "secondary_button_url",
+    "event_timeline_section",
+    "event_start_date",
+    "column_break_ae9v",
+    "event_end_date",
+    "livestreaming_section",
+    "livestream_link",
+    "event_information_section",
+    "event_bio",
+    "event_description",
+    "proposal_page_description",
+    "event_sponsors_section",
+    "sponsor_list",
+    "deck_link",
+    "community_partners_section",
+    "community_partners",
+    "volunteers_tab",
+    "event_members_section",
+    "event_members",
+    "schedule_tab",
+    "schedule_section",
+    "event_schedule",
+    "section_break_vlwf",
+    "hall_options",
+    "column_break_wqtz",
+    "schedule_page_description",
+    "tickets_tab",
+    "is_paid_event",
+    "tickets_status",
+    "tiers",
+    "ticket_form_description",
+    "section_break_idyt",
+    "paid_tshirts_available",
+    "column_break_cntx",
+    "t_shirt_price",
+    "section_break_hjyr",
+    "custom_fields"
+  ],
+  "fields": [
+    {
+      "fieldname": "event_infomation_section",
+      "fieldtype": "Section Break",
+      "label": "Basic Information"
+    },
+    {
+      "fieldname": "event_name",
+      "fieldtype": "Data",
+      "in_list_view": 1,
+      "label": "Event Name",
+      "reqd": 1
+    },
+    {
+      "fieldname": "column_break_pua4",
+      "fieldtype": "Column Break"
+    },
+    {
+      "fieldname": "event_type",
+      "fieldtype": "Link",
+      "in_list_view": 1,
+      "label": "Event Type",
+      "mandatory_depends_on": "eval:doc.is_external_event == 0",
+      "options": "FOSS Event Type"
+    },
+    {
+      "fieldname": "chapter_information_section",
+      "fieldtype": "Section Break",
+      "label": "Organizing Chapter"
+    },
+    {
+      "fieldname": "chapter",
+      "fieldtype": "Link",
+      "in_list_view": 1,
+      "label": "Chapter",
+      "options": "FOSS Chapter",
+      "search_index": 1
+    },
+    {
+      "default": "0",
+      "fieldname": "must_attend",
+      "fieldtype": "Check",
+      "label": "Must Attend"
+    },
+    {
+      "fieldname": "map_link",
+      "fieldtype": "Data",
+      "label": "Map Link",
+      "options": "URL"
+    },
+    {
+      "fieldname": "event_timeline_section",
+      "fieldtype": "Section Break",
+      "label": "Event Timeline"
+    },
+    {
+      "fieldname": "event_start_date",
+      "fieldtype": "Datetime",
+      "label": "Event Start Date & Time",
+      "mandatory_depends_on": "eval:doc.is_external_event == 0"
+    },
+    {
+      "fieldname": "event_end_date",
+      "fieldtype": "Datetime",
+      "label": "Event End Date & Time",
+      "mandatory_depends_on": "eval:doc.is_external_event == 0"
+    },
+    {
+      "fieldname": "column_break_ae9v",
+      "fieldtype": "Column Break"
+    },
+    {
+      "fieldname": "event_location",
+      "fieldtype": "Data",
+      "label": "Location"
+    },
+    {
+      "depends_on": "eval:doc.is_external_event == 0",
+      "fieldname": "event_description",
+      "fieldtype": "Text Editor",
+      "label": "Description",
+      "mandatory_depends_on": "eval:doc.is_external_event == 0"
+    },
+    {
+      "fieldname": "status",
+      "fieldtype": "Select",
+      "label": "Status",
+      "options": "\nDraft\nLive\nApproved\nConcluded\nCancelled",
+      "reqd": 1
+    },
+    {
+      "fieldname": "event_members_section",
+      "fieldtype": "Section Break",
+      "label": "Event Volunteers"
+    },
+    {
+      "fieldname": "event_members",
+      "fieldtype": "Table",
+      "label": "Event Team Members",
+      "options": "FOSS Chapter Event Member"
+    },
+    {
+      "fieldname": "column_break_tzza",
+      "fieldtype": "Column Break"
+    },
+    {
+      "fieldname": "event_information_section",
+      "fieldtype": "Section Break",
+      "label": "Event Information"
+    },
+    {
+      "fieldname": "event_sponsors_section",
+      "fieldtype": "Section Break",
+      "label": "Event Sponsors"
+    },
+    {
+      "fieldname": "sponsor_list",
+      "fieldtype": "Table",
+      "label": "Sponsors",
+      "options": "FOSS Event Sponsor"
+    },
+    {
+      "fieldname": "community_partners_section",
+      "fieldtype": "Section Break",
+      "label": "Community Partners"
+    },
+    {
+      "fieldname": "community_partners",
+      "fieldtype": "Table",
+      "label": "Community Partners",
+      "options": "FOSS Event Community Partner"
+    },
+    {
+      "fieldname": "deck_link",
+      "fieldtype": "Data",
+      "label": "Deck Link",
+      "options": "URL"
+    },
+    {
+      "fieldname": "cta_section_section",
+      "fieldtype": "Section Break",
+      "label": "CTA Section"
+    },
+    {
+      "fieldname": "primary_button_label",
+      "fieldtype": "Data",
+      "label": "Primary Button Label"
+    },
+    {
+      "fieldname": "primary_button_url",
+      "fieldtype": "Data",
+      "label": "Primary Button URL"
+    },
+    {
+      "fieldname": "column_break_hrox",
+      "fieldtype": "Column Break"
+    },
+    {
+      "fieldname": "secondary_button_label",
+      "fieldtype": "Data",
+      "label": "Secondary Button Label"
+    },
+    {
+      "fieldname": "secondary_button_url",
+      "fieldtype": "Data",
+      "label": "Secondary Button URL"
+    },
+    {
+      "fieldname": "volunteers_tab",
+      "fieldtype": "Tab Break",
+      "label": "Volunteers"
+    },
+    {
+      "fieldname": "schedule_tab",
+      "fieldtype": "Tab Break",
+      "label": "Schedule"
+    },
+    {
+      "fieldname": "event_schedule",
+      "fieldtype": "Table",
+      "label": "Event Schedule",
+      "options": "FOSS Event Schedule"
+    },
+    {
+      "fieldname": "route",
+      "fieldtype": "Data",
+      "label": "Route"
+    },
+    {
+      "fieldname": "column_break_yozf",
+      "fieldtype": "Column Break"
+    },
+    {
+      "default": "0",
+      "fieldname": "is_published",
+      "fieldtype": "Check",
+      "label": "Is Published?"
+    },
+    {
+      "fieldname": "event_bio",
+      "fieldtype": "Data",
+      "label": "Short Event Bio"
+    },
+    {
+      "fieldname": "navbar_controls_section",
+      "fieldtype": "Section Break",
+      "label": "Navbar Controls"
+    },
+    {
+      "default": "0",
+      "fieldname": "show_speakers",
+      "fieldtype": "Check",
+      "label": "Show Speakers"
+    },
+    {
+      "default": "0",
+      "fieldname": "show_rsvp",
+      "fieldtype": "Check",
+      "label": "Show RSVP"
+    },
+    {
+      "fieldname": "column_break_moaa",
+      "fieldtype": "Column Break"
+    },
+    {
+      "default": "0",
+      "fieldname": "show_cfp",
+      "fieldtype": "Check",
+      "label": "Show CFP"
+    },
+    {
+      "default": "0",
+      "fieldname": "show_photos",
+      "fieldtype": "Check",
+      "label": "Show Photos"
+    },
+    {
+      "depends_on": "eval:doc.is_external_event == 0",
+      "fieldname": "meta_info_section",
+      "fieldtype": "Section Break",
+      "label": "Meta Info"
+    },
+    {
+      "fetch_from": "chapter.banner_image",
+      "fetch_if_empty": 1,
+      "fieldname": "banner_image",
+      "fieldtype": "Attach Image",
+      "label": "Event Banner Image"
+    },
+    {
+      "fieldname": "schedule_section",
+      "fieldtype": "Section Break",
+      "label": "Schedule"
+    },
+    {
+      "fetch_from": "chapter.chapter_name",
+      "fieldname": "chapter_name",
+      "fieldtype": "Data",
+      "label": "Chapter Name"
+    },
+    {
+      "depends_on": "eval:doc.is_external_event == 0",
+      "description": "Only enter the permalink endpoint.\nRoute will be set as events/< event_permalink >",
+      "fieldname": "event_permalink",
+      "fieldtype": "Data",
+      "in_list_view": 1,
+      "in_preview": 1,
+      "label": "Event Permalink",
+      "mandatory_depends_on": "eval:doc.is_external_event == 0"
+    },
+    {
+      "default": "0",
+      "fieldname": "show_schedule",
+      "fieldtype": "Check",
+      "label": "Show Schedule"
+    },
+    {
+      "fieldname": "tickets_tab",
+      "fieldtype": "Tab Break",
+      "label": "Tickets"
+    },
+    {
+      "default": "0",
+      "fieldname": "is_paid_event",
+      "fieldtype": "Check",
+      "label": "Is paid event?"
+    },
+    {
+      "depends_on": "eval:doc.is_paid_event==1",
+      "fieldname": "tiers",
+      "fieldtype": "Table",
+      "label": "Tiers",
+      "options": "FOSS Ticket Tier"
+    },
+    {
+      "default": "0",
+      "depends_on": "eval:doc.is_paid_event==1",
+      "fieldname": "paid_tshirts_available",
+      "fieldtype": "Check",
+      "label": "Paid T Shirts available?"
+    },
+    {
+      "fieldname": "section_break_idyt",
+      "fieldtype": "Section Break"
+    },
+    {
+      "fieldname": "column_break_cntx",
+      "fieldtype": "Column Break"
+    },
+    {
+      "depends_on": "eval:doc.paid_tshirts_available==1",
+      "description": "INR",
+      "fieldname": "t_shirt_price",
+      "fieldtype": "Currency",
+      "label": "T Shirt Price",
+      "mandatory_depends_on": "eval:doc.paid_tshirts_available==1",
+      "non_negative": 1
+    },
+    {
+      "fieldname": "section_break_hjyr",
+      "fieldtype": "Section Break"
+    },
+    {
+      "depends_on": "eval:doc.is_paid_event==1",
+      "description": "Any custom fields you want to collect while ticket booking",
+      "fieldname": "custom_fields",
+      "fieldtype": "Table",
+      "label": "Custom Fields",
+      "options": "FOSS Event Field"
+    },
+    {
+      "fieldname": "ticket_form_description",
+      "fieldtype": "Markdown Editor",
+      "label": "Ticket Form Description"
+    },
+    {
+      "default": "0",
+      "fieldname": "is_external_event",
+      "fieldtype": "Check",
+      "label": "Is External Event?"
+    },
+    {
+      "fieldname": "column_break_okxh",
+      "fieldtype": "Column Break"
+    },
+    {
+      "fieldname": "external_event_url",
+      "fieldtype": "Data",
+      "label": "External Event URL"
+    },
+    {
+      "default": "Live",
+      "fieldname": "tickets_status",
+      "fieldtype": "Select",
+      "label": "Tickets Status",
+      "options": "Live\nClosed"
+    },
+    {
+      "fieldname": "section_break_vlwf",
+      "fieldtype": "Section Break"
+    },
+    {
+      "fieldname": "hall_options",
+      "fieldtype": "Small Text",
+      "label": "Hall Options"
+    },
+    {
+      "fieldname": "column_break_wqtz",
+      "fieldtype": "Column Break"
+    },
+    {
+      "fieldname": "event_logo",
+      "fieldtype": "Attach Image",
+      "label": "Event logo"
+    },
+    {
+      "fieldname": "schedule_page_description",
+      "fieldtype": "Long Text",
+      "label": "Schedule Page Description"
+    },
+    {
+      "fieldname": "proposal_page_description",
+      "fieldtype": "Text",
+      "label": "Proposal page description"
+    },
+    {
+      "fieldname": "livestreaming_section",
+      "fieldtype": "Section Break",
+      "label": "Livestreaming"
+    },
+    {
+      "fieldname": "livestream_link",
+      "fieldtype": "Data",
+      "label": "Livestream Link",
+      "options": "URL"
+    }
+  ],
+  "has_web_view": 1,
+  "index_web_pages_for_search": 1,
+  "is_published_field": "is_published",
+  "links": [
+    {
+      "group": "RSVP",
+      "link_doctype": "FOSS Event RSVP Submission",
+      "link_fieldname": "event"
+    },
+    {
+      "group": "Tickets",
+      "link_doctype": "FOSS Event Ticket",
+      "link_fieldname": "event"
+    },
+    {
+      "group": "Emailing",
+      "link_doctype": "Email Group",
+      "link_fieldname": "event"
+    }
+  ],
+  "modified": "2024-12-12 11:36:27.114146",
+  "modified_by": "Administrator",
+  "module": "Chapters",
+  "name": "FOSS Chapter Event",
+  "naming_rule": "Random",
+  "owner": "Administrator",
+  "permissions": [
+    {
+      "create": 1,
+      "delete": 1,
+      "email": 1,
+      "export": 1,
+      "print": 1,
+      "read": 1,
+      "report": 1,
+      "role": "System Manager",
+      "share": 1,
+      "write": 1
+    },
+    {
+      "create": 1,
+      "delete": 1,
+      "read": 1,
+      "role": "Chapter Team Member",
+      "select": 1,
+      "write": 1
+    },
+    {
+      "read": 1,
+      "role": "All",
+      "select": 1
+    },
+    {
+      "read": 1,
+      "role": "Guest",
+      "select": 1
+    }
+  ],
+  "search_fields": "event_permalink, chapter",
+  "show_title_field_in_link": 1,
+  "sort_field": "modified",
+  "sort_order": "DESC",
+  "states": [
+    {
+      "color": "Orange",
+      "title": "Draft"
+    },
+    {
+      "color": "Green",
+      "title": "Live"
+    },
+    {
+      "color": "Gray",
+      "title": "Concluded"
+    },
+    {
+      "color": "Red",
+      "title": "Cancelled"
+    }
+  ],
+  "title_field": "event_name"
 }

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
@@ -1,549 +1,562 @@
 {
-  "actions": [],
-  "allow_guest_to_view": 1,
-  "allow_rename": 1,
-  "autoname": "hash",
-  "creation": "2023-07-01 23:55:20.934607",
-  "default_view": "List",
-  "doctype": "DocType",
-  "editable_grid": 1,
-  "engine": "InnoDB",
-  "field_order": [
-    "is_external_event",
-    "column_break_okxh",
-    "external_event_url",
-    "meta_info_section",
-    "is_published",
-    "column_break_yozf",
-    "route",
-    "navbar_controls_section",
-    "show_speakers",
-    "show_rsvp",
-    "show_schedule",
-    "column_break_moaa",
-    "show_cfp",
-    "show_photos",
-    "chapter_information_section",
-    "chapter",
-    "column_break_tzza",
-    "chapter_name",
-    "event_infomation_section",
-    "must_attend",
-    "event_name",
-    "event_permalink",
-    "status",
-    "event_type",
-    "column_break_pua4",
-    "event_logo",
-    "banner_image",
-    "event_location",
-    "map_link",
-    "cta_section_section",
-    "primary_button_label",
-    "primary_button_url",
-    "column_break_hrox",
-    "secondary_button_label",
-    "secondary_button_url",
-    "event_timeline_section",
-    "event_start_date",
-    "column_break_ae9v",
-    "event_end_date",
-    "event_information_section",
-    "event_bio",
-    "event_description",
-    "proposal_page_description",
-    "event_sponsors_section",
-    "sponsor_list",
-    "deck_link",
-    "community_partners_section",
-    "community_partners",
-    "volunteers_tab",
-    "event_members_section",
-    "event_members",
-    "schedule_tab",
-    "schedule_section",
-    "event_schedule",
-    "section_break_vlwf",
-    "hall_options",
-    "column_break_wqtz",
-    "schedule_page_description",
-    "tickets_tab",
-    "is_paid_event",
-    "tickets_status",
-    "tiers",
-    "ticket_form_description",
-    "section_break_idyt",
-    "paid_tshirts_available",
-    "column_break_cntx",
-    "t_shirt_price",
-    "section_break_hjyr",
-    "custom_fields"
-  ],
-  "fields": [
-    {
-      "fieldname": "event_infomation_section",
-      "fieldtype": "Section Break",
-      "label": "Basic Information"
-    },
-    {
-      "fieldname": "event_name",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "label": "Event Name",
-      "reqd": 1
-    },
-    {
-      "fieldname": "column_break_pua4",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "event_type",
-      "fieldtype": "Link",
-      "in_list_view": 1,
-      "label": "Event Type",
-      "mandatory_depends_on": "eval:doc.is_external_event == 0",
-      "options": "FOSS Event Type"
-    },
-    {
-      "fieldname": "chapter_information_section",
-      "fieldtype": "Section Break",
-      "label": "Organizing Chapter"
-    },
-    {
-      "fieldname": "chapter",
-      "fieldtype": "Link",
-      "in_list_view": 1,
-      "label": "Chapter",
-      "options": "FOSS Chapter",
-      "search_index": 1
-    },
-    {
-      "default": "0",
-      "fieldname": "must_attend",
-      "fieldtype": "Check",
-      "label": "Must Attend"
-    },
-    {
-      "fieldname": "map_link",
-      "fieldtype": "Data",
-      "label": "Map Link",
-      "options": "URL"
-    },
-    {
-      "fieldname": "event_timeline_section",
-      "fieldtype": "Section Break",
-      "label": "Event Timeline"
-    },
-    {
-      "fieldname": "event_start_date",
-      "fieldtype": "Datetime",
-      "label": "Event Start Date & Time",
-      "mandatory_depends_on": "eval:doc.is_external_event == 0"
-    },
-    {
-      "fieldname": "event_end_date",
-      "fieldtype": "Datetime",
-      "label": "Event End Date & Time",
-      "mandatory_depends_on": "eval:doc.is_external_event == 0"
-    },
-    {
-      "fieldname": "column_break_ae9v",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "event_location",
-      "fieldtype": "Data",
-      "label": "Location"
-    },
-    {
-      "depends_on": "eval:doc.is_external_event == 0",
-      "fieldname": "event_description",
-      "fieldtype": "Text Editor",
-      "label": "Description",
-      "mandatory_depends_on": "eval:doc.is_external_event == 0"
-    },
-    {
-      "fieldname": "status",
-      "fieldtype": "Select",
-      "label": "Status",
-      "options": "\nDraft\nLive\nApproved\nConcluded\nCancelled",
-      "reqd": 1
-    },
-    {
-      "fieldname": "event_members_section",
-      "fieldtype": "Section Break",
-      "label": "Event Volunteers"
-    },
-    {
-      "fieldname": "event_members",
-      "fieldtype": "Table",
-      "label": "Event Team Members",
-      "options": "FOSS Chapter Event Member"
-    },
-    {
-      "fieldname": "column_break_tzza",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "event_information_section",
-      "fieldtype": "Section Break",
-      "label": "Event Information"
-    },
-    {
-      "fieldname": "event_sponsors_section",
-      "fieldtype": "Section Break",
-      "label": "Event Sponsors"
-    },
-    {
-      "fieldname": "sponsor_list",
-      "fieldtype": "Table",
-      "label": "Sponsors",
-      "options": "FOSS Event Sponsor"
-    },
-    {
-      "fieldname": "community_partners_section",
-      "fieldtype": "Section Break",
-      "label": "Community Partners"
-    },
-    {
-      "fieldname": "community_partners",
-      "fieldtype": "Table",
-      "label": "Community Partners",
-      "options": "FOSS Event Community Partner"
-    },
-    {
-      "fieldname": "deck_link",
-      "fieldtype": "Data",
-      "label": "Deck Link",
-      "options": "URL"
-    },
-    {
-      "fieldname": "cta_section_section",
-      "fieldtype": "Section Break",
-      "label": "CTA Section"
-    },
-    {
-      "fieldname": "primary_button_label",
-      "fieldtype": "Data",
-      "label": "Primary Button Label"
-    },
-    {
-      "fieldname": "primary_button_url",
-      "fieldtype": "Data",
-      "label": "Primary Button URL"
-    },
-    {
-      "fieldname": "column_break_hrox",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "secondary_button_label",
-      "fieldtype": "Data",
-      "label": "Secondary Button Label"
-    },
-    {
-      "fieldname": "secondary_button_url",
-      "fieldtype": "Data",
-      "label": "Secondary Button URL"
-    },
-    {
-      "fieldname": "volunteers_tab",
-      "fieldtype": "Tab Break",
-      "label": "Volunteers"
-    },
-    {
-      "fieldname": "schedule_tab",
-      "fieldtype": "Tab Break",
-      "label": "Schedule"
-    },
-    {
-      "fieldname": "event_schedule",
-      "fieldtype": "Table",
-      "label": "Event Schedule",
-      "options": "FOSS Event Schedule"
-    },
-    {
-      "fieldname": "route",
-      "fieldtype": "Data",
-      "label": "Route"
-    },
-    {
-      "fieldname": "column_break_yozf",
-      "fieldtype": "Column Break"
-    },
-    {
-      "default": "0",
-      "fieldname": "is_published",
-      "fieldtype": "Check",
-      "label": "Is Published?"
-    },
-    {
-      "fieldname": "event_bio",
-      "fieldtype": "Data",
-      "label": "Short Event Bio"
-    },
-    {
-      "fieldname": "navbar_controls_section",
-      "fieldtype": "Section Break",
-      "label": "Navbar Controls"
-    },
-    {
-      "default": "0",
-      "fieldname": "show_speakers",
-      "fieldtype": "Check",
-      "label": "Show Speakers"
-    },
-    {
-      "default": "0",
-      "fieldname": "show_rsvp",
-      "fieldtype": "Check",
-      "label": "Show RSVP"
-    },
-    {
-      "fieldname": "column_break_moaa",
-      "fieldtype": "Column Break"
-    },
-    {
-      "default": "0",
-      "fieldname": "show_cfp",
-      "fieldtype": "Check",
-      "label": "Show CFP"
-    },
-    {
-      "default": "0",
-      "fieldname": "show_photos",
-      "fieldtype": "Check",
-      "label": "Show Photos"
-    },
-    {
-      "depends_on": "eval:doc.is_external_event == 0",
-      "fieldname": "meta_info_section",
-      "fieldtype": "Section Break",
-      "label": "Meta Info"
-    },
-    {
-      "fetch_from": "chapter.banner_image",
-      "fetch_if_empty": 1,
-      "fieldname": "banner_image",
-      "fieldtype": "Attach Image",
-      "label": "Event Banner Image"
-    },
-    {
-      "fieldname": "schedule_section",
-      "fieldtype": "Section Break",
-      "label": "Schedule"
-    },
-    {
-      "fetch_from": "chapter.chapter_name",
-      "fieldname": "chapter_name",
-      "fieldtype": "Data",
-      "label": "Chapter Name"
-    },
-    {
-      "depends_on": "eval:doc.is_external_event == 0",
-      "description": "Only enter the permalink endpoint.\nRoute will be set as events/< event_permalink >",
-      "fieldname": "event_permalink",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "in_preview": 1,
-      "label": "Event Permalink",
-      "mandatory_depends_on": "eval:doc.is_external_event == 0"
-    },
-    {
-      "default": "0",
-      "fieldname": "show_schedule",
-      "fieldtype": "Check",
-      "label": "Show Schedule"
-    },
-    {
-      "fieldname": "tickets_tab",
-      "fieldtype": "Tab Break",
-      "label": "Tickets"
-    },
-    {
-      "default": "0",
-      "fieldname": "is_paid_event",
-      "fieldtype": "Check",
-      "label": "Is paid event?"
-    },
-    {
-      "depends_on": "eval:doc.is_paid_event==1",
-      "fieldname": "tiers",
-      "fieldtype": "Table",
-      "label": "Tiers",
-      "options": "FOSS Ticket Tier"
-    },
-    {
-      "default": "0",
-      "depends_on": "eval:doc.is_paid_event==1",
-      "fieldname": "paid_tshirts_available",
-      "fieldtype": "Check",
-      "label": "Paid T Shirts available?"
-    },
-    {
-      "fieldname": "section_break_idyt",
-      "fieldtype": "Section Break"
-    },
-    {
-      "fieldname": "column_break_cntx",
-      "fieldtype": "Column Break"
-    },
-    {
-      "depends_on": "eval:doc.paid_tshirts_available==1",
-      "description": "INR",
-      "fieldname": "t_shirt_price",
-      "fieldtype": "Currency",
-      "label": "T Shirt Price",
-      "mandatory_depends_on": "eval:doc.paid_tshirts_available==1",
-      "non_negative": 1
-    },
-    {
-      "fieldname": "section_break_hjyr",
-      "fieldtype": "Section Break"
-    },
-    {
-      "depends_on": "eval:doc.is_paid_event==1",
-      "description": "Any custom fields you want to collect while ticket booking",
-      "fieldname": "custom_fields",
-      "fieldtype": "Table",
-      "label": "Custom Fields",
-      "options": "FOSS Event Field"
-    },
-    {
-      "fieldname": "ticket_form_description",
-      "fieldtype": "Markdown Editor",
-      "label": "Ticket Form Description"
-    },
-    {
-      "default": "0",
-      "fieldname": "is_external_event",
-      "fieldtype": "Check",
-      "label": "Is External Event?"
-    },
-    {
-      "fieldname": "column_break_okxh",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "external_event_url",
-      "fieldtype": "Data",
-      "label": "External Event URL"
-    },
-    {
-      "default": "Live",
-      "fieldname": "tickets_status",
-      "fieldtype": "Select",
-      "label": "Tickets Status",
-      "options": "Live\nClosed"
-    },
-    {
-      "fieldname": "section_break_vlwf",
-      "fieldtype": "Section Break"
-    },
-    {
-      "fieldname": "hall_options",
-      "fieldtype": "Small Text",
-      "label": "Hall Options"
-    },
-    {
-      "fieldname": "column_break_wqtz",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "event_logo",
-      "fieldtype": "Attach Image",
-      "label": "Event logo"
-    },
-    {
-      "fieldname": "schedule_page_description",
-      "fieldtype": "Long Text",
-      "label": "Schedule Page Description"
-    },
-    {
-      "fieldname": "proposal_page_description",
-      "fieldtype": "Text",
-      "label": "Proposal page description"
-    }
-  ],
-  "has_web_view": 1,
-  "index_web_pages_for_search": 1,
-  "is_published_field": "is_published",
-  "links": [
-    {
-      "group": "RSVP",
-      "link_doctype": "FOSS Event RSVP Submission",
-      "link_fieldname": "event"
-    },
-    {
-      "group": "Tickets",
-      "link_doctype": "FOSS Event Ticket",
-      "link_fieldname": "event"
-    },
-    {
-      "group": "Emailing",
-      "link_doctype": "Email Group",
-      "link_fieldname": "event"
-    }
-  ],
-  "modified": "2024-12-03 13:58:56.451845",
-  "modified_by": "Administrator",
-  "module": "Chapters",
-  "name": "FOSS Chapter Event",
-  "naming_rule": "Random",
-  "owner": "Administrator",
-  "permissions": [
-    {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "System Manager",
-      "share": 1,
-      "write": 1
-    },
-    {
-      "create": 1,
-      "delete": 1,
-      "read": 1,
-      "role": "Chapter Team Member",
-      "select": 1,
-      "write": 1
-    },
-    {
-      "read": 1,
-      "role": "All",
-      "select": 1
-    },
-    {
-      "read": 1,
-      "role": "Guest",
-      "select": 1
-    }
-  ],
-  "search_fields": "event_permalink, chapter",
-  "show_title_field_in_link": 1,
-  "sort_field": "modified",
-  "sort_order": "DESC",
-  "states": [
-    {
-      "color": "Orange",
-      "title": "Draft"
-    },
-    {
-      "color": "Green",
-      "title": "Live"
-    },
-    {
-      "color": "Gray",
-      "title": "Concluded"
-    },
-    {
-      "color": "Red",
-      "title": "Cancelled"
-    }
-  ],
-  "title_field": "event_name"
+ "actions": [],
+ "allow_guest_to_view": 1,
+ "allow_rename": 1,
+ "autoname": "hash",
+ "creation": "2023-07-01 23:55:20.934607",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "is_external_event",
+  "column_break_okxh",
+  "external_event_url",
+  "meta_info_section",
+  "is_published",
+  "column_break_yozf",
+  "route",
+  "navbar_controls_section",
+  "show_speakers",
+  "show_rsvp",
+  "show_schedule",
+  "column_break_moaa",
+  "show_cfp",
+  "show_photos",
+  "chapter_information_section",
+  "chapter",
+  "column_break_tzza",
+  "chapter_name",
+  "event_infomation_section",
+  "must_attend",
+  "event_name",
+  "event_permalink",
+  "status",
+  "event_type",
+  "column_break_pua4",
+  "event_logo",
+  "banner_image",
+  "event_location",
+  "map_link",
+  "cta_section_section",
+  "primary_button_label",
+  "primary_button_url",
+  "column_break_hrox",
+  "secondary_button_label",
+  "secondary_button_url",
+  "event_timeline_section",
+  "event_start_date",
+  "column_break_ae9v",
+  "event_end_date",
+  "livestreaming_section",
+  "livestream_link",
+  "event_information_section",
+  "event_bio",
+  "event_description",
+  "proposal_page_description",
+  "event_sponsors_section",
+  "sponsor_list",
+  "deck_link",
+  "community_partners_section",
+  "community_partners",
+  "volunteers_tab",
+  "event_members_section",
+  "event_members",
+  "schedule_tab",
+  "schedule_section",
+  "event_schedule",
+  "section_break_vlwf",
+  "hall_options",
+  "column_break_wqtz",
+  "schedule_page_description",
+  "tickets_tab",
+  "is_paid_event",
+  "tickets_status",
+  "tiers",
+  "ticket_form_description",
+  "section_break_idyt",
+  "paid_tshirts_available",
+  "column_break_cntx",
+  "t_shirt_price",
+  "section_break_hjyr",
+  "custom_fields"
+ ],
+ "fields": [
+  {
+   "fieldname": "event_infomation_section",
+   "fieldtype": "Section Break",
+   "label": "Basic Information"
+  },
+  {
+   "fieldname": "event_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Event Name",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_pua4",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "event_type",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Event Type",
+   "mandatory_depends_on": "eval:doc.is_external_event == 0",
+   "options": "FOSS Event Type"
+  },
+  {
+   "fieldname": "chapter_information_section",
+   "fieldtype": "Section Break",
+   "label": "Organizing Chapter"
+  },
+  {
+   "fieldname": "chapter",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Chapter",
+   "options": "FOSS Chapter",
+   "search_index": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "must_attend",
+   "fieldtype": "Check",
+   "label": "Must Attend"
+  },
+  {
+   "fieldname": "map_link",
+   "fieldtype": "Data",
+   "label": "Map Link",
+   "options": "URL"
+  },
+  {
+   "fieldname": "event_timeline_section",
+   "fieldtype": "Section Break",
+   "label": "Event Timeline"
+  },
+  {
+   "fieldname": "event_start_date",
+   "fieldtype": "Datetime",
+   "label": "Event Start Date & Time",
+   "mandatory_depends_on": "eval:doc.is_external_event == 0"
+  },
+  {
+   "fieldname": "event_end_date",
+   "fieldtype": "Datetime",
+   "label": "Event End Date & Time",
+   "mandatory_depends_on": "eval:doc.is_external_event == 0"
+  },
+  {
+   "fieldname": "column_break_ae9v",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "event_location",
+   "fieldtype": "Data",
+   "label": "Location"
+  },
+  {
+   "depends_on": "eval:doc.is_external_event == 0",
+   "fieldname": "event_description",
+   "fieldtype": "Text Editor",
+   "label": "Description",
+   "mandatory_depends_on": "eval:doc.is_external_event == 0"
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "label": "Status",
+   "options": "\nDraft\nLive\nApproved\nConcluded\nCancelled",
+   "reqd": 1
+  },
+  {
+   "fieldname": "event_members_section",
+   "fieldtype": "Section Break",
+   "label": "Event Volunteers"
+  },
+  {
+   "fieldname": "event_members",
+   "fieldtype": "Table",
+   "label": "Event Team Members",
+   "options": "FOSS Chapter Event Member"
+  },
+  {
+   "fieldname": "column_break_tzza",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "event_information_section",
+   "fieldtype": "Section Break",
+   "label": "Event Information"
+  },
+  {
+   "fieldname": "event_sponsors_section",
+   "fieldtype": "Section Break",
+   "label": "Event Sponsors"
+  },
+  {
+   "fieldname": "sponsor_list",
+   "fieldtype": "Table",
+   "label": "Sponsors",
+   "options": "FOSS Event Sponsor"
+  },
+  {
+   "fieldname": "community_partners_section",
+   "fieldtype": "Section Break",
+   "label": "Community Partners"
+  },
+  {
+   "fieldname": "community_partners",
+   "fieldtype": "Table",
+   "label": "Community Partners",
+   "options": "FOSS Event Community Partner"
+  },
+  {
+   "fieldname": "deck_link",
+   "fieldtype": "Data",
+   "label": "Deck Link",
+   "options": "URL"
+  },
+  {
+   "fieldname": "cta_section_section",
+   "fieldtype": "Section Break",
+   "label": "CTA Section"
+  },
+  {
+   "fieldname": "primary_button_label",
+   "fieldtype": "Data",
+   "label": "Primary Button Label"
+  },
+  {
+   "fieldname": "primary_button_url",
+   "fieldtype": "Data",
+   "label": "Primary Button URL"
+  },
+  {
+   "fieldname": "column_break_hrox",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "secondary_button_label",
+   "fieldtype": "Data",
+   "label": "Secondary Button Label"
+  },
+  {
+   "fieldname": "secondary_button_url",
+   "fieldtype": "Data",
+   "label": "Secondary Button URL"
+  },
+  {
+   "fieldname": "volunteers_tab",
+   "fieldtype": "Tab Break",
+   "label": "Volunteers"
+  },
+  {
+   "fieldname": "schedule_tab",
+   "fieldtype": "Tab Break",
+   "label": "Schedule"
+  },
+  {
+   "fieldname": "event_schedule",
+   "fieldtype": "Table",
+   "label": "Event Schedule",
+   "options": "FOSS Event Schedule"
+  },
+  {
+   "fieldname": "route",
+   "fieldtype": "Data",
+   "label": "Route"
+  },
+  {
+   "fieldname": "column_break_yozf",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_published",
+   "fieldtype": "Check",
+   "label": "Is Published?"
+  },
+  {
+   "fieldname": "event_bio",
+   "fieldtype": "Data",
+   "label": "Short Event Bio"
+  },
+  {
+   "fieldname": "navbar_controls_section",
+   "fieldtype": "Section Break",
+   "label": "Navbar Controls"
+  },
+  {
+   "default": "0",
+   "fieldname": "show_speakers",
+   "fieldtype": "Check",
+   "label": "Show Speakers"
+  },
+  {
+   "default": "0",
+   "fieldname": "show_rsvp",
+   "fieldtype": "Check",
+   "label": "Show RSVP"
+  },
+  {
+   "fieldname": "column_break_moaa",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "show_cfp",
+   "fieldtype": "Check",
+   "label": "Show CFP"
+  },
+  {
+   "default": "0",
+   "fieldname": "show_photos",
+   "fieldtype": "Check",
+   "label": "Show Photos"
+  },
+  {
+   "depends_on": "eval:doc.is_external_event == 0",
+   "fieldname": "meta_info_section",
+   "fieldtype": "Section Break",
+   "label": "Meta Info"
+  },
+  {
+   "fetch_from": "chapter.banner_image",
+   "fetch_if_empty": 1,
+   "fieldname": "banner_image",
+   "fieldtype": "Attach Image",
+   "label": "Event Banner Image"
+  },
+  {
+   "fieldname": "schedule_section",
+   "fieldtype": "Section Break",
+   "label": "Schedule"
+  },
+  {
+   "fetch_from": "chapter.chapter_name",
+   "fieldname": "chapter_name",
+   "fieldtype": "Data",
+   "label": "Chapter Name"
+  },
+  {
+   "depends_on": "eval:doc.is_external_event == 0",
+   "description": "Only enter the permalink endpoint.\nRoute will be set as events/< event_permalink >",
+   "fieldname": "event_permalink",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_preview": 1,
+   "label": "Event Permalink",
+   "mandatory_depends_on": "eval:doc.is_external_event == 0"
+  },
+  {
+   "default": "0",
+   "fieldname": "show_schedule",
+   "fieldtype": "Check",
+   "label": "Show Schedule"
+  },
+  {
+   "fieldname": "tickets_tab",
+   "fieldtype": "Tab Break",
+   "label": "Tickets"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_paid_event",
+   "fieldtype": "Check",
+   "label": "Is paid event?"
+  },
+  {
+   "depends_on": "eval:doc.is_paid_event==1",
+   "fieldname": "tiers",
+   "fieldtype": "Table",
+   "label": "Tiers",
+   "options": "FOSS Ticket Tier"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.is_paid_event==1",
+   "fieldname": "paid_tshirts_available",
+   "fieldtype": "Check",
+   "label": "Paid T Shirts available?"
+  },
+  {
+   "fieldname": "section_break_idyt",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_cntx",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval:doc.paid_tshirts_available==1",
+   "description": "INR",
+   "fieldname": "t_shirt_price",
+   "fieldtype": "Currency",
+   "label": "T Shirt Price",
+   "mandatory_depends_on": "eval:doc.paid_tshirts_available==1",
+   "non_negative": 1
+  },
+  {
+   "fieldname": "section_break_hjyr",
+   "fieldtype": "Section Break"
+  },
+  {
+   "depends_on": "eval:doc.is_paid_event==1",
+   "description": "Any custom fields you want to collect while ticket booking",
+   "fieldname": "custom_fields",
+   "fieldtype": "Table",
+   "label": "Custom Fields",
+   "options": "FOSS Event Field"
+  },
+  {
+   "fieldname": "ticket_form_description",
+   "fieldtype": "Markdown Editor",
+   "label": "Ticket Form Description"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_external_event",
+   "fieldtype": "Check",
+   "label": "Is External Event?"
+  },
+  {
+   "fieldname": "column_break_okxh",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "external_event_url",
+   "fieldtype": "Data",
+   "label": "External Event URL"
+  },
+  {
+   "default": "Live",
+   "fieldname": "tickets_status",
+   "fieldtype": "Select",
+   "label": "Tickets Status",
+   "options": "Live\nClosed"
+  },
+  {
+   "fieldname": "section_break_vlwf",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "hall_options",
+   "fieldtype": "Small Text",
+   "label": "Hall Options"
+  },
+  {
+   "fieldname": "column_break_wqtz",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "event_logo",
+   "fieldtype": "Attach Image",
+   "label": "Event logo"
+  },
+  {
+   "fieldname": "schedule_page_description",
+   "fieldtype": "Long Text",
+   "label": "Schedule Page Description"
+  },
+  {
+   "fieldname": "proposal_page_description",
+   "fieldtype": "Text",
+   "label": "Proposal page description"
+  },
+  {
+   "fieldname": "livestreaming_section",
+   "fieldtype": "Section Break",
+   "label": "Livestreaming"
+  },
+  {
+   "fieldname": "livestream_link",
+   "fieldtype": "Data",
+   "label": "Livestream Link",
+   "options": "URL"
+  }
+ ],
+ "has_web_view": 1,
+ "index_web_pages_for_search": 1,
+ "is_published_field": "is_published",
+ "links": [
+  {
+   "group": "RSVP",
+   "link_doctype": "FOSS Event RSVP Submission",
+   "link_fieldname": "event"
+  },
+  {
+   "group": "Tickets",
+   "link_doctype": "FOSS Event Ticket",
+   "link_fieldname": "event"
+  },
+  {
+   "group": "Emailing",
+   "link_doctype": "Email Group",
+   "link_fieldname": "event"
+  }
+ ],
+ "modified": "2024-12-12 11:36:27.114146",
+ "modified_by": "Administrator",
+ "module": "Chapters",
+ "name": "FOSS Chapter Event",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "read": 1,
+   "role": "Chapter Team Member",
+   "select": 1,
+   "write": 1
+  },
+  {
+   "read": 1,
+   "role": "All",
+   "select": 1
+  },
+  {
+   "read": 1,
+   "role": "Guest",
+   "select": 1
+  }
+ ],
+ "search_fields": "event_permalink, chapter",
+ "show_title_field_in_link": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [
+  {
+   "color": "Orange",
+   "title": "Draft"
+  },
+  {
+   "color": "Green",
+   "title": "Live"
+  },
+  {
+   "color": "Gray",
+   "title": "Concluded"
+  },
+  {
+   "color": "Red",
+   "title": "Cancelled"
+  }
+ ],
+ "title_field": "event_name"
 }

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -68,6 +68,7 @@ class FOSSChapterEvent(WebsiteGenerator):
         is_external_event: DF.Check
         is_paid_event: DF.Check
         is_published: DF.Check
+        livestream_link: DF.Data | None
         map_link: DF.Data | None
         must_attend: DF.Check
         paid_tshirts_available: DF.Check

--- a/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
+++ b/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
@@ -367,14 +367,13 @@
       let start_time = frappe.datetime.get_datetime_as_string('{{doc.event_start_date}}')
       let end_time = frappe.datetime.get_datetime_as_string('{{doc.event_end_date}}')
 
-      if (frappe.datetime.now_date() < start_time.split(' ')[0] ){
+      if (frappe.datetime.now_date() < start_time.split(' ')[0]) {
         return
-      }
-      else {
+      } else {
         $('#livestream_link').removeClass('hidden')
       }
 
-      if ( now_time >= start_time && now_time <= end_time) {
+      if (now_time >= start_time && now_time <= end_time) {
         $('#livestream_link').text('Livestreaming now!')
       }
     }

--- a/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
+++ b/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
@@ -37,7 +37,7 @@
           {% if doc.livestream_link %}
             <a
               id="livestream_link"
-              class="secondary-button hidden"
+              class="secondary-button"
               href="{{ doc.livestream_link }}"
               target="_blank"
             >
@@ -366,12 +366,6 @@
       let now_time = frappe.datetime.now_datetime()
       let start_time = frappe.datetime.get_datetime_as_string('{{doc.event_start_date}}')
       let end_time = frappe.datetime.get_datetime_as_string('{{doc.event_end_date}}')
-
-      if (frappe.datetime.now_date() < start_time.split(' ')[0]) {
-        return
-      } else {
-        $('#livestream_link').removeClass('hidden')
-      }
 
       if (now_time >= start_time && now_time <= end_time) {
         $('#livestream_link').text('Livestreaming now!')

--- a/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
+++ b/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
@@ -34,6 +34,16 @@
           <h1 class="header--event-title">{{ doc.event_name }}</h1>
         </div>
         <div class="d-flex gap-4" id="header-cta">
+          {% if doc.livestream_link %}
+            <a
+              id="livestream_link"
+              class="secondary-button hidden"
+              href="{{ doc.livestream_link }}"
+              target="_blank"
+            >
+              Watch Livestream
+            </a>
+          {% endif %}
           {% if doc.is_paid_event %}
             <button
               class="primary-button ticket-button"
@@ -325,6 +335,7 @@
   <script src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js"></script>
   <script>
     $(document).ready(function () {
+      handleLivestreamLabel()
       $('.schedule-grid').hide()
       $('.schedule-grid[data-date="{{schedule_dict.days[0]}}"]').show()
 
@@ -349,6 +360,23 @@
       $(event.target).addClass('dark-button active')
       $('.schedule-grid').hide()
       $('.schedule-grid[data-date="' + $(event.target).data('day') + '"]').show()
+    }
+
+    function handleLivestreamLabel() {
+      let now_time = frappe.datetime.now_datetime()
+      let start_time = frappe.datetime.get_datetime_as_string('{{doc.event_start_date}}')
+      let end_time = frappe.datetime.get_datetime_as_string('{{doc.event_end_date}}')
+
+      if (frappe.datetime.now_date() < start_time.split(' ')[0] ){
+        return
+      }
+      else {
+        $('#livestream_link').removeClass('hidden')
+      }
+
+      if ( now_time >= start_time && now_time <= end_time) {
+        $('#livestream_link').text('Livestreaming now!')
+      }
     }
   </script>
 {% endblock %}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕Feature

## Description

<!-- Briefly describe the changes introduced by this pull request -->

Added a new url field to event doctype called `livestream_link`, to set livestreaming link.

Made ui changes to the event page, so that livestream can be joined directly from the event page. The CTA is dynamic, it stays hidden till the day of the livestream, while the event is live (`event_start_time < now_time < event_end_time`), then the CTA is `Livestreaming Now!` and after event ends, the CTA stays up as `Watch Livestream`.

Made changes in dashboard ui to enable users to set the link.

## Related Issues & Docs
closes #708 
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

## Screenshots/GIFs/Screen Recordings (if applicable)

#### When event is happening
![image](https://github.com/user-attachments/assets/2ec43ea3-8e97-4463-81d6-236c487748cd)

#### When event has ended / not yet started:
![image](https://github.com/user-attachments/assets/b3cb6d47-1b38-49a9-9837-3b000b48a860)

#### Dashboard
![image](https://github.com/user-attachments/assets/8dcf7799-e8ca-44e2-a189-4c0b36521e18)

