### PR TITLE
fix: remove unwanted `,` in upcoming events template

### DIFF
--- a/fossunited/fossunited/web_template/upcoming_foss_events_section/upcoming_foss_events_section.html
+++ b/fossunited/fossunited/web_template/upcoming_foss_events_section/upcoming_foss_events_section.html
@@ -52,17 +52,21 @@
 
     {% from "fossunited/templates/macros/event_card.html" import event_card %}
     {%
-      set events =
-      frappe.get_all(
-        "FOSS Chapter Event",
-        fields=["*"],
-        filters={
-          "status": "Live",
-          "is_published": 1,
-          "event_start_date": ['>=', frappe.utils.now()],
-        }, page_length=8,
-        order_by='event_start_date'),
+      set events = frappe.get_all(
+      "FOSS Chapter Event",
+      fields=["*"],
+      filters={
+        "status": "Live",
+        "is_published": 1,
+        "event_start_date": ['>=', frappe.utils.now()],
+      },
+      page_length=8,
+      order_by='event_start_date')
     %}
-    <div class="events-grid-4">{% for event in events %}{{ event_card(event) }}{% endfor %}</div>
+    {% if events | length %}
+      <div class="events-grid-4">{% for event in events %}{{ event_card(event) }}{% endfor %}</div>
+    {% else %}
+      <p>No upcoming events.</p>
+    {% endif %}
   </div>
 </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛Bug Fix

## Description

<!-- Briefly describe the changes introduced by this pull request -->

I accidentally added a `,` at the time of fetching events in the template. This resulted in a creation of a set with 2 items, an empty array and array of all events. Since empty array had no params, the error was occurring as per #725 .
This PR fixes that, and also adds an empty state for the events.


## Related Issues & Docs

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
closes #725 

