### PR TITLE
make ticket transfer page public to avoid login

### DIFF
--- a/dashboard/src/router.js
+++ b/dashboard/src/router.js
@@ -75,6 +75,7 @@ const routes = [
         props: true,
       },
     ],
+    meta: { isPublicPage: true },
   },
   {
     path: '/review/:id',

--- a/dashboard/src/router.js
+++ b/dashboard/src/router.js
@@ -67,15 +67,16 @@ const routes = [
         path: '',
         name: 'TicketTransfer',
         component: () => import('@/pages/TicketTransfer.vue'),
+        meta: { isPublicPage: true },
       },
       {
         path: 'process',
         name: 'TicketTransferProcess',
         component: () => import('@/pages/TicketTransferProcess.vue'),
         props: true,
+        meta: { isPublicPage: true },
       },
     ],
-    meta: { isPublicPage: true },
   },
   {
     path: '/review/:id',
@@ -312,6 +313,10 @@ let router = createRouter({
 })
 
 router.beforeEach(async (to, from, next) => {
+  // Public routes: no need to resolve user/session first
+  if (to.meta.isPublicPage) {
+    return next()
+  }
   let isLoggedIn = Boolean(sessionUser())
   try {
     await userResource.promise


### PR DESCRIPTION
- When buying ticket needs no fossunited account, even ticket transfer need no account login

- We already validate the ticket first step, so there is no spam to randomly mock tickets
- We also take second step to validate via email to confirm owner to transfer by approve

so its sensible that we make this page public for users need.

## 🚦 Status

- [ ] Draft
- [x] Ready for review

---

## 🔗 Related Issue

Closes / Addresses: A telegram user had complained that why would they need to login/make account for just ticket transfer

---

## ❗ Problem

<!-- Briefly describe the problem or motivation for this PR -->
- When buying tickets need no fossunited account, why would tranfer need an account.
---

## ✅ Solution

<!-- Describe your solution and what you changed -->
We validate this via 2 steps:
1. Check ticket is valid or exists
2. Get confirmation from owner via their email

So there is no spam as such for this process.
---

## 📋 Progress (All must be checked to merge)

- [ ] Tested locally
- [ ] 

---

## 📝 Changelog

<commit>: <!-- e.g., feat: add user login endpoint -->

---

## 🖼️ Visualization

<!-- Add screenshots, diagrams, or screen recordings if applicable -->
Again, https://fossunited.org/dashboard/ticket-transfer should not need fossunited account login
---

## 🔮 Further Ahead

<!-- Mention any follow-up work or related PRs planned -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The Ticket Transfer flow is now publicly accessible so recipients can open shared ticket-transfer links without signing in.
  * Both the main ticket-transfer page and its in-flow "process" step are reachable publicly.
  * Public ticket-transfer pages skip session/user resolution to speed access.
  * All other pages retain the existing authentication requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->