### PR TITLE
test(hackathon): add tests for `Hackathon Team Join Request` doctype

### DIFF
--- a/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/foss_hackathon_join_team_request.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/foss_hackathon_join_team_request.json
@@ -5,6 +5,7 @@
   "doctype": "DocType",
   "engine": "InnoDB",
   "field_order": [
+    "status",
     "is_outgoing_request",
     "section_break_kkvz",
     "team",
@@ -15,22 +16,24 @@
     "hackathon",
     "hackathon_name",
     "section_break_vjrk",
-    "reciever_email",
-    "column_break_vhdr",
-    "status"
+    "reciever_email"
   ],
   "fields": [
     {
       "fieldname": "team",
       "fieldtype": "Link",
+      "in_list_view": 1,
       "label": "Team",
-      "options": "FOSS Hackathon Team"
+      "options": "FOSS Hackathon Team",
+      "reqd": 1
     },
     {
       "fieldname": "requested_by",
       "fieldtype": "Link",
+      "in_list_view": 1,
       "label": "Requested By",
-      "options": "User"
+      "options": "User",
+      "reqd": 1
     },
     {
       "fieldname": "column_break_prrb",
@@ -39,8 +42,10 @@
     {
       "fieldname": "hackathon",
       "fieldtype": "Link",
+      "in_list_view": 1,
       "label": "Hackathon",
-      "options": "FOSS Hackathon"
+      "options": "FOSS Hackathon",
+      "reqd": 1
     },
     {
       "default": "0",
@@ -55,12 +60,10 @@
     {
       "fieldname": "reciever_email",
       "fieldtype": "Data",
+      "in_list_view": 1,
       "label": "Reciever Email",
-      "options": "Email"
-    },
-    {
-      "fieldname": "column_break_vhdr",
-      "fieldtype": "Column Break"
+      "options": "Email",
+      "reqd": 1
     },
     {
       "default": "Pending",
@@ -77,7 +80,6 @@
       "fetch_from": "requested_by.full_name",
       "fieldname": "sender_name",
       "fieldtype": "Data",
-      "hidden": 1,
       "label": "Sender Name",
       "read_only": 1
     },
@@ -99,7 +101,7 @@
     }
   ],
   "links": [],
-  "modified": "2024-06-25 13:11:47.195942",
+  "modified": "2024-12-19 18:33:17.914678",
   "modified_by": "Administrator",
   "module": "FOSS Hackathon",
   "name": "FOSS Hackathon Join Team Request",
@@ -145,5 +147,18 @@
   ],
   "sort_field": "modified",
   "sort_order": "DESC",
-  "states": []
+  "states": [
+    {
+      "color": "Orange",
+      "title": "Pending"
+    },
+    {
+      "color": "Green",
+      "title": "Accepted"
+    },
+    {
+      "color": "Red",
+      "title": "Rejected"
+    }
+  ]
 }

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/foss_hackathon_join_team_request.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/foss_hackathon_join_team_request.py
@@ -2,11 +2,13 @@
 # For license information, please see license.txt
 
 import frappe
+import frappe.permissions
 from frappe.model.document import Document
 
 from fossunited.doctype_ids import (
     HACKATHON_PARTICIPANT,
     HACKATHON_TEAM,
+    HACKATHON_TEAM_MEMBER,
     JOIN_TEAM_REQUEST,
 )
 
@@ -20,17 +22,19 @@ class FOSSHackathonJoinTeamRequest(Document):
     if TYPE_CHECKING:
         from frappe.types import DF
 
-        hackathon: DF.Link | None
+        hackathon: DF.Link
         hackathon_name: DF.Data | None
         is_outgoing_request: DF.Check
-        reciever_email: DF.Data | None
-        requested_by: DF.Link | None
+        reciever_email: DF.Data
+        requested_by: DF.Link
         sender_name: DF.Data | None
         status: DF.Literal["Pending", "Accepted", "Rejected"]  # noqa: F821
-        team: DF.Link | None
+        team: DF.Link
         team_name: DF.Data | None
     # end: auto-generated types
-    pass
+
+    def before_insert(self):
+        self.validate_sender_as_member()
 
     def before_save(self):
         if self.has_value_changed("status"):
