### PR TITLE
Auto close jobs after threshold duration

### DIFF
--- a/fossunited/doctype_ids.py
+++ b/fossunited/doctype_ids.py
@@ -42,6 +42,11 @@ EVENT_TICKET = "FOSS Event Ticket"
 TICKET_TRANSFER = "FOSS Event Ticket Transfer"
 TICKET_TIER = "FOSS Ticket Tier"
 
+# Job-related identifiers
+JOB = "Job Board"
+JOB_STATUS_APPROVED = "Approved"
+JOB_STATUS_EXPIRED = "Expired"
+
 # Payments
 
 RAZORPAY_PAYMENT = "Razorpay Payment"

--- a/fossunited/hooks.py
+++ b/fossunited/hooks.py
@@ -108,4 +108,7 @@ scheduler_events = {
     "daily_long": [
         "fossunited.scheduled_tasks.conclude_events",
     ],
+    "monthly": [
+        "fossunited.scheduled_tasks.update_past_job_status",
+    ],
 }

--- a/fossunited/scheduled_tasks.py
+++ b/fossunited/scheduled_tasks.py
@@ -1,8 +1,8 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import frappe
 
-from fossunited.doctype_ids import EVENT
+from fossunited.doctype_ids import EVENT, JOB, JOB_STATUS_APPROVED, JOB_STATUS_EXPIRED
 
 
 def conclude_events():
@@ -25,5 +25,58 @@ def conclude_events():
             frappe.log_error(
                 frappe.get_traceback(),
                 f"Error while concluding events through scheduler- ID:{doc.name}\nError:{str(e)}",
+            )
+            continue
+
+
+def update_past_job_status():
+    """
+    Updates the job status to Expired, if they are Approved (active) and
+    were last modified more than 3 months ago (90 days).
+    """
+    cutoff_date = datetime.now() - timedelta(days=90)
+    past_active_jobs = frappe.get_all(
+        JOB,
+        filters={"status": JOB_STATUS_APPROVED, "modified": ["<", cutoff_date]},
+        fields=["name"],
+    )
+
+    for jobs in past_active_jobs:
+        try:
+            # Get the actual document object
+            job_doc = frappe.get_doc(JOB, jobs.name)
+            job_doc.status = JOB_STATUS_EXPIRED
+            job_doc.save(ignore_permissions=True)
+            frappe.db.commit()
+
+            # Send notification email after successful update
+            if job_doc.mail:
+                cc_email = ["developers@fossunited.org"]
+                subject = (
+                    f"Job Posting Auto-Expiry Notice: "
+                    f"{frappe.utils.escape_html(job_doc.name)} | "
+                    f"{frappe.utils.escape_html(job_doc.job_title)}"
+                )
+
+                message = (
+                    f"<p>Dear {frappe.utils.escape_html(job_doc.company_name)},</p>"
+                    f"<p>Your job posting titled"
+                    f"<strong>{frappe.utils.escape_html(job_doc.job_title)}</strong> "
+                    f"has not been updated in over 90 days and "
+                    f"will now be automatically marked as "
+                    f"<strong>Expired</strong>.</p>"
+                    f"<p>If you wish to keep this job open, please update the job post.</p>"
+                    f"<p>Regards,<br>FossUnited Team</p>"
+                )
+                frappe.sendmail(
+                    recipients=[job_doc.mail],
+                    cc=cc_email,
+                    subject=subject,
+                    message=message,
+                )
+        except Exception as e:
+            frappe.log_error(
+                frappe.get_traceback(),
+                f"Error updating job status - ID:{job_doc.name}\nError:{str(e)}",
             )
             continue


### PR DESCRIPTION
+ Set frappe schedules to auto expire jobs older than 90 days (3 months) that are Active (Approved) till now.
+ Scheduled to run monthly to check.
+ Sends email to Company and CC fossunited foundation for informing about the action.

Closes #1066


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Job postings approved but inactive for over 90 days are now automatically marked as expired monthly.
  * Job posters receive email notifications when their job posting expires due to inactivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->