### PR TITLE
fix: rsvp status change error after unpublish

### DIFF
--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
@@ -1,6 +1,7 @@
 import frappe
 from frappe.model.document import Document
 
+from fossunited.api.chapter import check_if_chapter_member
 from fossunited.api.emailing import add_to_email_group, create_email_group
 from fossunited.doctype_ids import EVENT, EVENT_RSVP, RSVP_RESPONSE
 
@@ -31,15 +32,33 @@ class FOSSEventRSVPSubmission(Document):
         submitted_by: DF.Link | None
     # end: auto-generated types
 
-    pass
-
     def validate(self):
         self.validate_linked_rsvp_exists()
+
+    def before_insert(self):
+        self.validate_rsvp_is_published()
 
     def after_insert(self):
         self.handle_submission_status()
         self.close_rsvp_on_max_count()
         self.handle_add_to_email_group()
+
+    def validate_linked_rsvp_exists(self):
+        if not frappe.db.exists(EVENT_RSVP, self.linked_rsvp):
+            frappe.throw("Invalid RSVP", frappe.DoesNotExistError)
+
+    def validate_rsvp_is_published(self):
+        is_system_user = frappe.get_roles(frappe.session.user).count("System Manager")
+        is_chapter_member = check_if_chapter_member(chapter=self.chapter, user=frappe.session.user)
+
+        # If the user is system user or team member,
+        # don't check for validation before rsvp submission creation
+        if is_system_user or is_chapter_member:
+            return
+
+        rsvp_published = frappe.db.get_value(EVENT_RSVP, self.linked_rsvp, "is_published")
+        if not rsvp_published:
+            frappe.throw("RSVP is not published")
 
     def close_rsvp_on_max_count(self):
         max_count = self.get_max_count()
@@ -78,14 +97,6 @@ class FOSSEventRSVPSubmission(Document):
 
         # If the RSVP does not require host approval, set the status to Accepted
         self.status = "Accepted"
