### PR TITLE
fix: [login] change email input type from text to email

### DIFF
--- a/dashboard/src/pages/Login.vue
+++ b/dashboard/src/pages/Login.vue
@@ -2,7 +2,7 @@
   <div class="m-3 flex flex-row items-center justify-center">
     <Card title="Login to your FrappeUI App!" class="w-full max-w-md mt-4">
       <form class="flex flex-col space-y-2 w-full" @submit.prevent="submit">
-        <Input required name="email" type="text" placeholder="johndoe@email.com" label="User ID" />
+        <Input required name="email" type="email" placeholder="johndoe@email.com" label="User ID" />
         <Input required name="password" type="password" placeholder="••••••" label="Password" />
         <Button :loading="session.login.loading" variant="solid">Login</Button>
       </form>


### PR DESCRIPTION
Searched through a simple regex query, did not find any other instance. I guess this one was an oversight.