### PR TITLE
chore!(event): remove deprecated `Approved` option

### DIFF
--- a/dashboard/src/pages/ChapterEvents.vue
+++ b/dashboard/src/pages/ChapterEvents.vue
@@ -55,7 +55,7 @@ const upcoming_events = createListResource({
   filters: [
     ['chapter', '=', route.params.id],
     ['event_end_date', '>', new Date()],
-    ['status', 'in', ['Approved', 'Live', 'Draft', 'Cancelled']],
+    ['status', 'in', ['Live', 'Draft', 'Cancelled']],
   ],
   auto: true,
 })

--- a/dashboard/src/pages/EventDetails.vue
+++ b/dashboard/src/pages/EventDetails.vue
@@ -101,10 +101,6 @@
               value: 'Draft',
             },
             {
-              label: 'Approved',
-              value: 'Approved',
-            },
-            {
               label: 'Live',
               value: 'Live',
             },

--- a/dashboard/src/pages/MyChapters.vue
+++ b/dashboard/src/pages/MyChapters.vue
@@ -59,7 +59,7 @@ const scheduled_events = createListResource({
   fields: ['name', 'event_name', 'event_type', 'chapter_name', 'status', 'event_start_date'],
   filters: {
     event_end_date: ['>', new Date()],
-    status: ['in', ['', 'Draft', 'Live']],
+    status: ['in', ['Draft', 'Live']],
   },
   orderBy: 'event_start_date',
 })

--- a/dashboard/src/pages/MyChapters.vue
+++ b/dashboard/src/pages/MyChapters.vue
@@ -59,7 +59,7 @@ const scheduled_events = createListResource({
   fields: ['name', 'event_name', 'event_type', 'chapter_name', 'status', 'event_start_date'],
   filters: {
     event_end_date: ['>', new Date()],
-    status: ['in', ['', 'Draft', 'Approved', 'Live']],
+    status: ['in', ['', 'Draft', 'Live']],
   },
   orderBy: 'event_start_date',
 })

--- a/fossunited/api/reviewer.py
+++ b/fossunited/api/reviewer.py
@@ -159,7 +159,7 @@ def get_events_by_open_cfp() -> list:
     events = frappe.db.get_list(
         EVENT,
         filters={
-            "status": ["in", ["Approved", "Live"]],
+            "status": "Live",
             "is_published": 1,
             "event_start_date": [">=", frappe.utils.nowdate()],
         },

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
@@ -163,10 +163,11 @@
       "mandatory_depends_on": "eval:doc.is_external_event == 0"
     },
     {
+      "default": "Draft",
       "fieldname": "status",
       "fieldtype": "Select",
       "label": "Status",
-      "options": "\nDraft\nLive\nApproved\nConcluded\nCancelled",
+      "options": "Draft\nLive\nConcluded\nCancelled",
       "reqd": 1
     },
     {
@@ -470,22 +471,21 @@
   "is_published_field": "is_published",
   "links": [
     {
+      "group": "Participants",
+      "link_doctype": "FOSS Chapter Event Participant",
+      "link_fieldname": "event_name"
+    },
+    {
       "group": "RSVP",
       "link_doctype": "FOSS Event RSVP Submission",
-      "link_fieldname": "event"
+      "link_fieldname": "chapter"
     },
     {
-      "group": "Tickets",
       "link_doctype": "FOSS Event Ticket",
-      "link_fieldname": "event"
-    },
-    {
-      "group": "Emailing",
-      "link_doctype": "Email Group",
       "link_fieldname": "event"
     }
   ],
-  "modified": "2024-12-03 13:58:56.451845",
+  "modified": "2024-12-12 13:47:54.934609",
   "modified_by": "Administrator",
   "module": "Chapters",
   "name": "FOSS Chapter Event",

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -84,7 +84,7 @@ class FOSSChapterEvent(WebsiteGenerator):
         show_schedule: DF.Check
         show_speakers: DF.Check
         sponsor_list: DF.Table[FOSSEventSponsor]
-        status: DF.Literal["", "Draft", "Live", "Approved", "Concluded", "Cancelled"]  # noqa: F722, F821
+        status: DF.Literal["Draft", "Live", "Concluded", "Cancelled"]  # noqa: F722, F821
         t_shirt_price: DF.Currency
         ticket_form_description: DF.MarkdownEditor | None
         tickets_status: DF.Literal["Live", "Closed"]  # noqa: F722, F821

--- a/fossunited/fossunited/web_template/upcoming_foss_events_section/upcoming_foss_events_section.html
+++ b/fossunited/fossunited/web_template/upcoming_foss_events_section/upcoming_foss_events_section.html
@@ -53,9 +53,15 @@
     {% from "fossunited/templates/macros/event_card.html" import event_card %}
     {%
       set events =
-      frappe.get_all("FOSS Chapter Event", fields=["*"], filters={"status": ["in", ["Approved",
-      "Live"]], "is_published": 1, "event_start_date": ['>=', frappe.utils.now()]}, page_length=8,
-      order_by='event_start_date')
+      frappe.get_all(
+        "FOSS Chapter Event",
+        fields=["*"],
+        filters={
+          "status": "Live",
+          "is_published": 1,
+          "event_start_date": ['>=', frappe.utils.now()],
+        }, page_length=8,
+        order_by='event_start_date'),
     %}
     <div class="events-grid-4">{% for event in events %}{{ event_card(event) }}{% endfor %}</div>
   </div>

--- a/fossunited/tests/utils.py
+++ b/fossunited/tests/utils.py
@@ -135,7 +135,7 @@ def insert_test_event(chapter: dict, **kwargs):
         event_type (str, optional): Type of event. Defaults to "FOSS Meetup".
         start_date (datetime, optional): Event start date. Defaults to today.
         end_date (datetime, optional): Event end date. Defaults to next day.
-        status (str, optional): Event status. Defaults to "Approved".
+        status (str, optional): Event status. Defaults to "Live".
 
     Returns:
         event doc: Created event document


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] ⚙️Chore
- [x] 🧑‍💻Refactor

## Description

<!-- Briefly describe the changes introduced by this pull request -->
This PR removes the deprecated `Approved` status option in event doctype


## Related Issues & Docs
closes #684 
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
