### PR TITLE
Update team page

### DIFF
--- a/fossunited/fossunited/doctype/foss_united_team/foss_united_team.js
+++ b/fossunited/fossunited/doctype/foss_united_team/foss_united_team.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, Frappe x FOSSUnited and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("FOSS United Team", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/fossunited/fossunited/doctype/foss_united_team/foss_united_team.json
+++ b/fossunited/fossunited/doctype/foss_united_team/foss_united_team.json
@@ -35,7 +35,7 @@
       "fieldtype": "Select",
       "in_standard_filter": 1,
       "label": "Org Role",
-      "options": "\nFounder\nBoard\nGovernance Board\nFull-Time\nPart-Time\nIntern\nFellow\nVolunteer"
+      "options": "\nFounder\nBoard\nGoverning Board\nFull-Time\nPart-Time\nIntern\nFellow\nVolunteer"
     },
     {
       "fieldname": "user_individual_details_section",

--- a/fossunited/fossunited/doctype/foss_united_team/foss_united_team.json
+++ b/fossunited/fossunited/doctype/foss_united_team/foss_united_team.json
@@ -35,7 +35,7 @@
       "fieldtype": "Select",
       "in_standard_filter": 1,
       "label": "Org Role",
-      "options": "\nFounder\nBoard\nFull-Time\nPart-Time\nIntern\nFellow\nVolunteer"
+      "options": "\nFounder\nBoard\nGovernance Board\nFull-Time\nPart-Time\nIntern\nFellow\nVolunteer"
     },
     {
       "fieldname": "user_individual_details_section",
@@ -94,7 +94,7 @@
   ],
   "index_web_pages_for_search": 1,
   "links": [],
-  "modified": "2024-05-21 13:19:50.477734",
+  "modified": "2025-08-19 14:51:58.365494",
   "modified_by": "Administrator",
   "module": "FOSSUnited",
   "name": "FOSS United Team",

--- a/fossunited/fossunited/doctype/foss_united_team/foss_united_team.py
+++ b/fossunited/fossunited/doctype/foss_united_team/foss_united_team.py
@@ -22,7 +22,7 @@ class FOSSUnitedTeam(Document):
             "",  # noqa: F722, F821
             "Founder",  # noqa: F821
             "Board",  # noqa: F821
-            "Governance Board",  # noqa: F722
+            "Governing Board",  # noqa: F722
             "Full-Time",  # noqa: F821
             "Part-Time",  # noqa: F821
             "Intern",  # noqa: F821

--- a/fossunited/fossunited/doctype/foss_united_team/foss_united_team.py
+++ b/fossunited/fossunited/doctype/foss_united_team/foss_united_team.py
@@ -22,6 +22,7 @@ class FOSSUnitedTeam(Document):
             "",  # noqa: F722, F821
             "Founder",  # noqa: F821
             "Board",  # noqa: F821
+            "Governance Board",  # noqa: F722
             "Full-Time",  # noqa: F821
             "Part-Time",  # noqa: F821
             "Intern",  # noqa: F821

--- a/fossunited/fossunited/doctype/foss_united_team/test_foss_united_team.py
+++ b/fossunited/fossunited/doctype/foss_united_team/test_foss_united_team.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Frappe x FOSSUnited and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestFOSSUnitedTeam(FrappeTestCase):
+    pass

--- a/fossunited/fossunited/web_template/team_list_section/team_list_section.html
+++ b/fossunited/fossunited/web_template/team_list_section/team_list_section.html
@@ -1,9 +1,9 @@
-{% macro render_team_section(title, members, extra_info) %}
+{% macro render_team_section(title, members, extra_info=None) %}
   {% if members %}
     <div class="member-section">
       <div class="header-container">
         <h5>{{ title }}</h5>
-        {{ extra_info or "" }}
+        {% if extra_info %}{{ extra_info | safe }}{% endif %}
       </div>
       <div class="teams-container">
         {% for member in members %}
@@ -11,7 +11,7 @@
             <div class="team-member">
               <div class="team-member-image">
                 <img
-                  src="{{ member.headshot if member.headshot else 'assets/fossunited/images/defaults/user_profile_image.png' }}"
+                  src="{{ member.headshot if member.headshot else '/assets/fossunited/images/defaults/user_profile_image.png' }}"
                   alt="{{ member.full_name }}"
                 />
               </div>
