### PR TITLE
add small doc on event permalink

### DIFF
--- a/dashboard/src/pages/CreateEventForm.vue
+++ b/dashboard/src/pages/CreateEventForm.vue
@@ -33,13 +33,14 @@
               :type="'text'"
               size="md"
               label="Event Permalink&ast;"
+              description="This text will be added to the event URL, creating a link in the format: <event-page>/<event-permalink>"
             />
             <FormControl
               :value="getEventLink()"
               size="md"
               label="Event Link"
               :disabled="true"
-              description="The event link will be as shown above."
+              description="The event URL will appear as shown above, using the structure: <event-page>/<event-permalink>."
             />
             <FormControl
               v-model="temp_event.status"


### PR DESCRIPTION
simple doc for description part.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Clarified copy for the Event Permalink field to explain it appends to the event URL as <event-page>/<event-permalink>.
  * Updated the Event Link field description to reference and match the displayed URL structure.

* **Documentation**
  * Improved in-app helper text to make the resulting event URL format explicit.

* **Chores**
  * No functional changes; adjustments limited to UI copy for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->