### PR TITLE
fix: add better error when banner deletion on event occurs

### DIFF
--- a/dashboard/src/pages/EventDetails.vue
+++ b/dashboard/src/pages/EventDetails.vue
@@ -228,7 +228,7 @@ const setBannerImage = (file) => {
   if (file.file_url) {
     toast.success('Banner image uploaded successfully')
   } else {
-    toast.info('Banner image removed successfully')
+    toast.info('Banner image removed successfully, will default to chapter banner if set.')
   }
 }
 


### PR DESCRIPTION
closes #1023 
![image](https://github.com/user-attachments/assets/124f643c-3287-4125-b496-323140871cb3)
