### PR TITLE
feat: converting and storing profile and banner images in webp in the backend

### DIFF
--- a/fossunited/api/profile.py
+++ b/fossunited/api/profile.py
@@ -1,10 +1,11 @@
-import frappe
 import io
+
+import frappe
+from frappe.utils.file_manager import save_file
 from PIL import Image
 
 from fossunited.api.dashboard import get_session_user_profile
 from fossunited.doctype_ids import CHAPTER, RESTRICTED_USERNAME, USER_PROFILE
-from frappe.utils.file_manager import save_file
 
 
 def convert_image_to_webp(image_content: bytes) -> bytes:
@@ -38,11 +39,7 @@ def set_profile_image(file_url: str) -> bool:
         filename = f"profile_{user_doc.name}.webp"
 
         saved_file = save_file(
-            fname=filename,
-            content=webp_image,
-            dt=USER_PROFILE,
-            dn=user_doc.name,
-            is_private=False
+            fname=filename, content=webp_image, dt=USER_PROFILE, dn=user_doc.name, is_private=False
         )
 
         frappe.db.set_value(USER_PROFILE, user_doc.name, "profile_photo", saved_file.file_url)
@@ -69,26 +66,12 @@ def set_cover_image(file_url: str) -> bool:
         filename = f"cover_{user_doc.name}.webp"
 
         saved_file = save_file(
-            fname=filename,
-            content=webp_image,
-            dt=USER_PROFILE,
-            dn=user_doc.name,
-            is_private=False
+            fname=filename, content=webp_image, dt=USER_PROFILE, dn=user_doc.name, is_private=False
         )
 
         frappe.db.set_value(USER_PROFILE, user_doc.name, "cover_image", saved_file.file_url)
         return True
 
-    except Exception as e:
-        frappe.throw(str(e))
-
-
-@frappe.whitelist()
-def toggle_profile_privacy(value):
-    user_doc = get_session_user_profile()
-    try:
-        frappe.db.set_value(USER_PROFILE, user_doc.name, "is_private", value)
-        return True
     except Exception as e:
         frappe.throw(str(e))
 

--- a/fossunited/api/profile.py
+++ b/fossunited/api/profile.py
@@ -1,40 +1,93 @@
 import frappe
+import io
+from PIL import Image
 
 from fossunited.api.dashboard import get_session_user_profile
-from fossunited.doctype_ids import CHAPTER, RESTRICTED_USERNAME, USER_PROFILE
+from fossunited.doctype_ids import USER_PROFILE
+from frappe.utils.file_manager import save_file
+
+
+def convert_image_to_webp(image_content: bytes) -> bytes:
+    """
+    Convert the given image content to WebP format using Pillow.
+    Returns the converted image as bytes.
+    """
+    try:
+        with Image.open(io.BytesIO(image_content)) as img:
+            img = img.convert("RGB")
+            webp_io = io.BytesIO()
+            img.save(webp_io, format="WEBP", quality=80)
+            return webp_io.getvalue()
+    except Exception as e:
+        frappe.throw(f"Failed to process image: {str(e)}")
 
 
 @frappe.whitelist()
 def set_profile_image(file_url: str) -> bool:
+    """
+    Download the image from file_url, convert it to WebP, save it using Frappe's file handling,
+    and update the user's profile image.
+    """
     user_doc = get_session_user_profile()
     try:
-        frappe.db.set_value(
-            USER_PROFILE,
-            user_doc.name,
-            "profile_photo",
-            file_url,
+        file_path = frappe.get_site_path("public", file_url.lstrip("/"))
+        with open(file_path, "rb") as f:
+            original_image = f.read()
+
+        webp_image = convert_image_to_webp(original_image)
+        filename = f"profile_{user_doc.name}.webp"
+
+        saved_file = save_file(
+            fname=filename,
+            content=webp_image,
+            dt=USER_PROFILE,
+            dn=user_doc.name,
+            is_private=False
         )
-        frappe.db.set_value(
-            "User",
-            frappe.session.user,
-            "user_image",
-            file_url,
-        )
+
+        frappe.db.set_value(USER_PROFILE, user_doc.name, "profile_photo", saved_file.file_url)
+        frappe.db.set_value("User", frappe.session.user, "user_image", saved_file.file_url)
         return True
+
     except Exception as e:
         frappe.throw(str(e))
 
 
 @frappe.whitelist()
-def set_cover_image(file_url):
+def set_cover_image(file_url: str) -> bool:
+    """
+    Download the image from file_url, convert it to WebP, save it using Frappe's file handling,
+    and update the cover image in the user's profile.
+    """
     user_doc = get_session_user_profile()
     try:
-        frappe.db.set_value(
-            USER_PROFILE,
-            user_doc.name,
-            "cover_image",
-            file_url,
+        file_path = frappe.get_site_path("public", file_url.lstrip("/"))
+        with open(file_path, "rb") as f:
+            original_image = f.read()
+
+        webp_image = convert_image_to_webp(original_image)
+        filename = f"cover_{user_doc.name}.webp"
+
+        saved_file = save_file(
+            fname=filename,
+            content=webp_image,
+            dt=USER_PROFILE,
+            dn=user_doc.name,
+            is_private=False
         )
+
+        frappe.db.set_value(USER_PROFILE, user_doc.name, "cover_image", saved_file.file_url)
+        return True
+
+    except Exception as e:
+        frappe.throw(str(e))
+
+
+@frappe.whitelist()
+def toggle_profile_privacy(value):
+    user_doc = get_session_user_profile()
+    try:
+        frappe.db.set_value(USER_PROFILE, user_doc.name, "is_private", value)
         return True
     except Exception as e:
         frappe.throw(str(e))

--- a/fossunited/api/profile.py
+++ b/fossunited/api/profile.py
@@ -3,7 +3,7 @@ import io
 from PIL import Image
 
 from fossunited.api.dashboard import get_session_user_profile
-from fossunited.doctype_ids import USER_PROFILE
+from fossunited.doctype_ids import CHAPTER, RESTRICTED_USERNAME, USER_PROFILE
 from frappe.utils.file_manager import save_file
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "razorpay~=1.4.2",
     "PyGithub~=2.3.0",
     "Faker~=27.0.0",
+    "Pillow~=10.0.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕Feature
- [x] 🏎️Optimization

## Description

Changed the  set_profile_image and set_cover_image methods to convert and store user uploaded images as webp. This change seems to work with the dashboard page without any faults (have not extensively tested but it seems to work well on my locally hosted version). used the Pillow library as mentioned in #748 for the conversion. 

Converting image into webp with a quality setting of 100, leads to it increasing in size by a lot, so i changed it to 80. Any quality setting above 85 results in the image actually increasing in size. By setting the image quality to 80%, it decreases in size by 20%.

Of note is that on the production website right now it fetches images from github instead of our server if user (logged in?) using github, and these do not seem to be in webp format. Also, there is no compression or checking of image size right now, so this could possibly be abused by users.

## Related Issues & Docs

closes #748 
