### PR TITLE
close rsvp and cfp form when event ends

### DIFF
--- a/fossunited/scheduled_tasks.py
+++ b/fossunited/scheduled_tasks.py
@@ -18,14 +18,20 @@ def conclude_events():
     """
     events = frappe.db.get_all(
         EVENT,
-        {"status": "Live", "event_end_date": ["<", datetime.today()]},
+        {
+            "status": ["in", ["Live", "Cancelled"]],
+            "event_end_date": ["<", datetime.today()],
+        },
         ["name", "status", "event_end_date", "event_start_date"],
         page_length=999,
     )
 
     for event in events:
         doc = frappe.get_doc(EVENT, event.name)
-        doc.status = "Concluded"
+        if doc.status == "Live":
+            doc.status = "Concluded"
+        else:
+            doc.status = "Cancelled"
         doc.show_rsvp = 0
         doc.show_cfp = 0
         past_rsvp = frappe.get_doc(EVENT_RSVP, {"event_name": doc.event_name})

--- a/fossunited/scheduled_tasks.py
+++ b/fossunited/scheduled_tasks.py
@@ -19,6 +19,8 @@ def conclude_events():
     for event in events:
         doc = frappe.get_doc(EVENT, event.name)
         doc.status = "Concluded"
+        doc.show_rsvp = 0
+        doc.show_cfp = 0
         try:
             doc.save(ignore_permissions=True)
         except Exception as e:

--- a/fossunited/scheduled_tasks.py
+++ b/fossunited/scheduled_tasks.py
@@ -2,7 +2,14 @@ from datetime import datetime, timedelta
 
 import frappe
 
-from fossunited.doctype_ids import EVENT, JOB, JOB_STATUS_APPROVED, JOB_STATUS_EXPIRED
+from fossunited.doctype_ids import (
+    EVENT,
+    EVENT_CFP,
+    EVENT_RSVP,
+    JOB,
+    JOB_STATUS_APPROVED,
+    JOB_STATUS_EXPIRED,
+)
 
 
 def conclude_events():
@@ -21,8 +28,14 @@ def conclude_events():
         doc.status = "Concluded"
         doc.show_rsvp = 0
         doc.show_cfp = 0
+        past_rsvp = frappe.get_doc(EVENT_RSVP, {"event_name": doc.event_name})
+        past_rsvp.is_published = 0
+        past_cfp = frappe.get_doc(EVENT_CFP, {"event_name": doc.event_name})
+        past_cfp.status = "Closed"
         try:
             doc.save(ignore_permissions=True)
+            past_rsvp.save(ignore_permissions=True)
+            past_cfp.save(ignore_permissions=True)
         except Exception as e:
             frappe.log_error(
                 frappe.get_traceback(),

--- a/fossunited/scheduled_tasks.py
+++ b/fossunited/scheduled_tasks.py
@@ -32,16 +32,21 @@ def conclude_events():
             doc.status = "Concluded"
         else:
             doc.status = "Cancelled"
+
         doc.show_rsvp = 0
         doc.show_cfp = 0
-        past_rsvp = frappe.get_doc(EVENT_RSVP, {"event_name": doc.event_name})
-        past_rsvp.is_published = 0
-        past_cfp = frappe.get_doc(EVENT_CFP, {"event_name": doc.event_name})
-        past_cfp.status = "Closed"
+
         try:
+            # Fetch linked RSVP/CFP by `event` (link to Event name) and update if present
             doc.save(ignore_permissions=True)
-            past_rsvp.save(ignore_permissions=True)
-            past_cfp.save(ignore_permissions=True)
+            past_rsvp = frappe.get_doc(EVENT_RSVP, {"event_name": doc.event_name})
+            if past_rsvp:
+                past_rsvp.is_published = 0
+                past_rsvp.save(ignore_permissions=True)
+            past_cfp = frappe.get_doc(EVENT_CFP, {"event_name": doc.event_name})
+            if past_cfp:
+                past_cfp.status = "Closed"
+                past_cfp.save(ignore_permissions=True)
         except Exception as e:
             frappe.log_error(
                 frappe.get_traceback(),

--- a/fossunited/tests/test_scheduled_tasks.py
+++ b/fossunited/tests/test_scheduled_tasks.py
@@ -4,10 +4,15 @@ from unittest.mock import patch
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from fossunited.doctype_ids import CHAPTER, EVENT
+from fossunited.doctype_ids import CHAPTER, EVENT, EVENT_CFP, EVENT_RSVP
 from fossunited.scheduled_tasks import conclude_events
 
-from .utils import insert_test_chapter, insert_test_event
+from .utils import (
+    insert_cfp_form,
+    insert_rsvp_form,
+    insert_test_chapter,
+    insert_test_event,
+)
 
 
 class TestScheduledTasks(FrappeTestCase):
@@ -22,6 +27,9 @@ class TestScheduledTasks(FrappeTestCase):
             end_date=today.replace(hour=15, minute=30),
         )
 
+        self.event1_cfp = insert_cfp_form(event=self.event1.name, status="Live")
+        self.event1_rsvp = insert_rsvp_form(event=self.event1.name, is_published=1)
+
         # Event 2 is cancelled, and was supposed to end tomorrow
         self.event2 = insert_test_event(
             chapter=self.chapter,
@@ -29,6 +37,8 @@ class TestScheduledTasks(FrappeTestCase):
             start_date=today.replace(hour=9, minute=00),
             end_date=today.replace(hour=15, minute=30),
         )
+        self.event2_cfp = insert_cfp_form(event=self.event2.name, status="Live")
+        self.event2_rsvp = insert_rsvp_form(event=self.event2.name, is_published=1)
 
         # Event 3 starts tomorrow, and ends the day-after tomorrow
         self.event3 = insert_test_event(
@@ -36,10 +46,14 @@ class TestScheduledTasks(FrappeTestCase):
             start_date=today.replace(hour=9, minute=00) + timedelta(days=1),
             end_date=today.replace(hour=14, minute=00) + timedelta(days=2),
         )
+        self.event3_cfp = insert_cfp_form(event=self.event3.name, status="Live")
+        self.event3_rsvp = insert_rsvp_form(event=self.event3.name, is_published=1)
 
     def tearDown(self):
         frappe.set_user("Administrator")
         frappe.delete_doc(CHAPTER, self.chapter.name, force=True)
+        frappe.delete_doc(EVENT_CFP, self.event1_cfp.name, force=True)
+        frappe.delete_doc(EVENT_RSVP, self.event1_rsvp.name, force=True)
         frappe.delete_doc(EVENT, self.event1.name, force=True)
         frappe.delete_doc(EVENT, self.event2.name, force=True)
         frappe.delete_doc(EVENT, self.event3.name, force=True)
@@ -58,14 +72,26 @@ class TestScheduledTasks(FrappeTestCase):
 
         # Fetch events to check their status
         self.event1.reload()
+        self.event1_cfp.reload()
+        self.event1_rsvp.reload()
         self.event2.reload()
+        self.event2_cfp.reload()
+        self.event2_rsvp.reload()
         self.event3.reload()
+        self.event3_cfp.reload()
+        self.event3_rsvp.reload()
 
         # First event should change the status to concluded
         self.assertEqual(self.event1.status, "Concluded")
+        self.assertEqual(self.event1_cfp.status, "Closed")
+        self.assertEqual(self.event1_rsvp.is_published, 0)
 
         # Second event should not change it's status, since it was cancelled
         self.assertEqual(self.event2.status, "Cancelled")
+        self.assertEqual(self.event2_cfp.status, "Closed")
+        self.assertEqual(self.event2_rsvp.is_published, 0)
 
         # Third event is still live, since its end_date > mock date set here
         self.assertEqual(self.event3.status, "Live")
+        self.assertEqual(self.event3_cfp.status, "Live")
+        self.assertEqual(self.event3_rsvp.is_published, 1)


### PR DESCRIPTION
- helps to hide forms and avoid manual closure by team

closes #1096

Unchecks (close) both RSVP and CFP form after event ends.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduled task now processes both Live and Cancelled events, marking them Concluded or Cancelled, clearing RSVP/CFP visibility, and updating linked RSVP forms to be unpublished and CFPs to be closed.
* **Tests**
  * Added tests and helpers validating event conclusion behavior and RSVP/CFP state transitions across Live, Cancelled, and Concluded scenarios (with controlled current-date patching).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->