@@ -60,12 +64,31 @@ class FOSSHackathonJoinTeamRequest(Document):
         requests = frappe.get_all(
             JOIN_TEAM_REQUEST,
             filters={
-                "team": self.team,
+                "hackathon": self.hackathon,
                 "status": "Pending",
                 "reciever_email": self.reciever_email,
+                "name": ["!=", self.name],
             },
+            pluck="name",
         )
         for request in requests:
-            request_doc = frappe.get_doc(JOIN_TEAM_REQUEST, request.name)
+            request_doc = frappe.get_doc(JOIN_TEAM_REQUEST, request)
             request_doc.status = "Rejected"
-            request_doc.save()
+            request_doc.save(ignore_permissions=True)
+
+    def validate_sender_as_member(self):
+        if frappe.permissions.is_system_user(frappe.session.user):
+            return
+
+        participant_id = frappe.db.get_value(
+            HACKATHON_PARTICIPANT, {"user": self.requested_by}, ["name"]
+        )
+
+        is_team_member = frappe.db.exists(
+            HACKATHON_TEAM_MEMBER, {"parent": self.team, "member": participant_id}
+        )
+
+        if not is_team_member:
+            frappe.throw("Request sender is not a team member", frappe.ValidationError)
+
+        return

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/foss_hackathon_join_team_request.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/foss_hackathon_join_team_request.py
@@ -77,6 +77,12 @@ class FOSSHackathonJoinTeamRequest(Document):
             request_doc.save(ignore_permissions=True)
 
     def validate_sender_as_member(self):
+        """
+        Validate that the user sending the invite (session user) is either a member
+        of the team or a has System User role.
+
+        System users should be able to make changes to this doctype for support reasons.
+        """
         if frappe.permissions.is_system_user(frappe.session.user):
             return
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/test_foss_hackathon_join_team_request.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_join_team_request/test_foss_hackathon_join_team_request.py
@@ -1,0 +1,151 @@
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from fossunited.doctype_ids import HACKATHON_TEAM_MEMBER
+from fossunited.tests.utils import (
+    insert_test_hackathon,
+    insert_test_hackathon_join_request,
+    insert_test_hackathon_participant,
+    insert_test_hackathon_team,
+)
+
+
+class TestFOSSHackathonJoinTeamRequest(IntegrationTestCase):
+    def setUp(self):
+        self.hackathon = insert_test_hackathon()
+
+        self.member1 = "test1@example.com"
+        participant = insert_test_hackathon_participant(
+            hackathon_id=self.hackathon.name, user=self.member1, email=self.member1
+        )
+
+        self.team = insert_test_hackathon_team(hackathon=self.hackathon)
+        # add member 1 to self.team
+        self.team.append(
+            "members",
+            {
+                "member": participant.name,
+                "full_name": participant.full_name,
+                "email": participant.email,
+            },
+        )
+        self.team.save()
+
+        self.reciever_email = "test4@example.com"
+        self.reciever_participant = insert_test_hackathon_participant(
+            hackathon_id=self.hackathon.name, user=self.reciever_email, email=self.reciever_email
+        )
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+        self.hackathon.delete(force=True)
+        self.team.delete(force=True)
+
+    def test_sender_is_team_member(self):
+        # Given a team member
+        frappe.set_user(self.member1)
+        # when the user tries to create a join request
+        # then it should be created without any problem
+        insert_test_hackathon_join_request(
+            hackathon_id=self.hackathon.name,
+            team_id=self.team.name,
+            requested_by=self.member1,
+            reciever_email=self.reciever_email,
+        )
+
+        # when a non member tries to send request
+        non_member_user = "test3@example.com"
+        frappe.set_user(non_member_user)
+        # then it should throw a frappe.ValidationError
+        with self.assertRaises(frappe.ValidationError):
+            insert_test_hackathon_join_request(
+                hackathon_id=self.hackathon.name,
+                team_id=self.team.name,
+                requested_by=non_member_user,
+                reciever_email=self.reciever_email,
+            )
+
+    def test_add_to_team(self):
+        # Given a join request
+        frappe.set_user(self.member1)
+        request = insert_test_hackathon_join_request(
+            hackathon_id=self.hackathon.name,
+            team_id=self.team.name,
+            requested_by=self.member1,
+            reciever_email=self.reciever_email,
+        )
+
+        self.assertFalse(
+            frappe.db.exists(
+                HACKATHON_TEAM_MEMBER,
+                {"parent": request.team, "member": self.reciever_participant.name},
+            )
+        )
+
+        # When the request is accepted
+        frappe.set_user(self.reciever_email)
+        request.status = "Accepted"
+        request.save()
+
+        # Then a team member should be added to the request's team
+        self.assertTrue(
+            frappe.db.exists(
+                HACKATHON_TEAM_MEMBER,
+                {"parent": request.team, "member": self.reciever_participant.name},
+            )
+        )
+
+    def test_reject_other_responses(self):
+        team1 = self.team
+        team1_member = self.member1
+        team2 = insert_test_hackathon_team(hackathon=self.hackathon)
+        team2_member = "test2@example.com"
+        team2_participant = insert_test_hackathon_participant(
+            hackathon_id=self.hackathon.name, user=team2_member, email=team2_member
+        )
+        team2.append(
+            "members",
+            {
+                "member": team2_participant.name,
+                "full_name": team2_participant.full_name,
+                "email": team2_participant.email,
+            },
+        )
+        team2.save()
+        team2.reload()
+
+        request_reciever = self.reciever_email
+
+        # As member of team 1
+        frappe.set_user(team1_member)
+        # Create a join request for request_reciever
+        request1 = insert_test_hackathon_join_request(
+            hackathon_id=self.hackathon.name,
+            team_id=team1.name,
+            requested_by=frappe.session.user,
+            reciever_email=request_reciever,
+        )
+        self.assertEqual(request1.status, "Pending")
+
+        # As member of team 2
+        frappe.set_user(team2_member)
+        # create a join request for same request_reciever
+        request2 = insert_test_hackathon_join_request(
+            hackathon_id=self.hackathon.name,
+            team_id=team2.name,
+            requested_by=frappe.session.user,
+            reciever_email=request_reciever,
+        )
+        self.assertEqual(request2.status, "Pending")
+
+        # if the first request is accepted by the reciever
+        frappe.set_user(request_reciever)
+        request1.status = "Accepted"
+        request1.save()
+        request1.reload()
+
+        self.assertEqual(request1.status, "Accepted")
+
+        # Then the second request should be automatically rejected
+        request2.reload()
+        self.assertEqual(request2.status, "Rejected")

