### PR TITLE
chore(CI): run CI on `ubuntu-22.04`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
     name: Server


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] ⚙️Chore

## Description

<!-- Briefly describe the changes introduced by this pull request -->

- CI is failing because it seems like mariadb install path has been changed for ubuntu latest.
- This PR changes the runs-on from `ubuntu-latest` to `ubuntu-22.04`. This is supposed to fix the mariadb install error and make CI run again
