### PR TITLE
fix: buggy "Pending Review" count

### DIFF
--- a/dashboard/src/components/reviewers/ReviewListItem.vue
+++ b/dashboard/src/components/reviewers/ReviewListItem.vue
@@ -15,7 +15,7 @@
         <span class="text-sm text-gray-800">Submissions: {{ event.submission_count }}</span>
         <span class="text-sm md:pl-2 text-green-800">Reviewed: {{ event.reviewed_count }}</span>
         <span class="text-sm md:pl-2 text-orange-800"
-          >Pending Review: {{ event.reviewed_count }}</span
+          >Pending Review: {{ event.not_reviewed_count }}</span
         >
       </div>
     </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛Bug Fix

## Description
- `Pending Review` and `Reviewed`  were accessing the same key of event prop which led to the bug.
- Now accessing the correct `not_reviewed_count` key
<!-- Briefly describe the changes introduced by this pull request -->

## Related Issues & Docs
closes #737 
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
