### PR TITLE
FEAT: Add chapter info for external events associated with chapter

### DIFF
--- a/fossunited/templates/macros/event_card.html
+++ b/fossunited/templates/macros/event_card.html
@@ -13,11 +13,8 @@
     {% endif %}
   >
     <div class="event-card-contents">
-      {% if not event.is_external_event %}
-        {%
-          set chapter = frappe.get_doc("FOSS Chapter",
-          event.chapter)
-        %}
+      {% set chapter = frappe.get_doc("FOSS Chapter", event.chapter) %}
+      {% if chapter %}
         <div
           class="chapter-brand-block {% if chapter.chapter_type == 'FOSS Club' %}club-brand{% endif %}"
         >

--- a/fossunited/templates/macros/event_card.html
+++ b/fossunited/templates/macros/event_card.html
@@ -13,8 +13,8 @@
     {% endif %}
   >
     <div class="event-card-contents">
-      {% set chapter = frappe.get_doc("FOSS Chapter", event.chapter) %}
-      {% if chapter %}
+      {% if event.chapter %}
+        {% set chapter = frappe.get_doc("FOSS Chapter", event.chapter) %}
         <div
           class="chapter-brand-block {% if chapter.chapter_type == 'FOSS Club' %}club-brand{% endif %}"
         >


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕Feature

## Description

For any event, if there is no chapter info, it is left empty in the event card. If chapter info is provided, always display it - for both chapter events + external events.

## Related Issues & Docs

fixes #746 

## Checklist

- [x] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [x] I have tested these changes locally.
- [ ] ~I have updated the documentation (If applicable).~
- [x] The code follows the project's coding standards.
- [ ] ~I have added/updated tests, if applicable.~

## Screenshots/GIFs/Screen Recordings (if applicable)

![Screenshot from 2024-12-26 13-41-52](https://github.com/user-attachments/assets/8fa60f3f-b825-46e4-819d-25198d36d5f7)