### PR TITLE
Dash profile

### DIFF
--- a/dashboard/src/pages/MyProfile.vue
+++ b/dashboard/src/pages/MyProfile.vue
@@ -186,6 +186,127 @@
             <FormControl v-model="profile_dict.devto" type="url" label="Dev.to" />
             <FormControl v-model="profile_dict.medium" type="url" label="Medium" />
             <FormControl v-model="profile_dict.mastodon" type="url" label="Mastodon" />
+
+            <div class="col-span-2 py-1 border-b">
+              <h4 class="text-md font-medium uppercase">Education Details</h4>
+            </div>
+
+            <div
+              v-for="(edu, index) in profile_dict.education"
+              :key="index"
+              class="grid [grid-template-columns:auto_auto_auto_auto_auto_40px] gap-4 my-2 col-span-2"
+            >
+              <FormControl
+                v-model="profile_dict.education[index].institution"
+                label="College/Institute"
+              />
+              <FormControl v-model="profile_dict.education[index].degree" label="Degree" />
+              <FormControl
+                v-model="profile_dict.education[index].field_of_study"
+                label="Field of Study"
+              />
+              <FormControl v-model="profile_dict.education[index].start_year" label="Start Year" />
+              <FormControl v-model="profile_dict.education[index].end_year" label="End Year" />
+              <button
+                class="h-7 bg-gray-200 hover:bg-red-600 text-white text-xs rounded self-end"
+                @click="deleteItem('education', index)"
+              >
+                ✕
+              </button>
+            </div>
+
+            <div class="col-span-2 mt-2">
+              <Button variant="solid" size="md" theme="gray" @click="addEducation">
+                + Add More
+              </Button>
+            </div>
+
+            <div class="col-span-2 py-1 border-b">
+              <h4 class="text-md font-medium uppercase">Work Experience</h4>
+            </div>
+
+            <div
+              v-for="(work, index) in profile_dict.experience"
+              :key="index"
+              class="grid [grid-template-columns:auto_auto_auto_auto_auto_40px] gap-4 my-2 col-span-2"
+            >
+              <FormControl v-model="profile_dict.experience[index].title" label="Job Title" />
+              <FormControl v-model="profile_dict.experience[index].company" label="Company" />
+              <FormControl
+                v-model="profile_dict.experience[index].company_website"
+                label="Company Website"
+                type="url"
+              />
+              <FormControl
+                v-model="profile_dict.experience[index].employment_type"
+                label="Employment Type"
+                type="select"
+                :options="[
+                  { label: 'Full-time', value: 'Full-time' },
+                  { label: 'Part-time', value: 'Part-time' },
+                  { label: 'Internship', value: 'Internship' },
+                  { label: 'Freelance', value: 'Freelance' },
+                  { label: 'Self-employed', value: 'Self-employed' },
+                  { label: 'Trainee', value: 'Trainee' },
+                ]"
+              />
+              <FormControl
+                v-model="profile_dict.experience[index].start_date"
+                label="Start Date"
+                type="date"
+              />
+              <button
+                class="h-7 bg-gray-200 hover:bg-red-600 text-white text-xs rounded self-end"
+                @click="deleteItem('experience', index)"
+              >
+                ✕
+              </button>
+            </div>
+
+            <div class="col-span-2 mt-2">
+              <Button variant="solid" size="md" theme="gray" @click="addWorkExp">
+                + Add More
+              </Button>
+            </div>
+
+            <div class="col-span-2 py-1 border-b">
+              <h4 class="text-md font-medium uppercase">Project Details</h4>
+            </div>
+
+            <div
+              v-for="(proj, index) in profile_dict.projects"
+              :key="index"
+              class="grid [grid-template-columns:auto_auto_auto_auto_40px] gap-4 my-2 col-span-2"
+            >
+              <FormControl
+                v-model="profile_dict.projects[index].project_name"
+                label="Project Name"
+              />
+              <FormControl
+                v-model="profile_dict.projects[index].project_link"
+                label="Project Link"
+                type="url"
+              />
+              <FormControl v-model="profile_dict.projects[index].tagline" label="Tagline" />
+              <FormControl
+                v-model="profile_dict.projects[index].cover_image"
+                label="Cover Image"
+                type="url"
+              />
+              <button
+                class="h-7 bg-gray-200 hover:bg-red-600 text-white text-xs rounded self-end"
+                @click="deleteItem('projects', index)"
+              >
+                ✕
+              </button>
+            </div>
+
+            <div class="col-span-2 mt-2">
+              <Button variant="solid" size="md" theme="gray" @click="addProjects">
+                + Add More
+              </Button>
+            </div>
+
             <ErrorMessage class="col-span-2" :message="updateErrors" />
             <div class="hidden md:block"></div>
             <div class="flex justify-end">
