### PR TITLE
added aria-roles in TicketTshirtInsightCard.vue

### DIFF
--- a/dashboard/src/components/event/TicketTshirtInsightCard.vue
+++ b/dashboard/src/components/event/TicketTshirtInsightCard.vue
@@ -5,26 +5,30 @@
     :options="{
       title: 'Sold T-shirt Details',
     }"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="dialog-title"
   >
     <template #body-content>
       <div class="text-sm">
+        <h2 id="dialog-title" class="sr-only">Sold T-shirt Details</h2>
         <p class="mb-2">T-shirts sold for this event.</p>
       </div>
-      <table class="w-3/4 table-fixed text-center">
+      <table class="w-3/4 table-fixed text-center" role="table" aria-describedby="dialog-title">
         <thead class="text-xs text-gray-700 uppercase bg-gray-50">
-          <tr>
-            <th class="p-2 border">Size</th>
-            <th class="p-2 border">Quantity</th>
+          <tr role="row">
+            <th class="p-2 border" role="columnheader" scope="col">Size</th>
+            <th class="p-2 border" role="columnheader" scope="col">Quantity</th>
           </tr>
         </thead>
         <tbody>
-          <tr v-for="(quantity, size) in insight.tshirt_size_count" :key="size">
-            <td class="p-2 text-base border">{{ size }}</td>
-            <td class="p-2 text-base border">{{ quantity }}</td>
+          <tr v-for="(quantity, size) in insight.tshirt_size_count" :key="size" role="row">
+            <td class="p-2 text-base border" role="cell">{{ size }}</td>
+            <td class="p-2 text-base border" role="cell">{{ quantity }}</td>
           </tr>
-          <tr>
-            <td class="p-2 text-base font-semibold">Total</td>
-            <td class="p-2 text-base font-semibold">{{ insight.tshirts_sold }}</td>
+          <tr role="row">
+            <td class="p-2 text-base font-semibold" role="rowheader">Total</td>
+            <td class="p-2 text-base font-semibold" role="cell">{{ insight.tshirts_sold }}</td>
           </tr>
         </tbody>
       </table>
@@ -32,17 +36,18 @@
   </Dialog>
   <div class="flex flex-col w-full border rounded-sm p-4">
     <div class="text-sm flex gap-2 items-center uppercase font-semibold">
-      <IconShirtFilled class="w-5 h-5" />
+      <IconShirtFilled class="w-5 h-5" aria-hidden="true" />
       <span> T-shirts Sold </span>
     </div>
     <div class="flex gap-2 items-end justify-between mt-6">
       <div class="prose">
-        <h2 class="">{{ insight.tshirts_sold }}</h2>
+        <h2 id="total-tshirts" class="text-lg font-bold">{{ insight.tshirts_sold }}</h2>
       </div>
-      <Button class="w-fit" label="View Details" @click="showDialog = true" />
+      <Button class="w-fit" label="View Details" @click="showDialog = true" aria-labelledby="dialog-title" />
     </div>
   </div>
 </template>
+
 <script setup>
 import { Dialog } from 'frappe-ui'
 import { defineProps, ref } from 'vue'


### PR DESCRIPTION
This PR improves the TicketTshirtInsightCard.vue component by adding ARIA roles and accessibility enhancements to ensure better usability for screen readers and assistive technologies.

Changes Made:
✅ Added role="dialog" and aria-modal="true" for the modal dialog.
✅ Associated the dialog with a hidden heading (h2) using aria-labelledby="dialog-title".
✅ Improved table semantics by explicitly defining:

role="table" for the table structure.
role="columnheader" for <th> elements.
role="cell" for <td> elements.
role="rowheader" for the total row label.
✅ Ensured aria-hidden="true" for decorative icons to avoid unnecessary screen reader focus.
✅ Set aria-labelledby="dialog-title" on the View Details button to improve accessibility.
Why This is Needed?
♿ Enhances accessibility by making the dialog and table screen-reader friendly.
✅ Follows Web Content Accessibility Guidelines (WCAG) for better UI compliance.
🛠️ Improves semantic clarity, ensuring assistive technologies interpret the structure correctly.

