### PR TITLE
feat(profiles)!: share profile with its linked user

### DIFF
--- a/fossunited/api/profile.py
+++ b/fossunited/api/profile.py
@@ -81,7 +81,7 @@ def update_profile(fields_dict):
         for field, value in updated_fields.items():
             if hasattr(profile, field):
                 setattr(profile, field, value)
-        profile.save(ignore_permissions=True)
+        profile.save()
 
         user_updates = {}
         if fields_dict.get("full_name") != user_doc.full_name:
@@ -101,7 +101,7 @@ def update_profile(fields_dict):
             for field, value in user_updates.items():
                 setattr(user, field, value)
 
-            user.save(ignore_permissions=True)
+            user.save()
 
         return True
 

--- a/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.py
@@ -71,6 +71,9 @@ class FOSSUserProfile(WebsiteGenerator):
         self.validate_username()
         self.set_route()
 
+    def after_insert(self):
+        self.share_user_with_self()
+
     def on_update(self):
         prev_user_doc = self.get_doc_before_save()
         if prev_user_doc is None:
@@ -133,3 +136,21 @@ class FOSSUserProfile(WebsiteGenerator):
 
     def on_trash(self):
         frappe.delete_doc("User", self.user, force=True)
+
+    def share_user_with_self(self):
+        """
+        Share the profile document with it's user.
+        Give user Read and Write permissions.
+        """
+        share_doc = frappe.get_doc(
+            {
+                "doctype": "DocShare",
+                "user": self.user,
+                "share_doctype": self.doctype,
+                "share_name": self.name,
+                "read": 1,
+                "write": 1,
+                "share": 1,
+            }
+        )
+        share_doc.insert()

--- a/fossunited/patches.txt
+++ b/fossunited/patches.txt
@@ -5,3 +5,4 @@
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
 fossunited.patches.v1_0.duplicate_event_name_to_reference_field  #31-12-2024
+fossunited.patches.v1_0.handle_sharing_all_existing_profiles

--- a/fossunited/patches/v1_0/handle_sharing_all_existing_profiles.py
+++ b/fossunited/patches/v1_0/handle_sharing_all_existing_profiles.py
@@ -1,0 +1,29 @@
+import frappe
+
+from fossunited.doctype_ids import USER_PROFILE
+
+
+def execute():
+    """
+    In this patch, all the existing profiles will be shared with their own user.
+    And these users will be given "Read", "Write" and "Share" perms to their profiles.
+    """
+    profiles = frappe.db.get_all(USER_PROFILE, ["name", "user"], page_length=99999)
+
+    for p in profiles:
+        share_doc = frappe.get_doc(
+            {
+                "doctype": "DocShare",
+                "user": p.user,
+                "share_doctype": USER_PROFILE,
+                "share_name": p.name,
+                "read": 1,
+                "write": 1,
+                "share": 1,
+            }
+        )
+        try:
+            share_doc.insert()
+        except Exception as e:
+            frappe.log_error(f"Error while sharing profile for profile: {p.name}", str(e))
+            continue


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕Feature
- [x] ⚙️Chore

## Description

<!-- Briefly describe the changes introduced by this pull request -->
Sharing a profile with it's linked user will result in better perms management. This will also help us in removing redundant custom validation code from our codebase.

closes #767 

- This PR adds that functionality. After a profile is created, a method runs which shares the profile with the user linked to itself.
Behind the scenes:
`DocShare` is a doctype that handles the sharing workflow in Frappe. We create `DocShare` document for the profiles, where a user is linked, and the permissions which they should have are defined.

![image](https://github.com/user-attachments/assets/e125ef41-ccf7-4958-8ddd-4d6e95cbb1bf)
_DocShare Schema_

ex: for user `lead@example.com`, suppose there is a profile with id `lead`
Then we would create the following docshare:
```
{
   "user":"lead@example.com",
   "document_type": "FOSS User Profile",
   "document_name": "lead",
   "read": 1,
   "write": 1,
}
```


- This PR also adds a patch, which will handle sharing all the existing profiles in production environment