@@ -216,29 +337,34 @@ const profile_dict = reactive({
   full_name: '',
   user: '',
   username: '',
-  bio: '',
-  cfp_visibility: '',
-  current_city: '',
-  about: '',
-  website: '',
-  x: '',
-  linkedin: '',
-  github: '',
-  gitlab: '',
-  instagram: '',
-  youtube: '',
-  devto: '',
-  medium: '',
-  mastodon: '',
 })
+
+function deepAssign(target, source) {
+  for (const key in source) {
+    if (Array.isArray(source[key])) {
+      // Replace entire array (or you can go deeper if needed)
+      target[key] = source[key]
+    } else if (source[key] !== null && typeof source[key] === 'object') {
+      if (!target[key] || typeof target[key] !== 'object') {
+        target[key] = {}
+      }
+      deepAssign(target[key], source[key])
+    } else {
+      target[key] = source[key]
+    }
+  }
+}
 
 const profile = createResource({
   url: 'fossunited.api.dashboard.get_session_user_profile',
   auto: true,
   onSuccess(data) {
-    Object.keys(profile_dict).forEach((key) => {
-      profile_dict[key] = data[key]
-    })
+    // assignValues(profile_dict, data)
+    deepAssign(profile_dict, data)
+    const eduLength = Array.isArray(profile_dict.education) ? profile_dict.education.length : 0
+    // console.log('Updated PROFILE_DICT:', JSON.stringify(profile_dict, null, 2))
+    // console.log('Updated DATA:', JSON.stringify(data, null, 2))
+    // console.log('Updated EDUCATION:', JSON.stringify(profile_dict.education.length, null, 2))
   },
 })
 
@@ -334,10 +460,10 @@ const updateErrors = ref('')
 
 const isValidUrl = (url) => {
   try {
-    const parsed = new URL(url);
-    return parsed.protocol === "http:" || parsed.protocol === "https:";
+    const parsed = new URL(url)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
   } catch (_) {
-    return false;
+    return false
   }
 }
 
@@ -452,6 +578,46 @@ const updateProfile = createResource({
     toast.error('Error updating profile: ' + err.messages)
   },
 })
