### PR TITLE
feat: add `All` permissions in CFP Submission

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -208,7 +208,7 @@ class FOSSChapterEvent(WebsiteGenerator):
         context.cfp_status_block = self.get_cfp_status_block()
         context.user_cfp_submissions = self.get_user_cfp_submissions()
         context.recent_cfp_submissions = self.get_recent_cfp_submissions()
-        context.all_cfp_link = f'/dashboard/cfp/{self.route.split("c/")[1]}'
+        context.all_cfp_link = f'/dashboard/cfp/all/{self.route.split("c/")[1]}'
         context.schedule_dict = self.get_schedule_dict()
         context.no_cache = 1
 

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.json
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.json
@@ -319,7 +319,7 @@
   "has_web_view": 1,
   "is_published_field": "is_published",
   "links": [],
-  "modified": "2025-03-12 23:26:04.096228",
+  "modified": "2025-03-17 11:21:12.555842",
   "modified_by": "Administrator",
   "module": "FOSSUnited",
   "name": "FOSS Event CFP Submission",
@@ -336,6 +336,18 @@
       "report": 1,
       "role": "System Manager",
       "share": 1,
+      "write": 1
+    },
+    {
+      "create": 1,
+      "role": "All"
+    },
+    {
+      "create": 1,
+      "delete": 1,
+      "if_owner": 1,
+      "read": 1,
+      "role": "All",
       "write": 1
     },
     {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕Feature
- [x] 🐛Bug Fix

## Description

<!-- Briefly describe the changes introduced by this pull request -->

Users were having issues where PermissionError was being thrown when they tried to create a CFP Submission. This was due to lack of permissions for `All` users. Added that in this PR:

- All have the perm to create Submissions
- A user can only see the details of the proposals that they are a `owner` of
