### PR TITLE
feat: email workflow for hackathon participants

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.json
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.json
@@ -235,19 +235,19 @@
       "fieldtype": "Data",
       "label": "Telegram",
       "options": "URL"
-   },
-   {
+    },
+    {
       "fieldname": "whatsapp",
       "fieldtype": "Data",
       "label": "WhatsApp",
       "options": "URL"
-   },
-   {
+    },
+    {
       "fieldname": "discord",
       "fieldtype": "Data",
       "label": "Discord",
       "options": "URL"
-   }
+    }
   ],
   "has_web_view": 1,
   "index_web_pages_for_search": 1,

--- a/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
@@ -5,7 +5,8 @@ from datetime import datetime
 import frappe
 from frappe.website.website_generator import WebsiteGenerator
 
-from fossunited.doctype_ids import CHAPTER, HACKATHON_PROJECT, PROPOSAL, USER_PROFILE
+from fossunited.api.emailing import create_email_group
+from fossunited.doctype_ids import CHAPTER, HACKATHON, HACKATHON_PROJECT, PROPOSAL, USER_PROFILE
 
 no_cache = 1
 
@@ -66,6 +67,13 @@ class FOSSHackathon(WebsiteGenerator):
 
     def before_save(self):
         self.set_route()
+
+    def after_insert(self):
+        create_email_group(
+            type="Event Participants",
+            reference_document=self.name,
+            document_type=HACKATHON,
+        )
 
     def set_route(self):
         if self.permalink:

--- a/fossunited/foss_hackathon/doctype/foss_hackathon/test_foss_hackathon.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/test_foss_hackathon.py
@@ -1,6 +1,7 @@
 import frappe
 from frappe.tests import IntegrationTestCase
 
+from fossunited.doctype_ids import EMAIL_GROUP, HACKATHON
 from fossunited.tests.utils import insert_test_chapter, insert_test_hackathon
 
 
@@ -22,3 +23,37 @@ class TestFOSSHackathon(IntegrationTestCase):
                 self.hackathon.route,
                 f"hack/{self.hackathon.hackathon_name.lower().replace(' ', '-')}",
             )
+
+    def test_email_group_creation_on_create(self):
+        # When the self.hackathon was created
+        # An email group must have been created linked to this hackathon
+        self.assertIsNotNone(
+            frappe.db.exists(
+                EMAIL_GROUP,
+                {
+                    "document_type": HACKATHON,
+                    "reference_document": self.hackathon.name,
+                    "group_type": "Event Participants",
+                },
+            )
+        )
+        # Asserting that there's only 1 email group of document type Hackathon
+        self.assertEqual(frappe.db.count(EMAIL_GROUP, {"document_type": HACKATHON}), 1)
+
+        # When a new hackathon is created
+        new_hackathon = insert_test_hackathon(chapter=self.chapter.name)
+        # Then a new email group linked to this new hackathon must be created
+        self.assertIsNotNone(
+            frappe.db.exists(
+                EMAIL_GROUP,
+                {
+                    "document_type": HACKATHON,
+                    "reference_document": new_hackathon.name,
+                    "group_type": "Event Participants",
+                },
+            )
+        )
+        # Assert that the email group count increases for document type of Hackathon
+        self.assertEqual(frappe.db.count(EMAIL_GROUP, {"document_type": HACKATHON}), 2)
+
+        new_hackathon.delete(force=True)

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.json
@@ -64,7 +64,8 @@
       "fieldname": "hackathon",
       "fieldtype": "Link",
       "label": "Hackathon",
-      "options": "FOSS Hackathon"
+      "options": "FOSS Hackathon",
+      "reqd": 1
     },
     {
       "fieldname": "meta_section",
@@ -128,7 +129,7 @@
     }
   ],
   "links": [],
