### PR TITLE
fix(cfp-submission): speaker email addition workflow

### DIFF
--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -71,17 +71,12 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         self.validate_linked_cfp_exists()
 
     def before_save(self):
-        self.set_name()
         self.set_route()
         self.set_scores()
         self.handle_status_change()
 
     def after_insert(self):
         self.handle_email_group("CFP Proposers")
-
-    def set_name(self):
-        self.first_name = self.full_name.split(" ")[0]
-        self.last_name = " ".join(self.full_name.split(" ")[1:])
 
     def set_route(self):
         event_route = frappe.db.get_value(EVENT, self.event, "route")
@@ -298,7 +293,11 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
             ["name"],
         )
 
-        try:
-            add_to_email_group(email_group, self.email)
-        except frappe.DuplicateEntryError:
-            pass
+        for speaker in self.speakers:
+            if not speaker.email:
+                continue
+
+            try:
+                add_to_email_group(email_group, speaker.email)
+            except frappe.DuplicateEntryError:
+                continue

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/test_foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/test_foss_event_cfp_submission.py
@@ -24,11 +24,19 @@ class TestFOSSEventCFPSubmission(IntegrationTestCase):
         self.event = insert_test_event(chapter=self.chapter)
 
         self.cfp = insert_cfp_form(event=self.event)
-        self.submission_email = fake.email()
+        speakers = [
+            {
+                "full_name": fake.name(),
+                "email": fake.email(),
+                "designation": fake.job(),
+                "organization": fake.company(),
+                "bio": "Test Submission",
+            }
+        ]
         self.submission = insert_cfp_submission(
             linked_cfp=self.cfp.name,
             event=self.event.name,
-            email=self.submission_email,
+            speakers=speakers,
         )
 
     def tearDown(self):
@@ -46,60 +54,64 @@ class TestFOSSEventCFPSubmission(IntegrationTestCase):
         cfp = self.cfp
 
         # When a submission is done by user
-        submission = self.submission
+        # Then the speaker emails should be added to an email group for this event,
+        # where type==CFP Proposers
 
-        # Then the email should be added to an email group linked to event for CFP Proposers
-        self.assertTrue(self.is_added_to_email_group(cfp.event, submission.email, "CFP Proposers"))
+        for speaker in self.submission.speakers:
+            self.assertTrue(
+                self.is_added_to_email_group(cfp.event, speaker.email, "CFP Proposers")
+            )
 
     def test_add_to_group_on_accept(self):
         # given a cfp and its submission
-        cfp = self.cfp
-        submission = self.submission
 
         frappe.set_user(LEAD)
         # When the status is changed to Approved
-        submission.status = "Approved"
-        submission.save()
+        self.submission.status = "Approved"
+        self.submission.save()
 
-        # Then it should be added to an email group for this event, where type==Accepted Proposers
-        self.assertTrue(
-            self.is_added_to_email_group(cfp.event, submission.email, "Accepted Proposers")
-        )
+        # Then the speaker emails of this submission should be added to an email group
+        # for this event, where type==Accepted Proposers
+
+        for speaker in self.submission.speakers:
+            self.assertTrue(
+                self.is_added_to_email_group(self.event, speaker.email, "Accepted Proposers")
+            )
 
     def test_add_to_group_on_reject(self):
         # given a cfp and its submission
-        cfp = self.cfp
-        submission = self.submission
-
         frappe.set_user(LEAD)
         # When the status is changed to Approved
-        submission.status = "Rejected"
-        submission.save()
+        self.submission.status = "Rejected"
+        self.submission.save()
 
-        # Then it should be added to an email group for this event, where type==Accepted Proposers
-        self.assertTrue(
-            self.is_added_to_email_group(cfp.event, submission.email, "Rejected Proposers")
-        )
+        # Then the speaker emails of this submission should be added to an email group
+        # for this event, where type==Rejected Proposers
+
+        for speaker in self.submission.speakers:
+            self.assertTrue(
+                self.is_added_to_email_group(self.event, speaker.email, "Rejected Proposers")
+            )
 
     def test_multiple_submission_by_same_email(self):
         # given a cfp
-        cfp = self.cfp
-
         # When multiple submissions are done by the same email
         # Then they should be submitted without any error.
         submission_email = "test4@example.com"
 
-        # ToDo: test by setting user with above email
-
+        frappe.set_user(submission_email)
         for _ in range(3):
             submission = insert_cfp_submission(
-                linked_cfp=cfp.name, event=cfp.event, email=submission_email
+                linked_cfp=self.cfp.name, event=self.cfp.event, email=submission_email
             )
 
             self.assertTrue(submission)
 
-        # And the email should be added to an email group linked to event for CFP Proposers
-        self.assertTrue(self.is_added_to_email_group(cfp.event, submission_email, "CFP Proposers"))
+        # And the speakers of these submissions should be added to the email group for this event
+        for speaker in self.submission.speakers:
+            self.assertTrue(
+                self.is_added_to_email_group(self.event, speaker.email, "CFP Proposers")
+            )
 
     def is_added_to_email_group(self, event_id, email, group_type):
         email_group = frappe.db.get_value(

--- a/fossunited/tests/utils.py
+++ b/fossunited/tests/utils.py
@@ -486,21 +486,37 @@ def insert_cfp_submission(linked_cfp: str, event: str, **kwargs):
         event (str): The id of the event linked to the submission.
         **kwargs: Additional arguments to be passed to the submission document.
     """
+    speakers = kwargs.get("speakers", [])
+    if not speakers:
+        speakers = [
+            {
+                "full_name": fake.name(),
+                "email": fake.email(),
+                "designation": fake.job(),
+                "organization": fake.company(),
+                "bio": "Test Submission",
+            }
+        ]
+
+    references = kwargs.get("references", [])
+    if not references:
+        references = [
+            {
+                "link": fake.url(),
+            }
+        ]
+
     submission_data = {
         "doctype": PROPOSAL,
         "status": kwargs.get("status", "Review Pending"),
         "linked_cfp": linked_cfp,
         "event": event,
         "submitted_by": kwargs.get("submitted_by", ""),
-        "full_name": kwargs.get("full_name", fake.name()),
-        "email": kwargs.get("email", fake.email()),
-        "designation": kwargs.get("designation", "SDE"),
-        "organization": kwargs.get("organization", fake.company()),
-        "bio": kwargs.get("bio", "Test Submission"),
+        "speakers": speakers,
         "is_first_talk": kwargs.get("is_first_talk", "No"),
         "session_type": kwargs.get("session_type", "Talk"),
         "talk_title": kwargs.get("talk_title", fake.text(max_nb_chars=20).strip()),
-        "talk_reference": kwargs.get("talk_reference", ""),
+        "references": references,
         "talk_description": kwargs.get("talk_description", fake.sentence()),
         "custom_answers": kwargs.get("custom_answers", []),
     }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛Bug Fix

## Description

<!-- Briefly describe the changes introduced by this pull request -->

Refactor and fix the email addition workflow to respective email email groups on CFP Submission actions.

The workflow was broken with recent refactor of the CFP. With addition of Speakers child table in CFP Submission, we were not adding all the speaker emails to the email groups but rather only the first speaker. 

This PR fixes that, and handles the avenue for additional speakers
