### PR TITLE
feat: RSVP Acceptance workflow

### DIFF
--- a/fossunited/api/emailing.py
+++ b/fossunited/api/emailing.py
@@ -67,7 +67,7 @@ def add_to_email_group(email_group: str, email: str):
         frappe.throw("This email group does not exist", frappe.DoesNotExistError)
 
     if frappe.db.exists(EMAIL_MEMBER, {"email_group": email_group, "email": email}):
-        frappe.throw("Email already a part of this email group", frappe.ValidationError)
+        frappe.throw("Email already a part of this email group", frappe.DuplicateEntryError)
 
     member = frappe.get_doc({"doctype": EMAIL_MEMBER, "email_group": email_group, "email": email})
     member.insert(ignore_permissions=True)

--- a/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.json
+++ b/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.json
@@ -13,6 +13,7 @@
     "column_break_vitn",
     "is_published",
     "section_break_ioxz",
+    "requires_host_approval",
     "allow_edit",
     "column_break_rwlt",
     "rsvp_count",
@@ -38,7 +39,8 @@
       "fieldtype": "Link",
       "in_list_view": 1,
       "label": "Event",
-      "options": "FOSS Chapter Event"
+      "options": "FOSS Chapter Event",
+      "reqd": 1
     },
     {
       "fieldname": "column_break_yrzh",
@@ -100,7 +102,7 @@
       "default": "0",
       "fieldname": "allow_edit",
       "fieldtype": "Check",
-      "label": "Allow RSVP Edit"
+      "label": "Allow Submission Edit"
     },
     {
       "default": "100",
@@ -120,13 +122,26 @@
       "fieldname": "event_name",
       "fieldtype": "Data",
       "label": "Event Name"
+    },
+    {
+      "default": "0",
+      "description": "Enable for host-enabled participant selection.\n\nIf unchecked, all the participants will be auto accepted.",
+      "fieldname": "requires_host_approval",
+      "fieldtype": "Check",
+      "label": "Requires Host Approval"
     }
   ],
   "has_web_view": 1,
   "index_web_pages_for_search": 1,
   "is_published_field": "is_published",
-  "links": [],
-  "modified": "2024-07-08 15:02:08.772824",
+  "links": [
+    {
+      "group": "Submissions",
+      "link_doctype": "FOSS Event RSVP Submission",
+      "link_fieldname": "linked_rsvp"
+    }
+  ],
+  "modified": "2024-12-20 16:37:53.619977",
   "modified_by": "Administrator",
   "module": "Chapters",
   "name": "FOSS Event RSVP",

--- a/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.py
@@ -24,15 +24,16 @@ class FOSSEventRSVP(WebsiteGenerator):
         allow_edit: DF.Check
         chapter: DF.Data | None
         custom_questions: DF.Table[FOSSCustomQuestion]
-        event: DF.Link | None
+        event: DF.Link
         event_name: DF.Data | None
         is_published: DF.Check
         max_rsvp_count: DF.Int
+        requires_host_approval: DF.Check
         route: DF.Data | None
         rsvp_count: DF.Int
         rsvp_description: DF.TextEditor | None
-
     # end: auto-generated types
+
     def before_save(self):
         self.set_route()
         self.enable_rsvp_tab()

--- a/fossunited/chapters/doctype/foss_event_rsvp/templates/foss_event_rsvp.html
+++ b/fossunited/chapters/doctype/foss_event_rsvp/templates/foss_event_rsvp.html
@@ -98,13 +98,21 @@
   <div class="form-container my-5">
     <div class="foss-form-header submitted-container">
       <h3 class="foss-form-heading-3xl">
-        {{ _("You have successfully RSVP'd for this event!") }} <i class="ti ti-rocket"></i>
+        {% if doc.requires_host_approval %}
+          {{ _("RSVP Submitted for Approval") }}
+        {% else %}
+          {{ _("You have successfully RSVP'd for this event!") }} <i class="ti ti-rocket"></i>
+        {% endif %}
       </h3>
       <div class="foss-form-description">
