### PR TITLE
revert and actual fix the schedule page redirect

### DIFF
--- a/dashboard/src/pages/EventSchedule.vue
+++ b/dashboard/src/pages/EventSchedule.vue
@@ -176,7 +176,7 @@ const showModifyScheduleItemDrawer = ref(false)
           variant="ghost"
           label="Go to Schedule Page"
           icon-right="arrow-up-right"
-          @click="redirectRoute(`schedule/${event.doc?.route}`, '_blank')"
+			@click="redirectRoute(`${event.doc?.route}/schedule`, '_blank')"
         />
       </div>
       <ManageHallOptions v-if="event.doc" v-model="event.doc.hall_options" />

--- a/fossunited/api/dashboard.py
+++ b/fossunited/api/dashboard.py
@@ -19,6 +19,9 @@ def get_event_from_permalink(permalink: str, fields: list) -> dict:
 
 @frappe.whitelist(allow_guest=True)
 def get_event_from_route(route: str, fields: list) -> dict:
+    # if route does not start with c/, add it
+    if not route.startswith("c/"):
+        route = f"c/{route}"
     return frappe.db.get_value(EVENT, {"route": route}, fields, as_dict=1)
 
 


### PR DESCRIPTION
- actually it was my local setup issue before, but now fixed the actual issue on production side

reverting and fixes #1088

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected the “Go to Schedule Page” link to use the <route>/schedule path, ensuring consistent navigation while still opening in a new tab.
  - Improved event route handling to accept routes with or without the “c/” prefix, reducing broken links and improving page resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->