### PR TITLE
FIX: Pull external event info for past events in chapter page

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
@@ -213,6 +213,8 @@ class FOSSChapter(WebsiteGenerator):
                 "banner_image",
                 "must_attend",
                 "event_location",
+                "is_external_event",
+                "external_event_url",
             ],
             order_by="event_end_date desc",
             page_length=999,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛Bug Fix

## Description

previously, we werent loading this information when displaying past events on the chapter timeline. in contrast, for the full events timeline, we load all of the event information. because of this, the external events associated with a chapter that are now displayed in the timeline don't work as expected i.e. they dont redirect to the external url when clicked.

this commit fixes this problem by simply loading the necessary info from the database when passing the event info to the UI

## Related Issues & Docs

see related #741 

## Checklist

- [x] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [x] I have tested these changes locally.
- [ ] I have updated the documentation (If applicable).
- [x] The code follows the project's coding standards.
- [ ] ~I have added/updated tests, if applicable.~