### PR TITLE
fix(event-dashboard): broken event volunteer workflow

### DIFF
--- a/dashboard/src/components/chapter/AddMember.vue
+++ b/dashboard/src/components/chapter/AddMember.vue
@@ -36,11 +36,11 @@ import { ref, defineProps, defineEmits, computed } from 'vue'
 const props = defineProps({
   chapter: {
     type: Object,
-    default: () => ({}),
+    default: () => null,
   },
   event: {
     type: Object,
-    default: () => ({}),
+    default: () => null,
   },
 })
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛Bug Fix

## Description

<!-- Briefly describe the changes introduced by this pull request -->

- Set default values for `chapter` and `event` props to `AddMember.vue` component to be null. This removes the bug in which the code was trying to make changes to a chapter.member object when chapter was not provided.

## Related Issues & Docs
closes #774 
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