-        {{
-          _("You have successfully RSVP'd for this event. If you need to make any changes, you can
-          edit the rsvp form.")
-        }}
+        {% if doc.requires_host_approval %}
+          {{ _("Your RSVP has been submitted for approval. You will receive an email once your RSVP has been approved.") }}
+        {% else %}
+          {{
+            _("You have successfully RSVP'd for this event. If you need to make any changes, you can
+            edit the rsvp form.")
+          }}
+        {% endif %}
       </div>
       <button onclick="window.location.pathname+='/{{ submission }}/edit'">
         Edit RSVP Response

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.json
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.json
@@ -14,6 +14,7 @@
     "column_break_tpys",
     "submitted_by",
     "chapter",
+    "status",
     "standard_questions_section",
     "name1",
     "im_a",
@@ -123,10 +124,17 @@
       "label": "Email",
       "options": "Email",
       "reqd": 1
+    },
+    {
+      "default": "Pending",
+      "fieldname": "status",
+      "fieldtype": "Select",
+      "label": "Status",
+      "options": "Pending\nAccepted\nRejected"
     }
   ],
   "links": [],
-  "modified": "2024-11-15 15:14:23.920437",
+  "modified": "2024-12-20 15:16:07.795271",
   "modified_by": "Administrator",
   "module": "Chapters",
   "name": "FOSS Event RSVP Submission",
@@ -163,6 +171,19 @@
   ],
   "sort_field": "modified",
   "sort_order": "DESC",
-  "states": [],
+  "states": [
+    {
+      "color": "Yellow",
+      "title": "Pending"
+    },
+    {
+      "color": "Green",
+      "title": "Accepted"
+    },
+    {
+      "color": "Red",
+      "title": "Rejected"
+    }
+  ],
   "track_changes": 1
 }

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
@@ -27,6 +27,7 @@ class FOSSEventRSVPSubmission(Document):
         im_a: DF.Literal["", "Student", "Professional", "FOSS Enthusiast", "Other"]  # noqa: F722, F821
         linked_rsvp: DF.Link
         name1: DF.Data
+        status: DF.Literal["Pending", "Accepted", "Rejected"]  # noqa: F722, F821
         submitted_by: DF.Link | None
     # end: auto-generated types
 
@@ -36,6 +37,7 @@ class FOSSEventRSVPSubmission(Document):
         self.validate_linked_rsvp_exists()
 
     def after_insert(self):
+        self.handle_submission_status()
         self.close_rsvp_on_max_count()
         self.handle_add_to_email_group()
 
@@ -57,6 +59,25 @@ class FOSSEventRSVPSubmission(Document):
     def get_max_count(self):
         max_count = frappe.db.get_value(EVENT_RSVP, self.linked_rsvp, "max_rsvp_count")
         return max_count
+
+    def handle_submission_status(self):
+        # Check if the RSVP is accepting all incoming responses
+        requires_host_approval = bool(
+            frappe.db.get_value(EVENT_RSVP, self.linked_rsvp, "requires_host_approval")
+        )
+
+        # If requires_host_approval == True, but the status is accepted at time of creation,
+        # Throw a frappe.PermissionError
+        if requires_host_approval and self.status == "Accepted":
+            frappe.throw("Invalid action. Status cannot be `Accepted`.", frappe.PermissionError)
+
+        # If the RSVP is accepting all incoming responses, set the status to accepted
+        if requires_host_approval:
+            self.status = "Pending"
+            return
+
+        # If the RSVP is not accepting all incoming responses, set the status to pending
+        self.status = "Accepted"
 
     def validate_linked_rsvp_exists(self):
         if not frappe.db.exists(EVENT_RSVP, self.linked_rsvp):

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
@@ -71,12 +71,12 @@ class FOSSEventRSVPSubmission(Document):
         if requires_host_approval and self.status == "Accepted":
             frappe.throw("Invalid action. Status cannot be `Accepted`.", frappe.PermissionError)
 
-        # If the RSVP is accepting all incoming responses, set the status to accepted
+        # If the RSVP requires host approval, set the status to Pending
         if requires_host_approval:
             self.status = "Pending"
             return
 
-        # If the RSVP is not accepting all incoming responses, set the status to pending
+        # If the RSVP does not require host approval, set the status to Accepted
         self.status = "Accepted"
 
     def validate_linked_rsvp_exists(self):

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
@@ -31,9 +31,15 @@ class TestFOSSEventRSVPSubmission(IntegrationTestCase):
         # Given an RSVP form with max count
         rsvp = self.rsvp
 
