### PR TITLE
De-clutter the events timeline page

### DIFF
--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -215,12 +215,86 @@ def get_grouped_events():
     return get_month_grouped_events(events, hackathons)
 
 
+def get_grouped_events_by_chapter_type():
+    """
+    Retrieves FOSS Chapter Events and Hackathons,
+    groups them by their parent Chapter's chapter_type (City Community or Club),
+    and then groups each by month and year.
+    """
+
+    # Get all events
+    events = frappe.get_all(
+        EVENT,
+        fields=["*"],
+        or_filters=[["is_published", "=", "1"], ["is_external_event", "=", "1"]],
+        order_by="event_start_date",
+    )
+
+    # Get all hackathons
+    hackathons = frappe.get_all(
+        HACKATHON,
+        fields=["*"],
+        filters={"is_published": 1},
+        order_by="start_date",
+    )
+
+    # Grouping events
+    city_events = []
+    club_events = []
+    city_hackathons = []
+    club_hackathons = []
+
+    # Cache to avoid duplicate lookups
+    chapter_type_cache = {}
+
+    def get_chapter_type(chapter_name):
+        """
+        Fetches chapter_type from the Chapter doctype.
+        Caches the result to avoid multiple DB hits.
+        """
+        if not chapter_name:
+            return None
+        if chapter_name in chapter_type_cache:
+            return chapter_type_cache[chapter_name]
+
+        # DB lookup
+        chapter_type = frappe.db.get_value(CHAPTER, chapter_name, "chapter_type")
+        chapter_type_cache[chapter_name] = chapter_type
+        return chapter_type
+
+    # Classify events
+    for event in events:
+        chapter_type = get_chapter_type(event.get("chapter"))
+        if chapter_type == "City Community":
+            city_events.append(event)
+        else:
+            club_events.append(event)
+
+    # Classify hackathons
+    for hackathon in hackathons:
+        chapter_type = get_chapter_type(hackathon.get("chapter"))
+        if chapter_type == "City Community":
+            city_hackathons.append(hackathon)
+        else:
+            club_hackathons.append(hackathon)
+
+    # Group and return
+    return {
+        "city": get_month_grouped_events(city_events, city_hackathons),
+        "club": get_month_grouped_events(club_events, club_hackathons),
+    }
+
+
 def get_chapter_details():
     """
     Retrieves FOSS Chapter Events and Hackathons, then groups them by month and year, separating
     upcoming and past events.
     """
-    chapters = frappe.db.get_all(CHAPTER, fields=["chapter_name", "name", "chapter_type"])
+    chapters = frappe.db.get_all(
+        CHAPTER,
+        fields=["chapter_name", "name", "chapter_type"],
+        filters={"chapter_type": "City Community"},
+    )
     return chapters
 
 

--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -306,12 +306,15 @@ def process_event(event, event_list, chapter=""):
     now = now_datetime()
     event_date = event.event_start_date if event.event_start_date else event.start_date
 
-    event_month_year = frappe.utils.formatdate(event_date, "MMMM yyyy")
-    event.month_year = event_month_year
-    if event_date > now:
-        event_list[f"Upcoming {chapter} FOSS Events"].append(event)
+    if event_date:
+        event_month_year = frappe.utils.formatdate(event_date, "MMMM yyyy")
+        event.month_year = event_month_year
+        if event_date > now:
+            event_list[f"Upcoming {chapter} FOSS Events"].append(event)
+        else:
+            event_list[f"Past {chapter} Events"].append(event)
     else:
-        event_list[f"Past {chapter} Events"].append(event)
+        pass
 
 
 def get_month_grouped_events(events, hackathons, chapter=""):

--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -220,7 +220,7 @@ def get_chapter_details():
     Retrieves FOSS Chapter Events and Hackathons, then groups them by month and year, separating
     upcoming and past events.
     """
-    chapters = frappe.db.get_all(CHAPTER, fields=["chapter_name", "name"])
+    chapters = frappe.db.get_all(CHAPTER, fields=["chapter_name", "name", "chapter_type"])
     return chapters
 
 

--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -280,8 +280,8 @@ def get_grouped_events_by_chapter_type():
 
     # Group and return
     return {
-        "city": get_month_grouped_events(city_events, city_hackathons),
-        "club": get_month_grouped_events(club_events, club_hackathons),
+        "city": get_month_grouped_events(city_events, city_hackathons, "City"),
+        "club": get_month_grouped_events(club_events, club_hackathons, "Club"),
     }
 
 
@@ -298,7 +298,7 @@ def get_chapter_details():
     return chapters
 
 
-def process_event(event, event_list):
+def process_event(event, event_list, chapter=""):
     """
     Processes a single event or hackathon, adding it to the upcoming or past events list based on
     the current date.
@@ -308,23 +308,23 @@ def process_event(event, event_list):
     event_month_year = frappe.utils.formatdate(event_date, "MMMM yyyy")
     event.month_year = event_month_year
     if event_date > now:
