### PR TITLE
[MAINT] Remove "Schedule" tab from event page

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -83,6 +83,8 @@ class FOSSChapterEvent(WebsiteGenerator):
         show_cfp: DF.Check
         show_photos: DF.Check
         show_rsvp: DF.Check
+        # This attribute is unused at the moment - it was previously used to determine whether
+        # or not to display the schedule tab on events
         show_schedule: DF.Check
         show_speakers: DF.Check
         sponsor_list: DF.Table[FOSSEventSponsor]
@@ -216,7 +218,6 @@ class FOSSChapterEvent(WebsiteGenerator):
             "speakers",
             "rsvp",
             "talk_proposal",
-            "schedule",
         ]
 
         if is_user_team_member(self.chapter, frappe.session.user):
@@ -228,8 +229,6 @@ class FOSSChapterEvent(WebsiteGenerator):
             navbar_items.remove("rsvp")
         if not self.show_cfp:
             navbar_items.remove("talk_proposal")
-        if not self.show_schedule:
-            navbar_items.remove("schedule")
 
         return navbar_items
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] ⚙️Chore

## Description

Remove the "Schedule" tab from the event page e.g. https://fossunited.org/c/hyderabad/2025-jan

## Related Issues & Docs

Related to #72 

## Checklist

- [x] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [ ] I have tested these changes locally.
- [ ] ~I have updated the documentation (If applicable).~
- [x] The code follows the project's coding standards.
- [ ] ~I have added/updated tests, if applicable.~

## Screenshots/GIFs/Screen Recordings (if applicable)

N/A

## Additional context

N/A