### PR TITLE
fix: manage timeline check, pass if not set

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
@@ -144,13 +144,15 @@
    "fieldname": "event_start_date",
    "fieldtype": "Datetime",
    "label": "Event Start Date & Time",
-   "mandatory_depends_on": "eval:doc.is_external_event == 0"
+   "mandatory_depends_on": "eval:doc.is_external_event == 0",
+   "reqd": 1
   },
   {
    "fieldname": "event_end_date",
    "fieldtype": "Datetime",
    "label": "Event End Date & Time",
-   "mandatory_depends_on": "eval:doc.is_external_event == 0"
+   "mandatory_depends_on": "eval:doc.is_external_event == 0",
+   "reqd": 1
   },
   {
    "fieldname": "column_break_ae9v",
@@ -529,7 +531,7 @@
    "link_fieldname": "event"
   }
  ],
- "modified": "2025-06-22 14:00:19.043741",
+ "modified": "2025-08-17 12:01:27.933102",
  "modified_by": "Administrator",
  "module": "Chapters",
  "name": "FOSS Chapter Event",
@@ -567,7 +569,6 @@
    "select": 1
   }
  ],
- "row_format": "Dynamic",
  "search_fields": "event_permalink, chapter",
  "show_title_field_in_link": 1,
  "sort_field": "modified",

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -61,14 +61,14 @@ class FOSSChapterEvent(WebsiteGenerator):
         deck_link: DF.Data | None
         event_bio: DF.Data | None
         event_description: DF.TextEditor | None
-        event_end_date: DF.Datetime | None
+        event_end_date: DF.Datetime
         event_location: DF.Data | None
         event_logo: DF.AttachImage | None
         event_members: DF.Table[FOSSChapterEventMember]
         event_name: DF.Data
         event_permalink: DF.Data | None
         event_schedule: DF.Table[FOSSEventSchedule]
-        event_start_date: DF.Datetime | None
+        event_start_date: DF.Datetime
         event_type: DF.Link | None
         external_event_url: DF.Data | None
         hall_options: DF.SmallText | None

--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -231,12 +231,17 @@ def process_event(event, event_list):
     """
     now = now_datetime()
     event_date = event.event_start_date if event.event_start_date else event.start_date
-    event_month_year = frappe.utils.formatdate(event_date, "MMMM yyyy")
-    event.month_year = event_month_year
-    if event_date > now:
-        event_list["Upcoming FOSS Events"].append(event)
+
+    if event_date:
+        event_month_year = frappe.utils.formatdate(event_date, "MMMM yyyy")
+        event.month_year = event_month_year
+
+        if event_date > now:
+            event_list["Upcoming FOSS Events"].append(event)
+        else:
+            event_list["Past Events"].append(event)
     else:
-        event_list["Past Events"].append(event)
+        pass
 
 
 def get_month_grouped_events(events, hackathons):


### PR DESCRIPTION
- If some event does not have start or end date (idk how although its made mandatory), the timeline does not show up due to Nonetype error

fixes #1093 

Code is simply made to pass any event which does not have start date set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Events and hackathons now show both Upcoming and Past sections.
  * Items are grouped and labeled by month and year when a date is available.

* **Bug Fixes**
  * Prevented crashes caused by undated items; only dated events/hackathons are listed.

* **Changes**
  * Event creation/edit forms now require start and end dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->