### PR TITLE
fix: misc filters

### DIFF
--- a/fossunited/api/proposal.py
+++ b/fossunited/api/proposal.py
@@ -68,7 +68,7 @@ def get_public_proposal_filters(
             "fieldname": "status",
             "fieldtype": "Select",
             "options": "Approved\nRejected\nReview Pending\nScreening",
-            "label": "Status",
+            "label": "Review Status",
         },
         {
             "fieldname": "session_type",

--- a/fossunited/api/proposal.py
+++ b/fossunited/api/proposal.py
@@ -106,13 +106,15 @@ def get_public_proposal_filters(
         )
 
         for index, field in enumerate(custom_fields, start=1):
+            if field.type == "Radio Group":
+                field.type = "Select"
+
             filter_fields.append(
                 {
                     "fieldname": f"custom_question_{index}",
                     "fieldtype": field.type,
                     "label": field.question,
                     "options": field.options or "",
-                    "description": field.description or "",
                 }
             )
 

--- a/fossunited/api/proposal.py
+++ b/fossunited/api/proposal.py
@@ -83,6 +83,7 @@ def get_public_proposal_filters(
             "label": "Is First Talk?",
         },
         {
+            "label": "Intended Audience",
             "fieldname": "intended_audience",
             "fieldtype": "Select",
             "options": "Beginner\nIntermediate\nAdvanced",


### PR DESCRIPTION
closes #1039 

- Removed description of custom questions from being rendered in filters list. This will prevent the buggy behaviour we have now.
- fixed intended_audience filter label
- renamed `Status` filter to `Review Status`