-  "modified": "2024-07-18 10:44:30.991416",
+  "modified": "2024-12-29 17:10:32.240540",
   "modified_by": "Administrator",
   "module": "FOSS Hackathon",
   "name": "FOSS Hackathon Participant",

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/test_foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/test_foss_hackathon_participant.py
@@ -1,0 +1,112 @@
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from fossunited.doctype_ids import EMAIL_GROUP, EMAIL_MEMBER, HACKATHON, USER_PROFILE
+from fossunited.tests.utils import (
+    insert_test_chapter,
+    insert_test_hackathon,
+    insert_test_hackathon_localhost,
+    insert_test_hackathon_participant,
+)
+
+
+class TestFOSSHackathonParticipant(IntegrationTestCase):
+    def setUp(self):
+        self.LOCALHOST_ORGANIZER = "test3@example.com"
+        self.PARTICIPANT_1 = "test1@example.com"
+        self.PARTICIPANT_2 = "test2@example.com"
+        self.chapter = insert_test_chapter()
+        self.hackathon = insert_test_hackathon(chapter=self.chapter.name)
+        self.participant_1 = insert_test_hackathon_participant(
+            hackathon_id=self.hackathon.name,
+            email=self.PARTICIPANT_1,
+            user=self.PARTICIPANT_1,
+        )
+        self.localhost = insert_test_hackathon_localhost(
+            parent_hackathon=self.hackathon.name,
+            organizers=[
+                {
+                    "profile": frappe.get_doc(
+                        USER_PROFILE,
+                        {"user": self.LOCALHOST_ORGANIZER},
+                    ),
+                }
+            ],
+        )
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+        self.participant_1.delete(force=True)
+        self.hackathon.delete(force=True)
+        self.chapter.delete(force=True)
+
+    def test_participant_creation(self):
+        # Testing that website users have the permission to create Participant doctype
+        frappe.set_user(self.PARTICIPANT_2)
+
+        participant = insert_test_hackathon_participant(
+            hackathon_id=self.hackathon.name,
+            email=frappe.session.user,
+            user=frappe.session.user,
+        )
+
+        participant.delete(force=True, ignore_permissions=True)
+
+    def test_add_to_email_group(self):
+        frappe.set_user(self.PARTICIPANT_2)
+
+        # Given a hackathon
+        # When a participant registers for this hackathon
+        participant = insert_test_hackathon_participant(
+            hackathon_id=self.hackathon.name,
+            email=frappe.session.user,
+            user=frappe.session.user,
+        )
+
+        email_group_id = frappe.db.get_value(
+            EMAIL_GROUP,
+            {
+                "document_type": HACKATHON,
+                "reference_document": self.hackathon.name,
+                "group_type": "Event Participants",
+            },
+            "name",
+        )
+
+        # Then that participant email should be added to an email group linked to the hackathon
+        self.assertIsNotNone(
+            frappe.db.exists(
+                EMAIL_MEMBER,
+                {
+                    "email_group": email_group_id,
+                    "email": frappe.session.user,
+                },
+            )
+        )
+
+        participant.delete(force=True, ignore_permissions=True)
+
+    def test_localhost_rejection(self):
+        frappe.set_user(self.PARTICIPANT_1)
+        # Given a participant who wants to attend hackathon locally
+        self.participant_1.wants_to_attend_locally = 1
+        self.participant_1.localhost = self.localhost.name
+        self.participant_1.save()
+
+        self.assertEqual(self.participant_1.localhost_request_status, "Pending")
+
+        # When the application is rejected by organizer
+        frappe.set_user(self.LOCALHOST_ORGANIZER)
+        self.participant_1.localhost_request_status = "Rejected"
+        self.participant_1.save()
+
+        # Then participant mode should be auto changed to removed
+        self.assertFalse(self.participant_1.wants_to_attend_locally)
+
+        # When the participant tries to apply for the same localhost again
+        frappe.set_user(self.PARTICIPANT_1)
+        self.participant_1.wants_to_attend_locally = 1
+        self.participant_1.localhost = self.localhost.name
+        # Then a permission error should be thrown
+        with self.assertRaises(frappe.PermissionError):
+            self.participant_1.save()

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/test_foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/test_foss_hackathon_participant.py
@@ -37,6 +37,7 @@ class TestFOSSHackathonParticipant(IntegrationTestCase):
     def tearDown(self):
         frappe.set_user("Administrator")
         self.participant_1.delete(force=True)
+        self.localhost.delete(force=True)
         self.hackathon.delete(force=True)
         self.chapter.delete(force=True)
 
@@ -107,6 +108,8 @@ class TestFOSSHackathonParticipant(IntegrationTestCase):
         frappe.set_user(self.PARTICIPANT_1)
         self.participant_1.wants_to_attend_locally = 1
         self.participant_1.localhost = self.localhost.name
+
+        self.assertEqual(self.participant_1.localhost_request_status, "Rejected")
         # Then a permission error should be thrown
         with self.assertRaises(frappe.PermissionError):
             self.participant_1.save()

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/test_foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/test_foss_hackathon_participant.py
@@ -13,7 +13,7 @@ from fossunited.tests.utils import (
 class TestFOSSHackathonParticipant(IntegrationTestCase):
     def setUp(self):
         self.LOCALHOST_ORGANIZER = "test3@example.com"
-        self.PARTICIPANT_1 = "test1@example.com"
+        self.PARTICIPANT_1 = "test4@example.com"
         self.PARTICIPANT_2 = "test2@example.com"
         self.chapter = insert_test_chapter()
         self.hackathon = insert_test_hackathon(chapter=self.chapter.name)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕Feature
- [x] Test

## Description

<!-- Briefly describe the changes introduced by this pull request -->

- Participant emails are now added to hackathon specific email groups of type "Event Participants"
- Tests added to make code more robust
- `Hackathon` field made mandatory in participant doctype
- Workflow added to create email groups at the time of Hackathon creation.

## Related Issues & Docs
#742 
#727 
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
