### PR TITLE
feat: Sponsor management from dashboard

### DIFF
--- a/dashboard/src/components/event/ManagePartnerDialog.vue
+++ b/dashboard/src/components/event/ManagePartnerDialog.vue
@@ -1,0 +1,123 @@
+<template>
+  <Dialog
+    v-model="show"
+    :options="{
+      title: isNew ? 'Add Community Partner' : 'Manage Community Partner',
+    }"
+  >
+    <template #body-content>
+      <div class="flex flex-col gap-3">
+        <FormControl v-model="partner.org_name" label="Community Name" required />
+        <FormControl v-model="partner.link" label="Website Link" type="url" required>
+          <template #prefix>
+            <IconLink class="w-4" />
+          </template>
+        </FormControl>
+        <FileUploaderArea v-model="partner.logo" label="Community Logo" />
+        <ErrorMessage :message="errorMessages" class="text-sm -mb-4" />
+      </div>
+    </template>
+    <template #actions>
+      <div class="grid grid-flow-col w-full">
+        <Button v-if="isNew" label="Add" variant="solid" @click="addPartner" />
+        <Button v-else label="Update" variant="solid" @click="handlePartnerUpdate" />
+      </div>
+    </template>
+  </Dialog>
+</template>
+<script setup>
+import { toast } from 'vue-sonner'
+import { inject, ref } from 'vue'
+import { Dialog, FormControl, ErrorMessage, createResource } from 'frappe-ui'
+import { IconLink } from '@tabler/icons-vue'
+import FileUploaderArea from '@/components/ui/FileUploaderArea.vue'
+
+const event = inject('event')
+const errorMessages = ref('')
+
+const show = defineModel('show', { required: true, type: Boolean, default: false })
+const partner = defineModel('partner', { required: true, type: Object })
+const props = defineProps({
+  isNew: {
+    default: false,
+    type: Boolean,
+  },
+})
+const emit = defineEmits(['reload:event'])
+
+const validateFields = () => {
+  const errors = []
+
+  if (!partner.value.org_name) {
+    errors.push('Organization name is required')
+  }
+
+  if (!partner.value.link) {
+    errors.push('Partner link is required')
+  }
+
+  if (!partner.value.logo) {
+    errors.push('Please add logo of partner')
+  }
+
+  return errors
+}
+const addPartner = () => {
+  const errors = validateFields()
+
+  if (errors.length) {
+    errorMessages.value = errors.join('\n')
+    return
+  }
+
+  event.setValue
+    .submit({
+      community_partners: [...event.doc.community_partners, partner.value],
+    })
+    .then(() => {
+      show.value = false
+      partner.value = {}
+      toast.success('Community Partner Added Successfully!')
+    })
+    .catch((err) => {
+      toast.error(err)
+      errorMessages.value = err
+    })
+}
+
+const handlePartnerUpdate = () => {
+  const errors = validateFields()
+
+  if (errors.length) {
+    errorMessages.value = errors.join('\n')
+    return
+  }
+
+  const fields = {
+    org_name: partner.value.org_name,
+    link: partner.value.link,
+    logo: partner.value.image,
+  }
+
+  createResource({
+    url: 'frappe.client.set_value',
+    makeParams() {
+      return {
+        doctype: 'FOSS Event Community Partner',
+        name: partner.value.name,
+        fieldname: fields,
+      }
+    },
+    onSuccess() {
+      toast.success('Community Partner Updated Successfully!')
+      emit('reload:event')
+      show.value = false
+    },
+    onError(err) {
+      errorMessages.value = err
+      toast.error(err)
+    },
+    auto: true,
+  })
+}
+</script>

