### PR TITLE
fix: validate event and tier parent

### DIFF
--- a/fossunited/payments/doctype/razorpay_payment/test_razorpay_payment.py
+++ b/fossunited/payments/doctype/razorpay_payment/test_razorpay_payment.py
@@ -2,11 +2,14 @@ import frappe
 from faker import Faker
 from frappe.tests import IntegrationTestCase
 
-from fossunited.doctype_ids import EVENT_TICKET, RAZORPAY_PAYMENT
+from fossunited.doctype_ids import EVENT, EVENT_TICKET, RAZORPAY_PAYMENT, TICKET_TIER
 from fossunited.tests.utils import (
     insert_test_chapter,
     insert_test_event,
     insert_test_razorpay_payment,
+)
+from fossunited.ticketing.doctype.foss_event_ticket.foss_event_ticket import (
+    TicketTierMismatchError,
 )
 
 fake = Faker()
@@ -108,3 +111,25 @@ class TestRazorpayPayment(IntegrationTestCase):
         # Then it should throw an error before it is created
         with self.assertRaises(frappe.PermissionError):
             insert_test_razorpay_payment(event=self.event.name)
+
+    def test_event_ticket_tier_mismatch(self):
+        event_1 = self.event
+        event_2 = insert_test_event(
+            chapter=self.chapter,
+            is_paid_event=1,
+            tiers=[
+                {
+                    "enabled": 1,
+                    "title": "Faulty",
+                    "price": 5,
+                    "maximum_tickets": 5,
+                }
+            ],
+            tickets_status="Live",
+        )
+
+        event_2_tier = frappe.get_doc(TICKET_TIER, {"parent": event_2.name, "parenttype": EVENT})
+
+        # create a payment for event_1 but with event_2 tier
+        with self.assertRaises(TicketTierMismatchError):
+            insert_test_razorpay_payment(event=event_1.name, tier=event_2_tier)

--- a/fossunited/payments/doctype/razorpay_payment/test_razorpay_payment.py
+++ b/fossunited/payments/doctype/razorpay_payment/test_razorpay_payment.py
@@ -84,7 +84,7 @@ class TestRazorpayPayment(IntegrationTestCase):
         # Given a event ticket payment with multiple participants
         number_of_attendees = 3
         payment = insert_test_razorpay_payment(
-            event=self.event.name, num_seats=number_of_attendees
+            event=self.event.name, attendees=[], num_seats=number_of_attendees
         )
         # The initial status should be `Pending`
         self.assertEqual(payment.status, "Pending")
@@ -133,3 +133,5 @@ class TestRazorpayPayment(IntegrationTestCase):
         # create a payment for event_1 but with event_2 tier
         with self.assertRaises(TicketTierMismatchError):
             insert_test_razorpay_payment(event=event_1.name, tier=event_2_tier)
+
+        event_2.delete()

--- a/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
@@ -155,6 +155,10 @@ def handle_payment_on_update(doc: "RazorpayPayment", event: str):
             raise
 
 
+class TicketTierMismatchError(frappe.ValidationError):
+    pass
+
+
 def validate_payment_before_insert(doc: "RazorpayPayment", event: str):
     # calculate total amount
     calculated_amount = 0
@@ -162,6 +166,9 @@ def validate_payment_before_insert(doc: "RazorpayPayment", event: str):
     attendees = payment_meta_data.get("attendees", [])
     tier = payment_meta_data.get("tier", {}).get("name")
     price, event_name = frappe.db.get_value("FOSS Ticket Tier", tier, ["price", "parent"])
+
+    if event_name != payment_meta_data.get("event"):
+        frappe.throw("This tier does not belong to this event!", TicketTierMismatchError)
 
     tshirt_price = frappe.db.get_value(EVENT, event_name, "t_shirt_price")
 


### PR DESCRIPTION
validate that the event ticket tier belongs to the specific event.

Earlier this was not validated, which could enable people to buy tickets for an event with a higher ticket price, on a lower price by passing a false tier of another event with low price.