### PR TITLE
avoid mandating linked proposal when schedule category is talk/other

### DIFF
--- a/dashboard/src/components/event/schedule/ModifyScheduleItem.vue
+++ b/dashboard/src/components/event/schedule/ModifyScheduleItem.vue
@@ -103,10 +103,7 @@ const validateScheduleItem = () => {
     selectedScheduleItem.value.linked_cfp = ''
   }
 
-  if (
-    selectedScheduleItem.value.category !== 'Opening Note' &&
-    selectedScheduleItem.value.category !== 'Break'
-  ) {
+  if (!['Talk', 'Other', 'Opening Note', 'Break'].includes(selectedScheduleItem.value.category)) {
     if (!selectedScheduleItem.value.linked_cfp) {
       errors.push('Linked Proposal is required')
     }


### PR DESCRIPTION
- closes #1103 Note: Doctype does not have mandatory flag, so its dashboard vue code that makes sure for mandating some items

Simple enough way to not show error when category is Talk or Other
`Linked Proposal is required`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated schedule item validation: the Linked Proposal field is now required only for specific categories. Lightning Talk, Workshop, and Panel Discussion now require a linked proposal, while Talk and Other no longer do. This clarifies form requirements and prevents unnecessary errors when editing or creating schedule items. Users will see clearer guidance and fewer blocking prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->