### PR TITLE
update dev setup with uv + nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+if command -v nix >/dev/null 2>&1; then
+  use nix
+fi
+source_env .venv/bin/activate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: 'node_modules|.git'
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
         # Needed because of the unsafe mermaid extension support in the mkdocs
@@ -14,7 +14,7 @@ repos:
   # Run the Ruff linter.
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.6
+    rev: v0.12.9
     hooks:
       # Run the Ruff linter.
       - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,19 @@ dependencies = [
     "PyGithub~=2.3.0",
     "Faker~=27.0.0",
     "Pillow~=11.0.0",
-    "ics~=0.7.2"
+    "ics~=0.7.2",
 ]
 
 [project.optional-dependencies]
+dev = [
+  "pre-commit==4.2.0",
+  "frappe-bench>=5.25.9",
+  "ruff==0.12.5",
+  "black==25.1.0",
+  "basedpyright>=1.31.0",
+  "python-lsp-server>=1.13.0",
+  "djlint>=1.36.4",
+]
 docs = [
     "mkdocs~=1.6.1",
     "mkdocs-material~=9.5.36",
@@ -38,3 +47,13 @@ select = [
     "E",
     "F",
 ]
+
+[tool.ty.rules]
+possibly-unresolved-reference = "warn"
+division-by-zero = "ignore"
+
+[tool.ty.environment]
+extra-paths = ["../frap/apps/frappe/"]
+
+[tool.basedpyright]
+extraPaths = ["../frap/apps/frappe/"]

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,20 @@
+with import <nixpkgs> {};
+let
+  pypkgs = (python311.withPackages ((ps: with ps; [
+	# for nix packaged python package
+	# numpy
+  ])));
+
+in
+  pkgs.mkShell {
+
+	nativeBuildInputs = [ pkgs.bashInteractive ];
+
+	buildInputs = with pkgs; [
+	  # pypkgs
+	  # ruff black
+	  # ty # basedpyright
+	  uv nodePackages.eslint nodePackages.prettier html-tidy nodePackages.yarn
+	];
+
+  }


### PR DESCRIPTION
- updated pre-commit package and ruff linter
- adds lsp and other formatter linter to pyproject

Users can use 'uv' tool to setup

I use direnv to maintain environment, so hopefully it helps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Automatic activation of Nix environments when available and of Python virtual environments to simplify local setup.
  - Added a reproducible Nix development shell scaffold for Python, JavaScript, and HTML tooling.
  - Upgraded pre-commit hook revisions for improved linting/validation.
  - Expanded development tooling and configurations for formatting, linting, and type-checking, including path settings for related apps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->