### PR TITLE
include speaker name for cfp filter search

### DIFF
--- a/dashboard/src/components/cfp-public/SubmissionsListView.vue
+++ b/dashboard/src/components/cfp-public/SubmissionsListView.vue
@@ -58,7 +58,7 @@ watch(
   () => searchTitle.value,
   () => {
     const search = searchTitle.value.trim().toLowerCase()
-    let filtered = submissions.originalData
+    let filtered = Array.isArray(submissions.originalData) ? submissions.originalData : []
 
     // Apply basic field filters (status, session_type, etc.)
     if (filters.value) {
@@ -67,19 +67,26 @@ watch(
 
     // Apply search on talk title or speaker name
     if (search) {
-      filtered = filtered.filter(submission => {
-        const titleMatch = submission.talk_title?.toLowerCase().includes(search)
-        const speakerMatch = submission._speaker?.some(s =>
-          s.full_name?.toLowerCase().includes(search)
-        )
-        return titleMatch || speakerMatch
+      filtered = filtered.filter((submission) => {
+        const title = submission.talk_title?.toLowerCase() ?? ''
+        // Prefer pre-joined string if present; fallback to array forms.
+        const speakerNameStr = submission.speaker_name?.toLowerCase() ?? ''
+        let speakerMatch = false
+        if (speakerNameStr) {
+          speakerMatch = speakerNameStr.includes(search)
+        } else {
+          const speakersArr = submission.speakers ?? submission._speaker
+          if (Array.isArray(speakersArr)) {
+            speakerMatch = speakersArr.some((s) => s?.full_name?.toLowerCase().includes(search))
+          }
+        }
+        return title.includes(search) || speakerMatch
       })
     }
 
     submissions.data = filtered
-  }
+  },
 )
-
 </script>
 <template>
   <Suspense>

--- a/dashboard/src/components/cfp-public/SubmissionsListView.vue
+++ b/dashboard/src/components/cfp-public/SubmissionsListView.vue
@@ -57,10 +57,29 @@ watch(
 watch(
   () => searchTitle.value,
   () => {
-    const _filters = { ...filters.value, talk_title: ['like', `${searchTitle.value}`] }
-    submissions.data = filterSubmissions(submissions.originalData, _filters)
-  },
+    const search = searchTitle.value.trim().toLowerCase()
+    let filtered = submissions.originalData
+
+    // Apply basic field filters (status, session_type, etc.)
+    if (filters.value) {
+      filtered = filterSubmissions(filtered, filters.value)
+    }
+
+    // Apply search on talk title or speaker name
+    if (search) {
+      filtered = filtered.filter(submission => {
+        const titleMatch = submission.talk_title?.toLowerCase().includes(search)
+        const speakerMatch = submission._speaker?.some(s =>
+          s.full_name?.toLowerCase().includes(search)
+        )
+        return titleMatch || speakerMatch
+      })
+    }
+
+    submissions.data = filtered
+  }
 )
+
 </script>
 <template>
   <Suspense>

--- a/dashboard/src/components/event/cfp/SubmissionsList.vue
+++ b/dashboard/src/components/event/cfp/SubmissionsList.vue
@@ -43,10 +43,22 @@ watch(
 watch(
   () => searchTitle.value,
   () => {
-    const _filters = { ...filters.value, talk_title: ['like', `${searchTitle.value}`] }
-    submissions.data = filterSubmissions(submissions.originalData, _filters)
-  },
+    const search = searchTitle.value.trim().toLowerCase()
+
+    if (!search) {
+      submissions.data = submissions.originalData
+      return
+    }
+
+    submissions.data = submissions.originalData.filter(sub => {
+      return (
+        sub.talk_title?.toLowerCase().includes(search) ||
+        sub.speaker_name?.toLowerCase().includes(search)
+      )
+    })
+  }
 )
+
 </script>
 
 <template>

--- a/fossunited/api/cfp.py
+++ b/fossunited/api/cfp.py
@@ -137,6 +137,28 @@ def get_cfp_submissions(event: str) -> list:
     # Bulk fetch review percentages
     review_percentages_data = _get_bulk_review_percentages_data(submission_names)
 
+    # Bulk fetch speakers for all submissions (outside selected range)
+    from collections import defaultdict
+
+    speakers_raw = frappe.db.get_all(
+        SPEAKER,
+        {"parent": ("in", submission_names)},
+        [
+            "parent",
+            "photo",
+            "full_name",
+            "designation",
+            "organization",
+            "linked_user",
+            "social_link",
+            "bio",
+        ],
+    )
+    speakers_by_submission = defaultdict(list)
+
+    for s in speakers_raw:
+        speakers_by_submission[s["parent"]].append(s)
+
     for submission in submissions:
         is_reviewed = submission.name in reviewed_submissions
         submission.update(
@@ -150,7 +172,7 @@ def get_cfp_submissions(event: str) -> list:
         submission.update(custom_answers_data.get(submission.name, {}))
         submission.update(review_percentages_data.get(submission.name, {}))
 
-        speakers = get_speakers(submission.name)
+        speakers = speakers_by_submission.get(submission.name, [])
         submission["speakers"] = speakers
         submission["speaker_name"] = ", ".join(
             s["full_name"] for s in speakers if s.get("full_name")

--- a/fossunited/api/cfp.py
+++ b/fossunited/api/cfp.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 import frappe
 
 from fossunited.api.proposal import _get_bulk_custom_answers_data
@@ -138,8 +140,6 @@ def get_cfp_submissions(event: str) -> list:
     review_percentages_data = _get_bulk_review_percentages_data(submission_names)
 
     # Bulk fetch speakers for all submissions (outside selected range)
-    from collections import defaultdict
-
     speakers_raw = frappe.db.get_all(
         SPEAKER,
         {"parent": ("in", submission_names)},
@@ -175,7 +175,7 @@ def get_cfp_submissions(event: str) -> list:
         speakers = speakers_by_submission.get(submission.name, [])
         submission["speakers"] = speakers
         submission["speaker_name"] = ", ".join(
-            s["full_name"] for s in speakers if s.get("full_name")
+            name for name in ((s.get("full_name") or "").strip() for s in speakers) if name
         )
 
     return submissions

--- a/fossunited/api/cfp.py
+++ b/fossunited/api/cfp.py
@@ -150,6 +150,12 @@ def get_cfp_submissions(event: str) -> list:
         submission.update(custom_answers_data.get(submission.name, {}))
         submission.update(review_percentages_data.get(submission.name, {}))
 
+        speakers = get_speakers(submission.name)
+        submission["speakers"] = speakers
+        submission["speaker_name"] = ", ".join(
+            s["full_name"] for s in speakers if s.get("full_name")
+        )
+
     return submissions
 
 


### PR DESCRIPTION
- just searching by cfp title is tedious, we can include speaker name as well to help narrow down info

## 🚦 Status

- [ ] Draft
- [x] Ready for review

---

## 🔗 Related Issue

Closes / Addresses: #1122

---

## ❗ Problem

<!-- Briefly describe the problem or motivation for this PR -->
searching only by talk title is tedious, and speaker name adds an additional info to narrow down

---

## ✅ Solution

<!-- Describe your solution and what you changed -->
Include fetching speaker names to help in filtering of all CFP

---

## 📋 Progress (All must be checked to merge)

- [x] Tested locally

---

## 📝 Changelog

<commit>: <!-- e.g., feat: add user login endpoint -->

---

## 🖼️ Visualization

<!-- Add screenshots, diagrams, or screen recordings if applicable -->
<img width="300" height="180" alt="image" src="https://github.com/user-attachments/assets/5b31c626-52ba-4a8f-bd5b-b1fe376eac8b" />


---

## 🔮 Further Ahead

<!-- Mention any follow-up work or related PRs planned -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Search submissions by talk title or speaker name (case-insensitive).

- Improvements
  - Clearing search restores the full list and respects other applied filters.
  - Search now applies after existing filters (two-stage filtering) for more accurate results.
  - Submission entries include associated speaker details for richer display and more reliable filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->