### PR TITLE
Added Keyboard Navigation for Event Cards and Improved Accessibility for Footer Social Media Links

### DIFF
--- a/fossunited/fossunited/web_template/foss_footer/foss_footer.html
+++ b/fossunited/fossunited/web_template/foss_footer/foss_footer.html
@@ -189,9 +189,9 @@
           <div class="social-media-credits">
             <div class="social-category-items">
               {% for child_item in footer_items %}{% if child_item.parent_label == "Social Media" %}
-                <a href="{{ child_item.url }}" class="footer-link">
-                  <img src="{{ child_item.custom_icon }}" alt="" />
-                </a>
+              <a href="{{ child_item.url }}" class="footer-link" aria-label="Visit our {{ child_item.label|default('social media')|title }} page">
+                <img src="{{ child_item.custom_icon }}" alt="{{ child_item.label|default('Social media icon')|title }}" />
+              </a>
               {% endif %}{% endfor %}
             </div>
 

--- a/fossunited/templates/macros/event_card.html
+++ b/fossunited/templates/macros/event_card.html
@@ -1,41 +1,32 @@
 {% macro event_card(event) %}
-  <div
+  <a
     class="event-card"
     data-docname="{{ event.name }}"
     data-route="{{ event.route }}"
-    {%
-      if
-      event.is_external_event
-    %}
-      onclick="window.open('{{ event.external_event_url }}', '_blank')"
+    {% if event.is_external_event %}
+      href="{{ event.external_event_url }}" target="_blank" rel="noopener noreferrer"
     {% else %}
-      onclick="window.location.pathname='/{{ event.route }}'"
+      href="/{{ event.route }}"
     {% endif %}
+    aria-label="Event {{ event.event_name }} is happening on {{ event.event_start_date.strftime('%d %b %Y') }} at location {{ event.event_location or 'To Be Announced' }}. Click to explore about the event."
   >
     <div class="event-card-contents">
       {% if event.chapter %}
         {% set chapter = frappe.get_doc("FOSS Chapter", event.chapter) %}
-        <div
-          class="chapter-brand-block {% if chapter.chapter_type == 'FOSS Club' %}club-brand{% endif %}"
-        >
+        <div class="chapter-brand-block {% if chapter.chapter_type == 'FOSS Club' %}club-brand{% endif %}">
           {% if chapter.chapter_type == 'FOSS Club' %}
-            <img src="/assets/fossunited/images/chapter/fossclub_logo.svg" alt="" />
+            <img src="/assets/fossunited/images/chapter/fossclub_logo.svg" alt="FOSS Club Logo" />
             <span>{{ chapter.chapter_name | truncate(25, True, '...', 0) }}</span>
           {% else %}
-            <span class="fff-forward"
-              >{{ chapter.city.upper() | truncate(25, True, '...', 0) }}</span
-            >
+            <span class="fff-forward">{{ chapter.city.upper() | truncate(25, True, '...', 0) }}</span>
           {% endif %}
         </div>
-      {% else %}
-        <div></div>
       {% endif %}
       <div class="event-card--date-section">
         <div class="event-card--date">{{ event.event_start_date.strftime("%d %b %Y") }}</div>
         {% if event.must_attend %}
           <div class="event-card--must-attend">
-            <i class="ti ti-star-filled"></i>
-            {{ _("Must Attend") }}
+            <i class="ti ti-star-filled"></i> {{ _("Must Attend") }}
           </div>
         {% endif %}
       </div>
@@ -47,5 +38,5 @@
         </div>
       </div>
     </div>
-  </div>
+  </a>
 {% endmacro %}

--- a/fossunited/templates/macros/event_card.html
+++ b/fossunited/templates/macros/event_card.html
@@ -8,7 +8,7 @@
     {% else %}
       href="/{{ event.route }}"
     {% endif %}
-    aria-label="Event {{ event.event_name }} is happening on {{ event.event_start_date.strftime('%d %b %Y') }} at location {{ event.event_location or 'To Be Announced' }}. Click to explore about the event."
+    aria-description="Event {{ event.event_name }} is happening on {{ event.event_start_date.strftime('%d %b %Y') }} at location {{ event.event_location or 'To Be Announced' }}. Click to explore about the event."
   >
     <div class="event-card-contents">
       {% if event.chapter %}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕Feature
- [x] ⚙️Chore
- [x] 🐛Bug Fix
- [ ] 🎨Style
- [x] 🧑‍💻Refactor
- [ ] 📕Documentation
- [ ] 🏎️Optimization

## Description

## Event Card 

### Before

https://github.com/user-attachments/assets/a0048a1c-4244-4b08-bfda-146ed9c5b6e3

### After

https://github.com/user-attachments/assets/41b1b41d-11d6-4337-8cc7-8262f588e3c5



## Footer Description
This PR enhances the accessibility of the footer’s social media icons by improving how assistive technologies interpret them. Specifically:

- Each `<a>` tag now includes a clear `aria-label` like “Visit our Twitter page” to describe the link’s destination to screen readers.
- Each `<img>` tag has a descriptive `alt` attribute (e.g., “Twitter”) to help non-visual users understand the icon.
- Used Jinja’s `|default` and `|title` filters to ensure graceful fallbacks and readable labels even when values are missing.
- Removed chapter-specific context to reflect that the footer is global and not tied to any specific section.

These changes ensure consistent, accessible navigation for users with screen readers and align with WCAG 2.1 standards.

## Related Issues & Docs
![Before](https://github.com/user-attachments/assets/90ccb67f-9ecd-4ba5-b464-cda6eeb150ff)
Closes #880 
## After chaning the code it was not checked because the footer was not loading on my local machine.
## Checklist
- [x] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [x] I have tested these changes locally.
- [ ] I have updated the documentation (If applicable).
- [x] The code follows the project's coding standards.
- [ ] I have added/updated tests, if applicable.



