### PR TITLE
De-clutter the events timeline page via select option

### DIFF
--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -203,7 +203,7 @@ def get_grouped_events_by_chapter_type():
     events = frappe.get_all(
         EVENT,
         fields=["*"],
-        or_filters=[["is_published", "=", "1"], ["is_external_event", "=", "1"]],
+        filters={"is_published": 1},
         order_by="event_start_date",
     )
 
@@ -271,6 +271,7 @@ def get_chapter_details():
         CHAPTER,
         fields=["chapter_name", "name", "chapter_type"],
         filters={"chapter_type": "City Community"},
+        order_by="chapter_name asc",
     )
     return chapters
 

--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -192,11 +192,14 @@ def validate_profile_completion():
     )
 
 
-def get_grouped_events():
+def get_grouped_events_by_chapter_type():
     """
-    Retrieves FOSS Chapter Events and Hackathons, then groups them by month and year, separating
-    upcoming and past events.
+    Retrieves FOSS Chapter Events and Hackathons,
+    groups them by their parent Chapter's chapter_type (City Community or Club),
+    and then groups each by month and year.
     """
+
+    # Get all events
     events = frappe.get_all(
         EVENT,
         fields=["*"],
@@ -204,15 +207,59 @@ def get_grouped_events():
         order_by="event_start_date",
     )
 
+    # Get all hackathons
     hackathons = frappe.get_all(
         HACKATHON,
         fields=["*"],
-        filters={
-            "is_published": 1,
-        },
+        filters={"is_published": 1},
         order_by="start_date",
     )
-    return get_month_grouped_events(events, hackathons)
+
+    # Grouping events
+    city_events = []
+    club_events = []
+    city_hackathons = []
+    club_hackathons = []
+
+    # Cache to avoid duplicate lookups
+    chapter_type_cache = {}
+
+    def get_chapter_type(chapter_name):
+        """
+        Fetches chapter_type from the Chapter doctype.
+        Caches the result to avoid multiple DB hits.
+        """
+        if not chapter_name:
+            return None
+        if chapter_name in chapter_type_cache:
+            return chapter_type_cache[chapter_name]
+
+        # DB lookup
+        chapter_type = frappe.db.get_value(CHAPTER, chapter_name, "chapter_type")
+        chapter_type_cache[chapter_name] = chapter_type
+        return chapter_type
+
+    # Classify events
+    for event in events:
+        chapter_type = get_chapter_type(event.get("chapter"))
+        if chapter_type == "City Community":
+            city_events.append(event)
+        else:
+            club_events.append(event)
+
+    # Classify hackathons
+    for hackathon in hackathons:
+        chapter_type = get_chapter_type(hackathon.get("chapter"))
+        if chapter_type == "City Community":
+            city_hackathons.append(hackathon)
+        else:
+            club_hackathons.append(hackathon)
+
+    # Group and return
+    return {
+        "city": get_month_grouped_events(city_events, city_hackathons, "City"),
+        "club": get_month_grouped_events(club_events, club_hackathons, "Club"),
+    }
 
 
 def get_chapter_details():
@@ -220,11 +267,15 @@ def get_chapter_details():
     Retrieves FOSS Chapter Events and Hackathons, then groups them by month and year, separating
     upcoming and past events.
     """
-    chapters = frappe.db.get_all(CHAPTER, fields=["chapter_name", "name"])
+    chapters = frappe.db.get_all(
+        CHAPTER,
+        fields=["chapter_name", "name", "chapter_type"],
+        filters={"chapter_type": "City Community"},
+    )
     return chapters
 
 
-def process_event(event, event_list):
+def process_event(event, event_list, chapter=""):
     """
     Processes a single event or hackathon, adding it to the upcoming or past events list based on
     the current date.
@@ -235,27 +286,26 @@ def process_event(event, event_list):
     if event_date:
         event_month_year = frappe.utils.formatdate(event_date, "MMMM yyyy")
         event.month_year = event_month_year
-
         if event_date > now:
-            event_list["Upcoming FOSS Events"].append(event)
+            event_list[f"Upcoming {chapter} FOSS Events"].append(event)
         else:
-            event_list["Past Events"].append(event)
+            event_list[f"Past {chapter} Events"].append(event)
     else:
         pass
 
 