--- a/dashboard/src/components/event/ManageSponsorDialog.vue
+++ b/dashboard/src/components/event/ManageSponsorDialog.vue
@@ -1,0 +1,149 @@
+<template>
+  <Dialog
+    v-model="show"
+    :options="{
+      title: isNew ? 'Add Sponsor' : 'Manage Sponsor',
+    }"
+  >
+    <template #body-content>
+      <div class="flex flex-col gap-3">
+        <FormControl
+          v-model="sponsor.tier"
+          label="Sponsorship Tier"
+          type="select"
+          :options="sponsorOptions"
+          required
+        />
+        <FormControl
+          v-if="sponsor.tier === 'Custom'"
+          v-model="sponsor.custom_tier"
+          label="Custom Tier"
+          :required="sponsor.tier === 'Custom'"
+        />
+        <FormControl v-model="sponsor.sponsor_name" label="Sponsor Name" required />
+        <FormControl v-model="sponsor.link" label="Website Link" type="url" required>
+          <template #prefix>
+            <IconLink class="w-4" />
+          </template>
+        </FormControl>
+        <FileUploaderArea v-model="sponsor.image" label="Sponsor Image" />
+        <ErrorMessage :message="errorMessages" class="text-sm -mb-4" />
+      </div>
+    </template>
+    <template #actions>
+      <div class="grid grid-flow-col w-full">
+        <Button v-if="isNew" label="Add" variant="solid" @click="addSponsor" />
+        <Button v-else label="Update" variant="solid" @click="handleSponsorUpdate" />
+      </div>
+    </template>
+  </Dialog>
+</template>
+<script setup>
+import { toast } from 'vue-sonner'
+import { inject, ref } from 'vue'
+import { Dialog, FormControl, ErrorMessage, createResource } from 'frappe-ui'
+import { IconLink } from '@tabler/icons-vue'
+import FileUploaderArea from '@/components/ui/FileUploaderArea.vue'
+
+const sponsorOptions = ref(['Platinum', 'Gold', 'Silver', 'Bronze', 'Venue Partner', 'Custom'])
+
+const event = inject('event')
+const errorMessages = ref('')
+
+const show = defineModel('show', { required: true, type: Boolean, default: false })
+const sponsor = defineModel('sponsor', { required: true, type: Object })
+const props = defineProps({
+  isNew: {
+    default: false,
+    type: Boolean,
+  },
+})
+const emit = defineEmits(['reload:event'])
+
+const validateFields = () => {
+  const errors = []
+
+  if (!sponsor.value.tier) {
+    errors.push('Tier is required')
+  }
+
+  if (sponsor.value.tier == 'Custom' && !sponsor.value.custom_tier) {
+    errors.push('Custom Tier cannot be null')
+  }
+
+  if (!sponsor.value.sponsor_name) {
+    errors.push('Sponsor name is required')
+  }
+
+  if (!sponsor.value.link) {
+    errors.push('Sponsor link is required')
+  }
+
+  if (!sponsor.value.image) {
+    errors.push('Please add logo of sponsor')
+  }
+
+  return errors
+}
+const addSponsor = () => {
+  const errors = validateFields()
+
+  if (errors.length) {
+    errorMessages.value = errors.join('\n')
+    return
+  }
+
+  event.setValue
+    .submit({
+      sponsor_list: [...event.doc.sponsor_list, sponsor.value],
+    })
+    .then(() => {
+      errorMessages.value = ''
+      show.value = false
+      sponsor.value = {}
+      toast.success('Sponsor Added Successfully!')
+    })
+    .catch((err) => {
+      toast.error(err)
+      errorMessages.value = err
+    })
+}
+
+const handleSponsorUpdate = () => {
+  const errors = validateFields()
+
+  if (errors.length) {
+    errorMessages.value = errors.join('\n')
+    return
+  }
+
+  const fields = {
+    tier: sponsor.value.tier,
+    custom_tier: sponsor.value.custom_tier,
+    sponsor_name: sponsor.value.sponsor_name,
+    link: sponsor.value.link,
+    image: sponsor.value.image,
+  }
+
+  createResource({
+    url: 'frappe.client.set_value',
+    makeParams() {
+      return {
+        doctype: 'FOSS Event Sponsor',
+        name: sponsor.value.name,
+        fieldname: fields,
+      }
+    },
+    onSuccess() {
+      toast.success('Sponsor Updated Successfully!')
+      emit('reload:event')
+      show.value = false
+    },
+    onError(err) {
+      errorMessages.value = err
+      toast.error(err)
+    },
+    auto: true,
+  })
+}
+</script>

