### PR TITLE
add bluesky logo for chapters

### DIFF
--- a/dashboard/src/pages/ChapterDetails.vue
+++ b/dashboard/src/pages/ChapterDetails.vue
@@ -202,6 +202,11 @@
             <IconBrandTelegram class="w-5 text-gray-800" />
           </template>
         </FormControl>
+        <FormControl v-model="chapter.doc.bluesky" :type="'url'" size="md" label="Bluesky">
+          <template #prefix>
+            <IconBrandBluesky class="w-5 text-gray-800" />
+          </template>
+        </FormControl>
         <FormControl v-model="chapter.doc.matrix" :type="'url'" size="md" label="Matrix">
           <template #prefix>
             <IconBrandMatrix class="w-5 text-gray-800" />
@@ -236,6 +241,7 @@ import {
   IconBrandMastodon,
   IconBrandX,
   IconBrandTelegram,
+  IconBrandBluesky,
   IconBrandMatrix,
   IconBrandWhatsapp,
   IconBrandDiscord,

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.json
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.json
@@ -39,6 +39,7 @@
   "instagram",
   "mastodon",
   "telegram",
+  "bluesky",
   "whatsapp",
   "discord",
   "chapter_members_section",
@@ -245,6 +246,12 @@
    "fieldname": "telegram",
    "fieldtype": "Data",
    "label": "Telegram",
+   "options": "URL"
+  },
+  {
+   "fieldname": "bluesky",
+   "fieldtype": "Data",
+   "label": "Bluesky",
    "options": "URL"
   },
   {

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
@@ -45,6 +45,7 @@ class FOSSChapter(WebsiteGenerator):
         slug: DF.Data | None
         state: DF.Link | None
         telegram: DF.Data | None
+        bluesky: DF.Data | None
         whatsapp: DF.Data | None
         x: DF.Data | None
     # end: auto-generated types
@@ -257,6 +258,7 @@ class FOSSChapter(WebsiteGenerator):
             "telegram",
             "whatsapp",
             "discord",
+            "bluesky",
         ]
         for k, v in self.as_dict().items():
             if k in SOCIAL_LINK_FIELDNAMES:


### PR DESCRIPTION
partially covers #1064

Only adds bluesky icon logo to chapters.

Zulip can be added once the PR is merged in svgl repo.

Logo in chapter page:
<img width="1283" height="611" alt="image" src="https://github.com/user-attachments/assets/5eb67388-d95d-453e-a688-f2425508f554" />

Logo in Dashboard chapter:
<img width="1189" height="449" alt="image" src="https://github.com/user-attachments/assets/24806110-4cbb-4c2b-97e2-de7a97a6a956" />


I hope it covers everywhere. Please let me know if I missed to cover it any place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a Bluesky social media link in the chapter details form and chapter profiles. Users can now enter and view Bluesky URLs alongside other social media fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->