### PR TITLE
fix: filter enabled tiers in BuyTickets component

### DIFF
--- a/dashboard/src/pages/BuyTickets.vue
+++ b/dashboard/src/pages/BuyTickets.vue
@@ -464,7 +464,7 @@ const event = createResource({
     }
   },
   onSuccess(data) {
-    const tiers = data.tiers
+    const tiers = data.tiers.filter((tier) => tier.enabled === 1)
     if (tiers.length > 0) {
       checkoutInfo.tier = tiers[0]
     }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛Bug Fix

## Description

<!-- Briefly describe the changes introduced by this pull request -->

There was a HUGE bug in the ticketing page.

So, the event data was being pulled in the ticketing page, and on success, the first tier in the tiers list was selected by default on page load EVEN IF THE TIER WAS DISABLED.

This let people "select" a disabled tier, and buy tickets of a disabled type tier. 

This was fixed by only selecting the `enabled` tiers onSuccess fetching of event, and selecting the first **enabled** tier as a default value.
