### PR TITLE
feat(hackathon): add `Volunteer` child table to Hackathon doctype

### DIFF
--- a/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.json
@@ -34,6 +34,8 @@
     "hackathon_sponsors_section",
     "sponsor_list",
     "community_partners",
+    "volunteers_tab",
+    "volunteers",
     "team_set_up_tab",
     "is_registration_live",
     "registration_page_setup_section",
@@ -321,6 +323,17 @@
       "label": "Organizing Chapter",
       "options": "FOSS Chapter",
       "reqd": 1
+    },
+    {
+      "fieldname": "volunteers_tab",
+      "fieldtype": "Tab Break",
+      "label": "Volunteers"
+    },
+    {
+      "fieldname": "volunteers",
+      "fieldtype": "Table",
+      "label": "Volunteers",
+      "options": "FOSS Chapter Event Member"
     }
   ],
   "has_web_view": 1,
@@ -348,7 +361,7 @@
       "link_fieldname": "parent_hackathon"
     }
   ],
-  "modified": "2024-12-26 13:49:52.499217",
+  "modified": "2025-02-19 12:55:26.241990",
   "modified_by": "Administrator",
   "module": "FOSS Hackathon",
   "name": "FOSS Hackathon",

--- a/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
@@ -22,6 +22,9 @@ class FOSSHackathon(WebsiteGenerator):
     if TYPE_CHECKING:
         from frappe.types import DF
 
+        from fossunited.chapters.doctype.foss_chapter_event_member.foss_chapter_event_member import (  # noqa: E501
+            FOSSChapterEventMember,
+        )
         from fossunited.chapters.doctype.foss_event_community_partner.foss_event_community_partner import (  # noqa: E501
             FOSSEventCommunityPartner,
         )
@@ -63,6 +66,7 @@ class FOSSHackathon(WebsiteGenerator):
         show_schedule_tab: DF.Check
         sponsor_list: DF.Table[FOSSEventSponsor]
         start_date: DF.Datetime
+        volunteers: DF.Table[FOSSChapterEventMember]
     # end: auto-generated types
 
     def before_save(self):
@@ -100,6 +104,8 @@ class FOSSHackathon(WebsiteGenerator):
             fields=["*"],
         )
 
+        context.volunteers = self.get_volunteers()
+
     def get_nav_items(self):
         nav_items = ["information", "submissions"]
         if self.show_schedule_tab:
@@ -130,6 +136,31 @@ class FOSSHackathon(WebsiteGenerator):
 
         schedule_dict["days"] = list(schedule_dict.keys())
         return schedule_dict
+
+    def get_volunteers(self):
+        members = []
+        for member in self.volunteers:
+            profile = frappe.db.get_value(
+                USER_PROFILE,
+                member.member,
+                [
+                    "profile_photo",
+                    "route",
+                ],
+                as_dict=1,
+            )
+            members.append(
+                {
+                    "full_name": member.full_name,
+                    "role": member.role or "Volunteer",
+                    "profile_picture": (
+                        profile.profile_photo
+                        or "/assets/fossunited/images/defaults/user_profile_image.png"
+                    ),
+                    "route": profile.route,
+                }
+            )
+        return members
 
 
 def get_speakers(schedule):

--- a/fossunited/foss_hackathon/doctype/foss_hackathon/templates/foss_hackathon.html
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/templates/foss_hackathon.html
@@ -123,10 +123,10 @@
           <h5>Community Partners</h5>
           <div class="sponsor--flex">
             {% for partner in doc.community_partners %}
-              <a href="{{ partner.organization_website }}" class="sponsor--block">
+              <a href="{{ partner.link }}" class="sponsor--block">
                 <img
-                  src="{{ partner.company_logo }}"
-                  alt="{{ partner.organization_name }}"
+                  src="{{ partner.logo }}"
+                  alt="{{ partner.org_name }}"
                   class="sponsor--image"
                 />
               </a>

--- a/fossunited/foss_hackathon/doctype/foss_hackathon/templates/foss_hackathon.html
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/templates/foss_hackathon.html
@@ -135,6 +135,17 @@
         </div>
       </div>
     {% endif %}
+    {% if doc.volunteers %}
+      <div class="event-members-section my-3">
+        <h5>Event Members</h5>
+        <div class="event--members-block">
+          {% from 'fossunited/templates/macros/member_card.html' import member_card %}
+          <div class="members-grid-6">
+            {% for volunteer in volunteers %}{{ member_card(volunteer) }}{% endfor %}
+          </div>
+        </div>
+      </div>
+    {% endif %}
   </div>
 {% endmacro %}
 {% macro render_schedule() %}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕Feature

## Description

<!-- Briefly describe the changes introduced by this pull request -->
- Added child table for adding volunteers for the hackathon, similar to events.
- Fixed how community partners are rendered on hackathon pages, as they were broken due to the use of deprecated fieldnames
