### PR TITLE
show city and state for foss club pages

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
@@ -234,28 +234,27 @@ class FOSSChapter(WebsiteGenerator):
     def get_social_links(self):
         socials = {}
         SOCIAL_LINK_FIELDNAMES = [
+            "mastodon",
+            "matrix",
+            "bluesky",
+            "telegram",
             "github",
             "gitlab",
-            "x",
-            "linkedin",
-            "instagram",
-            "mastodon",
             "youtube",
+            "linkedin",
             "facebook",
-            "matrix",
-            "telegram",
-            "whatsapp",
+            "instagram",
+            "x",
             "discord",
-            "bluesky",
         ]
         for k, v in self.as_dict().items():
-            if k in SOCIAL_LINK_FIELDNAMES:
+            if v and k in SOCIAL_LINK_FIELDNAMES:
                 if k == "matrix":
                     k = "matrix-light"
+                socials[k] = v
 
-                if v:
-                    socials[k] = v
-            else:
-                continue
+        def sort_key(item):
+            key = "matrix" if item[0] == "matrix-light" else item[0]
+            return SOCIAL_LINK_FIELDNAMES.index(key)
 
-        return socials
+        return dict(sorted(socials.items(), key=sort_key))

--- a/fossunited/chapters/doctype/foss_chapter/templates/foss_chapter.html
+++ b/fossunited/chapters/doctype/foss_chapter/templates/foss_chapter.html
@@ -16,30 +16,34 @@
         alt="Banner Image"
       />
       <div class="header--img-title-cta-section">
-        <div class="header--img-title">
-          <img
-            src="{{ doc.chapter_logo or default_chapter_logo }}"
-            alt="{{ doc.chapter_type }} Logo"
-            class="header-profile-image ml-lg-6"
-          />
-          <h1
-            class="pt-2 header--title {% if doc.chapter_type == 'City Community' %}city-chapter-heading{% else %}chapter-heading{% endif %}"
-          >
-            {{ doc.chapter_name }}
-          </h1>
+        <div>
+          <div class="header--img-title">
+            <img
+              src="{{ doc.chapter_logo or default_chapter_logo }}"
+              alt="{{ doc.chapter_type }} Logo"
+              class="header-profile-image ml-lg-6"
+            />
+            <div>
+              <h1
+                class="pt-2 header--title {% if doc.chapter_type == 'City Community' %}city-chapter-heading{% else %}chapter-heading{% endif %}"
+              >
+                {{ doc.chapter_name }}
+              </h1>
+              {% if doc.chapter_type == 'FOSS Club' %}
+                <i class="ti ti-map-pin"></i>
+                {{ doc.city }}, {{ doc.state }}
+              {% endif %}
+            </div>
+          </div>
         </div>
-        <!-- <div class="header--cta-section">
-                    <button class="primary-button">
-                        <i class="ti ti-user-plus"></i> Follow
-                    </button>
-                </div> -->
       </div>
     </div>
+
     <div class="header-section--socials">
       {% for (k,v) in social_links.items() %}
-      <a href="{{ v }}" aria-label="{{ k|title }} for {{ doc.chapter_name }} chapter.">
-        <img src="https://svgl.app/library/{{ k }}.svg" alt="{{ k|title }}" />
-      </a>
+        <a href="{{ v }}" aria-label="{{ k|title }} for {{ doc.chapter_name }} chapter.">
+          <img src="https://svgl.app/library/{{ k }}.svg" alt="{{ k|title }}" />
+        </a>
       {% endfor %}
     </div>
   </div>

--- a/fossunited/chapters/doctype/foss_chapter/templates/foss_chapter.html
+++ b/fossunited/chapters/doctype/foss_chapter/templates/foss_chapter.html
@@ -16,25 +16,37 @@
         alt="Banner Image"
       />
       <div class="header--img-title-cta-section">
