### PR TITLE
FEAT: Display IM rooms for foss chapters on page

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.json
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.json
@@ -37,6 +37,8 @@
     "instagram",
     "mastodon",
     "telegram",
+    "whatsapp",
+    "discord",
     "chapter_members_section",
     "chapter_members",
     "chapter_lead"
@@ -233,7 +235,19 @@
       "fieldtype": "Data",
       "label": "Telegram",
       "options": "URL"
-    }
+   },
+   {
+      "fieldname": "whatsapp",
+      "fieldtype": "Data",
+      "label": "WhatsApp",
+      "options": "URL"
+   },
+   {
+      "fieldname": "discord",
+      "fieldtype": "Data",
+      "label": "Discord",
+      "options": "URL"
+   }
   ],
   "has_web_view": 1,
   "index_web_pages_for_search": 1,
@@ -244,7 +258,7 @@
       "link_fieldname": "chapter"
     }
   ],
-  "modified": "2024-12-26 14:14:33.228467",
+  "modified": "2024-12-26 15:16:37.306667",
   "modified_by": "Administrator",
   "module": "Chapters",
   "name": "FOSS Chapter",

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.json
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.json
@@ -36,6 +36,7 @@
     "facebook",
     "instagram",
     "mastodon",
+    "telegram",
     "chapter_members_section",
     "chapter_members",
     "chapter_lead"
@@ -226,6 +227,12 @@
       "fieldtype": "Data",
       "label": "Slug",
       "unique": 1
+    },
+    {
+      "fieldname": "telegram",
+      "fieldtype": "Data",
+      "label": "Telegram",
+      "options": "URL"
     }
   ],
   "has_web_view": 1,
@@ -237,7 +244,7 @@
       "link_fieldname": "chapter"
     }
   ],
-  "modified": "2024-09-24 14:07:16.754531",
+  "modified": "2024-12-26 14:14:33.228467",
   "modified_by": "Administrator",
   "module": "Chapters",
   "name": "FOSS Chapter",

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
@@ -41,9 +41,10 @@ class FOSSChapter(WebsiteGenerator):
         route: DF.Data | None
         slug: DF.Data | None
         state: DF.Link | None
+        telegram: DF.Data | None
         x: DF.Data | None
-
     # end: auto-generated types
+
     def before_insert(self):
         self.handle_member_addition()
 
@@ -245,6 +246,8 @@ class FOSSChapter(WebsiteGenerator):
             "youtube",
             "medium",
             "facebook",
+            "matrix",
+            "telegram",
         ]
         for k, v in self.as_dict().items():
             if k in SOCIAL_LINK_FIELDNAMES:

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
@@ -28,6 +28,7 @@ class FOSSChapter(WebsiteGenerator):
         chapter_type: DF.Literal["City Community", "FOSS Club", "Conference"]  # noqa: F722, F821
         city: DF.Link | None
         country: DF.Link | None
+        discord: DF.Data | None
         email: DF.Data
         facebook: DF.Data | None
         google_map_link: DF.Data | None
@@ -42,6 +43,7 @@ class FOSSChapter(WebsiteGenerator):
         slug: DF.Data | None
         state: DF.Link | None
         telegram: DF.Data | None
+        whatsapp: DF.Data | None
         x: DF.Data | None
     # end: auto-generated types
 
@@ -248,6 +250,8 @@ class FOSSChapter(WebsiteGenerator):
             "facebook",
             "matrix",
             "telegram",
+            "whatsapp",
+            "discord",
         ]
         for k, v in self.as_dict().items():
             if k in SOCIAL_LINK_FIELDNAMES:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕Feature

## Description

The FOSS Chapter already had a field to store matrix IM room info. This PR updates the doctype to also have a Telegram, WhatsApp, Discord URL fields. These fields are now shown as part of the social links on the event page.

## Related Issues & Docs

fixes https://github.com/fossunited/fossunited/issues/707  

## Checklist

- [x] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [x] I have tested these changes locally.
- [ ] I have updated the documentation (If applicable).
- [x] The code follows the project's coding standards.
- [ ] ~I have added/updated tests, if applicable.~

## Screenshots/GIFs/Screen Recordings (if applicable)

![Screenshot from 2024-12-26 14-47-52](https://github.com/user-attachments/assets/33f618ea-9679-4a23-802c-ec58d2009128)