--- a/dashboard/src/components/event/PartnerCard.vue
+++ b/dashboard/src/components/event/PartnerCard.vue
@@ -1,0 +1,79 @@
+<template>
+  <Dialog
+    v-model="showConfimation"
+    class="z-50"
+    :options="{
+      title: 'Remove Partner?',
+      message: `Are you sure you want to remove partner - ${partner.org_name} ?`,
+      icon: {
+        name: 'alert-triangle',
+        appearance: 'warning',
+      },
+      actions: [
+        {
+          label: 'Cancel',
+          onClick: () => (showConfimation = false),
+        },
+        {
+          label: 'Remove',
+          theme: 'red',
+          onClick: handleDelete,
+        },
+      ],
+    }"
+  />
+  <div class="border p-4 flex flex-col gap-2 rounded items-center">
+    <div class="relative w-full">
+      <div v-if="editable" class="top-0 right-0 absolute flex flex-row-reverse gap-2 w-full">
+        <Button icon="trash" theme="red" @click="showConfimation = true" />
+        <Button icon="edit" @click="emit('edit:partner')" />
+      </div>
+      <img
+        :src="partner.logo"
+        class="w-full h-20 px-5 object-contain"
+        :alt="label || 'Image preview'"
+      />
+    </div>
+    <h4 class="text-md font-medium">{{ partner.org_name }}</h4>
+  </div>
+</template>
+
+<script setup>
+import { inject, ref } from 'vue'
+import { toast } from 'vue-sonner'
+import { Dialog } from 'frappe-ui'
+
+const showConfimation = ref(false)
+const event = inject('event')
+
+const emit = defineEmits(['edit:partner', 'reload:event'])
+
+const props = defineProps({
+  partner: {
+    type: Object,
+    required: true,
+  },
+  editable: {
+    type: Boolean,
+    default: () => true,
+  },
+})
+
+const handleDelete = () => {
+  toast.info('Removing partner...')
+  event.setValue
+    .submit({
+      community_partners: event.doc.community_partners.filter(
+        (s) => s.name !== props.partner.name,
+      ),
+    })
+    .then(() => {
+      toast.info('Partner removed successfully')
+      emit('reload:event')
+      showConfimation.value = false
+    })
+    .catch((err) => {
+      toast.error('Failed to remove partner' + err)
+    })
+}
+</script>

--- a/dashboard/src/components/event/SponsorCard.vue
+++ b/dashboard/src/components/event/SponsorCard.vue
@@ -1,0 +1,79 @@
+<template>
+  <Dialog
+    v-model="showConfimation"
+    class="z-50"
+    :options="{
+      title: 'Remove Sponsor?',
+      message: `Are you sure you want to remove sponsor - ${sponsor.sponsor_name} ?`,
+      icon: {
+        name: 'alert-triangle',
+        appearance: 'warning',
+      },
+      actions: [
+        {
+          label: 'Cancel',
+          onClick: () => (showConfimation = false),
+        },
+        {
+          label: 'Remove',
+          theme: 'red',
+          onClick: handleDelete,
+        },
+      ],
+    }"
+  />
+  <div class="border p-4 flex flex-col gap-2 rounded items-center">
+    <div class="relative w-full">
+      <div v-if="editable" class="top-0 right-0 absolute flex flex-row-reverse gap-2 w-full">
+        <Button icon="trash" theme="red" @click="showConfimation = true" />
+        <Button icon="edit" @click="emit('edit-sponsor')" />
+      </div>
+      <img
+        :src="sponsor.image"
+        class="w-full h-20 px-5 object-contain"
+        :alt="label || 'Image preview'"
+      />
+    </div>
+    <h4 class="text-md font-medium">{{ sponsor.sponsor_name }}</h4>
+    <p class="text-base text-gray-700">
+      {{ sponsor.tier == 'Custom' ? sponsor.custom_tier : sponsor.tier }}
+    </p>
+  </div>
+</template>
+<script setup>
+import { inject, ref } from 'vue'
+import { toast } from 'vue-sonner'
+import { Dialog } from 'frappe-ui'
+
+const showConfimation = ref(false)
+const event = inject('event')
+
+const emit = defineEmits(['edit-sponsor', 'reload:event'])
+
+const props = defineProps({
+  sponsor: {
+    type: Object,
+    required: true,
+  },
+  editable: {
+    type: Boolean,
+    default: () => true,
+  },
+})
+
+const handleDelete = () => {
+  toast.info('Removing sponsor...')
+  event.setValue
+    .submit({
+      sponsor_list: event.doc.sponsor_list.filter((s) => s.name !== props.sponsor.name),
+    })
+    .then(() => {
+      toast.info('Sponsor removed successfully')
+      emit('reload:event')
+      showConfimation.value = false
+    })
+    .catch((err) => {
+      toast.error('Failed to remove sponsor' + err)
+    })
+}
+</script>