+        # We are using distinct emails here to avoid any unintended duplicate error.
+        # So that we can insert the max count of submissions
+        emails = set()
+        while len(emails) < int(rsvp.max_rsvp_count):
+            emails.add(fake.email())
+
         # When submission count reaches the max count
-        for _ in range(int(rsvp.max_rsvp_count)):
-            insert_rsvp_submission(linked_rsvp=self.rsvp.name)
+        for email in emails:
+            insert_rsvp_submission(linked_rsvp=self.rsvp.name, email=email)
 
         # Then the RSVP must be unpublished
         is_published = frappe.db.get_value(EVENT_RSVP, rsvp.name, "is_published")

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
@@ -80,6 +80,28 @@ class TestFOSSEventRSVPSubmission(IntegrationTestCase):
         # Then the submission status should be pending
         self.assertTrue(submission.status, "Pending")
 
+    def test_pending_to_acceptance_workflow(self):
+        # Given an rsvp with requires_host_approval = True
+        rsvp = self.rsvp
+        rsvp.requires_host_approval = True
+        rsvp.save()
+
+        frappe.set_user(WEBSITE_USER)
+        # When a submission is created
+        submission = insert_rsvp_submission(linked_rsvp=rsvp.name)
+        # The status should be pending
+        self.assertTrue(submission.status, "Pending")
+
+        # Now, as the chapter member,
+        frappe.set_user("test1@example.com")
+        # We know `test1@example.com` is a chapter member
+        # because of how insert_test_chapter is implemented
+
+        # When the submission is accepted
+        submission.status = "Accepted"
+        # Then it should save without any errors
+        submission.save()
+
     def test_invalid_status_at_creation(self):
         # Given an rsvp with requires_host_approval = False
         rsvp = self.rsvp

--- a/fossunited/tests/utils.py
+++ b/fossunited/tests/utils.py
@@ -222,6 +222,8 @@ def insert_rsvp_form(event: str, **kwargs):
         event (str or dict, optional): Linked event for the RSVP form.
                 If not provided, a new test event will be generated.
         allow_edit (bool, optional): Whether RSVP can be edited. Defaults to True.
+        requires_host_approval(bool, optional): Whether to accept all incoming RSVPs.
+                Default: False.
         max_rsvp_count (int, optional): Maximum number of RSVPs. Defaults to 100.
         rsvp_description (str, optional): Description for the RSVP form.
         custom_questions (list, optional): List of custom questions for the RSVP form.
@@ -255,6 +257,7 @@ def insert_rsvp_form(event: str, **kwargs):
             "allow_edit": kwargs.get("allow_edit", 1),  # Default to allowing edits
             "event": event_name,
             "max_rsvp_count": kwargs.get("max_rsvp_count", 100),
+            "requires_host_approval": kwargs.get("requires_host_approval", False),
             "rsvp_description": kwargs.get(
                 "rsvp_description", fake.text(max_nb_chars=200).strip()
             ),
@@ -313,6 +316,7 @@ def insert_rsvp_submission(linked_rsvp: str, **kwargs):
             "name1": kwargs.get("name", fake.name()),
             "im_a": kwargs.get("im_a", "Professional"),
             "email": kwargs.get("email", fake.email()),
+            "status": kwargs.get("status", "Pending"),
             "confirm_attendance": kwargs.get("confirm_attendance", 1),
             "custom_answers": kwargs.get("custom_answers", []),
         }

--- a/fossunited/tests/utils.py
+++ b/fossunited/tests/utils.py
@@ -256,7 +256,7 @@ def insert_rsvp_form(event: str, **kwargs):
             "doctype": EVENT_RSVP,
             "allow_edit": kwargs.get("allow_edit", 1),  # Default to allowing edits
             "event": event_name,
-            "max_rsvp_count": kwargs.get("max_rsvp_count", 100),
+            "max_rsvp_count": kwargs.get("max_rsvp_count", 5),
             "requires_host_approval": kwargs.get("requires_host_approval", False),
             "rsvp_description": kwargs.get(
                 "rsvp_description", fake.text(max_nb_chars=200).strip()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕Feature

## Description

<!-- Briefly describe the changes introduced by this pull request -->
Give organizers the ability to cherry pick and accept RSVPs for specific events

Also added a variant success page message:
![image](https://github.com/user-attachments/assets/53273086-0237-43ad-80bd-185c6aaedee6)


## Related Issues & Docs
#739 

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