-
-    def validate_linked_rsvp_exists(self):
-        if not frappe.db.exists(EVENT_RSVP, self.linked_rsvp):
-            frappe.throw("Invalid RSVP", frappe.DoesNotExistError)
-
-        is_rsvp_published = frappe.db.get_value(EVENT_RSVP, self.linked_rsvp, "is_published")
-        if not is_rsvp_published:
-            frappe.throw("RSVP is not published", frappe.PermissionError)
 
     def handle_add_to_email_group(self):
         if not frappe.db.exists(

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
@@ -43,6 +43,10 @@ class FOSSEventRSVPSubmission(Document):
         self.close_rsvp_on_max_count()
         self.handle_add_to_email_group()
 
+    def before_save(self):
+        if self.has_value_changed("status") and not self.is_new():
+            self.handle_add_to_email_group()
+
     def validate_linked_rsvp_exists(self):
         if not frappe.db.exists(EVENT_RSVP, self.linked_rsvp):
             frappe.throw("Invalid RSVP", frappe.DoesNotExistError)
@@ -99,6 +103,9 @@ class FOSSEventRSVPSubmission(Document):
         self.status = "Accepted"
 
     def handle_add_to_email_group(self):
+        if self.status != "Accepted":
+            return
+
         if not frappe.db.exists(
             "Email Group",
             {

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
@@ -37,9 +37,9 @@ class FOSSEventRSVPSubmission(Document):
 
     def before_insert(self):
         self.validate_rsvp_is_published()
+        self.handle_submission_status()
 
     def after_insert(self):
-        self.handle_submission_status()
         self.close_rsvp_on_max_count()
         self.handle_add_to_email_group()
 

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
@@ -21,6 +21,14 @@ class TestFOSSEventRSVPSubmission(IntegrationTestCase):
         self.chapter = insert_test_chapter()
         self.event = insert_test_event(chapter=self.chapter)
         self.rsvp = insert_rsvp_form(event=self.event.name)
+        self.email_group = frappe.db.get_value(
+            "Email Group",
+            {
+                "reference_document": self.rsvp.event,
+                "document_type": EVENT,
+                "group_type": "Event Participants",
+            },
+        )
 
     def tearDown(self):
         frappe.set_user("Administrator")
@@ -49,22 +57,13 @@ class TestFOSSEventRSVPSubmission(IntegrationTestCase):
     def test_add_to_email_group(self):
         # Given an RSVP form for an event
         # When an RSVP response is done by a user
-        frappe.set_user(WEBSITE_USER)
+        frappe.set_user("Guest")
         insert_rsvp_submission(linked_rsvp=self.rsvp.name, email=WEBSITE_USER)
 
         # Then the email should be added to an email group linked to event for participants
-        email_group = frappe.db.get_value(
-            "Email Group",
-            {
-                "reference_document": self.rsvp.event,
-                "document_type": EVENT,
-                "group_type": "Event Participants",
-            },
-        )
-
         self.assertTrue(
             frappe.db.exists(
-                "Email Group Member", {"email": WEBSITE_USER, "email_group": email_group}
+                "Email Group Member", {"email": WEBSITE_USER, "email_group": self.email_group}
             )
         )
 
@@ -72,7 +71,7 @@ class TestFOSSEventRSVPSubmission(IntegrationTestCase):
         # Given an RSVP form with accept all incoming responses
         rsvp = self.rsvp
 
-        frappe.set_user(WEBSITE_USER)
+        frappe.set_user("Guest")
         # When a submission is done
         submission = insert_rsvp_submission(linked_rsvp=rsvp.name)
 
@@ -85,7 +84,7 @@ class TestFOSSEventRSVPSubmission(IntegrationTestCase):
         rsvp.requires_host_approval = True
         rsvp.save()
 
-        frappe.set_user(WEBSITE_USER)
+        frappe.set_user("Guest")
         # When a submission is created
         submission = insert_rsvp_submission(linked_rsvp=rsvp.name)
 
@@ -98,7 +97,7 @@ class TestFOSSEventRSVPSubmission(IntegrationTestCase):
         rsvp.requires_host_approval = True
         rsvp.save()
 
-        frappe.set_user(WEBSITE_USER)
+        frappe.set_user("Guest")
         # When a submission is created
         submission = insert_rsvp_submission(linked_rsvp=rsvp.name)
         # The status should be pending
@@ -120,7 +119,7 @@ class TestFOSSEventRSVPSubmission(IntegrationTestCase):
         rsvp.requires_host_approval = True
         rsvp.save()
 
-        frappe.set_user(WEBSITE_USER)
+        frappe.set_user("Guest")
         # When a submission is done with status accepted
         # Then a frappe.PermissionError should be raised
         with self.assertRaises(frappe.PermissionError):
@@ -134,7 +133,7 @@ class TestFOSSEventRSVPSubmission(IntegrationTestCase):
         rsvp.save()
 
         # When a submission is done
-        frappe.set_user(WEBSITE_USER)
+        frappe.set_user("Guest")
         submission = insert_rsvp_submission(linked_rsvp=rsvp.name)
 
         # It should be saved with status as pending
@@ -148,3 +147,85 @@ class TestFOSSEventRSVPSubmission(IntegrationTestCase):
         # Then the status should change without errors
         submission.status = "Rejected"
         submission.save()
+
+    def test_add_to_email_on_acceptance(self):
+        # Given an RSVP form which requires host approval
+        frappe.set_user(LEAD_USER)
+        rsvp = self.rsvp
+        rsvp.requires_host_approval = True
+        rsvp.save()
+
+        # When a submission is made
+        frappe.set_user("Guest")
+        submission = insert_rsvp_submission(linked_rsvp=rsvp.name)
+        self.assertEqual(submission.status, "Pending")
+
+        # Then the email should not be added to email group
+        # When status is pending
+
+        self.assertFalse(
+            frappe.db.exists(
+                "Email Group Member",
+                {
+                    "email": submission.email,
+                    "email_group": self.email_group,
+                },
+            )
+        )
+
+        # When status is changed to "Accepted"
+        frappe.set_user(LEAD_USER)
+        submission.status = "Accepted"
+        submission.save()
+
+        # Then the email should be added to email group
+        self.assertTrue(
+            frappe.db.exists(
+                "Email Group Member",
+                {
+                    "email": submission.email,
+                    "email_group": self.email_group,
+                },
+            )
+        )
+
+    def test_no_add_to_email_on_rejection(self):
+        # Given an RSVP form which requires host approval
+        frappe.set_user(LEAD_USER)
+        rsvp = self.rsvp
+        rsvp.requires_host_approval = True
+        rsvp.save()
+
+        # When a submission is made
+        frappe.set_user("Guest")
+        submission = insert_rsvp_submission(linked_rsvp=rsvp.name)
+        self.assertEqual(submission.status, "Pending")
+
+        # Then the email should not be added to email group
+        # When status is pending
+
+        self.assertFalse(
+            frappe.db.exists(
+                "Email Group Member",
+                {
+                    "email": submission.email,
+                    "email_group": self.email_group,
+                },
+            )
+        )
+
+        # When status is changed to "Accepted"
+        frappe.set_user(LEAD_USER)
+        submission.status = "Rejected"
+        submission.save()
+
+        # Then the email should be added to email group
+        self.assertFalse(
+            frappe.db.exists(
+                "Email Group Member",
+                {
+                    "email": submission.email,
+                    "email_group": self.email_group,
+                },
+            )
+        )

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
@@ -229,3 +229,16 @@ class TestFOSSEventRSVPSubmission(IntegrationTestCase):
                 },
             )
         )
+
+    def test_submission_to_unpublished_form(self):
+        # Given an rsvp form which is unpublished
+        rsvp = self.rsvp
+        rsvp.is_published = False
+        rsvp.save()
+
+        # When a user tries to create a submission
+        # Then a validation error must be thrown
+
+        frappe.set_user("Guest")
+        with self.assertRaises(frappe.ValidationError):
+            insert_rsvp_submission(linked_rsvp=rsvp.name)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] ⚙️Chore
- [x] 🐛Bug Fix

## Description

<!-- Briefly describe the changes introduced by this pull request -->
- code was doing unnecessary publish check of RSVP on a `validate` method. Moved that check to happen in `before_insert`. Made sure to bypass it for chapter members and system users, in case the chapter members need to add participants from their end.
- Code had a huge bug: we did not create workflow to add email to email groups when host approvals are required. All the RSVPs were auto added to `Event Participant` email group of an event even if their status was `Pending`. Fixed this by actually adding a workflow where a participant is only added to the Email group when their submission status is Accepted.
- Wrote tests for above.


Need to fix: [5 Year anniversary event](https://fossunited.org/c/bengaluru/five-year-anniversary) must have `Event Participant` email group with all the RSVP emails. We need to delete the existing email group members and add accepted participants via desk to that particular email group


## Related Issues & Docs
closes #772 
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
