### PR TITLE
Enhance Keyboard Accessibility for ChapterCard.vue (MyChapters Section)

### DIFF
--- a/dashboard/src/components/ChapterCard.vue
+++ b/dashboard/src/components/ChapterCard.vue
@@ -1,30 +1,25 @@
 <template>
-  <div
+  <Card
     role="button"
     tabindex="0"
     @click="goToChapter"
     @keyup.enter="goToChapter"
     @keyup.space.prevent="goToChapter"
-    class="focus:outline-none focus:ring-2 focus:ring-blue-600 rounded-[8px]"
+    class="border-2 border-transparent rounded-[8px] hover:border-gray-500 transition-colors hover:cursor-pointer"
   >
-    <Card
-      class="border-2 border-transparent rounded-[8px] hover:border-gray-500 transition-colors hover:cursor-pointer"
-    >
-      <template #actions-left>
-        <FossClubLogo
-          v-if="props.chapter.chapter_type == 'FOSS Club'"
-          class="w-7 h-7"
-        ></FossClubLogo>
-        <CityComunityBranding v-else>{{ props.chapter.chapter_type }}</CityComunityBranding>
-      </template>
+    <template #actions-left>
+      <FossClubLogo
+        v-if="props.chapter.chapter_type == 'FOSS Club'"
+        class="w-7 h-7"
+      ></FossClubLogo>
+      <CityComunityBranding v-else>{{ props.chapter.chapter_type }}</CityComunityBranding>
+    </template>
 
-      <div class="flex justify-between items-baseline">
-        <div class="text-lg font-medium">{{ props.chapter.chapter_name }}</div>
-      </div>
-    </Card>
-  </div>
+    <div class="flex justify-between items-baseline">
+      <div class="text-lg font-medium">{{ props.chapter.chapter_name }}</div>
+    </div>
+  </Card>
 </template>
-
 <script setup>
 import { useRouter } from 'vue-router'
 import FossClubLogo from '@/components/FossClubLogo.vue'

--- a/dashboard/src/components/ChapterCard.vue
+++ b/dashboard/src/components/ChapterCard.vue
@@ -36,10 +36,8 @@ const props = defineProps({
     required: true,
   },
 })
-
 const emit = defineEmits(['selected'])//helps to communicate with parent component
 const router = useRouter()
-
 const goToChapter = () => {
   emit('selected', props.chapter.chapter_name)
   router.push(`/chapter/${props.chapter.name}`)

--- a/dashboard/src/components/ChapterCard.vue
+++ b/dashboard/src/components/ChapterCard.vue
@@ -1,29 +1,47 @@
 <template>
-  <Card
-    class="border-2 border-transparent rounded-[8px] hover:border-gray-500 transition-colors hover:cursor-pointer"
-    @click="() => $router.push(`/chapter/${props.chapter.name}`)"
+  <div
+    role="button"
+    tabindex="0"
+    @click="goToChapter"
+    @keyup.enter="goToChapter"
+    @keyup.space.prevent="goToChapter"
+    class="focus:outline-none focus:ring-2 focus:ring-blue-600 rounded-[8px]"
   >
-    <template #actions-left>
-      <FossClubLogo
-        v-if="props.chapter.chapter_type == 'FOSS Club'"
-        class="w-7 h-7"
-      ></FossClubLogo>
-      <CityComunityBranding v-else>{{ props.chapter.chapter_type }}</CityComunityBranding>
-    </template>
-    <div class="flex justify-between items-baseline">
-      <div class="text-lg font-medium">{{ props.chapter.chapter_name }}</div>
-    </div>
-  </Card>
+    <Card
+      class="border-2 border-transparent rounded-[8px] hover:border-gray-500 transition-colors hover:cursor-pointer"
+    >
+      <template #actions-left>
+        <FossClubLogo
+          v-if="props.chapter.chapter_type == 'FOSS Club'"
+          class="w-7 h-7"
+        ></FossClubLogo>
+        <CityComunityBranding v-else>{{ props.chapter.chapter_type }}</CityComunityBranding>
+      </template>
+
+      <div class="flex justify-between items-baseline">
+        <div class="text-lg font-medium">{{ props.chapter.chapter_name }}</div>
+      </div>
+    </Card>
+  </div>
 </template>
 
 <script setup>
+import { useRouter } from 'vue-router'
 import FossClubLogo from '@/components/FossClubLogo.vue'
 import CityComunityBranding from '@/components/CityCommunityBranding.vue'
 
 const props = defineProps({
   chapter: {
     type: Object,
-    default: () => ({}),
+    required: true,
   },
 })
+
+const emit = defineEmits(['selected'])//helps to communicate with parent component
+const router = useRouter()
+
+const goToChapter = () => {
+  emit('selected', props.chapter.chapter_name)
+  router.push(`/chapter/${props.chapter.name}`)
+}
 </script>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕Feature
- [ ] ⚙️Chore
- [ ] 🐛Bug Fix
- [x] 🎨Style
- [x] 🧑‍💻Refactor
- [ ] 📕Documentation
- [ ] 🏎️Optimization

---

## Description

This PR improves accessibility by adding **keyboard navigation support** to `ChapterCard.vue` in the MyChapters section.

### ✅ Changes made:
- Wrapped the `Card` component inside a `div` with `role="button"` and `tabindex="0"`
- Added `@keyup.enter` and `@keyup.space` handlers to allow keyboard users to interact with the card
- Applied visual focus styles using Tailwind (`focus:outline-none`, `focus:ring`)
- Replaced inline `$router.push` with `useRouter()` and a `goToChapter()` method for cleaner logic

This change ensures that users relying on keyboard navigation or screen readers can interact with chapters just as smoothly as mouse users.

---

## Related Issues & Docs

No specific issue linked yet, but aligns with general accessibility best practices (WCAG) and UX improvements for inclusivity.

---

## Checklist

- [x] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [x] I have tested these changes locally.
- [x] The code follows the project's coding standards.
- [x] I have considered accessibility for keyboard/screen-reader users.
- [ ] I have added/updated tests, if applicable.

---

## Screenshots/GIFs/Screen Recordings (if applicable)

🔵 Keyboard focus ring visible on `ChapterCard.vue`  
🎯 Pressing `Enter` or `Space` now navigates correctly  
🖱️ Mouse click behavior preserved
![image](https://github.com/user-attachments/assets/8a5623df-0077-49c4-ac6a-24889e5dc962)
The blue outline on delhi shows it is now  accessible by tabs.

## Additional context

This update makes the My  Chapters dashboard more usable for everyone.  
Great for users who rely on keyboard navigation — and an important step toward a more accessible, inclusive frontend.

---

