### PR TITLE
fix: cta link in event hero

### DIFF
--- a/fossunited/chapters/web_template/events___hero/events___hero.html
+++ b/fossunited/chapters/web_template/events___hero/events___hero.html
@@ -112,7 +112,7 @@
 
     <div class="hero-cta">
       <div class="button-container">
-        <button class="primary-button" onclick="window.location.href='{{ newsletter_subscribe_link }}'">
+        <button class="primary-button" onclick="window.location.href='{{ cta_link }}'">
           {{ cta_text }}
         </button>
       </div>


### PR DESCRIPTION
- Bug Fix


The link in the event hero template was wrong. Don't know how i missed it