-        event_list["Upcoming FOSS Events"].append(event)
+        event_list[f"Upcoming {chapter} FOSS Events"].append(event)
     else:
-        event_list["Past Events"].append(event)
+        event_list[f"Past {chapter} Events"].append(event)
 
 
-def get_month_grouped_events(events, hackathons):
+def get_month_grouped_events(events, hackathons, chapter=""):
     """
     Groups events and hackathons by month and year, ensuring they are sorted chronologically
     within each group.
     """
-    grouped_events = {"Upcoming FOSS Events": [], "Past Events": []}
+    grouped_events = {f"Upcoming {chapter} FOSS Events": [], f"Past {chapter} Events": []}
 
     for event in events:
-        process_event(event, grouped_events)
+        process_event(event, grouped_events, chapter)
 
     for hackathon in hackathons:
-        process_event(hackathon, grouped_events)
+        process_event(hackathon, grouped_events, chapter)
 
     month_grouped_events = {key: {} for key in grouped_events}
 
@@ -334,7 +334,7 @@ def get_month_grouped_events(events, hackathons):
             month_grouped_events[key][month_year] = list(month_year_events)
 
     for key in month_grouped_events:
-        if key == "Upcoming FOSS Events":
+        if key == f"Upcoming {chapter} FOSS Events":
             sorted_month_years = sorted(
                 month_grouped_events[key].keys(),
                 key=lambda x: datetime.strptime(x, "%B %Y"),

--- a/fossunited/fossunited/web_template/events_timeline/events_timeline.html
+++ b/fossunited/fossunited/web_template/events_timeline/events_timeline.html
@@ -155,7 +155,9 @@
           <option value="All Cities" selected>All Cities</option>
           {% set chapter_details = get_chapter_details() %}
           {% for chapter in chapter_details %}
-            <option value="{{chapter.name}}">{{ chapter.chapter_name | truncate(15, False, '...', 0) }}</option>
+		  {% if chapter.chapter_type == "City Community" %}
+          <option value="{{chapter.name}}">{{ chapter.chapter_name | truncate(15, False, '...', 0) }}</option>
+		  {% endif %}
           {% endfor %}
         </select>
         <label for="cityChapter">City Chapter</label>

--- a/fossunited/fossunited/web_template/events_timeline/events_timeline.html
+++ b/fossunited/fossunited/web_template/events_timeline/events_timeline.html
@@ -155,9 +155,7 @@
           <option value="All Cities" selected>All Cities</option>
           {% set chapter_details = get_chapter_details() %}
           {% for chapter in chapter_details %}
-		  {% if chapter.chapter_type == "City Community" %}
           <option value="{{chapter.name}}">{{ chapter.chapter_name | truncate(15, False, '...', 0) }}</option>
-		  {% endif %}
           {% endfor %}
         </select>
         <label for="cityChapter">City Chapter</label>

--- a/fossunited/hooks.py
+++ b/fossunited/hooks.py
@@ -44,6 +44,7 @@ jinja = {
         "fossunited.fossunited.utils.get_user_editable_doctype_fields",
         "fossunited.fossunited.utils.get_signup_optin_checks",
         "fossunited.fossunited.utils.get_grouped_events",
+        "fossunited.fossunited.utils.get_grouped_events_by_chapter_type",
         "fossunited.fossunited.utils.get_chapter_details",
         "fossunited.stack.utils.get_stack_dict",
     ],


### PR DESCRIPTION
## 🚦 Status

- [ ] Draft
- [x] Ready for review

---

## 🔗 Related Issue

Closes / Addresses: #1097

---

## ❗ Problem

<!-- Briefly describe the problem or motivation for this PR -->
Too many club events clutter the timeline page.

---

## ✅ Solution

<!-- Describe your solution and what you changed -->
- Give select option to chose for showing only city events or club events or both
- Also List only city community names in city chapter (need no club names in it to filter, again too many)

---

## 📋 Progress (All must be checked to merge)

- [x] Tested locally
TBH this is a cursed PR, i had wasted so much time on it although I had code ready. But due to my local setup not loading `petiteVue` it look long enough to realize the code action.

---

## 📝 Changelog

<commit>: <!-- e.g., feat: add user login endpoint -->

---

## 🖼️ Visualization

<!-- Add screenshots, diagrams, or screen recordings if applicable -->
<img width="1100" height="600" alt="image" src="https://github.com/user-attachments/assets/dc4a016a-0d81-4798-89f4-4659642de5d8" />


---

## 🔮 Further Ahead

<!-- Mention any follow-up work or related PRs planned -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Events timeline now groups events and hackathons by chapter type (City vs Club) with separate month-based sections.
  - Section headers are dynamic per chapter, e.g., “Upcoming {chapter} FOSS Events” and “Past {chapter} Events”.
  - Grouped event data is exposed to templates for dynamic rendering.

- Style
  - Minor indentation cleanup in the events timeline template; no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->