### PR TITLE
feat: human-readable option type info for rsvp form fields

### DIFF
--- a/dashboard/src/pages/EventRsvpEdit.vue
+++ b/dashboard/src/pages/EventRsvpEdit.vue
@@ -147,11 +147,11 @@
             type="select"
             label="Type"
             :options="[
-              { label: 'Data', value: 'Data' },
+              { label: 'Text', value: 'Data' },
               { label: 'Select', value: 'Select' },
               { label: 'Long Text', value: 'Long Text' },
               { label: 'Text Editor', value: 'Text Editor' },
-              { label: 'Check', value: 'Check' },
+              { label: 'Checkbox', value: 'Check' },
             ]"
             description="The type of question you want to ask."
           />


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7ff586c5-d071-422e-aada-e3531ab2dc1b)
closes #451 