+
+function addEducation() {
+  profile_dict.education.push({
+    institution: '',
+    degree: '',
+    field_of_study: '',
+    start_year: '',
+    end_year: '',
+  })
+}
+
+function addWorkExp() {
+  profile_dict.experience.push({
+    title: '',
+    company: '',
+    company_website: '',
+    employment_type: '',
+    start_date: '',
+  })
+}
+
+function addProjects() {
+  profile_dict.projects.push({
+    project_title: '',
+    project_link: '',
+    tagline: '',
+  })
+}
+
+function deleteItem(field, index) {
+  if (!['projects', 'education', 'experience'].includes(field)) {
+    console.warn(`Invalid field: ${field}`)
+    return
+  }
+
+  const list = profile_dict[field]
+  if (Array.isArray(list) && index > -1 && index < list.length) {
+    list.splice(index, 1)
+  }
+}
 
 const handleUpdateProfile = () => {
   const errors = updateProfileErrors()

--- a/fossunited/api/dashboard.py
+++ b/fossunited/api/dashboard.py
@@ -98,35 +98,10 @@ def get_session_user_profile():
     Used mainly for dashboard header.
     Returns some basic information about the user profile.
     """
-    user = frappe.db.get_value(
+    user = frappe.get_doc(
         USER_PROFILE,
         {"user": frappe.session.user},
-        [
-            "full_name",
-            "username",
-            "profile_photo",
-            "cover_image",
-            "route",
-            "current_city",
-            "gender",
-            "website",
-            "about",
-            "bio",
-            "user",
-            "name",
-            "is_private",
-            "show_activity",
-            "cfp_visibility",
-            "github",
-            "gitlab",
-            "linkedin",
-            "mastodon",
-            "mastodon",
-            "x",
-            "instagram",
-            "devto",
-            "youtube",
-        ],
+        ["*"],
         as_dict=1,
     )
 

--- a/fossunited/api/profile.py
+++ b/fossunited/api/profile.py
@@ -39,7 +39,11 @@ def set_profile_image(file_url: str) -> bool:
         filename = f"profile_{user_doc.name}.webp"
 
         saved_file = save_file(
-            fname=filename, content=webp_image, dt=USER_PROFILE, dn=user_doc.name, is_private=False
+            fname=filename,
+            content=webp_image,
+            dt=USER_PROFILE,
+            dn=user_doc.name,
+            is_private=False,
         )
 
         frappe.db.set_value(USER_PROFILE, user_doc.name, "profile_photo", saved_file.file_url)
@@ -69,7 +73,11 @@ def set_cover_image(file_url: str) -> bool:
         filename = f"cover_{user_doc.name}.webp"
 
         saved_file = save_file(
-            fname=filename, content=webp_image, dt=USER_PROFILE, dn=user_doc.name, is_private=False
+            fname=filename,
+            content=webp_image,
+            dt=USER_PROFILE,
+            dn=user_doc.name,
+            is_private=False,
         )
 
         frappe.db.set_value(USER_PROFILE, user_doc.name, "cover_image", saved_file.file_url)
@@ -125,11 +133,19 @@ def update_profile(fields_dict):
             "devto": fields_dict.get("devto"),
             "medium": fields_dict.get("medium"),
             "mastodon": fields_dict.get("mastodon"),
+            "education": fields_dict.get("education"),
+            "experience": fields_dict.get("experience"),
+            "projects": fields_dict.get("projects"),
         }
 
         profile = frappe.get_doc(USER_PROFILE, user_doc.name)
         for field, value in updated_fields.items():
-            if hasattr(profile, field):
+            if field in ["education", "projects", "experience"] and isinstance(value, list):
+                profile.set(field, [])  # Clear existing
+                for row in value:
+                    profile.append(field, row)
+
+            elif hasattr(profile, field):
                 setattr(profile, field, value)
         profile.save()
 

--- a/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
@@ -491,12 +491,6 @@
       //for each header-with-button, find the section from its parent
       $('.header-with-button').each((index, element) => {
         let section = $(element).parent().attr('id').split('-')[0]
-        $(element).append(`
-                <button class="add-modal-button" name="add-${section}" onClick="addModal(this)">
-                    <i class="ti ti-plus"></i>
-                    Add ${section}
-                </button>
-            `)
       })
     }
 


### PR DESCRIPTION
Closed #545

Provided simple input fields in edit profile dashboard to add/delete
Education, Work experience and projects for Foss User Profile.

- Users can add and delete entries.
- They can edit in frappe form in their /u/username page as well.


https://github.com/user-attachments/assets/2ff82f14-5e8d-43a8-9e7d-24add537db64



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Add and delete items for Education, Work Experience, and Projects directly in My Profile.
  - Multi-entry sections now sync and persist reliably; full profile data is loaded.

- Refactor
  - Improved profile data merging for more accurate loading and editing.
  - Simplified profile state; removed redundant auto-inserted “Add” buttons from public profile headers.

- Style
  - Minor code style cleanups (no functional impact).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->