### PR TITLE
fix(profile): `Share` permission error on signup

### DIFF
--- a/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.py
@@ -153,4 +153,5 @@ class FOSSUserProfile(WebsiteGenerator):
                 "share": 1,
             }
         )
+        share_doc.flags.ignore_share_permission = 1
         share_doc.insert(ignore_permissions=True)

--- a/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
@@ -98,3 +98,36 @@ class TestFOSSUserProfile(IntegrationTestCase):
 
         profile.delete(force=True)
         test_user.delete(force=True)
+
+    def test_share_user_with_self(self):
+        frappe.set_user("Guest")
+
+        test_email = fake.email()
+
+        test_user = frappe.get_doc(
+            {
+                "doctype": "User",
+                "email": test_email,
+                "first_name": fake.name().split()[0],
+            },
+        ).insert(ignore_permissions=True)
+        test_user.reload()
+
+        profile_id = frappe.db.get_value(
+            USER_PROFILE,
+            {"user": test_user.name},
+            "name",
+        )
+
+        self.assertTrue(
+            frappe.db.exists(
+                "DocShare",
+                {
+                    "user": test_user.name,
+                    "share_doctype": USER_PROFILE,
+                    "share_name": profile_id,
+                },
+            )
+        )
+
+        test_user.delete(force=True)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛Bug Fix

## Description

<!-- Briefly describe the changes introduced by this pull request -->

- There were report of errors when users were trying to signup for our website. Related to #833 
![image](https://github.com/user-attachments/assets/570d11c0-6692-4415-b2de-3e70ddb8a84a)

- This issue was after #767 
- What the problem was: Users are created by `Guest` users. So when a user was created and subsequently their profile was created, we were trying to create a `DocShare` document as a `Guest` user. 
Guest users do no have permission to `Share` a FOSS User Profile doc, hence the error.

- This problem was solved by setting the `ignore_share_permission` to 1 while creating a DocShare
- This PR also adds a test for the above workflow, something which should have been there from day 1