@@ -33,7 +33,7 @@
   order_by="full_name")
 %}
 {%
-  set GovBoardMembers = frappe.get_all("FOSS United Team", fields=["full_name", "username", "headshot", "user_bio", "designation"], filters={"org_role": "Governance Board", "is_active": 1},
+  set GovBoardMembers = frappe.get_all("FOSS United Team", fields=["full_name", "username", "headshot", "user_bio", "designation"], filters={"org_role": "Governing Board", "is_active": 1},
   order_by="full_name")
 %}
 {%
@@ -58,7 +58,7 @@
     display: block;
   }
 
-  a:hover {
+  .team-member-link:hover {
     text-decoration: none !important;
   }
 
@@ -118,7 +118,7 @@
     align-items: center;
   }
 
-  .team-member:hover {
+  .team-member-link:hover .team-member {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
   }
 
@@ -168,7 +168,7 @@
     <h4>Meet the Workforce</h4>
     <div class="team-section">
       {{ render_team_section("Board", boardMembers) }}
-      {{ render_team_section("Governance Board", GovBoardMembers, '<a href="/blog/organization/meet-the-first-ever-elected-community-governance-board-foss-united" class="blog-link">View Blog Post</a>') }}
+      {{ render_team_section("Governing Board", GovBoardMembers, '<a href="/blog/organization/meet-the-first-ever-elected-community-governance-board-foss-united" class="blog-link">View Blog Post</a>') }}
       {{ render_team_section("Full-time and Part-time Staff", staff) }}
       {{ render_team_section("Fellows and Interns", fellowsInterns) }}
       {{ render_team_section("Active and Part-time Volunteers", volunteers) }}

--- a/fossunited/fossunited/web_template/team_list_section/team_list_section.html
+++ b/fossunited/fossunited/web_template/team_list_section/team_list_section.html
@@ -1,7 +1,80 @@
+{% macro render_team_section(title, members, extra_info) %}
+  {% if members %}
+    <div class="member-section">
+      <div class="header-container">
+        <h5>{{ title }}</h5>
+        {{ extra_info or "" }}
+      </div>
+      <div class="teams-container">
+        {% for member in members %}
+          <a href="/u/{{ member.username }}" class="team-member-link">
+            <div class="team-member">
+              <div class="team-member-image">
+                <img
+                  src="{{ member.headshot if member.headshot else 'assets/fossunited/images/defaults/user_profile_image.png' }}"
+                  alt="{{ member.full_name }}"
+                />
+              </div>
+              <div class="team-member-details">
+                <h6>{{ member.full_name }}</h6>
+                <p style="color: hsl(var(--clr-foss-mint-500));">@{{ member.username }}</p>
+                <p>{{ member.designation }}</p>
+              </div>
+            </div>
+          </a>
+        {% endfor %}
+      </div>
+    </div>
+  {% endif %}
+{% endmacro %}
+{%
+  set boardMembers = frappe.get_all("FOSS United Team", fields=["full_name", "username",
+      "headshot", "user_bio", "designation"], filters={"org_role": "Board", "is_active": 1},
+  order_by="full_name")
+%}
+{%
+  set GovBoardMembers = frappe.get_all("FOSS United Team", fields=["full_name", "username",
+      "headshot", "user_bio", "designation"], filters={"org_role": "Board", "is_active": 1},
+  order_by="full_name")
+%}
+{%
+  set staff = frappe.get_all("FOSS United Team", fields=["full_name",
+  "username", "headshot", "user_bio", "designation"], filters={"is_active": 1, "org_role":
+  ["in", ["Full-Time", "Part-Time"]]}, order_by ='full_name')
+%}
+{%
+  set fellowsInterns = frappe.get_all("FOSS United Team", fields=["full_name",
+  "username", "headshot", "user_bio", "designation"], filters={"is_active": 1, "org_role":
+  ["in", ["Fellow", "Intern"]]}, order_by ='full_name')
+%}
+{%
+  set volunteers = frappe.get_all("FOSS United Team", fields=["full_name",
+  "username", "headshot", "user_bio", "designation"], filters={"is_active": 1, "org_role":
+  "Volunteer"}, order_by ='full_name')
+%}
 <style>
+  .team-member-link {
+    text-decoration: none;
+    color: inherit;
+    display: block;
+  }
+
+  a:hover {
+    text-decoration: none !important;
+  }
+
   .team-list-section {
     display: flex;
     font-family: Inter;
+  }
+
+  .header-container {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .blog-link {
+    text-decoration: underline;
   }
 
   .team-list-container {
@@ -39,8 +112,15 @@
   .team-member {
     display: flex;
     gap: 3rem;
-
+    border: 1px solid #ccc;
+    border-radius: 10px;
+    padding: 16px;
+    transition: box-shadow 0.3s;
     align-items: center;
+  }
+
+  .team-member:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
   }
 
   .team-member-image {
@@ -84,119 +164,15 @@
     }
   }
 </style>
-
 <div class="team-list-section container">
   <div class="team-list-container">
     <h4>Meet the Workforce</h4>
-
     <div class="team-section">
-      {%
-        set boardMembers = frappe.get_all("FOSS United Team", fields=["full_name", "username",
-        "headshot", "user_bio", "designation"], filters={"org_role": "Board", "is_active": 1},
-        order_by="full_name")
-      %}
-      {% if boardMembers %}
-        <div class="member-section">
-          <h5>Board</h5>
-          <div class="teams-container">
-            {% for member in boardMembers %}
-              <div class="team-member">
-                <div class="team-member-image">
-                  <img
-                    src="{{ member.headshot if member.headshot else 'assets/fossunited/images/defaults/user_profile_image.png' }}"
-                    alt="{{ member.full_name }}"
-                  />
-                </div>
-                <div class="team-member-details">
-                  <h6>{{ member.full_name }}</h6>
-                  <a href="/u/{{ member.username }}">@{{ member.username }}</a>
-                  <p>{{ member.designation }}</p>
-                </div>
-              </div>
-            {% endfor %}
-          </div>
-        </div>
-      {% endif %}
-      {%
-        set staff = frappe.get_all("FOSS United Team", fields=["full_name",
-        "username", "headshot", "user_bio", "designation"], filters={"is_active": 1, "org_role":
-        ["in", ["Full-Time", "Part-Time"]]}, order_by ='full_name')
-      %}
-      {% if staff %}
-        <div class="member-section">
-          <h5>Full-time and Part-time Staff</h5>
-          <div class="teams-container">
-            {% for member in staff %}
-              <div class="team-member">
-                <div class="team-member-image">
-                  <img
-                    src="{{ member.headshot if member.headshot else 'assets/fossunited/images/defaults/user_profile_image.png' }}"
-                    alt="{{ member.full_name }}"
-                  />
-                </div>
-                <div class="team-member-details">
-                  <h6>{{ member.full_name }}</h6>
-                  <a href="/u/{{ member.username }}">@{{ member.username }}</a>
-                  <p>{{ member.designation }}</p>
-                </div>
-              </div>
-            {% endfor %}
-          </div>
-        </div>
-      {% endif %}
-      {%
-        set fellowsInterns = frappe.get_all("FOSS United Team", fields=["full_name",
-        "username", "headshot", "user_bio", "designation"], filters={"is_active": 1, "org_role":
-        ["in", ["Fellow", "Intern"]]}, order_by ='full_name')
-      %}
-      {% if fellowsInterns %}
-        <div class="member-section">
-          <h5>Fellows and Interns</h5>
-          <div class="teams-container">
-            {% for member in fellowsInterns %}
-              <div class="team-member">
-                <div class="team-member-image">
-                  <img
-                    src="{{ member.headshot if member.headshot else 'assets/fossunited/images/defaults/user_profile_image.png' }}"
-                    alt="{{ member.full_name }}"
-                  />
-                </div>
-                <div class="team-member-details">
-                  <h6>{{ member.full_name }}</h6>
-                  <a href="/u/{{ member.username }}">@{{ member.username }}</a>
-                  <p>{{ member.designation }}</p>
-                </div>
-              </div>
-            {% endfor %}
-          </div>
-        </div>
-      {% endif %}
-      {%
-        set volunteers = frappe.get_all("FOSS United Team", fields=["full_name",
-        "username", "headshot", "user_bio", "designation"], filters={"is_active": 1, "org_role":
-        "Volunteer"}, order_by ='full_name')
-      %}
-      {% if volunteers %}
-        <div class="member-section">
-          <h5>Active and Part-time Volunteers</h5>
-          <div class="teams-container">
-            {% for member in volunteers %}
-              <div class="team-member">
-                <div class="team-member-image">
-                  <img
-                    src="{{ member.headshot if member.headshot else 'assets/fossunited/images/defaults/user_profile_image.png' }}"
-                    alt="{{ member.full_name }}"
-                  />
-                </div>
-                <div class="team-member-details">
-                  <h6>{{ member.full_name }}</h6>
-                  <a href="/u/{{ member.username }}">@{{ member.username }}</a>
-                </div>
-              </div>
-            {% endfor %}
-          </div>
-        </div>
-      {% endif %}
+      {{ render_team_section("Board", boardMembers) }}
+      {{ render_team_section("Governance Board", GovBoardMembers, '<a href="/blog/organization/meet-the-first-ever-elected-community-governance-board-foss-united" class="blog-link">View Blog Post</a>') }}
+      {{ render_team_section("Full-time and Part-time Staff", staff) }}
+      {{ render_team_section("Fellows and Interns", fellowsInterns) }}
+      {{ render_team_section("Active and Part-time Volunteers", volunteers) }}
     </div>
   </div>
 </div>

--- a/fossunited/fossunited/web_template/team_list_section/team_list_section.html
+++ b/fossunited/fossunited/web_template/team_list_section/team_list_section.html
@@ -29,27 +29,27 @@
 {% endmacro %}
 {%
   set boardMembers = frappe.get_all("FOSS United Team", fields=["full_name", "username",
-      "headshot", "user_bio", "designation"], filters={"org_role": "Board", "is_active": 1},
-  order_by="full_name")
+      "headshot", "designation"], filters={"org_role": "Board", "is_active": 1},
+  order_by="full_name", limit_page_length=0)
 %}
 {%
-  set GovBoardMembers = frappe.get_all("FOSS United Team", fields=["full_name", "username", "headshot", "user_bio", "designation"], filters={"org_role": "Governing Board", "is_active": 1},
-  order_by="full_name")
+  set GovBoardMembers = frappe.get_all("FOSS United Team", fields=["full_name", "username", "headshot", "designation"], filters={"org_role": "Governing Board", "is_active": 1},
+  order_by="full_name", limit_page_length=0)
 %}
 {%
   set staff = frappe.get_all("FOSS United Team", fields=["full_name",
-  "username", "headshot", "user_bio", "designation"], filters={"is_active": 1, "org_role":
-  ["in", ["Full-Time", "Part-Time"]]}, order_by ='full_name')
+  "username", "headshot", "designation"], filters={"is_active": 1, "org_role":
+  ["in", ["Full-Time", "Part-Time"]]}, order_by ='full_name', limit_page_length=0)
 %}
 {%
   set fellowsInterns = frappe.get_all("FOSS United Team", fields=["full_name",
-  "username", "headshot", "user_bio", "designation"], filters={"is_active": 1, "org_role":
-  ["in", ["Fellow", "Intern"]]}, order_by ='full_name')
+  "username", "headshot", "designation"], filters={"is_active": 1, "org_role":
+  ["in", ["Fellow", "Intern"]]}, order_by ='full_name', limit_page_length=0)
 %}
 {%
   set volunteers = frappe.get_all("FOSS United Team", fields=["full_name",
-  "username", "headshot", "user_bio", "designation"], filters={"is_active": 1, "org_role":
-  "Volunteer"}, order_by ='full_name')
+  "username", "headshot", "designation"], filters={"is_active": 1, "org_role":
+  "Volunteer"}, order_by ='full_name', limit_page_length=0)
 %}
 <style>
   .team-member-link {

--- a/fossunited/fossunited/web_template/team_list_section/team_list_section.html
+++ b/fossunited/fossunited/web_template/team_list_section/team_list_section.html
@@ -33,8 +33,7 @@
   order_by="full_name")
 %}
 {%
-  set GovBoardMembers = frappe.get_all("FOSS United Team", fields=["full_name", "username",
-      "headshot", "user_bio", "designation"], filters={"org_role": "Board", "is_active": 1},
+  set GovBoardMembers = frappe.get_all("FOSS United Team", fields=["full_name", "username", "headshot", "user_bio", "designation"], filters={"org_role": "Governance Board", "is_active": 1},
   order_by="full_name")
 %}
 {%


### PR DESCRIPTION
This PR brings some updates to teams page.

Our teams are defined in foss united team doctype.

+ Added `Governance Board` role to show 5 governing board members
  - Also linked the to blog post beside heading
+ Made the common jinja macro for rendering team list

+ Further PR would be to list past employees + volunteers as well.

Here is a preview for it.

<img width="500" height="350" alt="image" src="https://github.com/user-attachments/assets/a227e83d-7923-41b1-abce-dffb1f8c607a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Governing Board" role and a dedicated Governing Board section on the Team page with a blog link.
  * Made each team member entry fully clickable, linking to their profile.

* **Improvements**
  * Consolidated team sections into a reusable layout; standardized ordering and active-only filtering.

* **Style**
  * Enhanced visuals: borders, padding, hover effects, header alignment, and responsive grid.

* **Tests**
  * Added a placeholder test suite for the Team module.

* **Chores**
  * Added a placeholder client-side script for future Team form enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->