-        <div>
-          <div class="header--img-title">
-            <img
-              src="{{ doc.chapter_logo or default_chapter_logo }}"
-              alt="{{ doc.chapter_type }} Logo"
-              class="header-profile-image ml-lg-6"
-            />
-            <div>
-              <h1
-                class="pt-2 header--title {% if doc.chapter_type == 'City Community' %}city-chapter-heading{% else %}chapter-heading{% endif %}"
+        <div class="header--img-title">
+          <!-- Chapter Logo -->
+          <img
+            src="{{ doc.chapter_logo or default_chapter_logo }}"
+            alt="{{ doc.chapter_type }} Logo"
+            class="header-profile-image ml-lg-6"
+          />
+          <!-- Title and Info -->
+          <div class="header-content-edit-section">
+            <div class="header--content-section pl-2">
+              <!-- Title -->
+              <div class="d-flex mb-0">
+                <h1
+                  class="pt-2 header--title mb-0 {% if doc.chapter_type == 'City Community' %}city-chapter-heading{% else %}chapter-heading{% endif %}"
+                >
+                  {{ doc.chapter_name }}
+                </h1>
+              </div>
+              <div
+                class="header--username-location ml-4"
+                style="font-size: var(--text-sm); margin-top: -20px;"
               >
-                {{ doc.chapter_name }}
-              </h1>
-              {% if doc.chapter_type == 'FOSS Club' and (doc.city or doc.state) %}
-                <span class="header--location">
-                  <i class="ti ti-map-pin" aria-hidden="true"></i>
-                  {% if doc.city %}{{ doc.city }}, {% endif %}{{ doc.state }}
-                </span>
-              {% endif %}
+                {% if doc.chapter_type == 'FOSS Club' and (doc.city or doc.state) %}
+                  <span>
+                    <i class="ti ti-map-pin" aria-hidden="true"></i>
+                    {% if doc.city %}{{ doc.city }},{% endif %} {{ doc.state }}
+                  </span>
+                  <div class="seperator-circle"></div>
+                {% endif %}
+                <span>Established {{ doc.creation.strftime('%B %Y') }}</span>
+              </div>
             </div>
           </div>
         </div>

--- a/fossunited/chapters/doctype/foss_chapter/templates/foss_chapter.html
+++ b/fossunited/chapters/doctype/foss_chapter/templates/foss_chapter.html
@@ -45,7 +45,7 @@
                   </span>
                   <div class="seperator-circle"></div>
                 {% endif %}
-                <span>Established {{ doc.creation.strftime('%B %Y') }}</span>
+                <span>Established in {{ frappe.utils.formatdate(doc.creation, "MMMM yyyy") }}</span>
               </div>
             </div>
           </div>

--- a/fossunited/chapters/doctype/foss_chapter/templates/foss_chapter.html
+++ b/fossunited/chapters/doctype/foss_chapter/templates/foss_chapter.html
@@ -29,9 +29,11 @@
               >
                 {{ doc.chapter_name }}
               </h1>
-              {% if doc.chapter_type == 'FOSS Club' %}
-                <i class="ti ti-map-pin"></i>
-                {{ doc.city }}, {{ doc.state }}
+              {% if doc.chapter_type == 'FOSS Club' and (doc.city or doc.state) %}
+                <span class="header--location">
+                  <i class="ti ti-map-pin" aria-hidden="true"></i>
+                  {% if doc.city %}{{ doc.city }}, {% endif %}{{ doc.state }}
+                </span>
               {% endif %}
             </div>
           </div>
@@ -40,10 +42,17 @@
     </div>
 
     <div class="header-section--socials">
-      {% for (k,v) in social_links.items() %}
-        <a href="{{ v }}" aria-label="{{ k|title }} for {{ doc.chapter_name }} chapter.">
-          <img src="https://svgl.app/library/{{ k }}.svg" alt="{{ k|title }}" />
-        </a>
+      {% for (k, v) in social_links.items() %}
+        {% if v and (v.startswith('http://') or v.startswith('https://')) %}
+          <a
+            href="{{ v }}"
+            aria-label="{{ k|title }} for {{ doc.chapter_name }} chapter."
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <img src="https://svgl.app/library/{{ k }}.svg" alt="{{ k|title }}" />
+          </a>
+        {% endif %}
       {% endfor %}
     </div>
   </div>


### PR DESCRIPTION
Closes #1098 

- Adds to show city and state for only foss club chapters.

<img width="370" height="240" alt="image" src="https://github.com/user-attachments/assets/4113207b-c058-49db-b9ec-9364c721a1c2" />

Any other info makes sense to add?
I found nothing else fits to be shown.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * For FOSS Clubs, the chapter title now shows city and state with a map-pin icon.
  * An "Established" month/year line is shown under the title.

* **Style**
  * Header layout restructured: clearer logo/title grouping and Follow CTA removed.
  * Social links: only valid HTTP(S) URLs shown, open in new tabs; social icons and display order standardized (including Mastodon/Matrix/Bluesky/Telegram prioritization) and minor formatting tidy-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->