### PR TITLE
feat: add `Talk Categories` and  `Preview Details` page to cfp submission

### DIFF
--- a/dashboard/src/components/cfp-public/PreviewSubmission.vue
+++ b/dashboard/src/components/cfp-public/PreviewSubmission.vue
@@ -1,0 +1,113 @@
+<template>
+  <div class="flex flex-col gap-4">
+    <div class="space-y-2">
+      <h3 class="text-2xl font-semibold">Preview Submission</h3>
+      <p class="text-sm text-gray-600">Review the details of your proposal before submitting.</p>
+    </div>
+    <div class="border p-4 md:p-8 bg-white rounded">
+      <div class="flex flex-col gap-3">
+        <h4 class="text-xl font-medium">
+          {{ getValueFromProposal('talk_title') }}
+        </h4>
+        <div class="text-sm flex gap-2 items-center">
+          <Badge
+            :label="getValueFromProposal('session_type')"
+            variant="outline"
+            theme="blue"
+            size="lg"
+          ></Badge>
+          <Badge
+            :label="getValueFromProposal('intended_audience')"
+            variant="outline"
+            theme="gray"
+            size="lg"
+          >
+            <template #prefix>
+              <IconUsersGroup class="h-4 w-4" />
+            </template>
+          </Badge>
+        </div>
+        <div class="space-y-2">
+          <label class="text-base font-medium text-gray-600">Session Categories</label>
+          <RenderSessionCategories :categories="getValueFromProposal('session_categories')" />
+        </div>
+        <div class="space-y-2">
+          <label class="text-base font-medium text-gray-600">Session Description</label>
+          <div
+            class="prose prose-sm border-l pl-2 border-outline-gray-3"
+            v-html="getValueFromProposal('talk_description')"
+          ></div>
+        </div>
+        <div v-if="getValueFromProposal('key_takeaways')" class="space-y-2">
+          <label class="text-base font-medium text-gray-600">Key Takeaways</label>
+          <div
+            class="prose prose-sm border-l pl-2 border-outline-gray-3"
+            v-html="getValueFromProposal('key_takeaways')"
+          ></div>
+        </div>
+        <div class="space-y-2">
+          <label class="text-base font-medium text-gray-600">References</label>
+          <div
+            v-for="(reference, index) in proposalReferences"
+            :key="index"
+            class="flex gap-2 items-center text-base text-gray-600 hover:cursor-pointer hover:text-gray-800 transition-colors"
+          >
+            <IconLink class="w-4 h-4" />
+            <a :href="reference.link" target="_blank">
+              {{ reference.link }}
+            </a>
+          </div>
+        </div>
+        <div class="space-y-2">
+          <label class="text-base font-medium text-gray-600">Speakers</label>
+          <div class="flex flex-col gap-2">
+            <SpeakerCard
+              v-for="(speaker, index) in proposalSpeakers"
+              :key="index"
+              :speaker="speaker"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="flex flex-col gap-2">
+      <div v-for="(field, index) in confirmationFields" :key="index">
+        <FormControl v-model="field.value" type="checkbox" :label="field.label" />
+        <span v-if="field.required" class="text-ink-red-3">*</span>
+      </div>
+    </div>
+  </div>
+</template>
+<script setup>
+import RenderSessionCategories from './RenderSessionCategories.vue'
+import SpeakerCard from './SpeakerCard.vue'
+import { IconUsersGroup, IconLink } from '@tabler/icons-vue'
+import { Badge, FormControl } from 'frappe-ui'
+
+const props = defineProps({
+  proposalFields: {
+    type: Object,
+    required: true,
+  },
+  proposalReferences: {
+    type: Object,
+    required: true,
+  },
+  proposalSpeakers: {
+    type: Object,
+    required: true,
+  },
+})
+
+const confirmationFields = defineModel('confirmationFields', {
+  type: Array,
+  required: true,
+})
+
+const getValueFromProposal = (fieldname) => {
+  const proposalField = props.proposalFields.find((field) => field.fieldname === fieldname)
+  if (proposalField) {
+    return proposalField.value
+  }
+}
+</script>

--- a/dashboard/src/components/cfp-public/RenderSessionCategories.vue
+++ b/dashboard/src/components/cfp-public/RenderSessionCategories.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="flex flex-wrap gap-2">
+    <div
+      v-for="(category, index) in categories"
+      :key="index"
+      class="p-2 flex gap-2 items-center text-sm rounded border border-gray-500 text-ink-gray-6 bg-gray-50"
+    >
+      {{ category }}
+    </div>
+  </div>
+</template>
+<script setup>
+defineProps({
+  categories: {
+    type: Array,
+    required: true,
+  },
+})
+</script>

--- a/dashboard/src/components/cfp-public/SessionDetailForm.vue
+++ b/dashboard/src/components/cfp-public/SessionDetailForm.vue
@@ -1,19 +1,22 @@
 <template>
-  <div class="flex flex-col gap-8 w-full p-8 border rounded bg-white">
+  <div class="flex flex-col gap-8 w-full p-4 md:p-8 border rounded bg-white">
     <h4 class="flex gap-2 items-center font-semibold">
       <IconClipboardText />
       <span>Submission Form</span>
     </h4>
     <RenderField
       v-for="(_field, index) in fields"
+      :id="`${_field.fieldname}_field`"
       :key="index"
       v-model:fields="fields"
       :field="_field"
