### PR TITLE
feat: add Telegram URL field in chapter details form

### DIFF
--- a/dashboard/src/pages/ChapterDetails.vue
+++ b/dashboard/src/pages/ChapterDetails.vue
@@ -156,6 +156,11 @@
             <IconBrandMastodon class="w-5 text-gray-800" />
           </template>
         </FormControl>
+        <FormControl v-model="chapter.doc.telegram" :type="'url'" size="md" label="Telegram">
+          <template #prefix>
+            <IconBrandTelegram class="w-5 text-gray-800" />
+          </template>
+        </FormControl>
       </div>
     </div>
   </div>
@@ -174,6 +179,7 @@ import {
   IconBrandLinkedin,
   IconBrandMastodon,
   IconBrandX,
+  IconBrandTelegram,
 } from '@tabler/icons-vue'
 
 const route = useRoute()


### PR DESCRIPTION
This PR adds support for including a Telegram group URL in the chapter details form on the dashboard.

### Changes

- Added a new input field labeled "Telegram URL" in the chapter details form (`/dashboard/chapter/community_name`)
- As the Telegram icon was available on svgl.app, the /c/community page was suitable for displaying the Telegram icon.

### Screenshots

- Dashboard Page 

![Screenshot 2025-05-18 at 9 29 41 PM](https://github.com/user-attachments/assets/82b302e7-06e8-4081-aba1-2439aa5e3bf7)

- Community Page ( c/community ) 

![Screenshot 2025-05-18 at 9 29 47 PM](https://github.com/user-attachments/assets/e68ae56a-6989-445f-8072-485d0c811a52)