--- a/dashboard/src/components/ui/FileUploaderArea.vue
+++ b/dashboard/src/components/ui/FileUploaderArea.vue
@@ -1,0 +1,134 @@
+<template>
+  <div class="flex flex-col gap-2">
+    <label v-if="label" class="text-xs text-gray-600">{{ label }}</label>
+    <div class="relative">
+      <!-- Image Preview -->
+      <div v-if="modelValue" class="mb-2">
+        <div class="relative w-full h-40 group">
+          <img
+            :src="modelValue"
+            class="w-full h-40 object-contain rounded border bg-gray-50"
+            :alt="label || 'Image preview'"
+          />
+          <div
+            class="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center gap-2"
+          >
+            <button
+              class="p-2 rounded-full bg-white/20 hover:bg-white/30 transition-colors"
+              @click="removeImage"
+            >
+              <IconTrash class="w-5 h-5 text-white" />
+            </button>
+            <button
+              class="p-2 rounded-full bg-white/20 hover:bg-white/30 transition-colors"
+              @click="$refs.fileUploader.openFileSelector()"
+            >
+              <IconEdit class="w-5 h-5 text-white" />
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <FileUploader
+        ref="fileUploader"
+        :file-types="fileTypes"
+        :validate-file="validateFile"
+        @success="handleSuccess"
+        @failure="handleError"
+      >
+        <template #default="{ uploading, progress, openFileSelector, error }">
+          <div
+            :class="[
+              'transition-all duration-200',
+              'border-2 border-dashed rounded-lg',
+              modelValue ? 'p-3' : 'p-8 hover:cursor-pointer',
+            ]"
+            @click="openFileSelector"
+          >
+            <!-- Upload Progress -->
+            <div v-if="uploading" class="flex flex-col items-center gap-2">
+              <div class="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
+                <div
+                  class="h-full bg-blue-500 transition-all duration-200"
+                  :style="{ width: `${progress}%` }"
+                />
+              </div>
+              <span class="text-sm text-gray-600">Uploading... {{ progress }}%</span>
+            </div>
+
+            <!-- Upload Prompt -->
+            <div v-if="!modelValue" class="flex flex-col items-center gap-3">
+              <IconPhotoScan
+                :class="[
+                  'w-8 h-8 transition-colors duration-200',
+                  isDragging ? 'text-blue-500' : 'text-gray-400',
+                ]"
+              />
+              <div class="text-center">
+                <p class="text-sm font-medium text-gray-700">Click to browse files</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- Error Message -->
+          <p v-if="error" class="mt-2 text-sm text-red-600">
+            {{ error }}
+          </p>
+        </template>
+      </FileUploader>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { FileUploader } from 'frappe-ui'
+import { IconPhotoScan, IconTrash, IconEdit } from '@tabler/icons-vue'
+
+const fileUploader = ref(null)
+const isDragging = ref(false)
+
+const model = defineModel({ type: String, default: '' })
+
+const props = defineProps({
+  // modelValue: {
+  //   type: String,
+  //   default: '',
+  // },
+  label: {
+    type: String,
+    default: '',
+  },
+  fileTypes: {
+    type: Array,
+    default: () => ['image/*', 'image/svg+xml'],
+  },
+  maxFileSize: {
+    type: Number,
+    default: 5,
+  },
+})
+
+const emit = defineEmits(['update:modelValue', 'error'])
+
+const validateFile = (file) => {
+  if (file.size > props.maxFileSize * 1024 * 1024) {
+    return `File size should not exceed ${props.maxFileSize}MB`
+  }
+  return null
+}
+
+const handleSuccess = (response) => {
+  // emit('update:modelValue', response.file_url)
+  model.value = response.file_url
+}
+
+const handleError = (error) => {
+  emit('error', error)
+}
+
+const removeImage = () => {
+  // emit('update:modelValue', '')
+  model.value = ''
+}
+</script>

