### PR TITLE
fix(user): ignore permissions when creating a share doc

### DIFF
--- a/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.py
@@ -153,4 +153,4 @@ class FOSSUserProfile(WebsiteGenerator):
                 "share": 1,
             }
         )
-        share_doc.insert()
+        share_doc.insert(ignore_permissions=True)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛Bug Fix

## Description

<!-- Briefly describe the changes introduced by this pull request -->

closes #833 

We need to ignore perms when creating a share doc
