### PR TITLE
chore: upgrade to pillow 11.0, icon CDN and fix team user handle

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter/templates/foss_chapter.html
+++ b/fossunited/chapters/doctype/foss_chapter/templates/foss_chapter.html
@@ -40,7 +40,7 @@
     <div class="header-section--socials">
       {% for (k,v) in social_links.items() %}
       <a href="{{ v }}" aria-label="{{ k|title }} for {{ doc.chapter_name }} chapter.">
-        <img src="https://cdn.simpleicons.org/{{ k }}" alt="{{ k|title }}" />
+        <img src="https://svgl.app/library/{{ k }}.svg" alt="{{ k|title }}" />
       </a>
       {% endfor %}
     </div>

--- a/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
@@ -99,7 +99,7 @@
       %}
         <div class="experience-card">
           <img
-            src="https://logo.clearbit.com/{{ values[0].company_website }}"
+            src="https://img.logo.dev/{{ values[0].company_website.lstrip("https://") }}"
             onerror="renderCompanyImage(this)"
             alt="{{ key }}"
             class="experience-card-logo"
@@ -208,7 +208,7 @@
               {% for company in doc.experience %}{% if company.is_working_here %}
                 <img
                   class="company-badge"
-                  src="https://logo.clearbit.com/{{ company.company_website }}"
+                  src="https://img.logo.dev/{{ company.company_website.lstrip("https://") }}"
                   alt=""
                 />
               {% endif %}{% endfor %}
@@ -255,7 +255,7 @@
         <div class="header-section--socials">
           {% for (key,value) in user_socials.items() %}
             <a rel="me nofollow" href="{{ value }}"
-              ><img src="https://cdn.simpleicons.org/{{ key }}" alt="{{ key }}"
+              ><img src="https://svgl.app/library/{{ key }}.svg" alt="{{ key }}"
             /></a>
           {% endfor %}
         </div>

--- a/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
@@ -98,6 +98,7 @@
         values) in experiences_dict.items()
       %}
         <div class="experience-card">
+          <!-- Company logos are provided by https://logo.dev -->
           <img
             src="https://img.logo.dev/{{ values[0].company_website.lstrip("https://") }}"
             onerror="renderCompanyImage(this)"
@@ -206,6 +207,7 @@
             <div class="d-flex mb-1">
               <h4 class="mr-1">{{ doc.full_name }}</h4>
               {% for company in doc.experience %}{% if company.is_working_here %}
+                <!-- Company logos are provided by https://logo.dev -->
                 <img
                   class="company-badge"
                   src="https://img.logo.dev/{{ company.company_website.lstrip("https://") }}"

--- a/fossunited/fossunited/web_template/team_list_section/team_list_section.html
+++ b/fossunited/fossunited/web_template/team_list_section/team_list_section.html
@@ -109,7 +109,7 @@
                 </div>
                 <div class="team-member-details">
                   <h6>{{ member.full_name }}</h6>
-                  <a href="/{{ member.username }}">@{{ member.username }}</a>
+                  <a href="/u/{{ member.username }}">@{{ member.username }}</a>
                   <p>{{ member.designation }}</p>
                 </div>
               </div>
@@ -136,7 +136,7 @@
                 </div>
                 <div class="team-member-details">
                   <h6>{{ member.full_name }}</h6>
-                  <a href="/{{ member.username }}">@{{ member.username }}</a>
+                  <a href="/u/{{ member.username }}">@{{ member.username }}</a>
                   <p>{{ member.designation }}</p>
                 </div>
               </div>
@@ -163,7 +163,7 @@
                 </div>
                 <div class="team-member-details">
                   <h6>{{ member.full_name }}</h6>
-                  <a href="/{{ member.username }}">@{{ member.username }}</a>
+                  <a href="/u/{{ member.username }}">@{{ member.username }}</a>
                   <p>{{ member.designation }}</p>
                 </div>
               </div>
@@ -190,7 +190,7 @@
                 </div>
                 <div class="team-member-details">
                   <h6>{{ member.full_name }}</h6>
-                  <a href="/{{ member.username }}">@{{ member.username }}</a>
+                  <a href="/u/{{ member.username }}">@{{ member.username }}</a>
                 </div>
               </div>
             {% endfor %}

--- a/fossunited/fossunited/web_template/team_page___founder_section/team_page___founder_section.html
+++ b/fossunited/fossunited/web_template/team_page___founder_section/team_page___founder_section.html
@@ -116,7 +116,7 @@
                 />
               </div>
               <div class="founder-member-details">
-                <a href="{{ '/' + member.username if member.username else member.portfolio_url }}">
+                <a href="{{ '/u/' + member.username if member.username else member.portfolio_url }}">
                   <h6>
                     {{ member.full_name }}
                     <i class="ti ti-arrow-up-right"></i>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "razorpay~=1.4.2",
     "PyGithub~=2.3.0",
     "Faker~=27.0.0",
-    "Pillow~=10.0.0"
+    "Pillow~=11.0.0"
 ]
 
 [project.optional-dependencies]
@@ -30,7 +30,9 @@ build-backend = "flit_core.buildapi"
 
 [tool.ruff]
 line-length = 99
-lint.select = [
+
+[tool.ruff.lint]
+select = [
     "I",
     "E",
     "F",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕Feature
- [x] ⚙️Chore
- [x] 🐛Bug Fix
- [ ] 🎨Style
- [ ] 🧑‍💻Refactor
- [ ] 📕Documentation
- [ ] 🏎️Optimization

## Description

1. Deprecation of Clearbit's free logo API, which can break the logos of companies in user profile's experience and work section. Migration to `logo.dev` as per their description works with current domain names.
2. User handles were not being redirected properly to their profile page in the team page for team members and founders due to usage of `/` instead of `/u/`
3. Simple Icons CDN does not support LinkedIn which leads to a broken icon being displayed for socials, using `svgl.app` fixes this
4. Usage of Pillow 10, breaking installation while using `bench get-app`, which is fixed by using Pillow 11 and it's been tested on Debian Bookworm and Ubuntu Noble.

## Related Issues & Docs

1. Closes #879

## Checklist

- [x] I have read the [contribution guidelines]("./docs/CONTRIBUTING.md").
- [x] I have tested these changes locally.
- [ ] I have updated the documentation (If applicable).
- [x] The code follows the project's coding standards.
- [ ] I have added/updated tests, if applicable.