### PR TITLE
fix(hackathon): sponsor blocks render fix

### DIFF
--- a/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
@@ -116,9 +116,9 @@ class FOSSHackathon(WebsiteGenerator):
     def get_sponsors(self):
         sponsors_dict = {}
         for sponsor in self.sponsor_list:
-            if sponsor.sponsorship_tier not in sponsors_dict:
-                sponsors_dict[sponsor.sponsorship_tier] = []
-            sponsors_dict[sponsor.sponsorship_tier].append(sponsor)
+            if sponsor.tier not in sponsors_dict:
+                sponsors_dict[sponsor.tier] = []
+            sponsors_dict[sponsor.tier].append(sponsor)
         return sponsors_dict
 
     def get_schedule_dict(self):

--- a/fossunited/foss_hackathon/doctype/foss_hackathon/templates/foss_hackathon.html
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/templates/foss_hackathon.html
@@ -104,9 +104,9 @@
             <div class="sponsor--tier-heading">{{ k }}</div>
             <div class="sponsor--flex">
               {% for sponsor in v %}
-                <a href="{{ sponsor.sponsor_link }}" class="sponsor--block">
+                <a href="{{ sponsor.link }}" target="_blank" class="sponsor--block">
                   <img
-                    src="{{ sponsor.sponsor_image }}"
+                    src="{{ sponsor.image }}"
                     alt="{{ sponsor.sponsor_name }}"
                     class="sponsor--image"
                   />
@@ -123,7 +123,7 @@
           <h5>Community Partners</h5>
           <div class="sponsor--flex">
             {% for partner in doc.community_partners %}
-              <a href="{{ partner.link }}" class="sponsor--block">
+              <a href="{{ partner.link }}" target="_blank" class="sponsor--block">
                 <img
                   src="{{ partner.logo }}"
                   alt="{{ partner.org_name }}"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛Bug Fix

## Description

<!-- Briefly describe the changes introduced by this pull request -->
closes #840 

Sponsor blocks were broken due to wrong / deprecated fields being fetched in the context.
