### PR TITLE
add date of confirmation for event sponsors

### DIFF
--- a/fossunited/fossunited/doctype/foss_event_sponsor/foss_event_sponsor.json
+++ b/fossunited/fossunited/doctype/foss_event_sponsor/foss_event_sponsor.json
@@ -5,7 +5,14 @@
   "doctype": "DocType",
   "editable_grid": 1,
   "engine": "InnoDB",
-  "field_order": ["tier", "custom_tier", "sponsor_name", "link", "image"],
+  "field_order": [
+    "tier",
+    "custom_tier",
+    "sponsor_name",
+    "link",
+    "image",
+    "date_of_confirm"
+  ],
   "fields": [
     {
       "fieldname": "sponsor_name",
@@ -41,12 +48,18 @@
       "fieldname": "image",
       "fieldtype": "Attach Image",
       "label": "Image"
+    },
+    {
+      "fieldname": "date_of_confirm",
+      "fieldtype": "Date",
+      "in_list_view": 1,
+      "label": "Date of Confirmation"
     }
   ],
   "index_web_pages_for_search": 1,
   "istable": 1,
   "links": [],
-  "modified": "2025-02-05 16:19:01.239189",
+  "modified": "2025-08-25 21:23:38.439821",
   "modified_by": "Administrator",
   "module": "FOSSUnited",
   "name": "FOSS Event Sponsor",

--- a/fossunited/fossunited/doctype/foss_event_sponsor/foss_event_sponsor.py
+++ b/fossunited/fossunited/doctype/foss_event_sponsor/foss_event_sponsor.py
@@ -14,6 +14,7 @@ class FOSSEventSponsor(Document):
         from frappe.types import DF
 
         custom_tier: DF.Data | None
+        date_of_confirm: DF.Date | None
         image: DF.AttachImage | None
         link: DF.Data
         parent: DF.Data


### PR DESCRIPTION
- Although we get creation for each item It is not practical to fill sponsors as they confirm This is a convenience to support with sorting of list based on their confirmation

Stage 1 (partial) fix for #1114 

## Change

**Backend** change for `FOSS Event Sponsor` doctype

- Adds an field option for the child doctype - `date_of_confirm` for `Date` to help in sorting of list
- NOTE: This field is optional, should it be mandatory?

Making it optional might risk the sorting, some might miss dates for few. In that case we might sort which were confirmed, and then show others in alphabetical
Making it mandatory will ease and give power to have full sorting of list.

This PR will be enough to get this in action for IndiaFoss page to sort.

---
## Next
Will be following up with front-end PR to add default sorting of sponsors list in events and hackathon page via this Date of confirmation.
If it does not exist (since this option is new) might use creation date or simply fall back to alphabetical sorting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Date of Confirmation” field to FOSS Event Sponsor.
  * The date is visible in list view and on the sponsor form for quick tracking.
  * Field appears after the Image field for a clearer flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->