### PR TITLE
fix: handle no cfp error in `get_events_by_open_cfp`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: 'node_modules|.git'
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
         # Needed because of the unsafe mermaid extension support in the mkdocs
@@ -14,7 +14,7 @@ repos:
   # Run the Ruff linter.
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.6.4
+    rev: v0.11.6
     hooks:
       # Run the Ruff linter.
       - id: ruff

--- a/dashboard/src/pages/MyProfile.vue
+++ b/dashboard/src/pages/MyProfile.vue
@@ -10,7 +10,10 @@
           <div class="relative">
             <img
               class="w-full aspect-[4.96/1]"
-              :src="profile.data.cover_image || '/assets/fossunited/images/defaults/user_profile_banner.png'"
+              :src="
+                profile.data.cover_image ||
+                '/assets/fossunited/images/defaults/user_profile_banner.png'
+              "
               alt="Banner Image"
             />
             <div class="top-3 right-3 absolute flex gap-1">
@@ -46,7 +49,10 @@
           <div class="z-10 w-fit relative -mt-12 mx-6">
             <img
               class="aspect-square border-4 border-white rounded w-28"
-              :src="profile.data.profile_photo || '/assets/fossunited/images/defaults/user_profile_image.png'"
+              :src="
+                profile.data.profile_photo ||
+                '/assets/fossunited/images/defaults/user_profile_image.png'
+              "
               alt="Profile Photo"
             />
             <FileUploader
@@ -106,7 +112,11 @@
                   ></span>
                 </div>
                 <div
-                  v-else-if="profile_dict.username && !usernameValidateErrors && profile_dict.username !== initialUsername"
+                  v-else-if="
+                    profile_dict.username &&
+                    !usernameValidateErrors &&
+                    profile_dict.username !== initialUsername
+                  "
                   class="flex"
                 >
                   <span class="text-sm text-green-500 mr-1 font-semibold">
@@ -320,8 +330,7 @@ const validateUsername = async () => {
         usernameValidateErrors.value = ''
       }
     } catch (_) {
-      usernameValidateErrors.value =
-        'Error checking username availability. Refresh and try again!'
+      usernameValidateErrors.value = 'Error checking username availability. Refresh and try again!'
     }
   } else {
     usernameValidateErrors.value = ''
@@ -335,7 +344,7 @@ watch(
     if (newValue.trim() !== '') {
       validateUsername()
     }
-  }
+  },
 )
 
 const isValidUsername = createResource({

--- a/fossunited/api/reviewer.py
+++ b/fossunited/api/reviewer.py
@@ -135,21 +135,22 @@ def get_events_by_open_cfp() -> list:
         list: List of events with open CFP
     """
     if not has_reviewer_role():
-        frappe.throw("Unauthorized Access")
+        frappe.throw("Unauthorized Access", frappe.PermissionError)
 
-    events = frappe.db.get_list(
+    events = frappe.get_all(
         EVENT,
         filters={
             "status": "Live",
             "is_published": 1,
             "event_start_date": [">=", frappe.utils.nowdate()],
+            "is_external_event": 0,
         },
         fields=[
             "name",
+            "chapter",
             "event_name",
             "event_start_date",
             "event_end_date",
-            "chapter",
         ],
         page_length=99,
         order_by="event_start_date",
@@ -161,15 +162,21 @@ def get_events_by_open_cfp() -> list:
         cfp = frappe.db.get_value(
             EVENT_CFP,
             {"event": event.name},
-            ["name", "chapter"],
+            ["name"],
             as_dict=1,
+            pluck=True,
         )
+
+        if not cfp:
+            continue
+
         chapter = frappe.db.get_value(
             CHAPTER,
             event.chapter,
             ["name", "chapter_name", "chapter_type"],
             as_dict=1,
         )
+
         submission_count = frappe.db.count(PROPOSAL, {"linked_cfp": cfp.name})
         reviewed_count, not_reviewed_count = get_reviewed_count(event=event.name)
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛Bug Fix

Reviewer's page is not rendering in the production. This is due to recent changes, and no handling of events with no CFP forms created. This PR handles that and fixes it