--- a/dashboard/src/layout/event/ManagePartnerView.vue
+++ b/dashboard/src/layout/event/ManagePartnerView.vue
@@ -1,0 +1,50 @@
+<template>
+  <ManagePartnerDialog
+    v-model:show="showDialog"
+    v-model:partner="selectedPartner"
+    :is-new="inAddNew"
+    class="z-50"
+    @reload:event="event.reload()"
+  />
+  <div class="flex flex-col gap-4 my-6">
+    <div class="flex flex-col gap-2">
+      <div class="prose">
+        <h2>Community Partners</h2>
+      </div>
+      <Button label="Add Partner" class="w-fit mb-1" @click="handleAddNew" />
+      <div v-if="event.doc.community_partners.length == 0" class="text-sm text-gray-800">
+        No partners added for this event.
+      </div>
+      <div v-else class="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <PartnerCard
+          v-for="partner in event.doc.community_partners"
+          :key="partner.name"
+          :partner="partner"
+          @edit:partner="handleEdit(partner)"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+<script setup>
+import { inject, reactive, ref } from 'vue'
+import PartnerCard from '@/components/event/PartnerCard.vue'
+import ManagePartnerDialog from '@/components/event/ManagePartnerDialog.vue'
+
+const inAddNew = ref(false)
+let selectedPartner = reactive({})
+const showDialog = ref(false)
+const event = inject('event')
+
+const handleAddNew = () => {
+  inAddNew.value = true
+  selectedPartner = {}
+  showDialog.value = true
+}
+
+const handleEdit = (partner) => {
+  inAddNew.value = false
+  selectedPartner = partner
+  showDialog.value = true
+}
+</script>

--- a/dashboard/src/layout/event/ManageSponsorView.vue
+++ b/dashboard/src/layout/event/ManageSponsorView.vue
@@ -24,7 +24,6 @@
         />
       </div>
     </div>
-    <div class="community-partners"></div>
   </div>
 </template>
 <script setup>

--- a/dashboard/src/layout/event/ManageSponsorView.vue
+++ b/dashboard/src/layout/event/ManageSponsorView.vue
@@ -1,0 +1,52 @@
+<template>
+  <ManageSponsorDialog
+    v-model:show="showSponsorDialog"
+    v-model:sponsor="selectedSponsor"
+    :is-new="inAddNew"
+    class="z-50"
+    @reload:event="event.reload()"
+  />
+  <div class="flex flex-col gap-4 my-6">
+    <div class="flex flex-col gap-2">
+      <div class="prose">
+        <h2>Sponsors</h2>
+      </div>
+      <Button label="Add Sponsor" class="w-fit mb-1" @click="handleAddNew" />
+      <div v-if="event.doc.sponsor_list.length == 0" class="text-sm text-gray-800">
+        No sponsors added for this event.
+      </div>
+      <div v-else class="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <SponsorCard
+          v-for="sponsor in event.doc.sponsor_list"
+          :key="sponsor.name"
+          :sponsor="sponsor"
+          @edit-sponsor="handleEditSponsor(sponsor)"
+        />
+      </div>
+    </div>
+    <div class="community-partners"></div>
+  </div>
+</template>
+<script setup>
+import { inject, reactive, ref } from 'vue'
+
+import SponsorCard from '@/components/event/SponsorCard.vue'
+import ManageSponsorDialog from '@/components/event/ManageSponsorDialog.vue'
+
+const inAddNew = ref(false)
+let selectedSponsor = reactive({})
+const showSponsorDialog = ref(false)
+const event = inject('event')
+
+const handleAddNew = () => {
+  inAddNew.value = true
+  selectedSponsor = {}
+  showSponsorDialog.value = true
+}
+
+const handleEditSponsor = (sponsor) => {
+  inAddNew.value = false
+  selectedSponsor = sponsor
+  showSponsorDialog.value = true
+}
+</script>

--- a/dashboard/src/layout/event/ManageSponsorView.vue
+++ b/dashboard/src/layout/event/ManageSponsorView.vue
@@ -27,25 +27,25 @@
   </div>
 </template>
 <script setup>
-import { inject, reactive, ref } from 'vue'
+import { inject, ref } from 'vue'
 
 import SponsorCard from '@/components/event/SponsorCard.vue'
 import ManageSponsorDialog from '@/components/event/ManageSponsorDialog.vue'
 
 const inAddNew = ref(false)
-let selectedSponsor = reactive({})
+let selectedSponsor = ref({})
 const showSponsorDialog = ref(false)
 const event = inject('event')
 
 const handleAddNew = () => {
   inAddNew.value = true
-  selectedSponsor = {}
+  selectedSponsor.value = {}
   showSponsorDialog.value = true
 }
 
 const handleEditSponsor = (sponsor) => {
   inAddNew.value = false
-  selectedSponsor = sponsor
+  selectedSponsor.value = sponsor
   showSponsorDialog.value = true
 }
 </script>

--- a/dashboard/src/pages/Event.vue
+++ b/dashboard/src/pages/Event.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script setup>
-import { ref, provide } from 'vue'
+import { ref, provide, watch } from 'vue'
 import { createResource, usePageMeta, createDocumentResource } from 'frappe-ui'
 import { RouterView, useRoute } from 'vue-router'
 import SideNavbar from '@/components/NewAppSidebar.vue'
