### PR TITLE
feat: chapter filter for /events/timeline (closes #940)

### DIFF
--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -223,34 +223,8 @@ def get_chapter_details():
     Retrieves FOSS Chapter Events and Hackathons, then groups them by month and year, separating
     upcoming and past events.
     """
-    events = frappe.get_all(
-        EVENT,
-        pluck="chapter",
-        filters={
-            "status": ["in", ["Approved", "Live", "Concluded"]],
-            "is_published": 1,
-        },
-        order_by="event_start_date",
-    )
-
-    hackathons = frappe.get_all(
-        HACKATHON,
-        pluck="chapter",
-        filters={
-            "is_published": 1,
-        },
-        order_by="start_date",
-    )
-
-    arr = events + hackathons
-
-    res = []
-
-    for val in arr:
-        if val not in res:
-            res.append(val)
-
-    return res
+    chapters = frappe.db.get_all(CHAPTER, fields=["chapter_name", "name"])
+    return chapters
 
 
 def process_event(event, event_list):

--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -225,7 +225,7 @@ def get_chapter_details():
     """
     events = frappe.get_all(
         EVENT,
-        pluck="chapter",
+        pluck="chapter_name",
         filters={
             "status": ["in", ["Approved", "Live", "Concluded"]],
             "is_published": 1,

--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -218,6 +218,41 @@ def get_grouped_events():
     return get_month_grouped_events(events, hackathons)
 
 
+def get_chapter_details():
+    """
+    Retrieves FOSS Chapter Events and Hackathons, then groups them by month and year, separating
+    upcoming and past events.
+    """
+    events = frappe.get_all(
+        EVENT,
+        pluck="chapter",
+        filters={
+            "status": ["in", ["Approved", "Live", "Concluded"]],
+            "is_published": 1,
+        },
+        order_by="event_start_date",
+    )
+
+    hackathons = frappe.get_all(
+        HACKATHON,
+        pluck="chapter",
+        filters={
+            "is_published": 1,
+        },
+        order_by="start_date",
+    )
+
+    arr = events + hackathons
+
+    res = []
+
+    for val in arr:
+        if val not in res:
+            res.append(val)
+
+    return res
+
+
 def process_event(event, event_list):
     """
     Processes a single event or hackathon, adding it to the upcoming or past events list based on

--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -225,7 +225,7 @@ def get_chapter_details():
     """
     events = frappe.get_all(
         EVENT,
-        pluck="chapter_name",
+        pluck="chapter",
         filters={
             "status": ["in", ["Approved", "Live", "Concluded"]],
             "is_published": 1,

--- a/fossunited/fossunited/web_template/events_timeline/events_timeline.html
+++ b/fossunited/fossunited/web_template/events_timeline/events_timeline.html
@@ -119,6 +119,20 @@
       <p id="must-attend-desc" class="sr-only">
         Filter the events to show only those marked as must-attend.
       </p>
+      <!-- City Chapter selector -->
+      <div class="must-attend-checkbox">
+        <select id="cityChapter" v-model="cityChapter">
+          <option value="All Cities" selected>All Cities</option>
+          {% set chapter_details = get_chapter_details() %}
+          {% for chapter in chapter_details %}
+            <option value="{{chapter}}">{{ chapter }}</option>
+          {% endfor %}
+        </select>
+        <label for="cityChapter">City Chapter</label>
+      </div>
+      <p id="must-attend-desc" class="sr-only">
+        Filter the events to show only those in your city.
+      </p>
     </div>
 
     <!--Primary Event cards listing-->
@@ -144,7 +158,7 @@
                 <div
                   class="event-card-holder"
                   role="listitem"
-                  v-if="canShow('{{ event.event_name }}', '{{ event_date_text }}', !!{{ event.must_attend }})"
+                  v-if="canShow('{{ event.event_name }}', '{{ event_date_text }}', !!{{ event.must_attend }}, '{{ event.chapter }}')"
                 >
                   {{ event_card(event) }}
                 </div>
@@ -152,7 +166,7 @@
                 <div
                   class="event-card-holder"
                   role="listitem"
-                  v-if="canShow('{{ event.hackathon_name }}', '{{ event_date_text }}')"
+                  v-if="canShow('{{ event.event_name }}', '{{ event_date_text }}', !!{{ event.must_attend }}, '{{ event.chapter }}')"
                 >
                   {{ hackathon_card(event) }}
                 </div>
@@ -179,7 +193,7 @@
               <div
                 class="event-card-holder"
                 role="listitem"
-                v-if="canShow('{{ event.event_name }}', '{{ event_date_text }}', !!{{ event.must_attend }})"
+                v-if="canShow('{{ event.event_name }}', '{{ event_date_text }}', !!{{ event.must_attend }}, '{{ event.chapter }}')"
               >
                 {% if event.event_name %}
                   {{ event_card(event) }}
@@ -199,8 +213,13 @@
       searchText: '',
       ticker: 1,
       mustAttendOnly: false,
-      canShow(eventName, eventDate, eventMustAttend) {
+      cityChapter: 'All Cities',
+      canShow(eventName, eventDate, eventMustAttend, eventCityChapter) {
         if (this.mustAttendOnly && !eventMustAttend) {
+          return false
+        }
+
+        if (this.cityChapter != 'All Cities' && eventCityChapter != this.cityChapter) {
           return false
         }
 
@@ -209,8 +228,8 @@
         }
 
         return (
-          eventName.toLowerCase().includes(this.searchText) ||
-          eventDate.toLowerCase().includes(this.searchText)
+          eventName.toLowerCase().includes(this.searchText.toLowerCase()) ||
+          eventDate.toLowerCase().includes(this.searchText.toLowerCase())
         )
       },
       updateTicker() {

--- a/fossunited/fossunited/web_template/events_timeline/events_timeline.html
+++ b/fossunited/fossunited/web_template/events_timeline/events_timeline.html
@@ -158,7 +158,7 @@
                 <div
                   class="event-card-holder"
                   role="listitem"
-                  v-if="canShow('{{ event.event_name }}', '{{ event_date_text }}', !!{{ event.must_attend }}, '{{ event.chapter }}')"
+                  v-if="canShow('{{ event.event_name }}', '{{ event_date_text }}', !!{{ event.must_attend }}, '{{ event.chapter_name }}')"
                 >
                   {{ event_card(event) }}
                 </div>
@@ -166,7 +166,7 @@
                 <div
                   class="event-card-holder"
                   role="listitem"
-                  v-if="canShow('{{ event.event_name }}', '{{ event_date_text }}', !!{{ event.must_attend }}, '{{ event.chapter }}')"
+                  v-if="canShow('{{ event.hackathon_name }}', '{{ event_date_text }}', !!{{ event.must_attend }}, '{{ event.chapter }}')"
                 >
                   {{ hackathon_card(event) }}
                 </div>
@@ -190,14 +190,19 @@
           {% for month, month_events in events.items() %}
             {% for event in month_events %}
               {% set event_date_text = event.event_start_date.strftime("%d %b %Y") if event.event_start_date else event.start_date.strftime("%d %b %Y") %}
+                {% if event.event_name %}
               <div
                 class="event-card-holder"
                 role="listitem"
-                v-if="canShow('{{ event.event_name }}', '{{ event_date_text }}', !!{{ event.must_attend }}, '{{ event.chapter }}')"
+                v-if="canShow('{{ event.event_name }}', '{{ event_date_text }}', !!{{ event.must_attend }}, '{{ event.chapter_name }}')"
               >
-                {% if event.event_name %}
                   {{ event_card(event) }}
                 {% else %}
+              <div
+                class="event-card-holder"
+                role="listitem"
+                v-if="canShow('{{ event.hackathon_name }}', '{{ event_date_text }}', !!{{ event.must_attend }}, '{{ event.chapter }}')"
+              >
                   {{ hackathon_card(event) }}
                 {% endif %}
               </div>

--- a/fossunited/fossunited/web_template/events_timeline/events_timeline.html
+++ b/fossunited/fossunited/web_template/events_timeline/events_timeline.html
@@ -125,7 +125,7 @@
           <option value="All Cities" selected>All Cities</option>
           {% set chapter_details = get_chapter_details() %}
           {% for chapter in chapter_details %}
-            <option value="{{chapter}}">{{ chapter }}</option>
+            <option value="{{chapter.name}}">{{ chapter.chapter_name }}</option>
           {% endfor %}
         </select>
         <label for="cityChapter">City Chapter</label>

--- a/fossunited/fossunited/web_template/events_timeline/events_timeline.html
+++ b/fossunited/fossunited/web_template/events_timeline/events_timeline.html
@@ -154,11 +154,12 @@
             v-show="ticker > 0 && $el?.children.length > 0"
           >
             {% for event in month_events %}
+              {% set event_date_text = event.event_start_date.strftime("%d %b %Y") if event.event_start_date else event.start_date.strftime("%d %b %Y") %}
               {% if event.event_name %}
                 <div
                   class="event-card-holder"
                   role="listitem"
-                  v-if="canShow('{{ event.event_name }}', '{{ event_date_text }}', !!{{ event.must_attend }}, '{{ event.chapter_name }}')"
+                  v-if="canShow('{{ event.event_name }}', '{{ event_date_text }}', !!{{ event.must_attend }}, '{{ event.chapter }}')"
                 >
                   {{ event_card(event) }}
                 </div>
@@ -166,7 +167,7 @@
                 <div
                   class="event-card-holder"
                   role="listitem"
-                  v-if="canShow('{{ event.hackathon_name }}', '{{ event_date_text }}', !!{{ event.must_attend }}, '{{ event.chapter }}')"
+                  v-if="canShow('{{ event.hackathon_name }}', '{{ event_date_text }}', true, '{{ event.chapter }}')"
                 >
                   {{ hackathon_card(event) }}
                 </div>
@@ -194,18 +195,19 @@
               <div
                 class="event-card-holder"
                 role="listitem"
-                v-if="canShow('{{ event.event_name }}', '{{ event_date_text }}', !!{{ event.must_attend }}, '{{ event.chapter_name }}')"
+                v-if="canShow('{{ event.event_name }}', '{{ event_date_text }}', !!{{ event.must_attend }}, '{{ event.chapter }}')"
               >
                   {{ event_card(event) }}
+              </div>
                 {% else %}
               <div
                 class="event-card-holder"
                 role="listitem"
-                v-if="canShow('{{ event.hackathon_name }}', '{{ event_date_text }}', !!{{ event.must_attend }}, '{{ event.chapter }}')"
+                v-if="canShow('{{ event.hackathon_name }}', '{{ event_date_text }}', true, '{{ event.chapter }}')"
               >
                   {{ hackathon_card(event) }}
-                {% endif %}
               </div>
+                {% endif %}
             {% endfor %}
           {% endfor %}
         {% endfor %}

--- a/fossunited/hooks.py
+++ b/fossunited/hooks.py
@@ -44,6 +44,7 @@ jinja = {
         "fossunited.fossunited.utils.get_user_editable_doctype_fields",
         "fossunited.fossunited.utils.get_signup_optin_checks",
         "fossunited.fossunited.utils.get_grouped_events",
+        "fossunited.fossunited.utils.get_chapter_details",
         "fossunited.stack.utils.get_stack_dict",
     ],
     "filters": [


### PR DESCRIPTION
- made the search bar case-insensitive
- added a filter that allows users to select their closest chapter
- closes #940 
![image](https://github.com/user-attachments/assets/1e9ad73b-1661-46e0-b65a-bdc45228cccd)
![image](https://github.com/user-attachments/assets/58df41e9-a4fe-4dfc-bae6-4820578da69a)
