### PR TITLE
Implement custom fields (QA) for RSVP forms in Dashboard Insights

### DIFF
--- a/dashboard/src/pages/EventRsvpInsights.vue
+++ b/dashboard/src/pages/EventRsvpInsights.vue
@@ -4,34 +4,38 @@
       <div class="flex items-center justify-between">
         <div class="font-semibold text-gray-800">
           Attendees
-
-          <span class="text-gray-700 text-base font-normal"
-            >({{ submissions.data.length }}/{{ rsvp_form.data.max_rsvp_count }})</span
-          >
+          <span class="text-gray-700 text-base font-normal">
+            ({{ submissions.data.length }}/{{ rsvp_form.data.max_rsvp_count }})
+          </span>
         </div>
         <Button size="md" icon-left="download" @click="downloadAttendeeList">Download</Button>
       </div>
+
       <ListView
-        :columns="[
-          { label: 'Name', key: 'name1' },
-          { label: 'Email', key: 'email' },
-          { label: 'I am a', key: 'im_a' },
-        ]"
+        :columns="listColumns"
         :rows="submissions.data"
         row-key="name"
         :options="{
           selectable: false,
+          resizeColumn: true,
           emptyState: {
             description: 'No one has RSVPed for the event yet.',
           },
         }"
-      />
+      >
+        <template #cell="{ item }">
+          <span>
+            {{ truncate(item, 30) }}
+          </span>
+        </template>
+      </ListView>
     </div>
   </div>
 </template>
+
 <script setup>
 import { useRoute } from 'vue-router'
-import { inject, ref } from 'vue'
+import { inject, ref, computed } from 'vue'
 import { createListResource, createResource, ListView, Button } from 'frappe-ui'
 
 const route = useRoute()
@@ -49,7 +53,16 @@ const rsvp_form = createResource({
   auto: true,
 })
 