+      :class="{ hidden: _field.fieldname === 'other_category' }"
     />
     <ReferencesComponent v-model:references="references" />
   </div>
 </template>
 <script setup>
+import { watch } from 'vue'
 import RenderField from '@/components/form/RenderField.vue'
 import ReferencesComponent from '@/components/cfp-public/ReferencesComponent.vue'
 import { IconClipboardText } from '@tabler/icons-vue'
@@ -27,4 +30,50 @@ const references = defineModel('references', {
   type: Array,
   required: true,
 })
+
+// Watch to show or hide the other category field based on session categories
+watch(
+  () => fields.value,
+  (newVal) => {
+    if (newVal) {
+      const otherCategory = newVal.find((field) => field.fieldname === 'other_category')
+      const categories = newVal.find((field) => field.fieldname === 'session_categories')
+
+      if (categories.value.includes('Other')) {
+        let otherCategoryDiv = document.getElementById(`${otherCategory.fieldname}_field`)
+        otherCategoryDiv.classList.remove('hidden')
+      }
+
+      if (!categories.value.includes('Other')) {
+        let otherCategoryDiv = document.getElementById(`${otherCategory.fieldname}_field`)
+        otherCategoryDiv.classList.add('hidden')
+      }
+    }
+  },
+  { deep: true },
+)
+
+// mechanism to add new category to session categories
+watch(
+  () => fields.value,
+  (newVal) => {
+    if (newVal) {
+      const otherCategory = newVal.find((field) => field.fieldname === 'other_category')
+      const categories = newVal.find((field) => field.fieldname === 'session_categories')
+
+      if (otherCategory.value) {
+        if (otherCategory.value && otherCategory.value.endsWith('\n')) {
+          const newCategory = otherCategory.value.trim()
+          categories.options.push({
+            label: newCategory,
+            value: newCategory,
+          })
+          categories.value.push(newCategory)
+          otherCategory.value = '' // Clear the input after adding
+        }
+      }
+    }
+  },
+  { deep: true },
+)
 </script>

--- a/dashboard/src/components/cfp-public/SpeakerCard.vue
+++ b/dashboard/src/components/cfp-public/SpeakerCard.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="flex flex-col gap-2 p-4 border border-outline-gray-2 rounded">
+    <div class="flex gap-6 justify-between">
+      <div class="flex flex-col gap-2 justify-between">
+        <div class="flex flex-col gap-1">
+          <h5 class="text-lg font-medium">{{ getValue('full_name') }}</h5>
+          <a :href="getValue('social_link')" target="_blank">
+            <Badge
+              :label="getValue('social_link')"
+              variant="subtle"
+              theme="gray"
+              size="lg"
+              class="border-outline-gray-3 border"
+            >
+              <template #prefix>
+                <IconWorld class="h-4 w-4" />
+              </template>
+            </Badge>
+          </a>
+        </div>
+        <div class="flex flex-col gap-1 text-sm font-medium">
+          <span>{{ getValue('designation') }}</span>
+          <span>{{ getValue('organization') }}</span>
+        </div>
+      </div>
+      <img class="w-24 h-24 border rounded" :src="getValue('photo')" alt="Speaker Image" />
+    </div>
+    <div class="space-y-1 p-2">
+      <label class="text-base font-medium text-gray-600">Bio</label>
+      <div
+        class="prose prose-sm border-l pl-2 border-outline-gray-3"
+        v-html="getValue('bio')"
+      ></div>
+    </div>
+  </div>
+</template>
+<script setup>
+import { Badge } from 'frappe-ui'
+import { IconWorld } from '@tabler/icons-vue'
+
+const props = defineProps({
+  speaker: {
+    type: Object,
+    required: true,
+  },
+})
+
+const getValue = (fieldname) => {
+  const speakerField = props.speaker.find((field) => field.fieldname === fieldname)
+  return speakerField.value
+}
+</script>

--- a/dashboard/src/components/cfp-public/SpeakersForm.vue
+++ b/dashboard/src/components/cfp-public/SpeakersForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col gap-8 w-full p-8 border rounded bg-white">
+  <div class="flex flex-col gap-8 w-full p-4 md:p-8 border rounded bg-white">
     <h4 class="flex gap-2 items-center font-semibold">
       <IconUserCircle />
       <span>Speaker Information</span>

--- a/dashboard/src/components/form/RenderField.vue
+++ b/dashboard/src/components/form/RenderField.vue
@@ -1,21 +1,24 @@
 <template>
-  <component
-    :is="getComponent"
-    v-model="fields[getFieldIndex(field.fieldname)]['value']"
-    :label="field.label"
-    :required="field.required"
-    :type="field.fieldtype"
-    variant="outline"
-    :options="field.options || []"
-    :description="field.description"
-    size="md"
-  ></component>
+  <div>
+    <component
+      :is="getComponent"
+      v-model="fields[getFieldIndex(field.fieldname)]['value']"
+      :label="field.label"
+      :required="field.required"
+      :type="field.fieldtype"
+      variant="outline"
+      :options="field.options || []"
+      :description="field.description"
+      size="md"
+    ></component>
+  </div>
 </template>
 <script setup>
 import { FormControl } from 'frappe-ui'
-import { computed } from 'vue'
+import { computed, watch } from 'vue'
 import TextEditor from '@/components/ui/TextEditor.vue'
 import RadioGroup from '@/components/ui/RadioGroup.vue'
