### PR TITLE
fix: handle DuplicateEntryError for ticket emails

### DIFF
--- a/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
@@ -109,7 +109,10 @@ class FOSSEventTicket(Document):
             },
             ["name"],
         )
-        add_to_email_group(email_group, self.email)
+        try:
+            add_to_email_group(email_group, self.email)
+        except frappe.DuplicateEntryError:
+            pass
 
     def is_ticket_live(self):
         tickets_status = frappe.db.get_value(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛Bug Fix


hotfix. 
We are already handling it for CFP and RSVP, makes sense to handle it for Tickets too.

One might wonder why handle the exception at all if we are going to ignore it in the end, well if we do not handle it explicitly, frappe will throw a ValidationError, which will be even harder to handle.