-const isEventLead = ref(false);
+const all_form = createResource({
+  url: 'frappe.client.get',
+  params: {
+    doctype: 'FOSS Event RSVP Submission',
+    fields: ['*'],
+  },
+  auto: true,
+})
+
+const isEventLead = ref(false)
 const event_lead = createResource({
   url: 'fossunited.api.chapter.check_if_event_lead',
   makeParams() {
@@ -63,35 +76,85 @@ const event_lead = createResource({
   auto: true,
 })
 
-const submissions = createListResource({
-  doctype: 'FOSS Event RSVP Submission',
-  fields: ['*'],
-  filters: {
-    event: route.params.id,
+const submissions = createResource({
+  url: 'fossunited.api.chapter.get_submissions_with_answers',
+  params: {
+    event_id: route.params.id,
   },
-  pageLength: 99999,
   auto: true,
-  transform(data) {
-    if (!isEventLead.value) {
-      data.forEach((submission) => {
-        submission.email = submission.email.replace(/(?<=.{3}).(?=[^@]*?@)/g, '*')
-      })
+})
+
+function truncate(text, length = 20) {
+  return text?.length > length ? text.slice(0, length) + '…' : text || ''
+}
+
+const listColumns = computed(() => {
+  const baseKeys = ['name1', 'email', 'im_a']
+  const columns = baseKeys.map((key) => {
+    const labelMap = { name1: 'Name', email: 'Email', im_a: 'I am a' }
+    return {
+      label: labelMap[key] || key,
+      key,
     }
-  },
+  })
+
+  if (isEventLead.value && Array.isArray(submissions.data)) {
+    const customFields = new Set()
+
+    submissions.data.forEach((submission) => {
+      Object.keys(submission).forEach((key) => {
+        // Exclude base keys AND 'name' (internal doctype name)
+        if (!baseKeys.includes(key) && key !== 'name') {
+          customFields.add(key)
+        }
+      })
+    })
+
+    Array.from(customFields)
+      .sort()
+      .forEach((question) => {
+        columns.push({
+          label: question.length > 40 ? question.slice(0, 40) + '…' : question,
+          key: question,
+        })
+      })
+  }
+
+  return columns
 })
 
 const downloadAttendeeList = () => {
-  const csv = submissions.data
-    .map((submission) => {
-      return [submission.name1, submission.email, submission.im_a].join(',')
-    })
-    .join('\n')
+  if (!Array.isArray(submissions.data)) return
 
-  const blob = new Blob([csv], { type: 'text/csv' })
+  const columns = listColumns.value
+
+  // Build header row using column labels
+  const headers = columns.map((col) => col.label)
+  const csvRows = [headers.join(',')]
+
+  // Build each row using column keys
+  submissions.data.forEach((submission) => {
+    const row = columns.map(({ key }) => {
+      const val = submission[key]
+      if (typeof val === 'string' || typeof val === 'number') {
+        return `"${val}"`
+      }
+      if (typeof val === 'object' && val?.answer) {
+        return `"${val.answer}"`
+      }
+      return ''
+    })
+
+    csvRows.push(row.join(','))
+  })
+
+  // Download the CSV
+  const csv = csvRows.join('\n')
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
   const url = URL.createObjectURL(blob)
   const a = document.createElement('a')
   a.href = url
-  a.download = `Attendee List-${rsvp_form.data.event_name}-${new Date().toISOString().split('T')[0]}.csv`
+  a.download = `Attendee List - ${rsvp_form.data.event_name} - ${new Date().toISOString().split('T')[0]}.csv`
   a.click()
   URL.revokeObjectURL(url)
 }

--- a/dashboard/src/pages/EventRsvpInsights.vue
+++ b/dashboard/src/pages/EventRsvpInsights.vue
@@ -82,25 +82,19 @@ const listColumns = computed(() => {
 
   if (isEventLead.value && Array.isArray(submissions.data) && submissions.data.length > 0) {
     const customFields = new Set()
-
+    const labels = {}
     submissions.data.forEach((submission) => {
       Object.keys(submission).forEach((key) => {
-        if (key.startsWith('cf_')) {
-          customFields.add(key)
-        }
+        if (key.startsWith('cf_')) customFields.add(key)
       })
+      if (submission._answers) {
+        Object.assign(labels, submission._answers)
+      }
     })
-
-    const firstSubmission = submissions.data[0]
-
     Array.from(customFields)
       .sort()
       .forEach((key) => {
-        const label = firstSubmission._answers?.[key] || key
-        columns.push({
-          label,
-          key,
-        })
+        columns.push({ label: labels[key] || key, key })
       })
   }
 
@@ -114,5 +108,4 @@ const downloadAttendeeList2 = () => {
     '_self',
   )
 }
-
 </script>

--- a/dashboard/src/pages/EventRsvpInsights.vue
+++ b/dashboard/src/pages/EventRsvpInsights.vue
@@ -8,7 +8,7 @@
             ({{ submissions.data.length }}/{{ rsvp_form.data.max_rsvp_count }})
           </span>
         </div>
-        <Button size="md" icon-left="download" @click="downloadAttendeeList">Download</Button>
+        <Button size="md" icon-left="download" @click="downloadAttendeeList2">Download</Button>
       </div>
 
       <ListView
@@ -22,13 +22,7 @@
             description: 'No one has RSVPed for the event yet.',
           },
         }"
-      >
-        <template #cell="{ item }">
-          <span>
-            {{ truncate(item, 30) }}
-          </span>
-        </template>
-      </ListView>
+      />
     </div>
   </div>
 </template>
@@ -53,15 +47,6 @@ const rsvp_form = createResource({
   auto: true,
 })
 
-const all_form = createResource({
-  url: 'frappe.client.get',
-  params: {
-    doctype: 'FOSS Event RSVP Submission',
-    fields: ['*'],
-  },
-  auto: true,
-})
-
 const isEventLead = ref(false)
 const event_lead = createResource({
   url: 'fossunited.api.chapter.check_if_event_lead',
@@ -80,13 +65,10 @@ const submissions = createResource({
   url: 'fossunited.api.chapter.get_submissions_with_answers',
   params: {
     event_id: route.params.id,
+    full: false,
   },
   auto: true,
 })
-
-function truncate(text, length = 20) {
-  return text?.length > length ? text.slice(0, length) + '…' : text || ''
-}
 
 const listColumns = computed(() => {
   const baseKeys = ['name1', 'email', 'im_a']
@@ -98,24 +80,26 @@ const listColumns = computed(() => {
     }
   })
 
-  if (isEventLead.value && Array.isArray(submissions.data)) {
+  if (isEventLead.value && Array.isArray(submissions.data) && submissions.data.length > 0) {
     const customFields = new Set()
 
     submissions.data.forEach((submission) => {
       Object.keys(submission).forEach((key) => {
-        // Exclude base keys AND 'name' (internal doctype name)
-        if (!baseKeys.includes(key) && key !== 'name') {
+        if (key.startsWith('cf_')) {
           customFields.add(key)
         }
       })
     })
 
+    const firstSubmission = submissions.data[0]
+
     Array.from(customFields)
       .sort()
-      .forEach((question) => {
+      .forEach((key) => {
+        const label = firstSubmission._answers?.[key] || key
         columns.push({
-          label: question.length > 40 ? question.slice(0, 40) + '…' : question,
-          key: question,
+          label,
+          key,
         })
       })
   }
@@ -123,39 +107,12 @@ const listColumns = computed(() => {
   return columns
 })
 
-const downloadAttendeeList = () => {
-  if (!Array.isArray(submissions.data)) return
-
-  const columns = listColumns.value
-
-  // Build header row using column labels
-  const headers = columns.map((col) => col.label)
-  const csvRows = [headers.join(',')]
-
-  // Build each row using column keys
-  submissions.data.forEach((submission) => {
-    const row = columns.map(({ key }) => {
-      const val = submission[key]
-      if (typeof val === 'string' || typeof val === 'number') {
-        return `"${val}"`
-      }
-      if (typeof val === 'object' && val?.answer) {
-        return `"${val.answer}"`
-      }
-      return ''
-    })
-
-    csvRows.push(row.join(','))
-  })
-
-  // Download the CSV
-  const csv = csvRows.join('\n')
-  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = `Attendee List - ${rsvp_form.data.event_name} - ${new Date().toISOString().split('T')[0]}.csv`
-  a.click()
-  URL.revokeObjectURL(url)
+const downloadAttendeeList2 = () => {
+  const eventId = route.params.id
+  window.open(
+    `/api/method/fossunited.api.chapter.download_attendee_list_csv?event_id=${eventId}`,
+    '_self',
+  )
 }
+
 </script>

--- a/dashboard/src/pages/EventRsvpInsights.vue
+++ b/dashboard/src/pages/EventRsvpInsights.vue
@@ -71,34 +71,20 @@ const submissions = createResource({
 })
 
 const listColumns = computed(() => {
-  const baseKeys = ['name1', 'email', 'im_a']
-  const columns = baseKeys.map((key) => {
-    const labelMap = { name1: 'Name', email: 'Email', im_a: 'I am a' }
-    return {
-      label: labelMap[key] || key,
-      key,
-    }
-  })
+  const columns = new Map()
 
-  if (isEventLead.value && Array.isArray(submissions.data) && submissions.data.length > 0) {
-    const customFields = new Set()
-    const labels = {}
+  // Collect keys from all submissions
+  if (Array.isArray(submissions.data)) {
     submissions.data.forEach((submission) => {
       Object.keys(submission).forEach((key) => {
-        if (key.startsWith('cf_')) customFields.add(key)
+        if (!columns.has(key)) {
+          columns.set(key, { key, label: key }) // Use key as label directly
+        }
       })
-      if (submission._answers) {
-        Object.assign(labels, submission._answers)
-      }
     })
-    Array.from(customFields)
-      .sort()
-      .forEach((key) => {
-        columns.push({ label: labels[key] || key, key })
-      })
   }
 
-  return columns
+  return Array.from(columns.values())
 })
 
 const downloadAttendeeList2 = () => {

--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -255,3 +255,54 @@ def mask_email(email: str) -> str:
         )
 
     return f"{visible}@{domain}"
+
+
+@frappe.whitelist()
+def download_attendee_list_csv(event_id: str) -> str:
+    """
+    Generates and returns a CSV string of RSVP submissions with custom field answers.
+    Accessible only by core team / event leads.
+    """
+    import csv
+    import io
+
+    # Get full submission data (labels and answers)
+    submissions = get_submissions_with_answers(event_id, full=True)
+
+    if not submissions:
+        return ""
+
+    # Determine all columns
+    base_keys = ["name1", "email", "im_a"]
+    label_map = {"name1": "Name", "email": "Email", "im_a": "I am a"}
+
+    custom_keys = sorted({key for s in submissions for key in s.keys() if key.startswith("cf_")})
+
+    # Use first row’s _answers mapping to get labels
+    first_answers = submissions[0].get("_answers", {})
+    columns = base_keys + custom_keys
+    headers = [label_map.get(k, first_answers.get(k, k)) for k in columns]
+
+    # Escape helper (like toCSVCell)
+    def escape_csv_cell(value):
+        s = "" if value is None else str(value)
+        if s.startswith(("=", "+", "-", "@")):
+            s = "'" + s
+        return s.replace('"', '""')
+
+    # Prepare CSV content
+    output = io.StringIO()
+    writer = csv.writer(output, quoting=csv.QUOTE_ALL, lineterminator="\r\n")
+
+    writer.writerow([escape_csv_cell(h) for h in headers])
+
+    for row in submissions:
+        writer.writerow([escape_csv_cell(row.get(col, "")) for col in columns])
+
+    csv_data = output.getvalue()
+    safe_event_name = frappe.db.get_value(EVENT, event_id, "event_name", cache=True) or "event"
+    filename = f"Attendee List - {safe_event_name.replace(' ', '_')}.csv"
+
+    frappe.response["filename"] = filename
+    frappe.response["filecontent"] = csv_data
+    frappe.response["type"] = "download"

--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -140,6 +140,7 @@ def get_submissions_with_answers(event_id: str, full: bool = False) -> list[dict
         filters={"event": event_id},
         fields=["name", "name1", "email", "im_a"],
         order_by="creation asc",
+        limit_page_length=9999,
     )
 
     if not check_if_event_lead(event_id):
@@ -150,6 +151,8 @@ def get_submissions_with_answers(event_id: str, full: bool = False) -> list[dict
 
     # Event lead: fetch full answers
     submission_ids = [s["name"] for s in submissions]
+    if not submission_ids:
+        return submissions
 
     answers = frappe.get_all(
         RSVP_CUSTOM_FIELD,
@@ -158,7 +161,9 @@ def get_submissions_with_answers(event_id: str, full: bool = False) -> list[dict
             "parenttype": RSVP_RESPONSE,
             "parentfield": "custom_answers",
         },
-        fields=["parent", "question", "response"],
+        fields=["parent", "question", "response", "idx"],
+        order_by="parent asc, idx asc",
+        limit_page_length=0,
     )
 
     answers_by_parent = {}

--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -109,3 +109,47 @@ def generate_ics(event_ids):
         c.events.add(e)
 
     return c.serialize()
+
+
+@frappe.whitelist()
+def get_submissions_with_answers(event_id):
+    if not frappe.session.user or frappe.session.user == "Guest":
+        frappe.throw("Not permitted", frappe.PermissionError)
+
+    submissions = frappe.get_all(
+        "FOSS Event RSVP Submission",
+        filters={"event": event_id},
+        fields=["name", "name1", "email", "im_a"],
+    )
+
+    if not check_if_event_lead(event_id):
+        # Mask email and return without answers
+        for s in submissions:
+            s["email"] = mask_email(s["email"])
+        return submissions
+
+    # Event lead: fetch answers
+    submission_ids = [s["name"] for s in submissions]
+
+    answers = frappe.get_all(
+        "FOSS Custom Answer",
+        filters={"parent": ["in", submission_ids]},
+        fields=["parent", "question", "response"],
+    )
+
+    answers_by_parent = {}
+    for a in answers:
+        answers_by_parent.setdefault(a["parent"], []).append(a)
+
+    for s in submissions:
+        for a in answers_by_parent.get(s["name"], []):
+            # Use question as field key
+            s[a["question"]] = a["response"]
+
+    return submissions
+
+
+def mask_email(email):
+    import re
+
+    return re.sub(r"(?<=.{3}).(?=[^@]*?@)", "*", email)

--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -144,9 +144,9 @@ def get_submissions_with_answers(event_id: str, full: bool = False) -> list[dict
     )
 
     if not check_if_event_lead(event_id):
-        # Mask email and return limited data
         for s in submissions:
             s["email"] = mask_email(s.get("email"))
+            s.pop("name", None)
         return submissions
 
     # Event lead: fetch full answers
@@ -179,17 +179,17 @@ def get_submissions_with_answers(event_id: str, full: bool = False) -> list[dict
             if response is None:
                 response = ""
             if not full:
-                response = _truncate_label(str(response), 50)
+                response = _truncate_label(str(response), 30)
 
-            s[f"cf_{key}"] = response
+            s[f"{key}"] = response
 
             # Truncate label if not full
             raw_label = a.get("question")
             label = "" if raw_label is None else str(raw_label)
             if not full:
-                label = _truncate_label(label, 50)
+                label = _truncate_label(label, 30)
 
-            s.setdefault("_answers", {})[f"cf_{key}"] = label
+        s.pop("name", None)
 
     return submissions
 
@@ -277,25 +277,24 @@ def download_attendee_list_csv(event_id: str) -> str:
     import io
     import re
 
-    # Get full submission data (labels and answers)
+    # Get full submission data (each is a dict)
     submissions = get_submissions_with_answers(event_id, full=True)
 
     if not submissions:
         return ""
 
-    # Determine all columns
-    base_keys = ["name1", "email", "im_a"]
-    label_map = {"name1": "Name", "email": "Email", "im_a": "I am a"}
+    # Start with keys from the first row to preserve order
+    columns = list(submissions[0].keys())
+    seen = set(columns)
 
-    custom_keys = sorted({key for s in submissions for key in s.keys() if key.startswith("cf_")})
+    # Add any new keys from other rows (if any), in the order they appear
+    for row in submissions[1:]:
+        for key in row.keys():
+            if key not in seen:
+                columns.append(key)
+                seen.add(key)
 
-    # Union labels from all rows
-    labels = {}
-    for s in submissions:
-        if "_answers" in s and isinstance(s["_answers"], dict):
-            labels.update(s["_answers"])
-    columns = base_keys + custom_keys
-    headers = [label_map.get(k, labels.get(k, k)) for k in columns]
+    headers = columns
 
     # Escape helper (like toCSVCell)
     def cleanse_csv_cell(value):
@@ -314,12 +313,16 @@ def download_attendee_list_csv(event_id: str) -> str:
         writer.writerow([cleanse_csv_cell(row.get(col, "")) for col in columns])
 
     csv_data = "\ufeff" + output.getvalue()  # BOM for Excel
-    event_name = frappe.db.get_value(EVENT, event_id, "event_name", cache=True) or "event"
 
+    # Create safe filename
+    event_name = frappe.db.get_value(EVENT, event_id, "event_name", cache=True) or "event"
     safe_event_name = re.sub(r"[^A-Za-z0-9._-]+", "_", event_name)
     filename = f"Attendee_List_-_{safe_event_name}.csv"
 
+    # Set file response
     frappe.response["filename"] = filename
     frappe.response["filecontent"] = csv_data
     frappe.response["content_type"] = "text/csv; charset=utf-8"
     frappe.response["type"] = "download"
+
+    return csv_data

--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -4,7 +4,15 @@ from datetime import timedelta, timezone
 import frappe
 from ics import Calendar, Event
 
-from fossunited.doctype_ids import CHAPTER, EVENT, USER_PROFILE
+from fossunited.doctype_ids import (
+    CHAPTER,
+    CHAPTER_MEMBER,
+    EVENT,
+    EVENT_VOLUNTEER,
+    RSVP_CUSTOM_FIELD,
+    RSVP_RESPONSE,
+    USER_PROFILE,
+)
 
 
 @frappe.whitelist(allow_guest=True)
@@ -26,7 +34,7 @@ def check_if_chapter_member(chapter: str, user: str) -> bool:
 
     is_member = bool(
         frappe.db.exists(
-            "FOSS Chapter Lead Team Member",
+            CHAPTER_MEMBER,
             {
                 "parent": chapter,
                 "parenttype": CHAPTER,
@@ -55,7 +63,7 @@ def check_if_event_lead(event: str) -> bool:
 
     is_lead = bool(
         frappe.db.exists(
-            "FOSS Chapter Event Member",
+            EVENT_VOLUNTEER,
             {
                 "parent": event,
                 "parenttype": EVENT,
@@ -117,7 +125,7 @@ def get_submissions_with_answers(event_id):
         frappe.throw("Not permitted", frappe.PermissionError)
 
     submissions = frappe.get_all(
-        "FOSS Event RSVP Submission",
+        RSVP_RESPONSE,
         filters={"event": event_id},
         fields=["name", "name1", "email", "im_a"],
     )
@@ -132,7 +140,7 @@ def get_submissions_with_answers(event_id):
     submission_ids = [s["name"] for s in submissions]
 
     answers = frappe.get_all(
-        "FOSS Custom Answer",
+        RSVP_CUSTOM_FIELD,
         filters={"parent": ["in", submission_ids]},
         fields=["parent", "question", "response"],
     )

--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -179,7 +179,8 @@ def get_submissions_with_answers(event_id: str, full: bool = False) -> list[dict
             s[f"cf_{key}"] = response
 
             # Truncate label if not full
-            label = a["question"]
+            raw_label = a.get("question")
+            label = "" if raw_label is None else str(raw_label)
             if not full:
                 label = _truncate_label(label, 50)
 
@@ -224,7 +225,9 @@ def _safe_column_key(label: str) -> str:
 
 
 def _truncate_label(label: str, max_length: int = 50) -> str:
-    return label if len(label) <= max_length else label[:max_length].strip() + "…"
+    s = "" if label is None else str(label)
+    s = " ".join(s.split())  # collapse whitespace/newlines
+    return s if len(s) <= max_length else s[:max_length].rstrip() + "…"
 
 
 def mask_email(email: str) -> str:
@@ -281,10 +284,13 @@ def download_attendee_list_csv(event_id: str) -> str:
 
     custom_keys = sorted({key for s in submissions for key in s.keys() if key.startswith("cf_")})
 
-    # Use first row’s _answers mapping to get labels
-    first_answers = submissions[0].get("_answers", {})
+    # Union labels from all rows
+    labels = {}
+    for s in submissions:
+        if "_answers" in s and isinstance(s["_answers"], dict):
+            labels.update(s["_answers"])
     columns = base_keys + custom_keys
-    headers = [label_map.get(k, first_answers.get(k, k)) for k in columns]
+    headers = [label_map.get(k, labels.get(k, k)) for k in columns]
 
     # Escape helper (like toCSVCell)
     def cleanse_csv_cell(value):

--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -121,6 +121,17 @@ def generate_ics(event_ids):
 
 @frappe.whitelist()
 def get_submissions_with_answers(event_id):
+    """
+    Provide RSVP submission with answers for EventInsights
+
+    Args:
+        event_id (str): Event id
+
+    Returns:
+        Provides submission data with custom field (child doctype) only for Core team members,
+    else, just the submission rsvp parent doctype.
+
+    """
     if not frappe.session.user or frappe.session.user == "Guest":
         frappe.throw("Not permitted", frappe.PermissionError)
 
@@ -158,6 +169,10 @@ def get_submissions_with_answers(event_id):
 
 
 def mask_email(email):
+    """
+    Mask email address.
+    Returns: Initial 3 letter followed by * for email address.
+    """
     import re
 
     return re.sub(r"(?<=.{3}).(?=[^@]*?@)", "*", email)

--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -120,39 +120,44 @@ def generate_ics(event_ids):
 
 
 @frappe.whitelist()
-def get_submissions_with_answers(event_id):
+def get_submissions_with_answers(event_id: str, full: bool = False) -> list[dict]:
     """
-    Provide RSVP submission with answers for EventInsights
+    Provide RSVP submission with answers for EventInsights.
 
     Args:
-        event_id (str): Event id
-
+        event_id (str): Event ID
+        full (bool): If True, return full question labels and responses;
+                     otherwise truncate for UI display. Applicable for csv export/download.
     Returns:
-        Provides submission data with custom field (child doctype) only for Core team members,
-    else, just the submission rsvp parent doctype.
-
+        List of submission dicts with custom field answers for core team members.
     """
     if not frappe.session.user or frappe.session.user == "Guest":
         frappe.throw("Not permitted", frappe.PermissionError)
 
+    # Get basic submission fields
     submissions = frappe.get_all(
         RSVP_RESPONSE,
         filters={"event": event_id},
         fields=["name", "name1", "email", "im_a"],
+        order_by="creation asc",
     )
 
     if not check_if_event_lead(event_id):
-        # Mask email and return without answers
+        # Mask email and return limited data
         for s in submissions:
-            s["email"] = mask_email(s["email"])
+            s["email"] = mask_email(s.get("email"))
         return submissions
 
-    # Event lead: fetch answers
+    # Event lead: fetch full answers
     submission_ids = [s["name"] for s in submissions]
 
     answers = frappe.get_all(
         RSVP_CUSTOM_FIELD,
-        filters={"parent": ["in", submission_ids]},
+        filters={
+            "parent": ["in", submission_ids],
+            "parenttype": RSVP_RESPONSE,
+            "parentfield": "custom_answers",
+        },
         fields=["parent", "question", "response"],
     )
 
@@ -162,17 +167,91 @@ def get_submissions_with_answers(event_id):
 
     for s in submissions:
         for a in answers_by_parent.get(s["name"], []):
-            # Use question as field key
-            s[a["question"]] = a["response"]
+            key = _safe_column_key(a["question"])  # always max 50 chars
+
+            # Truncate the answer if not full
+            response = a["response"]
+            if not full:
+                response = _truncate_label(response, 50)
+
+            s[f"cf_{key}"] = response
+
+            # Truncate label if not full
+            label = a["question"]
+            if not full:
+                label = _truncate_label(label, 50)
+
+            s.setdefault("_answers", {})[f"cf_{key}"] = label
 
     return submissions
 
 
-def mask_email(email):
+def _safe_column_key(label: str) -> str:
     """
-    Mask email address.
-    Returns: Initial 3 letter followed by * for email address.
+    Sanitize and shorten a label to create a safe dictionary/column key.
+    This function:
+    - Ensures the label is a string; otherwise returns 'custom_field'.
+    - Normalizes whitespace and strips leading/trailing spaces.
+    - Removes all characters except alphanumerics, underscores, spaces, and hyphens.
+    - Replaces spaces with underscores.
+    - Converts the label to lowercase.
+    - Prefixes the key with an underscore if it starts with a dangerous character
+      (i.e., '=', '+', '-', '@') to prevent CSV injection.
+    - Truncates the key to a maximum of 80 characters.
+
+    Args:
+        label (str): The original label to sanitize.
+
+    Returns:
+        str: A sanitized, safe key string suitable for use in CSV headers or dict keys.
+
     """
     import re
 
-    return re.sub(r"(?<=.{3}).(?=[^@]*?@)", "*", email)
+    if not isinstance(label, str):
+        return "custom_field"
+
+    key = re.sub(r"\s+", " ", label).strip()  # Normalize spaces
+    key = re.sub(r"[^\w\s-]", "", key)  # Remove special chars
+    key = re.sub(r"\s+", "_", key).lower()  # Convert to snake_case
+
+    if not key or key[0] in "=+-@":
+        key = f"_{key}"
+
+    return key[:50]  # Limit to 50 characters
+
+
+def _truncate_label(label: str, max_length: int = 50) -> str:
+    return label if len(label) <= max_length else label[:max_length].strip() + "…"
+
+
+def mask_email(email: str) -> str:
+    """
+    Mask email to reduce PII exposure:
+    - Keep first 2 characters of local-part (or fewer if not available).
+    - For local-part length <= 2: keep first char, mask rest
+    - For 3 <= length <= 8: show first 3, mask the middle, show last
+    - For length > 8: show first 2, one middle char, show last
+    - Keep domain intact.
+    """
+    if not email or "@" not in email:
+        return "***"
+
+    local, domain = email.split("@", 1)
+    local_len = len(local)
+
+    if local_len <= 2:
+        visible = local[0] + "*" * (local_len - 1)
+    elif local_len <= 8:
+        visible = local[:3] + "*" * (local_len - 4) + local[-1]
+    else:
+        mid_index = local_len // 2
+        visible = (
+            local[:2]
+            + "*" * (mid_index - 2)
+            + local[mid_index]
+            + "*" * (local_len - mid_index - 2)
+            + local[-1]
+        )
+
+    return f"{visible}@{domain}"

--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -170,9 +170,11 @@ def get_submissions_with_answers(event_id: str, full: bool = False) -> list[dict
             key = _safe_column_key(a["question"])  # always max 50 chars
 
             # Truncate the answer if not full
-            response = a["response"]
+            response = a.get("response")
+            if response is None:
+                response = ""
             if not full:
-                response = _truncate_label(response, 50)
+                response = _truncate_label(str(response), 50)
 
             s[f"cf_{key}"] = response
 
@@ -243,7 +245,7 @@ def mask_email(email: str) -> str:
     if local_len <= 2:
         visible = local[0] + "*" * (local_len - 1)
     elif local_len <= 8:
-        visible = local[:3] + "*" * (local_len - 4) + local[-1]
+        visible = local[:3] + "*" * (local_len - 3)
     else:
         mid_index = local_len // 2
         visible = (
@@ -265,6 +267,7 @@ def download_attendee_list_csv(event_id: str) -> str:
     """
     import csv
     import io
+    import re
 
     # Get full submission data (labels and answers)
     submissions = get_submissions_with_answers(event_id, full=True)
@@ -284,25 +287,28 @@ def download_attendee_list_csv(event_id: str) -> str:
     headers = [label_map.get(k, first_answers.get(k, k)) for k in columns]
 
     # Escape helper (like toCSVCell)
-    def escape_csv_cell(value):
+    def cleanse_csv_cell(value):
         s = "" if value is None else str(value)
         if s.startswith(("=", "+", "-", "@")):
             s = "'" + s
-        return s.replace('"', '""')
+        return s
 
     # Prepare CSV content
     output = io.StringIO()
     writer = csv.writer(output, quoting=csv.QUOTE_ALL, lineterminator="\r\n")
 
-    writer.writerow([escape_csv_cell(h) for h in headers])
+    writer.writerow([cleanse_csv_cell(h) for h in headers])
 
     for row in submissions:
-        writer.writerow([escape_csv_cell(row.get(col, "")) for col in columns])
+        writer.writerow([cleanse_csv_cell(row.get(col, "")) for col in columns])
 
-    csv_data = output.getvalue()
-    safe_event_name = frappe.db.get_value(EVENT, event_id, "event_name", cache=True) or "event"
-    filename = f"Attendee List - {safe_event_name.replace(' ', '_')}.csv"
+    csv_data = "\ufeff" + output.getvalue()  # BOM for Excel
+    event_name = frappe.db.get_value(EVENT, event_id, "event_name", cache=True) or "event"
+
+    safe_event_name = re.sub(r"[^A-Za-z0-9._-]+", "_", event_name)
+    filename = f"Attendee_List_-_{safe_event_name}.csv"
 
     frappe.response["filename"] = filename
     frappe.response["filecontent"] = csv_data
+    frappe.response["content_type"] = "text/csv; charset=utf-8"
     frappe.response["type"] = "download"

--- a/fossunited/doctype_ids.py
+++ b/fossunited/doctype_ids.py
@@ -36,6 +36,7 @@ SPEAKER = "CFP Submission Speaker"
 # Event RSVP-related identifiers
 EVENT_RSVP = "FOSS Event RSVP"
 RSVP_RESPONSE = "FOSS Event RSVP Submission"
+RSVP_CUSTOM_FIELD = "FOSS Custom Answer"
 
 # Ticket-related identifiers
 EVENT_TICKET = "FOSS Event Ticket"

--- a/fossunited/tests/test_rsvp_insights_field.py
+++ b/fossunited/tests/test_rsvp_insights_field.py
@@ -1,0 +1,145 @@
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from fossunited.api.chapter import get_submissions_with_answers
+from fossunited.doctype_ids import (
+    CHAPTER,
+    EVENT,
+    EVENT_RSVP,
+    RSVP_RESPONSE,
+    USER_PROFILE,
+)
+
+from .utils import (
+    insert_rsvp_form,
+    insert_rsvp_submission,
+    insert_test_chapter,
+    insert_test_event,
+)
+
+
+class TestGetSubmissionsWithAnswersAPI(FrappeTestCase):
+    def setUp(self):
+        # Create a chapter → event → RSVP form
+        self.core_team_email = "test1@example.com"
+        self.volunteer_user = "volunteer@example.com"
+        self.chapter = insert_test_chapter(
+            members=[self.core_team_email, self.volunteer_user],
+        )
+        self.event = insert_test_event(self.chapter)
+        self.rsvp = insert_rsvp_form(self.event)
+        # Create one submission with a custom question
+        self.submission = insert_rsvp_submission(
+            linked_rsvp=self.rsvp.name,
+            name="Alice",
+            email="alice@example.com",
+            im_a="Student",
+            custom_answers=[{"question": "What’s your goal?", "response": "To learn"}],
+        )
+
+        # After insert_test_chapter is called
+        self.event.reload()
+        for member in self.event.event_members:
+            if frappe.db.get_value(USER_PROFILE, member.member, "user") == self.volunteer_user:
+                member.role = "Volunteer"
+
+        self.event.save(ignore_permissions=True)
+        self.event.reload()
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+        frappe.delete_doc(CHAPTER, self.chapter.name, force=True)
+        frappe.delete_doc(EVENT, self.event.name, force=True)
+        frappe.delete_doc(EVENT_RSVP, self.rsvp.name, force=True)
+        frappe.delete_doc(RSVP_RESPONSE, self.submission.name, force=True)
+
+    def test_guest_user_denied(self):
+        frappe.session.user = "Guest"
+        with self.assertRaises(frappe.PermissionError):
+            get_submissions_with_answers(self.event.name)
+
+    def test_non_event_lead_masks_email(self):
+        frappe.session.user = "random@example.com"
+        result = get_submissions_with_answers(self.event.name, full=False)
+        self.assertTrue(result)
+        # Check email is masked: basic pattern check
+        self.assertIn("@", result[0]["email"])
+        self.assertNotEqual(result[0]["email"], "alice@example.com")
+
+    def test_event_lead_full_email(self):
+        frappe.set_user(self.core_team_email)
+        result = get_submissions_with_answers(self.event.name, full=False)
+        self.assertTrue(result)
+        self.assertIn("@", result[0]["email"])
+        self.assertEqual(result[0]["email"], "alice@example.com")
+
+    def test_event_lead_gets_full_answers(self):
+        frappe.set_user(self.core_team_email)
+        result = get_submissions_with_answers(self.event.name, full=True)
+        self.assertIn("cf_whats_your_goal", result[0])
+        self.assertEqual(result[0]["cf_whats_your_goal"], "To learn")
+        self.assertEqual(result[0]["_answers"]["cf_whats_your_goal"], "What’s your goal?")
+
+    def test_truncation_when_full_false(self):
+        frappe.set_user(self.core_team_email)
+        # Use long question/response to test truncation
+        long_q = "Q" * 100
+        long_r = "R" * 100
+        # Create another submission
+        insert_rsvp_submission(
+            linked_rsvp=self.rsvp.name,
+            name="Bob",
+            email="bob@example.com",
+            custom_answers=[{"question": long_q, "response": long_r}],
+        )
+        result = get_submissions_with_answers(self.event.name, full=False)
+        for s in result:
+            for key, val in s.items():
+                if key.startswith("cf_"):
+                    self.assertLessEqual(len(val), 52)
+
+    def test_no_truncation_when_full_true(self):
+        frappe.set_user(self.core_team_email)
+        question = "What do you bring?"
+        response = "Experience and energy."
+        insert_rsvp_submission(
+            linked_rsvp=self.rsvp.name,
+            name="Charlie",
+            email="charlie@example.com",
+            custom_answers=[{"question": question, "response": response}],
+        )
+        result = get_submissions_with_answers(self.event.name, full=True)
+        found = False
+        for s in result:
+            if s.get("email") == "charlie@example.com":
+                found = True
+                self.assertEqual(s["cf_what_do_you_bring"], response)
+                self.assertEqual(s["_answers"]["cf_what_do_you_bring"], question)
+        self.assertTrue(found, "Charlie submission not found in results")
+
+    def test_non_core_basic_fields(self):
+        # Simulate a user who is part of the chapter (member) but not the core member
+        frappe.set_user(self.volunteer_user)
+
+        # Add another submission with custom fields
+        insert_rsvp_submission(
+            linked_rsvp=self.rsvp.name,
+            name="Bob",
+            email="bob@example.com",
+            im_a="Student",
+            custom_answers=[{"question": "Why are you attending?", "response": "To network"}],
+        )
+
+        result = get_submissions_with_answers(self.event.name)
+        for submission in result:
+            self.assertIn("name1", submission)
+            self.assertIn("email", submission)
+            self.assertIn("im_a", submission)
+
+            # Ensure no custom fields (starting with 'cf_') are present
+            for key in submission.keys():
+                self.assertFalse(
+                    key.startswith("cf_"),
+                    f"Non-lead should not see custom field: {key}",
+                )
+            self.assertNotIn("_answers", submission, "Non-lead should not see _answers")

--- a/fossunited/tests/test_rsvp_insights_field.py
+++ b/fossunited/tests/test_rsvp_insights_field.py
@@ -36,6 +36,7 @@ class TestGetSubmissionsWithAnswersAPI(FrappeTestCase):
             im_a="Student",
             custom_answers=[{"question": "What’s your goal?", "response": "To learn"}],
         )
+        self._extra_responses = []
 
         # After insert_test_chapter is called
         self.event.reload()
@@ -48,32 +49,35 @@ class TestGetSubmissionsWithAnswersAPI(FrappeTestCase):
 
     def tearDown(self):
         frappe.set_user("Administrator")
-        frappe.delete_doc(CHAPTER, self.chapter.name, force=True)
-        frappe.delete_doc(EVENT, self.event.name, force=True)
-        frappe.delete_doc(EVENT_RSVP, self.rsvp.name, force=True)
+        # Delete children first, then parents
+        for name in self._extra_responses:
+            frappe.delete_doc(RSVP_RESPONSE, name, force=True)
         frappe.delete_doc(RSVP_RESPONSE, self.submission.name, force=True)
+        frappe.delete_doc(EVENT_RSVP, self.rsvp.name, force=True)
+        frappe.delete_doc(EVENT, self.event.name, force=True)
+        frappe.delete_doc(CHAPTER, self.chapter.name, force=True)
 
     def test_guest_user_denied(self):
-        frappe.session.user = "Guest"
+        frappe.set_user("Guest")
         with self.assertRaises(frappe.PermissionError):
             get_submissions_with_answers(self.event.name)
 
-    def test_non_event_lead_masks_email(self):
-        frappe.session.user = "random@example.com"
+    def test_non_event_core_team_masks_email(self):
+        frappe.set_user(self.volunteer_user)
         result = get_submissions_with_answers(self.event.name, full=False)
         self.assertTrue(result)
         # Check email is masked: basic pattern check
         self.assertIn("@", result[0]["email"])
         self.assertNotEqual(result[0]["email"], "alice@example.com")
 
-    def test_event_lead_full_email(self):
+    def test_event_core_team_full_email(self):
         frappe.set_user(self.core_team_email)
         result = get_submissions_with_answers(self.event.name, full=False)
         self.assertTrue(result)
         self.assertIn("@", result[0]["email"])
         self.assertEqual(result[0]["email"], "alice@example.com")
 
-    def test_event_lead_gets_full_answers(self):
+    def test_event_core_team_gets_full_answers(self):
         frappe.set_user(self.core_team_email)
         result = get_submissions_with_answers(self.event.name, full=True)
         self.assertIn("cf_whats_your_goal", result[0])
@@ -86,7 +90,7 @@ class TestGetSubmissionsWithAnswersAPI(FrappeTestCase):
         long_q = "Q" * 100
         long_r = "R" * 100
         # Create another submission
-        insert_rsvp_submission(
+        _bob = insert_rsvp_submission(
             linked_rsvp=self.rsvp.name,
             name="Bob",
             email="bob@example.com",
@@ -102,12 +106,14 @@ class TestGetSubmissionsWithAnswersAPI(FrappeTestCase):
         frappe.set_user(self.core_team_email)
         question = "What do you bring?"
         response = "Experience and energy."
-        insert_rsvp_submission(
+        _charlie = insert_rsvp_submission(
             linked_rsvp=self.rsvp.name,
             name="Charlie",
             email="charlie@example.com",
             custom_answers=[{"question": question, "response": response}],
         )
+        self._extra_responses.append(_charlie.name)
+
         result = get_submissions_with_answers(self.event.name, full=True)
         found = False
         for s in result:
@@ -122,13 +128,14 @@ class TestGetSubmissionsWithAnswersAPI(FrappeTestCase):
         frappe.set_user(self.volunteer_user)
 
         # Add another submission with custom fields
-        insert_rsvp_submission(
+        _bob2 = insert_rsvp_submission(
             linked_rsvp=self.rsvp.name,
             name="Bob",
             email="bob@example.com",
             im_a="Student",
             custom_answers=[{"question": "Why are you attending?", "response": "To network"}],
         )
+        self._extra_responses.append(_bob2.name)
 
         result = get_submissions_with_answers(self.event.name)
         for submission in result:
@@ -140,6 +147,6 @@ class TestGetSubmissionsWithAnswersAPI(FrappeTestCase):
             for key in submission.keys():
                 self.assertFalse(
                     key.startswith("cf_"),
-                    f"Non-lead should not see custom field: {key}",
+                    f"Non-core_team should not see custom field: {key}",
                 )
-            self.assertNotIn("_answers", submission, "Non-lead should not see _answers")
+            self.assertNotIn("_answers", submission, "Non-core_team should not see _answers")

--- a/fossunited/tests/test_rsvp_insights_field.py
+++ b/fossunited/tests/test_rsvp_insights_field.py
@@ -32,9 +32,14 @@ class TestGetSubmissionsWithAnswersAPI(FrappeTestCase):
         self.submission = insert_rsvp_submission(
             linked_rsvp=self.rsvp.name,
             name="Alice",
-            email="alice@example.com",
+            email="alicewonderland@example.com",
             im_a="Student",
-            custom_answers=[{"question": "What’s your goal?", "response": "To learn"}],
+            custom_answers=[
+                {
+                    "question": "What’s your goal?",
+                    "response": "To become the king of the pirates and greatest swordsmen.",
+                }
+            ],
         )
         self._extra_responses = []
 
@@ -68,21 +73,23 @@ class TestGetSubmissionsWithAnswersAPI(FrappeTestCase):
         self.assertTrue(result)
         # Check email is masked: basic pattern check
         self.assertIn("@", result[0]["email"])
-        self.assertNotEqual(result[0]["email"], "alice@example.com")
+        self.assertNotEqual(result[0]["email"], "alicewonderland@example.com")
 
     def test_event_core_team_full_email(self):
         frappe.set_user(self.core_team_email)
         result = get_submissions_with_answers(self.event.name, full=False)
         self.assertTrue(result)
         self.assertIn("@", result[0]["email"])
-        self.assertEqual(result[0]["email"], "alice@example.com")
+        self.assertEqual(result[0]["email"], "alicewonderland@example.com")
 
     def test_event_core_team_gets_full_answers(self):
         frappe.set_user(self.core_team_email)
         result = get_submissions_with_answers(self.event.name, full=True)
-        self.assertIn("cf_whats_your_goal", result[0])
-        self.assertEqual(result[0]["cf_whats_your_goal"], "To learn")
-        self.assertEqual(result[0]["_answers"]["cf_whats_your_goal"], "What’s your goal?")
+        self.assertIn("whats_your_goal", result[0])
+        self.assertEqual(
+            result[0]["whats_your_goal"],
+            "To become the king of the pirates and greatest swordsmen.",
+        )
 
     def test_truncation_when_full_false(self):
         frappe.set_user(self.core_team_email)
@@ -99,7 +106,7 @@ class TestGetSubmissionsWithAnswersAPI(FrappeTestCase):
         result = get_submissions_with_answers(self.event.name, full=False)
         for s in result:
             for key, val in s.items():
-                if key.startswith("cf_"):
+                if key.startswith(""):
                     self.assertLessEqual(len(val), 52)
 
     def test_no_truncation_when_full_true(self):
@@ -119,8 +126,7 @@ class TestGetSubmissionsWithAnswersAPI(FrappeTestCase):
         for s in result:
             if s.get("email") == "charlie@example.com":
                 found = True
-                self.assertEqual(s["cf_what_do_you_bring"], response)
-                self.assertEqual(s["_answers"]["cf_what_do_you_bring"], question)
+                self.assertEqual(s["what_do_you_bring"], response)
         self.assertTrue(found, "Charlie submission not found in results")
 
     def test_non_core_basic_fields(self):
@@ -143,10 +149,9 @@ class TestGetSubmissionsWithAnswersAPI(FrappeTestCase):
             self.assertIn("email", submission)
             self.assertIn("im_a", submission)
 
-            # Ensure no custom fields (starting with 'cf_') are present
+            # Ensure no custom fields (starting with '') are present
             for key in submission.keys():
                 self.assertFalse(
-                    key.startswith("cf_"),
+                    key.startswith("why"),
                     f"Non-core_team should not see custom field: {key}",
                 )
-            self.assertNotIn("_answers", submission, "Non-core_team should not see _answers")

--- a/fossunited/tests/utils.py
+++ b/fossunited/tests/utils.py
@@ -90,15 +90,6 @@ def insert_test_chapter(**kwargs):
                 profile = frappe.db.get_value(USER_PROFILE, {"user": member}, "name")
                 if not profile:
                     # Create User and User Profile
-                    if not frappe.db.exists("User", member):
-                        frappe.get_doc(
-                            {
-                                "doctype": "User",
-                                "email": member,
-                                "first_name": member.split("@")[0],
-                            }
-                        ).insert(ignore_permissions=True)
-
                     user_profile = frappe.get_doc(
                         {
                             "doctype": USER_PROFILE,

--- a/fossunited/tests/utils.py
+++ b/fossunited/tests/utils.py
@@ -21,7 +21,9 @@ from fossunited.doctype_ids import (
     TICKET_TIER,
     USER_PROFILE,
 )
-from fossunited.ticketing.doctype.foss_ticket_tier.foss_ticket_tier import FOSSTicketTier
+from fossunited.ticketing.doctype.foss_ticket_tier.foss_ticket_tier import (
+    FOSSTicketTier,
+)
 
 fake = Faker()
 
@@ -87,8 +89,25 @@ def insert_test_chapter(**kwargs):
             try:
                 profile = frappe.db.get_value(USER_PROFILE, {"user": member}, "name")
                 if not profile:
-                    frappe.log_error(f"Profile not found for member: {member}")
-                    continue  # Skip invalid members
+                    # Create User and User Profile
+                    if not frappe.db.exists("User", member):
+                        frappe.get_doc(
+                            {
+                                "doctype": "User",
+                                "email": member,
+                                "first_name": member.split("@")[0],
+                            }
+                        ).insert(ignore_permissions=True)
+
+                    user_profile = frappe.get_doc(
+                        {
+                            "doctype": USER_PROFILE,
+                            "user": member,
+                            "full_name": member.split("@")[0].title(),
+                        }
+                    ).insert(ignore_permissions=True)
+
+                    profile = user_profile.name
 
                 chapter.append(
                     "chapter_members",
@@ -188,6 +207,7 @@ def insert_test_event(chapter: dict, **kwargs):
         # Create and insert event
         event = frappe.get_doc(event_data)
         event.insert()
+        event.save()
         event.reload()
 
         return event


### PR DESCRIPTION
## 🚦 Status

- [ ] Draft
- [x] Ready for review

---

## 🔗 Related Issue

Closes / Addresses: #473 

---

## ❗ Problem

<!-- Briefly describe the problem or motivation for this PR -->
Previously due to it being sensitive data, we ignored to include custom fields in insights view for RSVP.
And only way was to request for data via email so the team can get it via desk.

---

## ✅ Solution

<!-- Describe your solution and what you changed -->
But, RSVP is made by event core team to fill data, so they own rights to see or have them. Since they are conducting the event itself.

Although we can say sensitive data, its upto users and event organizer (core team member) to handle it.

This is especially required if foss club needs people will University/Academic ID number to identify which makes sense.

### Provided solution
- Enable only the Core Team Member to view this data in insights tab
- Also only they can get this fields in CSV file via download
- Other roles (volunteer, graphic,....) don't see this field nor in downloaded file.

So this solution if effective to handle custom field for only core team member for their own event.

+ Also created an API to handle this submission data in efficient way to query custom fields (child doctype).

---

## 📋 Progress (All must be checked to merge)

- [x] Tested locally
- [ ] 

---

## 📝 Changelog

<commit>: <!-- e.g., feat: add user login endpoint -->

---

## 🖼️ Visualization

<!-- Add screenshots, diagrams, or screen recordings if applicable -->
<img width="1400" height="280" alt="image" src="https://github.com/user-attachments/assets/2a3857dc-afb4-4ec8-89d7-a1d18fe249d0" />


---

## 🔮 Further Ahead

<!-- Mention any follow-up work or related PRs planned -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic attendee columns that surface custom RSVP questions and a server-side CSV export for downloads.

* **UI**
  * Attendees header count on one line; columns are resizable; non-leads see masked emails and truncated custom answers, leads see full emails and answers.

* **Tests**
  * New tests for access control, email masking, custom-field exposure, truncation, and CSV/export behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->