### PR TITLE
fix: dont use grouped view if a city chapter is filtered

### DIFF
--- a/fossunited/fossunited/web_template/events_timeline/events_timeline.html
+++ b/fossunited/fossunited/web_template/events_timeline/events_timeline.html
@@ -138,7 +138,7 @@
     <!--Primary Event cards listing-->
     {% set grouped_events = get_grouped_events() %}
     {% for group, events in grouped_events.items() %}
-      <div class="event-group" v-if="searchText.length == 0" role="region">
+      <div class="event-group" v-if="searchText.length == 0 && cityChapter === 'All Cities'" role="region">
         <h3>{{ group }}</h3>
         {% for month, month_events in events.items() %}
           <h4
@@ -180,7 +180,7 @@
 
     <!--Searched and Filtered event cards listing-->
     <div
-      v-if="searchText.length > 0"
+      v-if="searchText.length > 0 || cityChapter != 'All Cities'"
       aria-live="polite"
       role="region"
       aria-labelledby="filtered-events-label"

--- a/fossunited/fossunited/web_template/events_timeline/events_timeline.html
+++ b/fossunited/fossunited/web_template/events_timeline/events_timeline.html
@@ -125,7 +125,7 @@
           <option value="All Cities" selected>All Cities</option>
           {% set chapter_details = get_chapter_details() %}
           {% for chapter in chapter_details %}
-            <option value="{{chapter.name}}">{{ chapter.chapter_name }}</option>
+            <option value="{{chapter.name}}">{{ chapter.chapter_name | truncate(15, False, '...', 0) }}</option>
           {% endfor %}
         </select>
         <label for="cityChapter">City Chapter</label>


### PR DESCRIPTION
small bug on my part, didnt factor in how many gaps would come in the main deployment
Before:
![image](https://github.com/user-attachments/assets/166de704-841d-43fe-95e9-87948e496272)
Now:
![image](https://github.com/user-attachments/assets/b4bfb77a-7436-40e5-9c56-4733d087dd77)