--- a/fossunited/tests/utils.py
+++ b/fossunited/tests/utils.py
@@ -11,6 +11,7 @@ from fossunited.doctype_ids import (
     HACKATHON,
     HACKATHON_PARTICIPANT,
     HACKATHON_TEAM,
+    JOIN_TEAM_REQUEST,
     RSVP_RESPONSE,
     USER_PROFILE,
 )
@@ -435,3 +436,35 @@ def insert_test_hackathon_participant(hackathon_id: str, **kwargs):
     participant.reload()
 
     return participant
+
+
+def insert_test_hackathon_join_request(
+    hackathon_id: str, team_id: str, requested_by: str, reciever_email: str, **kwargs
+):
+    """
+    Generate a test hackathon join request with flexible configuration options.
+    Args:
+        hackathon_id (str): The ID of the hackathon to link the join request to.
+        team_id (str): The ID of the team to link the join request to.
+        requested_by(str): The user id of the user sending the request.
+        reciever_email (str): The email of the recipient of the join request.
+        **kwargs: Additional arguments to be passed to the join request document.
+    Returns:
+        request doc: Created hackathon join request document
+    Raises:
+        Exception: For any unexpected errors during join request generation
+    """
+    request_data = {
+        "doctype": JOIN_TEAM_REQUEST,
+        "hackathon": hackathon_id,
+        "team": team_id,
+        "requested_by": requested_by,
+        "reciever_email": reciever_email,
+    }
+    for key, value in kwargs.items():
+        if key not in request_data:
+            request_data[key] = value
+    request = frappe.get_doc(request_data)
+    request.insert()
+    request.reload()
+    return request


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Test

## Description
Add tests for `Hackathon Team Join Request` doctype
- Test that only a team member can send requests from a specific team.
- Test that acceptance workflow is working
- Made changes to the doctype to define the mandatory fields in a better way
<!-- Briefly describe the changes introduced by this pull request -->

## Related Issues & Docs
partial #727 
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->