### PR TITLE
show schedule pages with correct route

### DIFF
--- a/fossunited/api/dashboard.py
+++ b/fossunited/api/dashboard.py
@@ -19,9 +19,6 @@ def get_event_from_permalink(permalink: str, fields: list) -> dict:
 
 @frappe.whitelist(allow_guest=True)
 def get_event_from_route(route: str, fields: list) -> dict:
-    # if route does not start with c/, add it
-    if not route.startswith("c/"):
-        route = f"c/{route}"
     return frappe.db.get_value(EVENT, {"route": route}, fields, as_dict=1)
 
 


### PR DESCRIPTION
- idk why c/ was pre-pended here

Issue opened by @ansharora28

Currently there is no `schedule` page shown for any chapter events.

Eg: https://fossunited.org/dashboard/event/6ujtqen8oh/schedule

The page gives out 404 not found:
https://fossunited.org/schedule/c/bengaluru/aug-2025

Actually the page exists here:
https://fossunited.org/dashboard/schedule/bengaluru/aug-2025

- This was an minor API issue.
Which pre-pended `c/` to the route page.
But this conflicts or is taken care over at `hooks.py` via redirect.

I might be wrong with reasoning... Happy if its works ;)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed route handling when retrieving event data: routes are now used exactly as provided (no automatic prefixing), preventing mismatches and ensuring more consistent, predictable lookups. This reduces unexpected behavior when accessing event information and improves reliability across different route formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->