### PR TITLE
fix rss for newsletter and resolve validation

### DIFF
--- a/fossunited/fossunited/web_template/home_page___contact/home_page___contact.html
+++ b/fossunited/fossunited/web_template/home_page___contact/home_page___contact.html
@@ -98,11 +98,21 @@
         </p>
       </div>
 
-	  <div class="button-category">
-        <a href="{{ newsletter_subscribe_link }}" class="primary-button" role="button" tabindex="0">Subscribe</a>
-		<a href="{{ rss_feed_link }}" class="secondary-button" role="button" tabindex="0">RSS Feed</a>
-      </div>
+      <div class="button-category">
+        <a href="{{ newsletter_subscribe_link }}" class="primary-button" role="button" tabindex="0"
+          >Subscribe</a
+        >
+        <a href="{{ rss_feed_link }}" class="secondary-button" role="button" tabindex="0"
+          >RSS Feed
+        </a>
 
+        <link
+          rel="alternate"
+          type="application/atom+xml"
+          title="RSS Feed"
+          href="{{ rss_feed_link }}"
+        />
+      </div>
     </div>
 
     <div class="vertical-separator"></div>

--- a/fossunited/hooks.py
+++ b/fossunited/hooks.py
@@ -33,6 +33,10 @@ website_route_rules = [
         "from_route": "/hack/<permalink>/projects/all",
         "to_route": "/hackathon/projects",
     },
+    {
+        "from_route": "/blog/rss.xml",
+        "to_route": "/rss.xml",
+    },
 ]
 
 # add methods and filters to jinja environment

--- a/fossunited/www/rss.py
+++ b/fossunited/www/rss.py
@@ -52,7 +52,7 @@ def get_context(context):
             "message_html",
             "content_type",
         ],
-        filters={"published": 1},
+        filters={"email_sent": 1},
         order_by="modified desc",
         limit=20,
     )
@@ -76,7 +76,9 @@ def get_context(context):
             blog.content_type, prefix.rstrip("_")
         )
         value = getattr(blog, attr)
-        blog_content = markdown(value) if blog.content_type == "Markdown" else value
+        blog_content = (
+            markdown(value.replace("<br>", " ")) if blog.content_type == "Markdown" else value
+        )
         blog.content = f"<![CDATA[{blog_content}]]>"
 
     all_items = blog_list + news_list

--- a/fossunited/www/rss.py
+++ b/fossunited/www/rss.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2025, FOSS United Organization
 # License: MIT. See LICENSE
 
+import re
 from datetime import datetime, time
 from email.utils import format_datetime
 from urllib.parse import urljoin
@@ -76,9 +77,10 @@ def get_context(context):
             blog.content_type, prefix.rstrip("_")
         )
         value = getattr(blog, attr)
-        blog_content = (
-            markdown(value.replace("<br>", " ")) if blog.content_type == "Markdown" else value
-        )
+        if blog.content_type == "Markdown":
+            blog_content = markdown(re.sub(r"(?i)</?br\s*/?>", "\n", value))
+        else:
+            value
         blog.content = f"<![CDATA[{blog_content}]]>"
 
     all_items = blog_list + news_list

--- a/fossunited/www/rss.xml
+++ b/fossunited/www/rss.xml
@@ -1,4 +1,4 @@
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
     <title>{{ title }}</title>
     <description>{{ description }}</description>
@@ -12,7 +12,7 @@
     <item>
 	  <title>{{ i.title }}</title>
 	  <description>{{ i.content }}</description>
-	  <author>{{ i.author }}</author>
+	  <dc:creator>{{ i.author }}</dc:creator>
 	  <link>{{ i.link }}</link>
 	  <guid>{{ i.link }}</guid>
 	  <pubDate>{{ i.published_date }}</pubDate>


### PR DESCRIPTION
After rss merge found few issues.

>  <author>Vishal</author>
The author tag expects email, so made to use `<dc:creator>Name</dc:creator>`
to have valid name for writer.

- Newsletter were not parsed since I used filter `published`, but for newsletter we can use `email_sent` to get them.

- Also some markdown blog posts has `<br>` to force new line for rendering page.
  The markdown parser did not parse since it found html tags, it considered whole content as html only
  So replaced <br> to have new lines and most markdown should be fine.
  
- Another issue I found with a post was that an image file was uploaded as 
```html
<img src="/files/Elections &amp; Governance Open Mic Discuss upcoming elections with the Elections Working Group Every Saturday 1100 AM -1200 PM(4).png">
```

which is fine for readers, but this wont be valid rss (refer: [rssboard](https://www.rssboard.org/rss-validator/docs/error/InvalidUriChar.html))

With this PR closes off #1001 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Adopted Dublin Core for RSS author metadata to improve feed-reader compatibility.
  - Added a blog RSS alias so the feed is reachable at an additional URL.

- Bug Fixes
  - RSS now lists only newsletters that were actually sent.
  - Improved Markdown rendering in the RSS feed by normalizing line breaks for cleaner formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->