@@ -31,55 +31,62 @@ const event = createDocumentResource({
   doctype: 'FOSS Chapter Event',
   name: route.params.id,
   auto: true,
-  onSuccess(doc) {
-    // If sidebar items already set, don't append items again
-    if (sidebarMenuItems.value.length > 1) {
-      return
-    }
-    chapter.fetch()
-    let sidebar_items = {
-      items: [
-        {
-          label: 'Details',
-          route: `/event/${route.params.id}`,
-        },
-        {
-          label: 'RSVP',
-          route: `/event/${route.params.id}/rsvp`,
-        },
-        {
-          label: 'CFP',
-          route: `/event/${route.params.id}/cfp`,
-        },
-        {
-          label: 'Partners',
-          route: `/event/${route.params.id}/partner`,
-        },
-        {
-          label: 'Volunteers',
-          route: `/event/${route.params.id}/volunteers`,
-        },
-        {
-          label: 'Mailing',
-          route: `/event/${route.params.id}/mailing`,
-        },
-      ],
-    }
-
-    if (doc.is_paid_event) {
-      sidebar_items.items.splice(1, 1, {
-        label: 'Tickets',
-        route: `/event/${route.params.id}/tickets`,
-      })
-      sidebar_items.items.push({
-        label: 'Check-Ins',
-        route: `/event/${route.params.id}/checkins`,
-      })
-    }
-
-    sidebarMenuItems.value.push(sidebar_items)
-  },
 })