+import MultiselectInput from '@/components/ui/MultiselectInput.vue'
 
 const props = defineProps({
   field: {
@@ -35,6 +38,8 @@ const getComponent = computed(() => {
       return TextEditor
     case 'radio_group':
       return RadioGroup
+    case 'multiselect':
+      return MultiselectInput
     default:
       return FormControl
   }

--- a/dashboard/src/components/ui/Accordion.vue
+++ b/dashboard/src/components/ui/Accordion.vue
@@ -1,0 +1,39 @@
+<template>
+  <AccordionRoot>
+    <template v-for="(item, index) in accordianItems" :key="index">
+      <AccordionItem :value="item.value">
+        <AccordionHeader>
+          <AccordionTrigger>
+            <IconChevronDown class="w-4 h-4" />
+            <slot name="title">
+              {{ item.title }}
+            </slot>
+          </AccordionTrigger>
+        </AccordionHeader>
+        <AccordionContent>
+          <slot name="content">
+            {{ item.content }}
+          </slot>
+        </AccordionContent>
+      </AccordionItem>
+    </template>
+  </AccordionRoot>
+</template>
+<script setup>
+import { IconChevronDown } from '@tabler/icons-vue'
+import {
+  AccordionContent,
+  AccordionHeader,
+  AccordionItem,
+  AccordionRoot,
+  AccordionTrigger,
+} from 'radix-vue'
+
+defineProps({
+  accordianItems: {
+    type: Array,
+    required: false,
+    default: () => [],
+  },
+})
+</script>

--- a/dashboard/src/components/ui/MultiselectInput.vue
+++ b/dashboard/src/components/ui/MultiselectInput.vue
@@ -1,0 +1,52 @@
+<template>
+  <div>
+    <label class="text-base text-gray-500">
+      {{ label }}
+      <span v-if="required" class="text-red-500">*</span>
+    </label>
+    <div class="flex flex-wrap gap-3 mt-2">
+      <div
+        v-for="(option, index) in options"
+        :key="index"
+        class="p-2 flex gap-2 items-center text-sm rounded border text-ink-gray-5 hover:text-ink-gray-6 hover:cursor-pointer hover:border-gray-400 transition-all"
+        :class="{ 'text-ink-gray-8 border-gray-800 bg-gray-50': isSelected(option.value) }"
+        @click="toggleSelected(option.value)"
+      >
+        <IconCheck v-if="isSelected(option.value)" size="16" />
+        {{ option.label }}
+      </div>
+    </div>
+  </div>
+</template>
+<script setup>
+import { IconCheck } from '@tabler/icons-vue'
+import { FormControl } from 'frappe-ui'
+
+const props = defineProps({
+  label: {
+    type: String,
+    required: true,
+  },
+  required: {
+    type: Boolean,
+    default: false,
+  },
+  options: {
+    type: Array,
+    required: true,
+  },
+})
+
+const model = defineModel({ type: Array, required: true })
+const isSelected = (value) => {
+  return model.value.includes(value)
+}
+
+const toggleSelected = (value) => {
+  if (isSelected(value)) {
+    model.value = model.value.filter((item) => item !== value)
+  } else {
+    model.value.push(value)
+  }
+}
+</script>

--- a/dashboard/src/helpers/cfp.js
+++ b/dashboard/src/helpers/cfp.js
@@ -213,6 +213,40 @@ export const getSpeakerFields = () => {
   ]
 }
 
+export const getSubmissionConfirmationFields = () => {
+  return [
+    {
+      label: 'I have gone through the proposal guidelines before submitting the proposal',
+      fieldname: 'proposal_guidelines_ack',
+      fieldtype: 'checkbox',
+      required: true,
+      value: false,
+    },
+    {
+      label: 'I wrote this myself, it was NOT generated primarily by AI',
+      fieldname: 'authorship_ack',
+      fieldtype: 'checkbox',
+      required: true,
+      value: false,
+    },
+    {
+      label: 'I have included relevant references to provide as much context as possible',
+      fieldname: 'references_ack',
+      fieldtype: 'checkbox',
+      required: true,
+      value: false,
+    },
+    {
+      label:
+        'I am okay with doing a mock presentation of this talk to get better feedback if required (optional)',
+      fieldname: 'mock_presentation_ack',
+      fieldtype: 'checkbox',
+      required: false,
+      value: false,
+    },
+  ]
+}
+
 export const validateRequiredFields = (fields) => {
   const errors = []
 

--- a/dashboard/src/helpers/cfp.js
+++ b/dashboard/src/helpers/cfp.js
@@ -65,8 +65,8 @@ export const getProposalFormFields = (cfpData) => {
 
 const getSessionTypeOptions = (only_workshops, only_talk_proposals) => {
   let options = [
-    { label: 'Talk', value: 'Talk', description: '(Upto 45 mins)' },
-    { label: 'Lightning Talk', value: 'Lightning Talk', description: '(Upto 15 mins)' },
+    { label: 'Talk', value: 'Talk', description: '25-30 mins' },
+    { label: 'Lightning Talk', value: 'Lightning Talk', description: 'Upto 15 mins' },
     {
       label: 'Birds of Feather(BoF)',
       value: 'Birds of Feather(BoF)',

--- a/dashboard/src/helpers/cfp.js
+++ b/dashboard/src/helpers/cfp.js
@@ -19,6 +19,22 @@ export const getProposalFormFields = (cfpData) => {
       value: '',
     },
     {
+      label: 'Session Category',
+      fieldname: 'session_categories',
+      fieldtype: 'multiselect',
+      options: getSessionCategoryOptions(),
+      required: true,
+      value: [],
+    },
+    {
+      label: 'Other Category',
+      fieldname: 'other_category',
+      fieldtype: 'textarea',
+      required: false,
+      value: '',
+      description: 'Press Enter ⏎ after each category.',
+    },
+    {
       label: 'Is this your first talk?',
       fieldname: 'is_first_talk',
       fieldtype: 'radio_group',
@@ -84,6 +100,33 @@ const getSessionTypeOptions = (only_workshops, only_talk_proposals) => {
   }
 
   return options
+}
+
+const getSessionCategoryOptions = () => {
+  return [
+    {
+      value: 'Introducing a FOSS project or a new version of a popular project',
+      label: 'Introducing a FOSS project or a new version of a popular project',
+    },
+    { value: 'Tutorial about using a FOSS project', label: 'Tutorial about using a FOSS project' },
+    { value: 'Contributing to FOSS', label: 'Contributing to FOSS' },
+    { value: 'Technology architecture', label: 'Technology architecture' },
+    {
+      value: 'Engineering practice - productivity, debugging',
+      label: 'Engineering practice - productivity, debugging',
+    },
+    { value: 'Community', label: 'Community' },
+    { value: 'Technology / FOSS licenses, policy', label: 'Technology / FOSS licenses, policy' },
+    {
+      value: 'Story of a FOSS project - from inception to growth',
+      label: 'Story of a FOSS project - from inception to growth',
+    },
+    {
+      value: 'Knowledge Commons (Open Hardware, Open Science, Open Data etc.)',
+      label: 'Knowledge Commons (Open Hardware, Open Science, Open Data etc.)',
+    },
+    { value: 'Other', label: 'Other' },
+  ]
 }
 
 const getCustomQuestions = (questions) => {
@@ -228,6 +271,9 @@ const getTransformedProposalFields = (proposalFields) => {
         type: field.fieldtype,
         response: field.value,
       })
+    } else if (field.fieldname == 'session_categories') {
+      let categories = field.value.join('\n')
+      transformedFields['session_categories'] = categories
     } else {
       transformedFields[field.fieldname] = field.value
     }

--- a/dashboard/src/pages/cfp-public/CfpForm.vue
+++ b/dashboard/src/pages/cfp-public/CfpForm.vue
@@ -23,6 +23,13 @@
               v-model:references="proposalReferences"
             />
             <SpeakersForm v-else-if="curr_section === 2" v-model:speakers="proposalSpeakers" />
+            <PreviewSubmission
+              v-else-if="curr_section === 3"
+              v-model:confirmation-fields="proposalConfirmationFields"
+              :proposal-fields="proposalFormFields"
+              :proposal-references="proposalReferences"
+              :proposal-speakers="proposalSpeakers"
+            />
             <SubmissionSuccessView v-else-if="curr_section === 'success'" />
           </div>
         </transition>
@@ -58,6 +65,7 @@ import SpeakersForm from '@/components/cfp-public/SpeakersForm.vue'
 import StepButtons from '@/components/cfp-public/StepButtons.vue'
 import FormClosedSection from '@/components/cfp-public/FormClosedSection.vue'
 import SubmissionSuccessView from '@/components/cfp-public/SubmissionSuccessView.vue'
+import PreviewSubmission from '@/components/cfp-public/PreviewSubmission.vue'
 import { createResource, LoadingIndicator, usePageMeta, ErrorMessage } from 'frappe-ui'
 import { useRoute } from 'vue-router'
 import { provide, ref, watch, computed, inject } from 'vue'
@@ -65,6 +73,7 @@ import {
   getProposalFormFields,
   getReferenceItemSchema,
   getSpeakerFields,
+  getSubmissionConfirmationFields,
   validateRequiredFields,
   validateReferences,
   validateSpeakerFields,
@@ -73,7 +82,7 @@ import {
 import { toast } from 'vue-sonner'
 
 const curr_section = ref(0)
-const maxSectionIndex = 2
+const maxSectionIndex = 3
 
 const session = inject('$session')
 
@@ -82,8 +91,11 @@ const inLoading = ref(true)
 const proposalFormFields = ref([])
 const proposalReferences = ref([])
 const proposalSpeakers = ref([])
+const proposalConfirmationFields = ref([])
+
 proposalReferences.value.push(getReferenceItemSchema())
 proposalSpeakers.value.push(getSpeakerFields())
+proposalConfirmationFields.value = getSubmissionConfirmationFields()
 
 const errorMessages = ref('')
 
@@ -172,6 +184,13 @@ function nextStep() {
     errors = errors.concat(validateReferences(proposalReferences.value))
   }
 
+  if (curr_section.value == 2) {
+    const speakerErrors = validateSpeakerFields(proposalSpeakers.value)
+    if (speakerErrors.length) {
+      errors = errors.concat(speakerErrors) // Flattening the array
+    }
+  }
+
   if (errors.length) {
     errorMessages.value = errors.join('\n')
     return
@@ -194,11 +213,8 @@ function prevStep() {
 function submitForm() {
   let errors = []
 
-  if (curr_section.value == 2) {
-    const speakerErrors = validateSpeakerFields(proposalSpeakers.value)
-    if (speakerErrors.length) {
-      errors = errors.concat(speakerErrors) // Flattening the array
-    }
+  if (curr_section.value == 3) {
+    errors = errors.concat(validateRequiredFields(proposalConfirmationFields.value))
   }
 
   if (errors.length) {

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.js
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.js
@@ -1,8 +1,24 @@
-// Copyright (c) 2025, Frappe x FOSSUnited and contributors
-// For license information, please see license.txt
+const render_talk_categories = (frm) => {
+  let categories = frm.doc.session_categories
+    .split('\n')
+    .filter((category) => category.trim() !== '')
 
-// frappe.ui.form.on("FOSS Event CFP Submission", {
-// 	refresh(frm) {
+  let html = `<div>
+                               <label class="control-label">Talk Categories</label>
+                                <div style="display: flex; flex-wrap: wrap; gap: 8px;">`
+  categories.forEach((category) => {
+    html += `<div style="background: white; border: 1px solid #ddd; padding: 4px 8px; font-size: 12px; border-radius: 4px;">
+                                                         ${frappe.utils.escape_html(category)}
+                                                 </div>`
+  })
+  html += `   </div>
+                        </div>`
 
-// 	},
-// });
+  frm.set_df_property('categories_preview', 'options', html)
+}
+
+frappe.ui.form.on('FOSS Event CFP Submission', {
+  refresh(frm) {
+    render_talk_categories(frm)
+  },
+})

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.json
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.json
@@ -1,403 +1,417 @@
 {
-  "actions": [],
-  "allow_guest_to_view": 1,
-  "allow_rename": 1,
-  "autoname": "hash",
-  "creation": "2023-09-17 14:21:01.848016",
-  "default_view": "List",
-  "doctype": "DocType",
-  "editable_grid": 1,
-  "engine": "InnoDB",
-  "field_order": [
-    "meta_info_section",
-    "is_published",
-    "route",
-    "status",
-    "attendance_confirmed",
-    "first_name",
-    "last_name",
-    "column_break_vctq",
-    "linked_cfp",
-    "chapter",
-    "event",
-    "event_name",
-    "submitted_by",
-    "about_talk_section",
-    "talk_title",
-    "session_type",
-    "is_first_talk",
-    "talk_reference",
-    "references",
-    "column_break_mhza",
-    "intended_audience",
-    "talk_description",
-    "key_takeaways",
-    "speaker_information_section",
-    "speakers",
-    "personal_information_section",
-    "full_name",
-    "email",
-    "picture_url",
-    "designation",
-    "organization",
-    "column_break_dcfl",
-    "bio",
-    "section_break_ilij",
-    "custom_answers",
-    "reviews_tab",
-    "cfp_reviews_section",
-    "reviews",
-    "review_scores_section",
-    "positive_reviews",
-    "negative_reviews",
-    "unsure_reviews",
-    "column_break_fnih",
-    "approvability"
-  ],
-  "fields": [
-    {
-      "fieldname": "linked_cfp",
-      "fieldtype": "Link",
-      "label": "Linked CFP",
-      "options": "FOSS Event CFP",
-      "reqd": 1
-    },
-    {
-      "fetch_from": "linked_cfp.event",
-      "fieldname": "event",
-      "fieldtype": "Data",
-      "label": "Event"
-    },
-    {
-      "fieldname": "submitted_by",
-      "fieldtype": "Link",
-      "label": "Submitted By",
-      "options": "User"
-    },
-    {
-      "columns": 2,
-      "fetch_from": "linked_cfp.event_name",
-      "fieldname": "event_name",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "label": "Event Name"
-    },
-    {
-      "fieldname": "personal_information_section",
-      "fieldtype": "Section Break",
-      "label": "Personal Information"
-    },
-    {
-      "fetch_from": "submitted_by.email",
-      "fetch_if_empty": 1,
-      "fieldname": "email",
-      "fieldtype": "Data",
-      "label": "Email"
-    },
-    {
-      "fieldname": "column_break_dcfl",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "bio",
-      "fieldtype": "Text Editor",
-      "label": "Speaker Bio"
-    },
-    {
-      "fieldname": "organization",
-      "fieldtype": "Data",
-      "label": "Organization"
-    },
-    {
-      "fieldname": "designation",
-      "fieldtype": "Data",
-      "label": "Designation"
-    },
-    {
-      "fieldname": "about_talk_section",
-      "fieldtype": "Section Break",
-      "label": "Session Details"
-    },
-    {
-      "columns": 3,
-      "fieldname": "talk_title",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "in_standard_filter": 1,
-      "label": "Session Title",
-      "reqd": 1
-    },
-    {
-      "fieldname": "column_break_mhza",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "talk_description",
-      "fieldtype": "Text Editor",
-      "label": "Session Description",
-      "reqd": 1
-    },
-    {
-      "columns": 2,
-      "fieldname": "status",
-      "fieldtype": "Select",
-      "in_list_view": 1,
-      "in_standard_filter": 1,
-      "label": "Status",
-      "options": "Review Pending\nScreening\nApproved\nRejected",
-      "permlevel": 2
-    },
-    {
-      "description": "Link relevant references for your talk.",
-      "fieldname": "talk_reference",
-      "fieldtype": "Data",
-      "label": "Session Reference",
-      "options": "URL"
-    },
-    {
-      "fieldname": "section_break_ilij",
-      "fieldtype": "Section Break",
-      "label": "Custom Answers"
-    },
-    {
-      "fieldname": "custom_answers",
-      "fieldtype": "Table",
-      "label": "Custom Answers",
-      "options": "FOSS Custom Answer"
-    },
-    {
-      "fetch_from": "submitted_by.full_name",
-      "fetch_if_empty": 1,
-      "fieldname": "full_name",
-      "fieldtype": "Data",
-      "label": "Full Name"
-    },
-    {
-      "fieldname": "reviews_tab",
-      "fieldtype": "Tab Break",
-      "label": "Reviews"
-    },
-    {
-      "fieldname": "reviews",
-      "fieldtype": "Table",
-      "label": "Reviews",
-      "options": "FOSS Event CFP Review"
-    },
-    {
-      "fieldname": "route",
-      "fieldtype": "Data",
-      "label": "Route"
-    },
-    {
-      "fieldname": "column_break_vctq",
-      "fieldtype": "Column Break"
-    },
-    {
-      "default": "1",
-      "fieldname": "is_published",
-      "fieldtype": "Check",
-      "label": "Is Published?"
-    },
-    {
-      "default": "No",
-      "description": "This helps us to curate our agenda better.",
-      "fieldname": "is_first_talk",
-      "fieldtype": "Select",
-      "label": "Is this your first talk?",
-      "options": "Yes\nNo",
-      "reqd": 1
-    },
-    {
-      "fieldname": "meta_info_section",
-      "fieldtype": "Section Break",
-      "label": "Meta Info"
-    },
-    {
-      "default": "0",
-      "fieldname": "attendance_confirmed",
-      "fieldtype": "Check",
-      "label": "Attendance Confirmed"
-    },
-    {
-      "fieldname": "cfp_reviews_section",
-      "fieldtype": "Section Break",
-      "label": "CFP Reviews"
-    },
-    {
-      "fieldname": "review_scores_section",
-      "fieldtype": "Section Break",
-      "label": "Review Scores"
-    },
-    {
-      "fieldname": "positive_reviews",
-      "fieldtype": "Data",
-      "label": "Positive Reviews %"
-    },
-    {
-      "fieldname": "negative_reviews",
-      "fieldtype": "Data",
-      "label": "Negative Reviews  %"
-    },
-    {
-      "fieldname": "unsure_reviews",
-      "fieldtype": "Data",
-      "label": "Unsure Reviews  %"
-    },
-    {
-      "fieldname": "column_break_fnih",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "approvability",
-      "fieldtype": "Data",
-      "label": "Approvability  %"
-    },
-    {
-      "columns": 2,
-      "fetch_from": "linked_cfp.chapter",
-      "fieldname": "chapter",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "in_standard_filter": 1,
-      "label": "Chapter"
-    },
-    {
-      "fieldname": "session_type",
-      "fieldtype": "Select",
-      "label": "Session Type",
-      "options": "Talk\nLightning Talk\nPanel Discussion\nBirds of Feather(BoF)\nWorkshop",
-      "reqd": 1
-    },
-    {
-      "description": "Paste a URL for your publicly hosted photo. ",
-      "fieldname": "picture_url",
-      "fieldtype": "Data",
-      "label": "Picture (URL)",
-      "length": 512,
-      "options": "URL"
-    },
-    {
-      "fieldname": "first_name",
-      "fieldtype": "Data",
-      "label": "First Name"
-    },
-    {
-      "fieldname": "last_name",
-      "fieldtype": "Data",
-      "label": "Last Name"
-    },
-    {
-      "fieldname": "speaker_information_section",
-      "fieldtype": "Section Break",
-      "label": "Speaker Information"
-    },
-    {
-      "fieldname": "speakers",
-      "fieldtype": "Table",
-      "label": "Speakers",
-      "options": "CFP Submission Speaker"
-    },
-    {
-      "fieldname": "references",
-      "fieldtype": "Table",
-      "label": "References",
-      "options": "CFP Submission Reference"
-    },
-    {
-      "default": "Intermediate",
-      "fieldname": "intended_audience",
-      "fieldtype": "Select",
-      "label": "Intended Audience",
-      "options": "Beginner\nIntermediate\nAdvanced"
-    },
-    {
-      "fieldname": "key_takeaways",
-      "fieldtype": "Text Editor",
-      "label": "Key Takeaways"
-    }
-  ],
-  "has_web_view": 1,
-  "is_published_field": "is_published",
-  "links": [],
-  "modified": "2025-03-17 11:21:12.555842",
-  "modified_by": "Administrator",
-  "module": "FOSSUnited",
-  "name": "FOSS Event CFP Submission",
-  "naming_rule": "Random",
-  "owner": "Administrator",
-  "permissions": [
-    {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "System Manager",
-      "share": 1,
-      "write": 1
-    },
-    {
-      "create": 1,
-      "role": "All"
-    },
-    {
-      "create": 1,
-      "delete": 1,
-      "if_owner": 1,
-      "read": 1,
-      "role": "All",
-      "write": 1
-    },
-    {
-      "create": 1,
-      "delete": 1,
-      "read": 1,
-      "role": "Chapter Team Member",
-      "select": 1,
-      "write": 1
-    },
-    {
-      "permlevel": 1,
-      "read": 1,
-      "role": "Chapter Team Member",
-      "select": 1
-    },
-    {
-      "permlevel": 2,
-      "read": 1,
-      "role": "Chapter Team Member",
-      "write": 1
-    },
-    {
-      "create": 1,
-      "read": 1,
-      "role": "CFP Reviewer",
-      "select": 1,
-      "write": 1
-    }
-  ],
-  "row_format": "Dynamic",
-  "search_fields": "submitted_by, event, event_name, chapter",
-  "show_title_field_in_link": 1,
-  "sort_field": "modified",
-  "sort_order": "DESC",
-  "states": [
-    {
-      "color": "Light Blue",
-      "title": "Review Pending"
-    },
-    {
-      "color": "Red",
-      "title": "Rejected"
-    },
-    {
-      "color": "Green",
-      "title": "Approved"
-    }
-  ],
-  "title_field": "talk_title",
-  "track_changes": 1,
-  "track_seen": 1
+ "actions": [],
+ "allow_guest_to_view": 1,
+ "allow_rename": 1,
+ "autoname": "hash",
+ "creation": "2023-09-17 14:21:01.848016",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "meta_info_section",
+  "is_published",
+  "route",
+  "status",
+  "attendance_confirmed",
+  "first_name",
+  "last_name",
+  "column_break_vctq",
+  "linked_cfp",
+  "chapter",
+  "event",
+  "event_name",
+  "submitted_by",
+  "about_talk_section",
+  "talk_title",
+  "session_type",
+  "is_first_talk",
+  "talk_reference",
+  "references",
+  "session_categories",
+  "categories_preview",
+  "column_break_mhza",
+  "intended_audience",
+  "talk_description",
+  "key_takeaways",
+  "speaker_information_section",
+  "speakers",
+  "personal_information_section",
+  "full_name",
+  "email",
+  "picture_url",
+  "designation",
+  "organization",
+  "column_break_dcfl",
+  "bio",
+  "section_break_ilij",
+  "custom_answers",
+  "reviews_tab",
+  "cfp_reviews_section",
+  "reviews",
+  "review_scores_section",
+  "positive_reviews",
+  "negative_reviews",
+  "unsure_reviews",
+  "column_break_fnih",
+  "approvability"
+ ],
+ "fields": [
+  {
+   "fieldname": "linked_cfp",
+   "fieldtype": "Link",
+   "label": "Linked CFP",
+   "options": "FOSS Event CFP",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "linked_cfp.event",
+   "fieldname": "event",
+   "fieldtype": "Data",
+   "label": "Event"
+  },
+  {
+   "fieldname": "submitted_by",
+   "fieldtype": "Link",
+   "label": "Submitted By",
+   "options": "User"
+  },
+  {
+   "columns": 2,
+   "fetch_from": "linked_cfp.event_name",
+   "fieldname": "event_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Event Name"
+  },
+  {
+   "fieldname": "personal_information_section",
+   "fieldtype": "Section Break",
+   "label": "Personal Information"
+  },
+  {
+   "fetch_from": "submitted_by.email",
+   "fetch_if_empty": 1,
+   "fieldname": "email",
+   "fieldtype": "Data",
+   "label": "Email"
+  },
+  {
+   "fieldname": "column_break_dcfl",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "bio",
+   "fieldtype": "Text Editor",
+   "label": "Speaker Bio"
+  },
+  {
+   "fieldname": "organization",
+   "fieldtype": "Data",
+   "label": "Organization"
+  },
+  {
+   "fieldname": "designation",
+   "fieldtype": "Data",
+   "label": "Designation"
+  },
+  {
+   "fieldname": "about_talk_section",
+   "fieldtype": "Section Break",
+   "label": "Session Details"
+  },
+  {
+   "columns": 3,
+   "fieldname": "talk_title",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Session Title",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_mhza",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "talk_description",
+   "fieldtype": "Text Editor",
+   "label": "Session Description",
+   "reqd": 1
+  },
+  {
+   "columns": 2,
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "Review Pending\nScreening\nApproved\nRejected",
+   "permlevel": 2
+  },
+  {
+   "description": "Link relevant references for your talk.",
+   "fieldname": "talk_reference",
+   "fieldtype": "Data",
+   "label": "Session Reference",
+   "options": "URL"
+  },
+  {
+   "fieldname": "section_break_ilij",
+   "fieldtype": "Section Break",
+   "label": "Custom Answers"
+  },
+  {
+   "fieldname": "custom_answers",
+   "fieldtype": "Table",
+   "label": "Custom Answers",
+   "options": "FOSS Custom Answer"
+  },
+  {
+   "fetch_from": "submitted_by.full_name",
+   "fetch_if_empty": 1,
+   "fieldname": "full_name",
+   "fieldtype": "Data",
+   "label": "Full Name"
+  },
+  {
+   "fieldname": "reviews_tab",
+   "fieldtype": "Tab Break",
+   "label": "Reviews"
+  },
+  {
+   "fieldname": "reviews",
+   "fieldtype": "Table",
+   "label": "Reviews",
+   "options": "FOSS Event CFP Review"
+  },
+  {
+   "fieldname": "route",
+   "fieldtype": "Data",
+   "label": "Route"
+  },
+  {
+   "fieldname": "column_break_vctq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "1",
+   "fieldname": "is_published",
+   "fieldtype": "Check",
+   "label": "Is Published?"
+  },
+  {
+   "default": "No",
+   "description": "This helps us to curate our agenda better.",
+   "fieldname": "is_first_talk",
+   "fieldtype": "Select",
+   "label": "Is this your first talk?",
+   "options": "Yes\nNo",
+   "reqd": 1
+  },
+  {
+   "fieldname": "meta_info_section",
+   "fieldtype": "Section Break",
+   "label": "Meta Info"
+  },
+  {
+   "default": "0",
+   "fieldname": "attendance_confirmed",
+   "fieldtype": "Check",
+   "label": "Attendance Confirmed"
+  },
+  {
+   "fieldname": "cfp_reviews_section",
+   "fieldtype": "Section Break",
+   "label": "CFP Reviews"
+  },
+  {
+   "fieldname": "review_scores_section",
+   "fieldtype": "Section Break",
+   "label": "Review Scores"
+  },
+  {
+   "fieldname": "positive_reviews",
+   "fieldtype": "Data",
+   "label": "Positive Reviews %"
+  },
+  {
+   "fieldname": "negative_reviews",
+   "fieldtype": "Data",
+   "label": "Negative Reviews  %"
+  },
+  {
+   "fieldname": "unsure_reviews",
+   "fieldtype": "Data",
+   "label": "Unsure Reviews  %"
+  },
+  {
+   "fieldname": "column_break_fnih",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "approvability",
+   "fieldtype": "Data",
+   "label": "Approvability  %"
+  },
+  {
+   "columns": 2,
+   "fetch_from": "linked_cfp.chapter",
+   "fieldname": "chapter",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Chapter"
+  },
+  {
+   "fieldname": "session_type",
+   "fieldtype": "Select",
+   "label": "Session Type",
+   "options": "Talk\nLightning Talk\nPanel Discussion\nBirds of Feather(BoF)\nWorkshop",
+   "reqd": 1
+  },
+  {
+   "description": "Paste a URL for your publicly hosted photo. ",
+   "fieldname": "picture_url",
+   "fieldtype": "Data",
+   "label": "Picture (URL)",
+   "length": 512,
+   "options": "URL"
+  },
+  {
+   "fieldname": "first_name",
+   "fieldtype": "Data",
+   "label": "First Name"
+  },
+  {
+   "fieldname": "last_name",
+   "fieldtype": "Data",
+   "label": "Last Name"
+  },
+  {
+   "fieldname": "speaker_information_section",
+   "fieldtype": "Section Break",
+   "label": "Speaker Information"
+  },
+  {
+   "fieldname": "speakers",
+   "fieldtype": "Table",
+   "label": "Speakers",
+   "options": "CFP Submission Speaker"
+  },
+  {
+   "fieldname": "references",
+   "fieldtype": "Table",
+   "label": "References",
+   "options": "CFP Submission Reference"
+  },
+  {
+   "default": "Intermediate",
+   "fieldname": "intended_audience",
+   "fieldtype": "Select",
+   "label": "Intended Audience",
+   "options": "Beginner\nIntermediate\nAdvanced"
+  },
+  {
+   "fieldname": "key_takeaways",
+   "fieldtype": "Text Editor",
+   "label": "Key Takeaways"
+  },
+  {
+   "fieldname": "categories_preview",
+   "fieldtype": "HTML",
+   "label": "Categories Preview"
+  },
+  {
+   "depends_on": "eval:doc.session_categories == null",
+   "description": "Each category goes on a new line",
+   "fieldname": "session_categories",
+   "fieldtype": "Text",
+   "label": "Session Categories"
+  }
+ ],
+ "has_web_view": 1,
+ "is_published_field": "is_published",
+ "links": [],
+ "modified": "2025-03-30 13:12:40.743265",
+ "modified_by": "Administrator",
+ "module": "FOSSUnited",
+ "name": "FOSS Event CFP Submission",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "role": "All"
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "if_owner": 1,
+   "read": 1,
+   "role": "All",
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "read": 1,
+   "role": "Chapter Team Member",
+   "select": 1,
+   "write": 1
+  },
+  {
+   "permlevel": 1,
+   "read": 1,
+   "role": "Chapter Team Member",
+   "select": 1
+  },
+  {
+   "permlevel": 2,
+   "read": 1,
+   "role": "Chapter Team Member",
+   "write": 1
+  },
+  {
+   "create": 1,
+   "read": 1,
+   "role": "CFP Reviewer",
+   "select": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "search_fields": "submitted_by, event, event_name, chapter",
+ "show_title_field_in_link": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [
+  {
+   "color": "Light Blue",
+   "title": "Review Pending"
+  },
+  {
+   "color": "Red",
+   "title": "Rejected"
+  },
+  {
+   "color": "Green",
+   "title": "Approved"
+  }
+ ],
+ "title_field": "talk_title",
+ "track_changes": 1,
+ "track_seen": 1
 }

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -54,6 +54,7 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         references: DF.Table[CFPSubmissionReference]
         reviews: DF.Table[FOSSEventCFPReview]
         route: DF.Data | None
+        session_categories: DF.Text | None
         session_type: DF.Literal[
             "Talk", "Lightning Talk", "Panel Discussion", "Birds of Feather(BoF)", "Workshop"  # noqa: F722, F821
         ]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕Feature

## Description

<!-- Briefly describe the changes introduced by this pull request -->

Made changes as per the discussion #776 

- Talk categories multiselect added with avenue to add custom category
- `Preview Details` additional page added for preview before submit
- Checkboxes as per #774 added

[Screencast from 2025-03-31 12-57-29.webm](https://github.com/user-attachments/assets/7724ae4c-5f97-4489-bafb-ad87ac157db9)


desk view of session categories:
![image](https://github.com/user-attachments/assets/47cb8f37-7d7c-4eb1-88e0-33097f6553e5)

