### PR TITLE
feat: add `has_external_webpage` field to chapter event

### DIFF
--- a/dashboard/src/components/schedule/EventHeader.vue
+++ b/dashboard/src/components/schedule/EventHeader.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="w-full flex flex-col md:flex-row gap-4 justify-between md:items-center">
     <div class="flex gap-2 items-center">
-      <div v-if="event.is_external_event">
+      <div v-if="event.event_logo">
         <img :src="event.event_logo" :alt="event.event_name + ' Logo'" class="h-8" />
       </div>
       <div v-else>

--- a/dashboard/src/pages/events/AllProposals.vue
+++ b/dashboard/src/pages/events/AllProposals.vue
@@ -83,6 +83,7 @@ const event = createResource({
         'event_location',
         'event_bio',
         'is_external_event',
+        'has_external_webpage',
         'external_event_url',
         'event_logo',
         'proposal_page_description',
@@ -117,7 +118,7 @@ const breadcrumb_items = computed(() => {
   return [
     {
       label: event.data.event_name,
-      link: event.data.is_external_event
+      link: event.data.has_external_webpage
         ? event.data.external_event_url
         : createAbsoluteUrlFromRoute(event.data.route),
     },

--- a/dashboard/src/pages/schedule/Schedule.vue
+++ b/dashboard/src/pages/schedule/Schedule.vue
@@ -82,7 +82,7 @@ const breadcrumb_items = computed(() => {
   return [
     {
       label: event.data.event_name,
-      link: event.data.is_external_event
+      link: event.data.has_external_webpage
         ? event.data.external_event_url
         : getRedirectRoute(event.data.route),
     },

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
@@ -214,6 +214,7 @@ class FOSSChapter(WebsiteGenerator):
                 "must_attend",
                 "event_location",
                 "is_external_event",
+                "has_external_webpage",
                 "external_event_url",
             ],
             order_by="event_end_date desc",

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
@@ -10,6 +10,7 @@
   "engine": "InnoDB",
   "field_order": [
     "is_external_event",
+    "has_external_webpage",
     "column_break_okxh",
     "external_event_url",
     "meta_info_section",
@@ -420,6 +421,7 @@
     },
     {
       "default": "0",
+      "description": "If enabled, all aspects of the event will be managed independently by the organizer.\nThis option is only used to include the event in the event list for displaying its event card.",
       "fieldname": "is_external_event",
       "fieldtype": "Check",
       "label": "Is External Event?"
@@ -431,7 +433,8 @@
     {
       "fieldname": "external_event_url",
       "fieldtype": "Data",
-      "label": "External Event URL"
+      "label": "External Event URL",
+      "mandatory_depends_on": "eval:doc.is_external_event || doc.has_external_webpage"
     },
     {
       "default": "Live",
@@ -480,11 +483,18 @@
       "options": "URL"
     },
     {
+      "description": "eg. https://youtube.com/watch?v=VIDEOID becomes https://youtube.com/embed/VIDEOID",
       "fieldname": "livestream_embed_link",
       "fieldtype": "Data",
       "label": "Livestream Link for Embedding",
-      "description": "eg. https://youtube.com/watch?v=VIDEOID becomes https://youtube.com/embed/VIDEOID",
       "options": "URL"
+    },
+    {
+      "default": "0",
+      "description": "Event features like RSVP, CFP, and Tickets are managed directly on our website \u2014 only an external landing page is created.",
+      "fieldname": "has_external_webpage",
+      "fieldtype": "Check",
+      "label": "Has External Webpage?"
     }
   ],
   "has_web_view": 1,
@@ -506,7 +516,7 @@
       "link_fieldname": "event"
     }
   ],
-  "modified": "2024-12-12 13:47:54.934609",
+  "modified": "2025-05-20 15:13:04.902037",
   "modified_by": "Administrator",
   "module": "Chapters",
   "name": "FOSS Chapter Event",
@@ -544,6 +554,7 @@
       "select": 1
     }
   ],
+  "row_format": "Dynamic",
   "search_fields": "event_permalink, chapter",
   "show_title_field_in_link": 1,
   "sort_field": "modified",

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -171,7 +171,7 @@ class FOSSChapterEvent(WebsiteGenerator):
             )
 
     def validate_permalink(self):
-        if self.is_external_event:
+        if self.has_external_webpage:
             return
 
         if frappe.db.exists(
@@ -198,7 +198,7 @@ class FOSSChapterEvent(WebsiteGenerator):
         return
 
     def set_route(self):
-        if self.is_external_event:
+        if self.has_external_webpage:
             return
 
         event_route = frappe.db.get_value(CHAPTER, self.chapter, "route")

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -109,6 +109,9 @@ class FOSSChapterEvent(WebsiteGenerator):
         self.validate_permalink()
 
     def before_save(self):
+        if self.is_external_event:
+            self.has_external_webpage = True
+
         if self.has_value_changed("status"):
             self.update_published_status()
         self.set_route()

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -67,11 +67,12 @@ class FOSSChapterEvent(WebsiteGenerator):
         event_type: DF.Link | None
         external_event_url: DF.Data | None
         hall_options: DF.SmallText | None
+        has_external_webpage: DF.Check
         is_external_event: DF.Check
         is_paid_event: DF.Check
         is_published: DF.Check
-        livestream_link: DF.Data | None
         livestream_embed_link: DF.Data | None
+        livestream_link: DF.Data | None
         map_link: DF.Data | None
         must_attend: DF.Check
         paid_tshirts_available: DF.Check

--- a/fossunited/templates/macros/event_card.html
+++ b/fossunited/templates/macros/event_card.html
@@ -3,7 +3,7 @@
     class="event-card"
     data-docname="{{ event.name }}"
     data-route="{{ event.route }}"
-    {% if event.is_external_event %}
+    {% if event.has_external_webpage %}
       href="{{ event.external_event_url }}" target="_blank" rel="noopener noreferrer"
     {% else %}
       href="/{{ event.route }}"


### PR DESCRIPTION
different from `is_external_event` as `has_external_webpage` only defines an external web page for the event. 

All other functionalities such as CFP, RSVPs and Tickets are still handled via our own frappe backend, just as a normal event.