### PR TITLE
add invited talk option to support rfc

### DIFF
--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.json
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.json
@@ -267,7 +267,7 @@
    "fieldname": "session_type",
    "fieldtype": "Select",
    "label": "Session Type",
-   "options": "Talk\nLightning Talk\nPanel Discussion\nBirds of Feather(BoF)\nWorkshop",
+   "options": "Talk\nLightning Talk\nPanel Discussion\nBirds of Feather(BoF)\nWorkshop\nInvited Talk",
    "reqd": 1
   },
   {
@@ -339,7 +339,7 @@
  "has_web_view": 1,
  "is_published_field": "is_published",
  "links": [],
- "modified": "2025-06-22 22:55:30.082517",
+ "modified": "2025-08-19 21:25:18.448437",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "FOSS Event CFP Submission",
@@ -408,7 +408,6 @@
    "share": 1
   }
  ],
- "row_format": "Dynamic",
  "search_fields": "submitted_by, event, event_name, chapter",
  "show_title_field_in_link": 1,
  "sort_field": "modified",

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -89,6 +89,7 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         self.set_route()
         self.set_scores()
         self.handle_status_change()
+        self.validate_session_type_permissions()
 
     def after_insert(self):
         self.handle_email_group("CFP Proposers")
@@ -116,6 +117,18 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         linked_cfp = frappe.get_doc(EVENT_CFP, self.linked_cfp)
         if not linked_cfp.status == "Live":
             frappe.throw("The CFP Form for this event is not live", frappe.PermissionError)
+
+    def validate_session_type_permissions(self) -> None:
+        if self.session_type != "Invited Talk":
+            return
+        user = frappe.session.user
+        # Block Website Users outright
+        if frappe.db.get_value("User", user, "user_type") == "Website User":
+            frappe.throw("You cannot set Session Type to 'Invited Talk'.", frappe.PermissionError)
+        # Allow only specific desk roles to set this value
+        allowed_roles = {"System Manager", "Chapter Team Member", "CFP Reviewer"}
+        if not set(frappe.get_roles(user)).intersection(allowed_roles):
+            frappe.throw("You cannot set Session Type to 'Invited Talk'.", frappe.PermissionError)
 
     def get_context(self, context):
         event = frappe.get_doc(EVENT, self.event)

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -59,7 +59,12 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         route: DF.Data | None
         session_categories: DF.Text | None
         session_type: DF.Literal[
-            "Talk", "Lightning Talk", "Panel Discussion", "Birds of Feather(BoF)", "Workshop"  # noqa: F821, F722
+            "Talk",  # noqa: F821
+            "Lightning Talk",  # noqa: F722
+            "Panel Discussion",  # noqa: F821, F722
+            "Birds of Feather(BoF)",  # noqa: F722
+            "Workshop",  # noqa: F821
+            "Invited Talk",  # noqa: F821, F722
         ]
         speakers: DF.Table[CFPSubmissionSpeaker]
         status: DF.Literal["Review Pending", "Screening", "Approved", "Rejected", "Withdrawn"]  # noqa: F821, F722


### PR DESCRIPTION
- Closes #1090 Note: This (Invited Talk) option will be only handled via frappe app This is not meant to be shown in dashboard

Damn this is straight-forward solution.
I simply cracked and went into rabbit hole of trying client script and all.

Later realized CFPs are given via dashboard which has full code to control what is shown.

So the PR will simply add an option for mods to handle CFPs in frappe app.
For users/proposer it wont be shown.

For system user via frappe app you have control. Submitter can see only what dashboard is coded to see.
So Invited talk wont appear to them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Invited Talk” to the CFP session type dropdown; selecting it is now restricted to specific organizer/reviewer roles (website users cannot set it).
* **Chores**
  * Updated DocType metadata and type annotations; no impact on existing submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->