### PR TITLE
make adding schedule (proposals) have its own scrollbar to view

### DIFF
--- a/dashboard/src/pages/EventSchedule.vue
+++ b/dashboard/src/pages/EventSchedule.vue
@@ -155,8 +155,11 @@ const toggleShowSchedule = () => {
 const showModifyScheduleItemDrawer = ref(false)
 </script>
 <template>
-  <div class="flex">
-    <div class="md:basis-1/2 border-r min-h-svh p-6" :class="{ 'basis-full': isSmallScreen }">
+  <div class="flex h-screen overflow-hidden">
+    <div
+      class="md:basis-1/2 min-h-full overflow-y-auto border-r p-6"
+      :class="{ 'basis-full': isSmallScreen }"
+    >
       <Breadcrumbs class="mb-6" :items="breadcrumb_items" />
       <div class="prose">
         <h2 class="font-bold mb-4">Event Schedule</h2>
@@ -176,7 +179,7 @@ const showModifyScheduleItemDrawer = ref(false)
           variant="ghost"
           label="Go to Schedule Page"
           icon-right="arrow-up-right"
-			@click="redirectRoute(`${event.doc?.route}/schedule`, '_blank')"
+          @click="redirectRoute(`${event.doc?.route}/schedule`)"
         />
       </div>
       <ManageHallOptions v-if="event.doc" v-model="event.doc.hall_options" />
@@ -202,7 +205,7 @@ const showModifyScheduleItemDrawer = ref(false)
       </div>
     </div>
     <Suspense>
-      <div v-if="!isSmallScreen" class="basis-1/2 p-6">
+      <div v-if="!isSmallScreen" class="basis-1/2 p-6 min-h-full overflow-y-auto">
         <ModifyScheduleItem
           v-if="selectedScheduleItemIndex"
           v-model="event.doc.event_schedule[selectedScheduleItemIndex - 1]"


### PR DESCRIPTION
- Helps to have dual pane view and track changes Solves #1104

Video to demonstrate the scroll of left proposal view:

https://github.com/user-attachments/assets/409567bf-0644-465a-ba01-3eaf7c04c380



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Event Schedule page now uses full viewport height and enables independent scrolling for left and right panes, preventing content clipping and overflow issues.
  * Improved split-pane behavior across screen sizes for more consistent layout and readability.

* **Style**
  * Minor visual/spacing adjustments for a cleaner layout and smoother scrolling experience.
  * "Go to Schedule Page" action now navigates in-page (no longer opens a new tab); navigation logic otherwise unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->