+
+watch(
+  () => event.doc,
+  (doc) => {
+    if (doc) {
+      // If sidebar items already set, don't append items again
+      if (sidebarMenuItems.value.length > 1) {
+        return
+      }
+      chapter.fetch()
+      let sidebar_items = {
+        items: [
+          {
+            label: 'Details',
+            route: `/event/${route.params.id}`,
+          },
+          {
+            label: 'RSVP',
+            route: `/event/${route.params.id}/rsvp`,
+          },
+          {
+            label: 'CFP',
+            route: `/event/${route.params.id}/cfp`,
+          },
+          {
+            label: 'Partners',
+            route: `/event/${route.params.id}/partner`,
+          },
+          {
+            label: 'Volunteers',
+            route: `/event/${route.params.id}/volunteers`,
+          },
+          {
+            label: 'Mailing',
+            route: `/event/${route.params.id}/mailing`,
+          },
+        ],
+      }
+
+      if (doc.is_paid_event) {
+        sidebar_items.items.splice(1, 1, {
+          label: 'Tickets',
+          route: `/event/${route.params.id}/tickets`,
+        })
+        sidebar_items.items.push({
+          label: 'Check-Ins',
+          route: `/event/${route.params.id}/checkins`,
+        })
+      }
+
+      sidebarMenuItems.value = [...sidebarMenuItems.value, sidebar_items]
+    }
+  },
+)
+
 provide('event', event)
 
 const chapter = createResource({

--- a/dashboard/src/pages/EventPartner.vue
+++ b/dashboard/src/pages/EventPartner.vue
@@ -2,12 +2,14 @@
   <div v-if="event.doc" class="px-4 py-8 md:p-8 w-full z-0 min-h-screen">
     <EventHeader :event="event.doc" />
     <ManageSponsorView />
+    <ManagePartnerView />
   </div>
 </template>
 <script setup>
 import EventHeader from '@/components/EventHeader.vue'
 import { inject } from 'vue'
 import ManageSponsorView from '@/layout/event/ManageSponsorView.vue'
+import ManagePartnerView from '@/layout/event/ManagePartnerView.vue'
 
 const event = inject('event')
 </script>

--- a/dashboard/src/pages/EventPartner.vue
+++ b/dashboard/src/pages/EventPartner.vue
@@ -1,0 +1,13 @@
+<template>
+  <div v-if="event.doc" class="px-4 py-8 md:p-8 w-full z-0 min-h-screen">
+    <EventHeader :event="event.doc" />
+    <ManageSponsorView />
+  </div>
+</template>
+<script setup>
+import EventHeader from '@/components/EventHeader.vue'
+import { inject } from 'vue'
+import ManageSponsorView from '@/layout/event/ManageSponsorView.vue'
+
+const event = inject('event')
+</script>

--- a/dashboard/src/router.js
+++ b/dashboard/src/router.js
@@ -139,6 +139,11 @@ const routes = [
         ],
       },
       {
+        path: 'partner',
+        name: 'EventPartner',
+        component: () => import('@/pages/EventPartner.vue'),
+      },
+      {
         path: 'cfp',
         name: 'EventCfp',
         component: () => import('@/pages/EventCfp.vue'),

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -236,10 +236,25 @@ class FOSSChapterEvent(WebsiteGenerator):
     def get_sponsors(self):
         sponsors_dict = {}
         for sponsor in self.sponsor_list:
-            if sponsor.sponsorship_tier not in sponsors_dict:
-                sponsors_dict[sponsor.sponsorship_tier] = []
-            sponsors_dict[sponsor.sponsorship_tier].append(sponsor)
+            tier = self.get_tier(sponsor)
+            if tier not in sponsors_dict:
+                sponsors_dict[tier] = []
+            sponsors_dict[tier].append(sponsor)
+
+        sort_order = ["Platinum", "Gold", "Silver", "Bronze", "Custom"]
+        # Sort tiers based on their position in sort_order; unknown tiers go last
+        sponsors_dict = dict(
+            sorted(
+                sponsors_dict.items(),
+                key=lambda x: sort_order.index(x[0]) if x[0] in sort_order else len(sort_order),
+            )
+        )
         return sponsors_dict
+
+    def get_tier(self, sponsor):
+        if sponsor.tier == "Custom":
+            return sponsor.custom_tier
+        return sponsor.tier
 
     def get_volunteers(self):
         members = []

--- a/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
+++ b/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
@@ -137,12 +137,13 @@
               <div class="sponsor--tier-heading">{{ k }}</div>
               <div class="sponsor--flex">
                 {% for sponsor in v %}
-                  <a href="{{ sponsor.sponsor_link }}" class="sponsor--block">
+                  <a href="{{ sponsor.link }}" class="sponsor--block">
                     <img
-                      src="{{ sponsor.sponsor_image }}"
+                      src="{{ sponsor.image }}"
                       alt="{{ sponsor.sponsor_name }}"
                       class="sponsor--image"
                     />
+                    <p>{{ sponsor.sponsor_name }}</p>
                   </a>
                 {% endfor %}
               </div>
@@ -159,12 +160,13 @@
           <h5>Community Partners</h5>
           <div class="sponsor--flex">
             {% for partner in doc.community_partners %}
-              <a href="{{ partner.organization_website }}" class="sponsor--block">
+              <a href="{{ partner.link }}" class="sponsor--block">
                 <img
-                  src="{{ partner.company_logo }}"
-                  alt="{{ partner.organization_name }}"
+                  src="{{ partner.logo }}"
+                  alt="{{ partner.org_name }}"
                   class="sponsor--image"
                 />
+                <p>{{ partner.org_name }}</p>
               </a>
             {% endfor %}
           </div>

--- a/fossunited/chapters/doctype/foss_event_community_partner/foss_event_community_partner.json
+++ b/fossunited/chapters/doctype/foss_event_community_partner/foss_event_community_partner.json
@@ -5,33 +5,33 @@
   "doctype": "DocType",
   "editable_grid": 1,
   "engine": "InnoDB",
-  "field_order": ["organization_name", "organization_website", "company_logo"],
+  "field_order": ["org_name", "link", "logo"],
   "fields": [
     {
-      "fieldname": "organization_name",
+      "fieldname": "org_name",
       "fieldtype": "Data",
       "in_list_view": 1,
       "label": "Organization Name",
       "reqd": 1
     },
     {
-      "fieldname": "organization_website",
+      "fieldname": "link",
       "fieldtype": "Data",
       "in_list_view": 1,
-      "label": "Organization Website",
+      "label": "Link",
       "reqd": 1
     },
     {
-      "fieldname": "company_logo",
+      "fieldname": "logo",
       "fieldtype": "Attach Image",
-      "label": "Company Logo",
+      "label": "Logo",
       "reqd": 1
     }
   ],
   "index_web_pages_for_search": 1,
   "istable": 1,
   "links": [],
-  "modified": "2024-02-06 20:17:06.559041",
+  "modified": "2025-01-22 12:02:28.375273",
   "modified_by": "Administrator",
   "module": "Chapters",
   "name": "FOSS Event Community Partner",

--- a/fossunited/chapters/doctype/foss_event_community_partner/foss_event_community_partner.py
+++ b/fossunited/chapters/doctype/foss_event_community_partner/foss_event_community_partner.py
@@ -4,4 +4,20 @@ from frappe.model.document import Document
 
 
 class FOSSEventCommunityPartner(Document):
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        link: DF.Data
+        logo: DF.AttachImage
+        org_name: DF.Data
+        parent: DF.Data
+        parentfield: DF.Data
+        parenttype: DF.Data
+    # end: auto-generated types
+
     pass

--- a/fossunited/fossunited/doctype/foss_event_sponsor/foss_event_sponsor.json
+++ b/fossunited/fossunited/doctype/foss_event_sponsor/foss_event_sponsor.json
@@ -5,48 +5,49 @@
   "doctype": "DocType",
   "editable_grid": 1,
   "engine": "InnoDB",
-  "field_order": [
-    "sponsorship_tier",
-    "sponsor_name",
-    "sponsor_link",
-    "sponsor_image"
-  ],
+  "field_order": ["tier", "custom_tier", "sponsor_name", "link", "image"],
   "fields": [
-    {
-      "fieldname": "sponsorship_tier",
-      "fieldtype": "Select",
-      "in_list_view": 1,
-      "label": "Sponsorship Tier",
-      "options": "\nPlatinum\nGold\nSilver\nBronze",
-      "reqd": 1
-    },
     {
       "fieldname": "sponsor_name",
       "fieldtype": "Data",
       "in_list_view": 1,
       "label": "Sponsor Name",
-      "options": "Organization",
+      "reqd": 1
+    },
+    {
+      "depends_on": "eval:doc.tier=='Custom'",
+      "fieldname": "custom_tier",
+      "fieldtype": "Data",
+      "label": "Custom Tier",
+      "mandatory_depends_on": "eval:doc.tier=='Custom'"
+    },
+    {
+      "fieldname": "tier",
+      "fieldtype": "Select",
+      "in_list_view": 1,
+      "label": "Tier",
+      "options": "Platinum\nGold\nSilver\nBronze\nVenue Partner\nCustom",
       "reqd": 1
     },
     {
       "description": "Company Website Link",
-      "fieldname": "sponsor_link",
+      "fieldname": "link",
       "fieldtype": "Data",
       "in_list_view": 1,
-      "label": "Sponsor Link",
+      "label": "Link",
       "reqd": 1
     },
     {
-      "fieldname": "sponsor_image",
+      "fieldname": "image",
       "fieldtype": "Attach Image",
-      "label": "Sponsor Image",
+      "label": "Image",
       "reqd": 1
     }
   ],
   "index_web_pages_for_search": 1,
   "istable": 1,
   "links": [],
-  "modified": "2024-02-06 23:14:54.615822",
+  "modified": "2025-01-15 13:57:54.152664",
   "modified_by": "Administrator",
   "module": "FOSSUnited",
   "name": "FOSS Event Sponsor",

--- a/fossunited/fossunited/doctype/foss_event_sponsor/foss_event_sponsor.py
+++ b/fossunited/fossunited/doctype/foss_event_sponsor/foss_event_sponsor.py
@@ -5,4 +5,22 @@ from frappe.model.document import Document
 
 
 class FOSSEventSponsor(Document):
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        custom_tier: DF.Data | None
+        image: DF.AttachImage
+        link: DF.Data
+        parent: DF.Data
+        parentfield: DF.Data
+        parenttype: DF.Data
+        sponsor_name: DF.Data
+        tier: DF.Literal["Platinum", "Gold", "Silver", "Bronze", "Venue Partner", "Custom"]  # noqa: F722, F821
+    # end: auto-generated types
+
     pass

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -1659,6 +1659,10 @@ h6 {
 }
 
 .sponsor--block {
+  display: flex;
+  flex-direction: column;
+  font-weight: 600;
+  align-items: center;
   margin: 0 1rem;
 }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕Feature

## Description

<!-- Briefly describe the changes introduced by this pull request -->

- Made fieldname changes in `FOSS Event Sponsor` & `FOSS Event Community Partner` doctypes.
- Created dashboard components which will enable organizers to manage event partners from the dashboard

## Related Issues & Docs
closes #792
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

## Screenshots/GIFs/Screen Recordings (if applicable)

<!-- Visually demonstrate the changes, if applicable -->
[Screencast from 2025-01-23 11-02-31.webm](https://github.com/user-attachments/assets/40951baf-cbe9-4382-8e50-993b4bca29a4)