-def get_month_grouped_events(events, hackathons):
+def get_month_grouped_events(events, hackathons, chapter=""):
     """
     Groups events and hackathons by month and year, ensuring they are sorted chronologically
     within each group.
     """
-    grouped_events = {"Upcoming FOSS Events": [], "Past Events": []}
+    grouped_events = {f"Upcoming {chapter} FOSS Events": [], f"Past {chapter} Events": []}
 
     for event in events:
-        process_event(event, grouped_events)
+        process_event(event, grouped_events, chapter)
 
     for hackathon in hackathons:
-        process_event(hackathon, grouped_events)
+        process_event(hackathon, grouped_events, chapter)
 
     month_grouped_events = {key: {} for key in grouped_events}
 
@@ -265,7 +315,7 @@ def get_month_grouped_events(events, hackathons):
             month_grouped_events[key][month_year] = list(month_year_events)
 
     for key in month_grouped_events:
-        if key == "Upcoming FOSS Events":
+        if key == f"Upcoming {chapter} FOSS Events":
             sorted_month_years = sorted(
                 month_grouped_events[key].keys(),
                 key=lambda x: datetime.strptime(x, "%B %Y"),

--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -272,6 +272,7 @@ def get_chapter_details():
         fields=["chapter_name", "name", "chapter_type"],
         filters={"chapter_type": "City Community"},
         order_by="chapter_name asc",
+        page_length=9999,
     )
     return chapters
 

