### PR TITLE
permit core team members to add/edit members for chapters + remove lead role

### DIFF
--- a/dashboard/src/components/chapter/AddMember.vue
+++ b/dashboard/src/components/chapter/AddMember.vue
@@ -28,10 +28,6 @@
           v-model="role"
           :options="[
             {
-              label: 'Lead',
-              value: 'Lead',
-            },
-            {
               label: 'Core Team Member',
               value: 'Core Team Member',
             },

--- a/dashboard/src/components/chapter/EditMember.vue
+++ b/dashboard/src/components/chapter/EditMember.vue
@@ -15,11 +15,11 @@
             {
               label: 'Lead',
               value: 'Lead',
-              disabled: !isLead,
             },
             {
               label: 'Core Team Member',
               value: 'Core Team Member',
+              disabled: !isCoreTeam,
             },
             {
               label: 'Volunteer',
@@ -68,7 +68,7 @@ const props = defineProps({
     type: Object,
     default: () => null,
   },
-  isLead: {
+  isCoreTeam: {
     type: Boolean,
     default: false,
   },

--- a/dashboard/src/components/chapter/EditMember.vue
+++ b/dashboard/src/components/chapter/EditMember.vue
@@ -13,10 +13,6 @@
           v-model="role"
           :options="[
             {
-              label: 'Lead',
-              value: 'Lead',
-            },
-            {
               label: 'Core Team Member',
               value: 'Core Team Member',
               disabled: !isCoreTeam,

--- a/dashboard/src/pages/ChapterMembers.vue
+++ b/dashboard/src/pages/ChapterMembers.vue
@@ -114,7 +114,7 @@ const route = useRoute()
 
 const isCoreTeam = () => {
   const me = chapter.doc?.chapter_members?.find((m) => m.email === session.user)
-  return me ? ['Core Team Member'].includes(me.role) : false
+  return me ? me.role === 'Core Team Member' : false
 }
 
 const chapter = createDocumentResource({

--- a/dashboard/src/pages/ChapterMembers.vue
+++ b/dashboard/src/pages/ChapterMembers.vue
@@ -12,7 +12,7 @@
       <Button
         class="w-fit"
         label="Add New Member"
-        v-if="isLead()"
+        v-if="isCoreTeam()"
         icon-left="plus"
         size="md"
         @click="showAddmodal = true"
@@ -24,7 +24,7 @@
         :key="member.name"
         :title="member.full_name"
       >
-        <template v-if="member.email != session.user && member.role != 'Lead' && isLead()" #actions>
+        <template v-if="member.email != session.user && member.role != 'Lead' && isCoreTeam()" #actions>
           <Button label="Edit" @click="handleEditmodal(member)" />
           <Button theme="red" label="Remove" @click="handleRemoveModal(member)" />
         </template>
@@ -83,7 +83,7 @@
         class="z-50"
         :chapter="chapter"
         :member=selectedMember
-        :isLead=isLead()
+        :isCoreTeam=isCoreTeam()
         @update:edit-member="editNewMember"
         @close-dialog="showEditmodal = false"
       />
@@ -112,10 +112,10 @@ import ChapterHeader from '@/components/ChapterHeader.vue'
 const session = inject('$session')
 const route = useRoute()
 
-const isLead = () => {
+const isCoreTeam = () => {
     let currentUser = chapter.doc.chapter_members.filter((m) => m.email === session.user)
-    if (currentUser[0].role === "Lead") {
-      return true
+    if (["Lead", "Core Team Member"].includes(currentUser[0].role)) {
+      return true;
     }
     return false
 }

--- a/dashboard/src/pages/ChapterMembers.vue
+++ b/dashboard/src/pages/ChapterMembers.vue
@@ -24,7 +24,7 @@
         :key="member.name"
         :title="member.full_name"
       >
-        <template v-if="member.email != session.user && member.role != 'Lead' && isCoreTeam()" #actions>
+        <template v-if="member.email != session.user && isCoreTeam()" #actions>
           <Button label="Edit" @click="handleEditmodal(member)" />
           <Button theme="red" label="Remove" @click="handleRemoveModal(member)" />
         </template>
@@ -38,7 +38,7 @@
             <Badge
               class="w-fit"
               :label="member.role"
-              :theme="member.role === 'Lead' ? 'blue' : 'gray'"
+  			  :theme="member.role === 'Core Team Member' ? 'blue' : 'gray'"
               size="md"
             />
           </div>
@@ -83,7 +83,7 @@
         class="z-50"
         :chapter="chapter"
         :member=selectedMember
-        :isCoreTeam=isCoreTeam()
+        :isCoreTeam="isCoreTeam()"
         @update:edit-member="editNewMember"
         @close-dialog="showEditmodal = false"
       />
@@ -113,11 +113,8 @@ const session = inject('$session')
 const route = useRoute()
 
 const isCoreTeam = () => {
-    let currentUser = chapter.doc.chapter_members.filter((m) => m.email === session.user)
-    if (["Lead", "Core Team Member"].includes(currentUser[0].role)) {
-      return true;
-    }
-    return false
+  const me = chapter.doc?.chapter_members?.find((m) => m.email === session.user)
+  return me ? ['Lead', 'Core Team Member'].includes(me.role) : false
 }
 
 const chapter = createDocumentResource({

--- a/dashboard/src/pages/ChapterMembers.vue
+++ b/dashboard/src/pages/ChapterMembers.vue
@@ -82,7 +82,7 @@
         v-model="showEditmodal"
         class="z-50"
         :chapter="chapter"
-        :member=selectedMember
+        :member="selectedMember"
         :isCoreTeam="isCoreTeam()"
         @update:edit-member="editNewMember"
         @close-dialog="showEditmodal = false"

--- a/dashboard/src/pages/ChapterMembers.vue
+++ b/dashboard/src/pages/ChapterMembers.vue
@@ -114,7 +114,7 @@ const route = useRoute()
 
 const isCoreTeam = () => {
   const me = chapter.doc?.chapter_members?.find((m) => m.email === session.user)
-  return me ? ['Lead', 'Core Team Member'].includes(me.role) : false
+  return me ? ['Core Team Member'].includes(me.role) : false
 }
 
 const chapter = createDocumentResource({

--- a/dashboard/src/pages/EventVolunteers.vue
+++ b/dashboard/src/pages/EventVolunteers.vue
@@ -17,7 +17,7 @@
     <!-- VOLUNTEERS GRID -->
     <div class="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
       <Card v-for="member in event.doc.event_members" :key="member.name" :title="member.full_name">
-        <template v-if="member.email != session.user && member.role != 'Lead' && isCoreTeam()" #actions>
+        <template v-if="member.email != session.user && isCoreTeam()" #actions>
           <Button label="Edit" @click="handleEditmodal(member)" />
           <Button theme="red" label="Remove" @click="handleRemoveModal(member)" />
         </template>
@@ -31,7 +31,7 @@
             <Badge
               class="w-fit"
               :label="member.role"
-              :theme="member.role === 'Lead' ? 'blue' : 'gray'"
+			  :theme="member.role === 'Core Team Member' ? 'blue' : 'gray'"
               size="md"
             />
           </div>
@@ -75,7 +75,7 @@
         class="z-50"
         :event="event"
         :member=selectedMember
-        :isCoreTeam=isCoreTeam()
+        :isCoreTeam="isCoreTeam()"
         @update:edit-member="editNewMember"
         @close-dialog="showEditmodal = false"
       />
@@ -104,11 +104,8 @@ const session = inject('$session')
 const route = useRoute()
 
 const isCoreTeam = () => {
-    let currentUser = event.doc.event_members.filter((m) => m.email === session.user)
-    if (["Lead", "Core Team Member"].includes(currentUser[0].role)) {
-		return true;
-    }
-    return false
+  const me = event.doc?.event_members?.find((m) => m.email === session.user)
+  return me ? ['Lead', 'Core Team Member'].includes(me.role) : false
 }
 
 const event = createDocumentResource({

--- a/dashboard/src/pages/EventVolunteers.vue
+++ b/dashboard/src/pages/EventVolunteers.vue
@@ -105,7 +105,7 @@ const route = useRoute()
 
 const isCoreTeam = () => {
   const me = event.doc?.event_members?.find((m) => m.email === session.user)
-  return me ? ['Lead', 'Core Team Member'].includes(me.role) : false
+  return me ? ['Core Team Member'].includes(me.role) : false
 }
 
 const event = createDocumentResource({

--- a/dashboard/src/pages/EventVolunteers.vue
+++ b/dashboard/src/pages/EventVolunteers.vue
@@ -74,7 +74,7 @@
         v-model="showEditmodal"
         class="z-50"
         :event="event"
-        :member=selectedMember
+        :member="selectedMember"
         :isCoreTeam="isCoreTeam()"
         @update:edit-member="editNewMember"
         @close-dialog="showEditmodal = false"

--- a/dashboard/src/pages/EventVolunteers.vue
+++ b/dashboard/src/pages/EventVolunteers.vue
@@ -105,7 +105,7 @@ const route = useRoute()
 
 const isCoreTeam = () => {
   const me = event.doc?.event_members?.find((m) => m.email === session.user)
-  return me ? ['Core Team Member'].includes(me.role) : false
+  return me ? me.role === 'Core Team Member' : false
 }
 
 const event = createDocumentResource({

--- a/dashboard/src/pages/EventVolunteers.vue
+++ b/dashboard/src/pages/EventVolunteers.vue
@@ -7,7 +7,7 @@
       <Button
         class="w-fit"
         label="Add Volunteer"
-        v-if="isLead()"
+        v-if="isCoreTeam()"
         icon-left="plus"
         size="md"
         @click="showAddmodal = true"
@@ -17,7 +17,7 @@
     <!-- VOLUNTEERS GRID -->
     <div class="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
       <Card v-for="member in event.doc.event_members" :key="member.name" :title="member.full_name">
-        <template v-if="member.email != session.user && member.role != 'Lead' && isLead()" #actions>
+        <template v-if="member.email != session.user && member.role != 'Lead' && isCoreTeam()" #actions>
           <Button label="Edit" @click="handleEditmodal(member)" />
           <Button theme="red" label="Remove" @click="handleRemoveModal(member)" />
         </template>
@@ -75,7 +75,7 @@
         class="z-50"
         :event="event"
         :member=selectedMember
-        :isLead=isLead()
+        :isCoreTeam=isCoreTeam()
         @update:edit-member="editNewMember"
         @close-dialog="showEditmodal = false"
       />
@@ -103,10 +103,10 @@ const session = inject('$session')
 
 const route = useRoute()
 
-const isLead = () => {
+const isCoreTeam = () => {
     let currentUser = event.doc.event_members.filter((m) => m.email === session.user)
-    if (currentUser[0].role === "Lead") {
-      return true
+    if (["Lead", "Core Team Member"].includes(currentUser[0].role)) {
+		return true;
     }
     return false
 }

--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -61,7 +61,7 @@ def check_if_event_lead(event: str) -> bool:
                 "parenttype": EVENT,
                 "member": profile,
                 "parentfield": "event_members",
-                "role": "Lead",
+                "role": "Core Team Member",
             },
         )
     )

--- a/fossunited/api/tickets.py
+++ b/fossunited/api/tickets.py
@@ -276,26 +276,7 @@ def has_valid_permission(event_id: str) -> bool:
     """
     session_user = frappe.session.user
 
-    if not (
-        bool(
-            frappe.db.exists(
-                "Has Role",
-                {
-                    "role": "Chapter Lead",
-                    "parent": session_user,
-                },
-            )
-        )
-        or bool(
-            frappe.db.exists(
-                "Has Role",
-                {
-                    "role": "Chapter Team Member",
-                    "parent": session_user,
-                },
-            )
-        )
-    ):
+    if not frappe.db.exists("Has Role", {"role": "Chapter Team Member", "parent": session_user}):
         return False
 
     chapter_id = frappe.db.get_value(EVENT, event_id, ["chapter"])

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.json
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.json
@@ -43,8 +43,7 @@
   "whatsapp",
   "discord",
   "chapter_members_section",
-  "chapter_members",
-  "chapter_lead"
+  "chapter_members"
  ],
  "fields": [
   {
@@ -91,13 +90,6 @@
    "in_list_view": 1,
    "label": "Country",
    "options": "Country"
-  },
-  {
-   "fieldname": "chapter_lead",
-   "fieldtype": "Link",
-   "label": "Chapter Lead",
-   "options": "FOSS User Profile",
-   "read_only": 1
   },
   {
    "fieldname": "basic_information_section",
@@ -281,7 +273,7 @@
    "link_fieldname": "chapter"
   }
  ],
- "modified": "2025-07-28 12:34:56.000000",
+ "modified": "2025-08-11 12:59:52.035174",
  "modified_by": "Administrator",
  "module": "Chapters",
  "name": "FOSS Chapter",
@@ -316,7 +308,6 @@
   }
  ],
  "route": "c",
- "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
@@ -58,7 +58,6 @@ class FOSSChapter(WebsiteGenerator):
         self.validate_slug()
 
     def before_save(self):
-        self.set_chapter_lead()
         self.set_route()
 
     def on_update(self):
@@ -125,12 +124,6 @@ class FOSSChapter(WebsiteGenerator):
                 },
             )
         )
-
-    def set_chapter_lead(self):
-        for member in self.chapter_members:
-            if member.role == "Lead":
-                self.chapter_lead = member.chapter_member
-                break
 
     def set_route(self):
         if not self.slug:

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
@@ -75,8 +75,6 @@ class FOSSChapter(WebsiteGenerator):
                 continue
 
             roles = ["Chapter Team Member"]
-            if member.role == "Lead":
-                roles.append("Chapter Lead")
 
             self.add_member_roles(user, *roles)
 
@@ -91,8 +89,6 @@ class FOSSChapter(WebsiteGenerator):
                 user = frappe.db.get_value(USER_PROFILE, member.chapter_member, "user")
 
                 roles = ["Chapter Team Member"]
-                if member.role == "Lead":
-                    roles.append("Chapter Lead")
 
                 self.remove_member_roles(user, *roles)
 

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
@@ -22,7 +22,6 @@ class FOSSChapter(WebsiteGenerator):
 
         about_chapter: DF.TextEditor | None
         banner_image: DF.AttachImage | None
-        chapter_lead: DF.Link | None
         chapter_logo: DF.AttachImage | None
         chapter_members: DF.Table[FOSSChapterLeadTeamMember]
         chapter_name: DF.Data

--- a/fossunited/chapters/doctype/foss_chapter/test_foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/test_foss_chapter.py
@@ -10,7 +10,7 @@ fake = Faker()
 
 class TestFOSSChapter(FrappeTestCase):
     def setUp(self):
-        self.chapter = insert_test_chapter()
+        self.chapter = insert_test_chapter(members=["test1@example.com", "member2@example.com"])
 
     def tearDown(self):
         frappe.delete_doc(CHAPTER, self.chapter.name, force=True)
@@ -19,8 +19,7 @@ class TestFOSSChapter(FrappeTestCase):
         # Given a chapter
         chapter = self.chapter
 
-        # When the chapter was created, a lead was assigned to it.
-        # Then the lead should have the role of 'Chapter Lead' and 'Chapter Team Member'
+        # user must have 'Chapter Team Member' role given
         user = frappe.db.get_value(USER_PROFILE, chapter.chapter_members[0].chapter_member, "user")
         self.assertTrue(self.has_team_member_role(user))
 

--- a/fossunited/chapters/doctype/foss_chapter_event/test_foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/test_foss_chapter_event.py
@@ -11,8 +11,8 @@ from fossunited.tests.utils import insert_test_chapter, insert_test_event
 
 class TestFOSSChapterEvent(FrappeTestCase):
     def setUp(self):
-        self.lead = "test1@example.com"
-        self.chapter = insert_test_chapter(lead_email=self.lead)
+        self.core_team_email = "test1@example.com"
+        self.chapter = insert_test_chapter(members=[self.core_team_email])
         self.event = insert_test_event(
             chapter=self.chapter,
         )

--- a/fossunited/chapters/doctype/foss_chapter_event_member/foss_chapter_event_member.json
+++ b/fossunited/chapters/doctype/foss_chapter_event_member/foss_chapter_event_member.json
@@ -36,7 +36,6 @@
 	  "read_only": 1
 	},
 	{
-	  "fetch_from": ".",
 	  "fieldname": "role",
 	  "fieldtype": "Select",
 	  "in_list_view": 1,
@@ -47,7 +46,7 @@
   "index_web_pages_for_search": 1,
   "istable": 1,
   "links": [],
-  "modified": "2025-08-10 17:14:01.952866",
+  "modified": "2025-08-11 12:34:07.305886",
   "modified_by": "Administrator",
   "module": "Chapters",
   "name": "FOSS Chapter Event Member",

--- a/fossunited/chapters/doctype/foss_chapter_event_member/foss_chapter_event_member.json
+++ b/fossunited/chapters/doctype/foss_chapter_event_member/foss_chapter_event_member.json
@@ -6,43 +6,48 @@
   "doctype": "DocType",
   "editable_grid": 1,
   "engine": "InnoDB",
-  "field_order": ["member", "full_name", "email", "role"],
+  "field_order": [
+	"member",
+	"full_name",
+	"email",
+	"role"
+  ],
   "fields": [
-    {
-      "fieldname": "member",
-      "fieldtype": "Link",
-      "in_list_view": 1,
-      "label": "Member",
-      "options": "FOSS User Profile"
-    },
-    {
-      "fetch_from": "member.full_name",
-      "fieldname": "full_name",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "label": "Full Name",
-      "read_only": 1
-    },
-    {
-      "fetch_from": "member.email",
-      "fieldname": "email",
-      "fieldtype": "Data",
-      "label": "Email",
-      "read_only": 1
-    },
-    {
-      "fetch_from": ".",
-      "fieldname": "role",
-      "fieldtype": "Select",
-      "in_list_view": 1,
-      "label": "Role",
-      "options": "Volunteer\nCore Team Member\nLead\nGraphic Designer\nContent Writer\nMarketing"
-    }
+	{
+	  "fieldname": "member",
+	  "fieldtype": "Link",
+	  "in_list_view": 1,
+	  "label": "Member",
+	  "options": "FOSS User Profile"
+	},
+	{
+	  "fetch_from": "member.full_name",
+	  "fieldname": "full_name",
+	  "fieldtype": "Data",
+	  "in_list_view": 1,
+	  "label": "Full Name",
+	  "read_only": 1
+	},
+	{
+	  "fetch_from": "member.email",
+	  "fieldname": "email",
+	  "fieldtype": "Data",
+	  "label": "Email",
+	  "read_only": 1
+	},
+	{
+	  "fetch_from": ".",
+	  "fieldname": "role",
+	  "fieldtype": "Select",
+	  "in_list_view": 1,
+	  "label": "Role",
+	  "options": "Volunteer\nCore Team Member\nGraphic Designer\nContent Writer\nMarketing"
+	}
   ],
   "index_web_pages_for_search": 1,
   "istable": 1,
   "links": [],
-  "modified": "2024-04-02 12:42:29.219989",
+  "modified": "2025-08-10 17:14:01.952866",
   "modified_by": "Administrator",
   "module": "Chapters",
   "name": "FOSS Chapter Event Member",

--- a/fossunited/chapters/doctype/foss_chapter_event_member/foss_chapter_event_member.py
+++ b/fossunited/chapters/doctype/foss_chapter_event_member/foss_chapter_event_member.py
@@ -4,4 +4,22 @@ from frappe.model.document import Document
 
 
 class FOSSChapterEventMember(Document):
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        email: DF.Data | None
+        full_name: DF.Data | None
+        member: DF.Link | None
+        parent: DF.Data
+        parentfield: DF.Data
+        parenttype: DF.Data
+        role: DF.Literal[
+            "Volunteer", "Core Team Member", "Graphic Designer", "Content Writer", "Marketing"  # noqa: F722, F821
+        ]
+    # end: auto-generated types
     pass

--- a/fossunited/chapters/doctype/foss_chapter_lead_team_member/foss_chapter_lead_team_member.json
+++ b/fossunited/chapters/doctype/foss_chapter_lead_team_member/foss_chapter_lead_team_member.json
@@ -5,40 +5,45 @@
   "doctype": "DocType",
   "editable_grid": 1,
   "engine": "InnoDB",
-  "field_order": ["chapter_member", "role", "full_name", "email"],
+  "field_order": [
+	"chapter_member",
+	"role",
+	"full_name",
+	"email"
+  ],
   "fields": [
-    {
-      "fieldname": "chapter_member",
-      "fieldtype": "Link",
-      "in_list_view": 1,
-      "label": "Chapter Member",
-      "options": "FOSS User Profile"
-    },
-    {
-      "fieldname": "role",
-      "fieldtype": "Select",
-      "in_list_view": 1,
-      "label": "Role",
-      "options": "Lead\nCore Team Member\nVolunteer\nGraphic Designer\nContent Writer\nMarketing"
-    },
-    {
-      "fetch_from": "chapter_member.full_name",
-      "fieldname": "full_name",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "label": "Full Name"
-    },
-    {
-      "fetch_from": "chapter_member.email",
-      "fieldname": "email",
-      "fieldtype": "Data",
-      "label": "Email"
-    }
+	{
+	  "fieldname": "chapter_member",
+	  "fieldtype": "Link",
+	  "in_list_view": 1,
+	  "label": "Chapter Member",
+	  "options": "FOSS User Profile"
+	},
+	{
+	  "fieldname": "role",
+	  "fieldtype": "Select",
+	  "in_list_view": 1,
+	  "label": "Role",
+	  "options": "Core Team Member\nVolunteer\nGraphic Designer\nContent Writer\nMarketing"
+	},
+	{
+	  "fetch_from": "chapter_member.full_name",
+	  "fieldname": "full_name",
+	  "fieldtype": "Data",
+	  "in_list_view": 1,
+	  "label": "Full Name"
+	},
+	{
+	  "fetch_from": "chapter_member.email",
+	  "fieldname": "email",
+	  "fieldtype": "Data",
+	  "label": "Email"
+	}
   ],
   "index_web_pages_for_search": 1,
   "istable": 1,
   "links": [],
-  "modified": "2024-04-24 13:33:03.028303",
+  "modified": "2025-08-10 17:13:47.168479",
   "modified_by": "Administrator",
   "module": "Chapters",
   "name": "FOSS Chapter Lead Team Member",

--- a/fossunited/chapters/doctype/foss_chapter_lead_team_member/foss_chapter_lead_team_member.py
+++ b/fossunited/chapters/doctype/foss_chapter_lead_team_member/foss_chapter_lead_team_member.py
@@ -4,4 +4,22 @@ from frappe.model.document import Document
 
 
 class FOSSChapterLeadTeamMember(Document):
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        chapter_member: DF.Link | None
+        email: DF.Data | None
+        full_name: DF.Data | None
+        parent: DF.Data
+        parentfield: DF.Data
+        parenttype: DF.Data
+        role: DF.Literal[
+            "Core Team Member", "Volunteer", "Graphic Designer", "Content Writer", "Marketing"  # noqa: F722, F821
+        ]
+    # end: auto-generated types
     pass

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
@@ -13,12 +13,12 @@ from fossunited.tests.utils import (
 fake = Faker()
 
 WEBSITE_USER = "test2@example.com"
-LEAD_USER = "test1@example.com"
+CORE_TEAM = "test1@example.com"
 
 
 class TestFOSSEventRSVPSubmission(FrappeTestCase):
     def setUp(self):
-        self.chapter = insert_test_chapter()
+        self.chapter = insert_test_chapter(members=[CORE_TEAM])
         self.event = insert_test_event(chapter=self.chapter)
         self.rsvp = insert_rsvp_form(event=self.event.name)
         self.email_group = frappe.db.get_value(
@@ -127,7 +127,7 @@ class TestFOSSEventRSVPSubmission(FrappeTestCase):
 
     def test_status_change_after_unpublish(self):
         # Given an RSVP form which requires host approval
-        frappe.set_user(LEAD_USER)
+        frappe.set_user(CORE_TEAM)
         rsvp = self.rsvp
         rsvp.requires_host_approval = True
         rsvp.save()
@@ -139,7 +139,7 @@ class TestFOSSEventRSVPSubmission(FrappeTestCase):
         # It should be saved with status as pending
         self.assertEqual(submission.status, "Pending")
 
-        frappe.set_user(LEAD_USER)
+        frappe.set_user(CORE_TEAM)
         # When the RSVP form is unpublished
         rsvp.is_published = False
         rsvp.save()
@@ -150,7 +150,7 @@ class TestFOSSEventRSVPSubmission(FrappeTestCase):
 
     def test_add_to_email_on_acceptance(self):
         # Given an RSVP form which requires host approval
-        frappe.set_user(LEAD_USER)
+        frappe.set_user(CORE_TEAM)
         rsvp = self.rsvp
         rsvp.requires_host_approval = True
         rsvp.save()
@@ -174,7 +174,7 @@ class TestFOSSEventRSVPSubmission(FrappeTestCase):
         )
 
         # When status is changed to "Accepted"
-        frappe.set_user(LEAD_USER)
+        frappe.set_user(CORE_TEAM)
         submission.status = "Accepted"
         submission.save()
 
@@ -191,7 +191,7 @@ class TestFOSSEventRSVPSubmission(FrappeTestCase):
 
     def test_no_add_to_email_on_rejection(self):
         # Given an RSVP form which requires host approval
-        frappe.set_user(LEAD_USER)
+        frappe.set_user(CORE_TEAM)
         rsvp = self.rsvp
         rsvp.requires_host_approval = True
         rsvp.save()
@@ -215,7 +215,7 @@ class TestFOSSEventRSVPSubmission(FrappeTestCase):
         )
 
         # When status is changed to "Accepted"
-        frappe.set_user(LEAD_USER)
+        frappe.set_user(CORE_TEAM)
         submission.status = "Rejected"
         submission.save()
 

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/test_foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/test_foss_event_cfp_submission.py
@@ -15,12 +15,12 @@ from fossunited.tests.utils import (
 
 fake = Faker()
 
-LEAD = "test1@example.com"
+CoreTeam = "test1@example.com"
 
 
 class TestFOSSEventCFPSubmission(FrappeTestCase):
     def setUp(self):
-        self.chapter = insert_test_chapter(lead_email=LEAD)
+        self.chapter = insert_test_chapter(members=[CoreTeam])
         self.event = insert_test_event(chapter=self.chapter)
 
         self.cfp = insert_cfp_form(event=self.event.name, status="Live")
@@ -65,7 +65,7 @@ class TestFOSSEventCFPSubmission(FrappeTestCase):
     def test_add_to_group_on_accept(self):
         # given a cfp and its submission
 
-        frappe.set_user(LEAD)
+        frappe.set_user(CoreTeam)
         # When the status is changed to Approved
         self.submission.status = "Approved"
         self.submission.save()
@@ -80,7 +80,7 @@ class TestFOSSEventCFPSubmission(FrappeTestCase):
 
     def test_add_to_group_on_reject(self):
         # given a cfp and its submission
-        frappe.set_user(LEAD)
+        frappe.set_user(CoreTeam)
         # When the status is changed to Approved
         self.submission.status = "Rejected"
         self.submission.save()

--- a/fossunited/id/roles.py
+++ b/fossunited/id/roles.py
@@ -3,7 +3,6 @@
 WEBSITE_USER = "FOSS Website User"
 
 CHAPTER_MEMBER = "Chapter Team Member"
-CHAPTER_LEAD = "Chapter Lead"
 
 REVIEWER = "CFP Reviewer"
 

--- a/fossunited/patches.txt
+++ b/fossunited/patches.txt
@@ -7,3 +7,4 @@
 fossunited.patches.v1_0.duplicate_event_name_to_reference_field  #31-12-2024
 fossunited.patches.v1_0.handle_sharing_all_existing_profiles
 fossunited.patches.v1_0.migrate_old_cfps_to_new_schema
+fossunited.patches.v1_0.convert_lead_to_core_team_chapters

--- a/fossunited/patches/v1_0/convert_lead_to_core_team_chapters.py
+++ b/fossunited/patches/v1_0/convert_lead_to_core_team_chapters.py
@@ -1,6 +1,6 @@
 import frappe
 
-from fossunited.doctype_ids import CHAPTER, EVENT
+from fossunited.doctype_ids import CHAPTER, EVENT, USER_PROFILE
 
 
 def execute():
@@ -23,14 +23,26 @@ def execute():
                 members = getattr(doc, members_attr, [])
                 for member in members:
                     if member.role == "Lead":
+                        # Convert role value
                         member.role = "Core Team Member"
                         updated = True
 
+                        # Revoke legacy 'Chapter Lead' user role
+                        user = frappe.db.get_value(USER_PROFILE, member.chapter_member, "user")
+                        if user:
+                            frappe.db.delete(
+                                "Has Role",
+                                {"parent": user, "parenttype": "User", "role": "Chapter Lead"},
+                            )
+
                 if updated:
                     doc.save()
+                    # Commit after each doc to keep changes granular; acceptable for one-off patch
                     frappe.db.commit()
                     frappe.logger().info(f"Updated {doctype} {docname}: Lead roles.")
 
-        except Exception as e:
-            frappe.log_error(f"Error Changing role: {doctype} - {docname}", str(e))
-            continue
+        except Exception:
+            frappe.log_error(
+                title=f"Error changing roles for doctype {doctype}",
+                message=frappe.get_traceback(),
+            )

--- a/fossunited/patches/v1_0/convert_lead_to_core_team_chapters.py
+++ b/fossunited/patches/v1_0/convert_lead_to_core_team_chapters.py
@@ -1,0 +1,36 @@
+import frappe
+
+from fossunited.doctype_ids import CHAPTER, EVENT
+
+
+def execute():
+    """
+    This patch updates all documents of the specified doctypes to remove the 'Lead' role
+    and convert them to 'Core Team Member' role for the respective members attribute.
+    """
+
+    # Map doctype to the member attribute name
+    doctype_members_map = {CHAPTER: "chapter_members", EVENT: "event_members"}
+
+    for doctype, members_attr in doctype_members_map.items():
+        docnames = frappe.get_all(doctype, pluck="name")
+
+        try:
+            for docname in docnames:
+                doc = frappe.get_doc(doctype, docname)
+                updated = False
+
+                members = getattr(doc, members_attr, [])
+                for member in members:
+                    if member.role == "Lead":
+                        member.role = "Core Team Member"
+                        updated = True
+
+                if updated:
+                    doc.save()
+                    frappe.db.commit()
+                    frappe.logger().info(f"Updated {doctype} {docname}: Lead roles.")
+
+        except Exception as e:
+            frappe.log_error(f"Error Changing role: {doctype} - {docname}", str(e))
+            continue

--- a/fossunited/setup.py
+++ b/fossunited/setup.py
@@ -3,7 +3,6 @@ import frappe
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 
 from fossunited.id.roles import (
-    CHAPTER_LEAD,
     CHAPTER_MEMBER,
     HACKATHON_ORGANIZER,
     LOCALHOST_ORGANIZER,
@@ -91,7 +90,6 @@ def get_custom_roles():
     return [
         WEBSITE_USER,
         CHAPTER_MEMBER,
-        CHAPTER_LEAD,
         REVIEWER,
         HACKATHON_ORGANIZER,
         LOCALHOST_ORGANIZER,

--- a/fossunited/tests/test_emailing.py
+++ b/fossunited/tests/test_emailing.py
@@ -17,8 +17,8 @@ fake = Faker()
 
 class TestEmailing(FrappeTestCase):
     def setUp(self):
-        self.lead_email = "test1@example.com"
-        self.chapter = insert_test_chapter(lead_email=self.lead_email)
+        self.core_team_email = "test1@example.com"
+        self.chapter = insert_test_chapter(members=[self.core_team_email])
         self.event = insert_test_event(chapter=self.chapter)
 
         self.setup_campaign()
@@ -64,13 +64,13 @@ class TestEmailing(FrappeTestCase):
         )
 
     def test_send_test_email(self):
-        frappe.set_user(self.lead_email)
+        frappe.set_user(self.core_team_email)
 
         test_email = fake.email()
 
         send_test_email(self.newsletter.name, test_email)
 
     def test_send_campaign(self):
-        frappe.set_user(self.lead_email)
+        frappe.set_user(self.core_team_email)
 
         send_campaign(self.newsletter.name)

--- a/fossunited/tests/utils.py
+++ b/fossunited/tests/utils.py
@@ -101,7 +101,7 @@ def insert_test_chapter(**kwargs):
             "chapter_members",
             {
                 "chapter_member": lead_profile,
-                "role": "Lead",
+                "role": "Core Team Member",
             },
         )
 

--- a/fossunited/tests/utils.py
+++ b/fossunited/tests/utils.py
@@ -35,7 +35,6 @@ def insert_test_chapter(**kwargs):
         chapter_type (str, optional): Type of chapter. Defaults to CITY_COMMUNITY.
         city (str, optional): City of the chapter. Defaults to "Bangalore".
         state (str, optional): State of the chapter. Defaults to "Karnataka".
-        lead_email (str, optional): Email of the chapter lead. Defaults to "test1@example.com".
         members (List[str], optional): List of member emails to add to the chapter.
         **kwargs : Any additional arguments, such as for social media links
 
@@ -43,7 +42,7 @@ def insert_test_chapter(**kwargs):
         chapter doc: Created chapter document
 
     Raises:
-        ValueError: If lead_email or member emails are invalid
+        ValueError: If member emails are invalid
         Exception: For any unexpected errors during chapter creation
 
     Example:
@@ -51,7 +50,6 @@ def insert_test_chapter(**kwargs):
         chapter = insert_test_chapter(
             chapter_name="Python Developers Chapter",
             city="Mumbai",
-            lead_email="lead@example.com",
             members=["member1@example.com", "member2@example.com"]
         )
     ```
@@ -83,28 +81,6 @@ def insert_test_chapter(**kwargs):
             frappe.get_doc({"doctype": "Role", "role_name": "Chapter Team Member"}).insert(
                 ignore_permissions=True
             )
-        if not frappe.db.exists("Role", "Chapter Lead"):
-            frappe.get_doc({"doctype": "Role", "role_name": "Chapter Lead"}).insert(
-                ignore_permissions=True
-            )
-
-        # Handle chapter lead
-        lead_email = kwargs.get("lead_email", "test1@example.com")
-        try:
-            lead_profile = frappe.db.get_value(USER_PROFILE, {"user": lead_email}, "name")
-        except frappe.DoesNotExistError:
-            frappe.log_error(f"Lead profile not found for email: {lead_email}")
-            raise ValueError(f"Invalid lead email: {lead_email}")
-
-        # Add lead to chapter members
-        chapter.append(
-            "chapter_members",
-            {
-                "chapter_member": lead_profile,
-                "role": "Core Team Member",
-            },
-        )
-
         # Add additional members
         members = kwargs.get("members", [])
         for member in members:

--- a/fossunited/ticketing/doctype/foss_event_ticket/test_foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/test_foss_event_ticket.py
@@ -9,8 +9,8 @@ from fossunited.tests.utils import insert_test_chapter, insert_test_event, inser
 
 class TestFOSSEventTicket(FrappeTestCase):
     def setUp(self):
-        self.lead_email = "test1@example.com"
-        self.chapter = insert_test_chapter(lead_email=self.lead_email)
+        self.core_team_email = "test1@example.com"
+        self.chapter = insert_test_chapter(members=[self.core_team_email])
         self.event = insert_test_event(
             chapter=self.chapter,
             is_paid_event=True,
@@ -50,7 +50,7 @@ class TestFOSSEventTicket(FrappeTestCase):
         self.assertFalse(ticket.check_ins)
 
         # Set the user as a chapter member
-        frappe.set_user(self.lead_email)
+        frappe.set_user(self.core_team_email)
 
         # When the user checks in the attendee
         checkin_attendee(self.event.name, ticket.as_dict())


### PR DESCRIPTION
Closed #1086 

Tested locally...

- Core Team member can edit:
  
<img width="3387" height="678" alt="image" src="https://github.com/user-attachments/assets/cde1f07a-3e14-4939-8c7e-b679785d4a92" />
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Core Team Member" now governs adding, editing, and removing chapter members and event volunteers; "Lead" removed from user-facing role choices.

* **Refactor**
  * UI badges, permission checks and component props updated to use "Core Team Member".
  * Removed automatic chapter_lead synchronization and legacy chapter-lead role management.

* **Chores**
  * Migration patch added to convert existing "Lead" roles to "Core Team Member"; DocType role options and type hints updated.

* **Tests**
  * Test fixtures and setups updated to use core-team members instead of lead-based fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->