### PR TITLE
fix(speakers): only show speakers of approved talks

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -275,7 +275,9 @@ class FOSSChapterEvent(WebsiteGenerator):
         return members
 
     def get_speakers(self):
-        submissions = frappe.db.get_all(PROPOSAL, {"event": self.name}, pluck="name")
+        submissions = frappe.db.get_all(
+            PROPOSAL, {"event": self.name, "status": "Approved"}, pluck="name"
+        )
 
         speakers = []
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛Bug Fix

## Description

<!-- Briefly describe the changes introduced by this pull request -->

Speaker section was pulling in speakers from all the talks. This PR fixes that. Only pull speakers from sessions that are **Approved**