--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -283,17 +283,18 @@ def process_event(event, event_list, chapter=""):
     the current date.
     """
     now = now_datetime()
-    event_date = event.event_start_date if event.event_start_date else event.start_date
-
-    if event_date:
-        event_month_year = frappe.utils.formatdate(event_date, "MMMM yyyy")
-        event.month_year = event_month_year
-        if event_date > now:
-            event_list[f"Upcoming {chapter} FOSS Events"].append(event)
-        else:
-            event_list[f"Past {chapter} Events"].append(event)
+    # Support both Events (event_start_date) and Hackathons (start_date)
+    raw_dt = event.get("event_start_date") or event.get("start_date")
+    if not raw_dt:
+        return
+    event_dt = frappe.utils.get_datetime(raw_dt)
+    event["month_year"] = frappe.utils.formatdate(event_dt, "MMMM yyyy")
+    # store for stable sorting later
+    event["_sort_dt"] = event_dt
+    if event_dt > now:
+        event_list[f"Upcoming {chapter} FOSS Events"].append(event)
     else:
-        pass
+        event_list[f"Past {chapter} Events"].append(event)
 
 
 def get_month_grouped_events(events, hackathons, chapter=""):
@@ -312,7 +313,7 @@ def get_month_grouped_events(events, hackathons, chapter=""):
     month_grouped_events = {key: {} for key in grouped_events}
 
     for key, values in grouped_events.items():
-        values.sort(key=lambda x: x.event_start_date if x.event_start_date else x.start_date)
+        values.sort(key=lambda x: x.get("_sort_dt"))
         for month_year, month_year_events in itertools.groupby(values, key=lambda x: x.month_year):
             month_grouped_events[key][month_year] = list(month_year_events)
 

--- a/fossunited/fossunited/web_template/events_timeline/events_timeline.html
+++ b/fossunited/fossunited/web_template/events_timeline/events_timeline.html
@@ -301,10 +301,26 @@
 
       function downloadEventIcs() {
         let event_ids = new Array()
-      document.querySelectorAll('div.event-card-holder.upcomingcity').forEach((event) => {
+        const selectedSource = document.getElementById('selectedEventSource').value
+
+        const sourceToGroupClass = {
+          city: 'UpcomingCityFOSSEvents',
+          club: 'UpcomingClubFOSSEvents',
+        }
+
+        let selector
+
+        if (selectedSource === 'both') {
+          selector = Object.values(sourceToGroupClass)
+            .map((className) => `div.event-card-holder.${className}`)
+            .join(', ')
+        } else {
+          selector = `div.event-card-holder.${sourceToGroupClass[selectedSource]}`
+        }
+
+        document.querySelectorAll(selector).forEach((event) => {
           event_ids.push(event.id)
         })
-		console.warn(event_ids)
         frappe.call({
           method: 'fossunited.api.chapter.generate_ics',
           args: {

--- a/fossunited/fossunited/web_template/events_timeline/events_timeline.html
+++ b/fossunited/fossunited/web_template/events_timeline/events_timeline.html
@@ -1,7 +1,7 @@
 {% from "fossunited/templates/macros/event_card.html" import event_card %}
 {% from "fossunited/templates/macros/hackathon_card.html" import hackathon_card %}
 
-{% macro render_event_groups(grouped_items, show_city=true, show_club=false) %}
+{% macro render_event_groups(grouped_events, show_city=true, show_club=false) %}
   {% set items = [] %}
   {% if show_city %}
     {% set items = items + grouped_events.city.items() | list %}
@@ -132,9 +132,9 @@
   }
 
   .select-theme {
-	  border-radius: var(--radius-4, 8px);
+    border-radius: var(--radius-4, 8px);
     background: #1a1a1a;
-	color: #fff;
+    color: #fff;
     padding: 8px;
   }
 
@@ -212,14 +212,14 @@
         Filter the events to show only those marked as must-attend.
       </p>
 
-	  <div class="must-attend-checkbox">
-		<select id="selectedEventSource" v-model="selectedEventSource" class="select-theme">
-		  <option value="city">City Events</option>
-		  <option value="club">Club Events</option>
-		  <option value="both">Both</option>
-		</select>
-		<label for="selectedEventSource">Show Events</label>
-	  </div>
+      <div class="must-attend-checkbox">
+        <select id="selectedEventSource" v-model="selectedEventSource" class="select-theme">
+          <option value="city">City Events</option>
+          <option value="club">Club Events</option>
+          <option value="both">Both</option>
+        </select>
+        <label for="selectedEventSource">Show Events</label>
+      </div>
 
       <!-- City Chapter selector -->
       <div class="must-attend-checkbox">
@@ -247,15 +247,15 @@
     {% set grouped_events = get_grouped_events_by_chapter_type() %}
 
     <div v-if="selectedEventSource === 'city'">
-	  {{ render_event_groups(grouped_items, show_city=true, show_club=false) }}
+      {{ render_event_groups(grouped_events, show_city=true, show_club=false) }}
     </div>
 
     <div v-else-if="selectedEventSource === 'club'">
-	  {{ render_event_groups(grouped_items, show_city=false, show_club=true) }}
+      {{ render_event_groups(grouped_events, show_city=false, show_club=true) }}
     </div>
 
     <div v-else-if="selectedEventSource === 'both'">
-	  {{ render_event_groups(grouped_items, show_city=true, show_club=true) }}
+      {{ render_event_groups(grouped_events, show_city=true, show_club=true) }}
     </div>
 
     <script>
@@ -284,8 +284,8 @@
           )
         },
         updateTicker() {
-          // mentioning each variable here, will make sure reactivity is appliedie
-          // ie. every time one of thse 3 vars is changed, it will make sure to reload all v-shows/v-ifs
+          // Mention each variable here to ensure PetiteVue tracks dependencies.
+          // Whenever any of these change, v-show/v-if will update.
           this.selectedEventSource
           this.mustAttendOnly
           this.searchText
@@ -301,9 +301,10 @@
 
       function downloadEventIcs() {
         let event_ids = new Array()
-        document.querySelectorAll('div.UpcomingFOSSEvents.event-card-holder').forEach((event) => {
+      document.querySelectorAll('div.event-card-holder.upcomingcity').forEach((event) => {
           event_ids.push(event.id)
         })
+		console.warn(event_ids)
         frappe.call({
           method: 'fossunited.api.chapter.generate_ics',
           args: {

--- a/fossunited/fossunited/web_template/events_timeline/events_timeline.html
+++ b/fossunited/fossunited/web_template/events_timeline/events_timeline.html
@@ -1,6 +1,61 @@
 {% from "fossunited/templates/macros/event_card.html" import event_card %}
 {% from "fossunited/templates/macros/hackathon_card.html" import hackathon_card %}
 
+{% macro render_event_groups(grouped_items, show_city=true, show_club=false) %}
+  {% set items = [] %}
+  {% if show_city %}
+    {% set items = items + grouped_events.city.items() | list %}
+  {% endif %}
+  {% if show_club %}
+    {% set items = items + grouped_events.club.items() | list %}
+  {% endif %}
+  {% for group, events in items %}
+    <div class="event-group" role="region">
+      <h3>{{ group }}</h3>
+
+      {% for month, month_events in events.items() %}
+        <h4
+          class="event-month"
+          v-show="ticker > 0 && $el?.nextElementSibling.style.display != 'none'"
+        >
+          {{ month }}
+        </h4>
+
+        <div
+          class="events-grid-4"
+          role="group"
+          v-effect="updateTicker()"
+          v-show="ticker > 0 && $el?.children.length > 0"
+        >
+          {% for event in month_events %}
+            {% set event_date_text = event.event_start_date.strftime("%d %b %Y") if event.event_start_date else event.start_date.strftime("%d %b %Y") %}
+
+            {% if event.event_name %}
+              <div
+                class="event-card-holder {{ group | replace(" ", "") }}"
+                id="{{ event.name }}"
+                role="listitem"
+                v-if="canShow('{{ event.event_name }}', '{{ event_date_text }}', !!{{ event.must_attend }}, '{{ event.chapter }}')"
+              >
+                {{ event_card(event) }}
+              </div>
+            {% else %}
+              <div
+                class="event-card-holder {{ group | replace(" ", "") }}"
+                id="{{ event.name }}"
+                role="listitem"
+                v-if="canShow('{{ event.hackathon_name }}', '{{ event_date_text }}', true, '{{ event.chapter }}')"
+              >
+                {{ hackathon_card(event) }}
+              </div>
+            {% endif %}
+          {% endfor %}
+        </div>
+      {% endfor %}
+    </div>
+  {% endfor %}
+{% endmacro %}
+
 <link
   rel="stylesheet"
   href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/tabler-icons.min.css"
@@ -32,7 +87,7 @@
     border-radius: 0.5rem;
     border: 1px solid var(--Gray-200, #eaecf0);
     background-color: white;
-    min-width: 50%;
+    min-width: 40%;
     align-items: center;
   }
 
@@ -76,6 +131,13 @@
     gap: 1.5rem;
   }
 
+  .select-theme {
+	  border-radius: var(--radius-4, 8px);
+    background: #1a1a1a;
+	color: #fff;
+    padding: 8px;
+  }
+
   .ics-button {
     display: flex;
     height: 44px;
@@ -86,8 +148,8 @@
     gap: 8px;
     flex: 1 0 0;
     border-radius: var(--radius-4, 8px);
-    background: #1A1A1A;
-    color: #FAFAFA;
+    background: #1a1a1a;
+    color: #fafafa;
     /* text/base/medium */
     font-family: Inter;
     font-size: 14px;
@@ -98,7 +160,7 @@
     text-transform: uppercase;
   }
   .ics-button:hover {
-    background: #2B2B2B;
+    background: #2b2b2b;
   }
 
   @media (max-width: 768px) {
@@ -149,13 +211,25 @@
       <p id="must-attend-desc" class="sr-only">
         Filter the events to show only those marked as must-attend.
       </p>
+
+	  <div class="must-attend-checkbox">
+		<select id="selectedEventSource" v-model="selectedEventSource" class="select-theme">
+		  <option value="city">City Events</option>
+		  <option value="club">Club Events</option>
+		  <option value="both">Both</option>
+		</select>
+		<label for="selectedEventSource">Show Events</label>
+	  </div>
+
       <!-- City Chapter selector -->
       <div class="must-attend-checkbox">
-        <select id="cityChapter" v-model="cityChapter">
+        <select id="cityChapter" v-model="cityChapter" class="select-theme">
           <option value="All Cities" selected>All Cities</option>
           {% set chapter_details = get_chapter_details() %}
           {% for chapter in chapter_details %}
-            <option value="{{chapter.name}}">{{ chapter.chapter_name | truncate(15, False, '...', 0) }}</option>
+            <option value="{{ chapter.name }}">
+              {{ chapter.chapter_name | truncate(15, False, '...', 0) }}
+            </option>
           {% endfor %}
         </select>
         <label for="cityChapter">City Chapter</label>
@@ -170,111 +244,84 @@
     </button>
 
     <!--Primary Event cards listing-->
-    {% set grouped_events = get_grouped_events() %}
-    {% for group, events in grouped_events.items() %}
-      <div class="event-group" role="region">
-        <h3>{{ group }}</h3>
-        {% for month, month_events in events.items() %}
-          <h4
-            class="event-month"
-            v-show="ticker > 0 && $el?.nextElementSibling.style.display != 'none'"
-          >
-            {{ month }}
-          </h4>
-          <div
-            class="events-grid-4"
-            role="group"
-            v-effect="updateTicker()"
-            v-show="ticker > 0 && $el?.children.length > 0"
-          >
-            {% for event in month_events %}
-              {% set event_date_text = event.event_start_date.strftime("%d %b %Y") if event.event_start_date else event.start_date.strftime("%d %b %Y") %}
-              {% if event.event_name %}
-                <div
-                  class="event-card-holder {{ group | replace(" ", "") }}"
-                  id="{{ event.name }}"
-                  role="listitem"
-                  v-if="canShow('{{ event.event_name }}', '{{ event_date_text }}', !!{{ event.must_attend }}, '{{ event.chapter }}')"
-                >
-                  {{ event_card(event) }}
-                </div>
-              {% else %}
-                <div
-                  class="event-card-holder {{ group | replace(" ", "") }}"
-                  id="{{ event.name }}"
-                  role="listitem"
-                  v-if="canShow('{{ event.hackathon_name }}', '{{ event_date_text }}', true, '{{ event.chapter }}')"
-                >
-                  {{ hackathon_card(event) }}
-                </div>
-              {% endif %}
-            {% endfor %}
-          </div>
-        {% endfor %}
-      </div>
-    {% endfor %}
+    {% set grouped_events = get_grouped_events_by_chapter_type() %}
 
-  <script>
-    PetiteVue.createApp({
-      searchText: '',
-      ticker: 1,
-      mustAttendOnly: false,
-      cityChapter: 'All Cities',
-      canShow(eventName, eventDate, eventMustAttend, eventCityChapter) {
-        if (this.mustAttendOnly && !eventMustAttend) {
-          return false
-        }
+    <div v-if="selectedEventSource === 'city'">
+	  {{ render_event_groups(grouped_items, show_city=true, show_club=false) }}
+    </div>
 
-        if (this.cityChapter != 'All Cities' && eventCityChapter != this.cityChapter) {
-          return false
-        }
+    <div v-else-if="selectedEventSource === 'club'">
+	  {{ render_event_groups(grouped_items, show_city=false, show_club=true) }}
+    </div>
 
-        if (this.searchText.length == 0) {
-          return true
-        }
+    <div v-else-if="selectedEventSource === 'both'">
+	  {{ render_event_groups(grouped_items, show_city=true, show_club=true) }}
+    </div>
 
-        return (
-          eventName.toLowerCase().includes(this.searchText.toLowerCase()) ||
-          eventDate.toLowerCase().includes(this.searchText.toLowerCase())
-        )
-      },
-      updateTicker() {
-        // mentioning each variable here, will make sure reactivity is appliedie
-        // ie. every time one of thse 3 vars is changed, it will make sure to reload all v-shows/v-ifs
-        this.mustAttendOnly
-        this.searchText
-        this.cityChapter
-        PetiteVue.nextTick(() => {
-          this.ticker++
+    <script>
+      PetiteVue.createApp({
+        searchText: '',
+        ticker: 1,
+        mustAttendOnly: false,
+        cityChapter: 'All Cities',
+        selectedEventSource: 'city',
+        canShow(eventName, eventDate, eventMustAttend, eventCityChapter) {
+          if (this.mustAttendOnly && !eventMustAttend) {
+            return false
+          }
+
+          if (this.cityChapter != 'All Cities' && eventCityChapter != this.cityChapter) {
+            return false
+          }
+
+          if (this.searchText.length == 0) {
+            return true
+          }
+
+          return (
+            eventName.toLowerCase().includes(this.searchText.toLowerCase()) ||
+            eventDate.toLowerCase().includes(this.searchText.toLowerCase())
+          )
+        },
+        updateTicker() {
+          // mentioning each variable here, will make sure reactivity is appliedie
+          // ie. every time one of thse 3 vars is changed, it will make sure to reload all v-shows/v-ifs
+          this.selectedEventSource
+          this.mustAttendOnly
+          this.searchText
+          this.cityChapter
           PetiteVue.nextTick(() => {
             this.ticker++
+            PetiteVue.nextTick(() => {
+              this.ticker++
+            })
           })
-        })
-      },
-    }).mount()
+        },
+      }).mount()
 
-    function downloadEventIcs() {
-      let event_ids = new Array()
-      document.querySelectorAll('div.UpcomingFOSSEvents.event-card-holder').forEach((event) => {
-        event_ids.push(event.id)
-      })
-      frappe.call({
-        method: 'fossunited.api.chapter.generate_ics',
-        args: {
-          'event_ids': event_ids,
-        },
-        callback: (r) => {
-          if (r.message) {
-            const blob = new Blob([r.message], { type: 'text/calendar' })
-            const url = URL.createObjectURL(blob)
-            const a = document.createElement('a')
-            a.href = url
-            a.download = `events.ics`
-            a.click()
-            URL.revokeObjectURL(url)
-          }
-        },
-      })
-    }
-  </script>
+      function downloadEventIcs() {
+        let event_ids = new Array()
+        document.querySelectorAll('div.UpcomingFOSSEvents.event-card-holder').forEach((event) => {
+          event_ids.push(event.id)
+        })
+        frappe.call({
+          method: 'fossunited.api.chapter.generate_ics',
+          args: {
+            event_ids: event_ids,
+          },
+          callback: (r) => {
+            if (r.message) {
+              const blob = new Blob([r.message], { type: 'text/calendar' })
+              const url = URL.createObjectURL(blob)
+              const a = document.createElement('a')
+              a.href = url
+              a.download = `events.ics`
+              a.click()
+              URL.revokeObjectURL(url)
+            }
+          },
+        })
+      }
+    </script>
+  </div>
 </div>

--- a/fossunited/hooks.py
+++ b/fossunited/hooks.py
@@ -47,7 +47,7 @@ jinja = {
         "fossunited.fossunited.utils.get_user_socials",
         "fossunited.fossunited.utils.get_user_editable_doctype_fields",
         "fossunited.fossunited.utils.get_signup_optin_checks",
-        "fossunited.fossunited.utils.get_grouped_events",
+        "fossunited.fossunited.utils.get_grouped_events_by_chapter_type",
         "fossunited.fossunited.utils.get_chapter_details",
         "fossunited.stack.utils.get_stack_dict",
     ],


### PR DESCRIPTION
## 🚦 Status

- [ ] Draft
- [x] Ready for review

---

## 🔗 Related Issue

Closes / Addresses: #1097

---

## ❗ Problem

<!-- Briefly describe the problem or motivation for this PR -->
- Events/timeline page gets cluttered via many foss clubs events (during this peak month)

Its better to give option to filter so users can see what they want

---

## ✅ Solution

<!-- Describe your solution and what you changed -->
- Give select option to choose what to be show (opts: City, Club or both)
- For city chapter options, show only city community name to filter. Again clubs are clutter here. If they want to see by clubs, they can directly go to club page itself.

---

## 📋 Progress (All must be checked to merge)

- [x] Tested locally

---

## 📝 Changelog

<commit>: <!-- e.g., feat: add user login endpoint -->

---

## 🖼️ Visualization

<!-- Add screenshots, diagrams, or screen recordings if applicable -->
<img width="600" height="370" alt="image" src="https://github.com/user-attachments/assets/33c7af1f-5c12-4a82-89e9-8c7c25153eea" />


---

## 🔮 Further Ahead

<!-- Mention any follow-up work or related PRs planned -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added “Show Events” filter to display City, Club, or Both event sources (default: City).
  * Event timeline now groups events by chapter type with separate Upcoming/Past month groupings.
  * ICS downloads now respect the selected event source.

* Refactor
  * Centralized event rendering via a reusable template macro and updated templates to use chapter-type-aware grouping.

* Style
  * Themed selector styling, minor color tweaks, and reduced search panel minimum width.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->