### PR TITLE
Fixed banner image deletion logic

### DIFF
--- a/fossunited/api/profile.py
+++ b/fossunited/api/profile.py
@@ -58,6 +58,9 @@ def set_cover_image(file_url: str) -> bool:
     """
     user_doc = get_session_user_profile()
     try:
+        if len(file_url) == 0:
+            frappe.db.set_value(USER_PROFILE, user_doc.name, "cover_image", "")
+            return True
         file_path = frappe.get_site_path("public", file_url.lstrip("/"))
         with open(file_path, "rb") as f:
             original_image = f.read()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕Feature
- [ ] ⚙️Chore
- [x] 🐛Bug Fix
- [ ] 🎨Style
- [ ] 🧑‍💻Refactor
- [ ] 📕Documentation
- [ ] 🏎️Optimization

## Description
This issue was created by the PR #821 
Frontend was already handling empty file url logic, so just changed the file url being saved in the database to empty string. 

## Related Issues & Docs
Fixed #835 

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

## Checklist

- [ ] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [ ] I have tested these changes locally.
- [ ] I have updated the documentation (If applicable).
- [ ] The code follows the project's coding standards.
- [ ] I have added/updated tests, if applicable.