### PR TITLE
[MAINT] Remove static communities list image

### DIFF
--- a/fossunited/chapters/web_template/foss_communities___list/foss_communities___list.html
+++ b/fossunited/chapters/web_template/foss_communities___list/foss_communities___list.html
@@ -33,7 +33,7 @@
     justify-content: center;
     grid-template-rows: 1fr 1fr 1fr;
     grid-template-columns: 1fr 1fr 1fr;
-    width: 50%;
+    width: 100%;
   }
 
   .city-card {
@@ -66,15 +66,6 @@
     border-radius: 0.5rem;
   }
 
-  .city-list-image {
-    display: flex;
-    justify-content: flex-end;
-  }
-
-  .city-list-image img {
-    width: 80%;
-  }
-
   @media screen and (max-width: 768px) {
     .community-list-section {
       flex-direction: column;
@@ -89,10 +80,6 @@
 
     h2 {
       font-size: 1.5rem;
-    }
-
-    .city-list-image {
-      display: none;
     }
 
     .city-card-container {
@@ -150,10 +137,6 @@
             </div>
           </a>
         {% endfor %}
-      </div>
-
-      <div class="city-list-image">
-        <img src="{{ map_image }}" alt="India map with city communities" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] ⚙️Chore

## Description

Remove the static list image that displays city communities - the image is so out of date and we don't have any process at the moment to meaningfully update it. Best to remove it and maybe make it dynamic.

If we want to display this information visually, we should likely redesign how the content is displayed overall.

## Related Issues & Docs

fixes #795 

## Checklist

- [x] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [ ] I have tested these changes locally.
- [ ] ~I have updated the documentation (If applicable).~
- [x] The code follows the project's coding standards.
- [ ] ~I have added/updated tests, if applicable.~

## Screenshots/GIFs/Screen Recordings (if applicable)

N/A

## Additional context

N/A