### PR TITLE
Minor schedule fixes and enhancement

### DIFF
--- a/dashboard/src/components/schedule/EventCalendar.vue
+++ b/dashboard/src/components/schedule/EventCalendar.vue
@@ -1,31 +1,75 @@
 <template>
-  <div class="flex flex-wrap items-center gap-2">
-    <!-- Day Dropdown -->
-    <select
-      v-model="selectedDay"
-      class="px-2 py-1 bg-gray-100 border border-gray-300 text-xs rounded-[2px] focus:outline-none min-w-[100px]"
-    >
-      <option value="">All Days</option>
-      <option v-for="day in allDates" :key="day" :value="day">{{ day }}</option>
-    </select>
-
-    <!-- Hall Dropdown -->
-    <select
-      v-model="selectedHall"
-      class="px-2 py-1 bg-gray-100 border border-gray-300 text-xs rounded-[2px] focus:outline-none min-w-[100px]"
-    >
-      <option value="">All Halls</option>
-      <option v-for="hall in allHalls" :key="hall" :value="hall">{{ hall }}</option>
-    </select>
-
-    <!-- Download Button -->
+  <div>
+    <!-- Main Download Button -->
     <button
-      class="px-2 py-1 bg-gray-900 text-white text-xs font-medium rounded-[2px] flex items-center gap-1"
-      @click="handleDownload"
+      class="px-2 py-2 bg-gray-900 text-white text-xs font-medium rounded flex items-center gap-1"
+      @click="showDownloadModal = true"
     >
       <IconCalendarPlus class="w-4 h-4" />
       <span class="hidden md:inline uppercase">Download .ics</span>
     </button>
+
+    <!-- Modal -->
+    <div
+      v-if="showDownloadModal"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70"
+    >
+      <div class="bg-white rounded-md shadow-md p-4 w-[90%] max-w-sm">
+        <div class="flex justify-between items-center mb-4">
+          <h3 class="text-sm font-medium">
+            Download Calendar (.ics) for {{ props.event.event_name }}
+          </h3>
+          <button
+            class="text-gray-500 hover:text-black text-lg"
+            @click="showDownloadModal = false"
+          >
+            ×
+          </button>
+        </div>
+
+        <div class="flex flex-col gap-3">
+          <!-- Day Dropdown -->
+          <label class="text-xs">
+            Day
+            <select
+              v-model="selectedDay"
+              class="w-full mt-1 px-2 py-1 border border-gray-300 text-lg rounded bg-gray-900 text-white"
+            >
+              <option value="">All Days</option>
+              <option v-for="day in allDates" :key="day" :value="day">{{ day }}</option>
+            </select>
+          </label>
+
+          <!-- Hall Dropdown -->
+          <label class="text-xs">
+            Hall
+            <select
+              v-model="selectedHall"
+              class="w-full mt-1 px-2 py-1 border border-gray-300 text-lg rounded bg-gray-900 text-white"
+            >
+              <option value="">All Halls</option>
+              <option v-for="hall in allHalls" :key="hall" :value="hall">{{ hall }}</option>
+            </select>
+          </label>
+
+          <!-- Buttons -->
+          <div class="flex justify-end gap-2 mt-4">
+            <button
+              class="text-xs text-gray-600 hover:underline"
+              @click="showDownloadModal = false"
+            >
+              Cancel
+            </button>
+            <button
+              class="px-3 py-2 bg-gray-900 text-white text-base font-medium rounded"
+              @click="confirmDownload"
+            >
+              Download
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -34,6 +78,8 @@ import { createEvents } from 'ics'
 import { IconCalendarPlus } from '@tabler/icons-vue'
 import { toast } from 'vue-sonner'
 import { computed, defineProps, inject, ref } from 'vue'
+
+const showDownloadModal = ref(false)
 
 const props = defineProps({
   event: {
@@ -179,5 +225,10 @@ function handleDownload() {
   }
 
   generateAndDownloadIcs(sessions, filename, props.event)
+}
+
+function confirmDownload() {
+  showDownloadModal.value = false
+  handleDownload()
 }
 </script>

--- a/dashboard/src/components/schedule/EventCalendar.vue
+++ b/dashboard/src/components/schedule/EventCalendar.vue
@@ -13,11 +13,14 @@
     <div
       v-if="showDownloadModal"
       class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70"
+      role="dialog"
+      aria-modal="true"
+      :aria-labelledby="'ics-modal-title'"
     >
       <div class="bg-white rounded-md shadow-md p-4 w-[90%] max-w-sm">
         <div class="flex justify-between items-center mb-4">
-          <h3 class="text-sm font-medium">
-            Download Calendar (.ics) for {{ props.event.event_name }}
+          <h3 id="ics-modal-title" class="text-sm font-medium">
+            Download Calendar (.ics) for {{ event.event_name }}
           </h3>
           <button
             class="text-gray-500 hover:text-black text-lg"

--- a/dashboard/src/components/schedule/ScheduleView.vue
+++ b/dashboard/src/components/schedule/ScheduleView.vue
@@ -1,30 +1,46 @@
 <template>
-  <div
-    class="flex gap-4 w-full my-6"
-    :class="{
-      'flex-col': view === 'vertical',
-      'overflow-x-scroll flex-row min-h-[800px]': view === 'horizontal',
-    }"
-  >
+  <div class="w-full my-6">
+    <!-- Fake scrollbar container at the top -->
     <div
-      v-for="(sessions, hall) in schedule"
-      :key="hall"
-      :class="{
-        'flex-shrink-0 basis-1/2': view === 'horizontal',
-      }"
+      ref="scrollTop"
+      class="overflow-x-scroll scrollbar-thick scrollbar-thumb-black-800 scrollbar-track-gray-300 mb-4"
+      @scroll="syncScroll('top')"
     >
-      <SessionListHeader
-        :title="hall"
-        :collapsible="isCollapsible"
-        :view="view"
-        @collapse-hall="toggleCollapse(hall)"
-      />
-      <SessionList v-if="!isCollapsed(hall)" :sessions="sessions" :view="view" />
+      <div :style="{ width: scrollWidth + 'px' }" class="h-4"></div>
+    </div>
+
+    <!-- original container, now scroll-disabled -->
+    <div
+      ref="scrollMain"
+      class="flex gap-4 w-full"
+      :class="{
+        'flex-col': view === 'vertical',
+        'flex-row min-h-[800px]': view === 'horizontal',
+      }"
+      style="overflow-x: scroll"
+      @scroll="syncScroll('main')"
+    >
+      <div
+        v-for="(sessions, hall) in schedule"
+        :key="hall"
+        :class="{
+          'flex-shrink-0 basis-1/2': view === 'horizontal',
+        }"
+      >
+        <SessionListHeader
+          :title="hall"
+          :collapsible="isCollapsible"
+          :view="view"
+          @collapse-hall="toggleCollapse(hall)"
+        />
+        <SessionList v-if="!isCollapsed(hall)" :sessions="sessions" :view="view" />
+      </div>
     </div>
   </div>
 </template>
+
 <script setup>
-import { defineProps, ref, computed, watch } from 'vue'
+import { defineProps, ref, computed, watch, onMounted, nextTick } from 'vue'
 import SessionList from '@/components/schedule/SessionList.vue'
 import SessionListHeader from '@/components/schedule/SessionListHeader.vue'
 
@@ -68,4 +84,22 @@ watch(
   },
   { immediate: true },
 )
+const scrollTop = ref(null)
+const scrollMain = ref(null)
+const scrollWidth = ref(0)
+
+const syncScroll = (source) => {
+  if (source === 'top') {
+    scrollMain.value.scrollLeft = scrollTop.value.scrollLeft
+  } else if (source === 'main') {
+    scrollTop.value.scrollLeft = scrollMain.value.scrollLeft
+  }
+}
+
+onMounted(() => {
+  nextTick(() => {
+    // Measure actual scrollable width from scrollMain’s content
+    scrollWidth.value = scrollMain.value.scrollWidth
+  })
+})
 </script>

--- a/dashboard/src/components/schedule/ScheduleView.vue
+++ b/dashboard/src/components/schedule/ScheduleView.vue
@@ -4,13 +4,14 @@
     <div
       v-if="view === 'horizontal'"
       ref="scrollTop"
-      class="overflow-x-scroll scrollbar-thick scrollbar-thumb-black-800 scrollbar-track-gray-300 mb-4"
+      aria-hidden="true"
+      role="presentation"
+      class="overflow-x-scroll scrollbar-thick scrollbar-thumb-gray-800 scrollbar-track-gray-300 mb-4"
       @scroll="syncScroll('top')"
     >
       <div :style="{ width: scrollWidth + 'px' }" class="h-4"></div>
     </div>
 
-    <!-- original container, now scroll-disabled -->
     <div
       ref="scrollMain"
       class="flex gap-4 w-full relative"
@@ -22,7 +23,7 @@
     >
       <!-- Your sessions -->
       <div
-        v-for="(sessions, hall) in schedule"
+        v-for="hall in orderedHalls"
         :key="hall"
         :class="{
           'flex-shrink-0 basis-1/2': view === 'horizontal',
@@ -34,14 +35,14 @@
           :view="view"
           @collapse-hall="toggleCollapse(hall)"
         />
-        <SessionList v-if="!isCollapsed(hall)" :sessions="sessions" :view="view" />
+        <SessionList v-if="!isCollapsed(hall)" :sessions="schedule[hall]" :view="view" />
       </div>
 
       <!-- Shadow indicator -->
     </div>
     <div
       v-if="view === 'horizontal' && showRightShadow"
-      class="absolute mt-10 top-0 right-0 h-full pointer-events-none w-15 transition-opacity duration-300"
+      class="absolute mt-10 top-0 right-0 h-full pointer-events-none w-16 transition-opacity duration-300"
       style="background: linear-gradient(to left, #a4a4a4, transparent)"
     ></div>
   </div>
@@ -57,10 +58,6 @@ const props = defineProps({
     type: Object,
     required: true,
   },
-  day: {
-    type: String,
-    required: true,
-  },
   view: {
     type: String,
     required: true,
@@ -69,6 +66,8 @@ const props = defineProps({
 })
 
 const isCollapsible = computed(() => props.view === 'vertical')
+
+const orderedHalls = computed(() => Object.keys(props.schedule || {}).sort())
 
 const collapsedHalls = ref({})
 
@@ -88,6 +87,8 @@ watch(
     if (view === 'vertical' && schedule) {
       collapsedHalls.value = Object.fromEntries(Object.keys(schedule).map((hall) => [hall, true]))
     }
+    // Recompute metrics after DOM updates caused by schedule/view changes
+    nextTick(() => updateScrollMetrics())
   },
   { immediate: true },
 )
@@ -109,28 +110,47 @@ const updateRightShadow = () => {
   showRightShadow.value = scrollPosition < scrollThreshold
 }
 
-const syncScroll = (source) => {
-  if (source === 'top') {
-    scrollMain.value.scrollLeft = scrollTop.value.scrollLeft
-  } else if (source === 'main') {
-    scrollTop.value.scrollLeft = scrollMain.value.scrollLeft
-  }
+// Prevent re-entrant scroll syncing
+const isSyncing = ref(false)
 
-  // After syncing, update shadow visibility
+// Keep scrollWidth and shadow in sync with the actual content
+const updateScrollMetrics = () => {
+  const container = scrollMain.value
+  if (!container) return
+  scrollWidth.value = container.scrollWidth
   updateRightShadow()
+}
+
+const syncScroll = (source) => {
+  // Only sync in horizontal view
+  if (props.view !== 'horizontal') return
+  const topEl = scrollTop.value
+  const mainEl = scrollMain.value
+  if (!topEl || !mainEl) return
+  if (isSyncing.value) return
+  isSyncing.value = true
+
+  if (source === 'top') {
+    mainEl.scrollLeft = topEl.scrollLeft
+  } else if (source === 'main') {
+    topEl.scrollLeft = mainEl.scrollLeft
+  }
+  updateRightShadow()
+  requestAnimationFrame(() => {
+    isSyncing.value = false
+  })
 }
 
 onMounted(() => {
   nextTick(() => {
-    scrollWidth.value = scrollMain.value.scrollWidth
-    updateRightShadow()
+    updateScrollMetrics()
   })
 
-  // Update shadow on window resize (optional but recommended)
-  window.addEventListener('resize', updateRightShadow)
+  // Keep metrics in sync on window resize
+  window.addEventListener('resize', updateScrollMetrics)
 })
 
 onBeforeUnmount(() => {
-  window.removeEventListener('resize', updateRightShadow)
+  window.removeEventListener('resize', updateScrollMetrics)
 })
 </script>

--- a/dashboard/src/components/schedule/ScheduleView.vue
+++ b/dashboard/src/components/schedule/ScheduleView.vue
@@ -24,7 +24,7 @@
   </div>
 </template>
 <script setup>
-import { defineProps, ref, computed } from 'vue'
+import { defineProps, ref, computed, watch } from 'vue'
 import SessionList from '@/components/schedule/SessionList.vue'
 import SessionListHeader from '@/components/schedule/SessionListHeader.vue'
 
@@ -58,4 +58,14 @@ const isCollapsed = (hall) => {
   // Collapse only matters in vertical view
   return props.view === 'vertical' && collapsedHalls.value[hall]
 }
+
+watch(
+  () => [props.schedule, props.view],
+  ([schedule, view]) => {
+    if (view === 'vertical' && schedule) {
+      collapsedHalls.value = Object.fromEntries(Object.keys(schedule).map((hall) => [hall, true]))
+    }
+  },
+  { immediate: true },
+)
 </script>

--- a/dashboard/src/components/schedule/ScheduleView.vue
+++ b/dashboard/src/components/schedule/ScheduleView.vue
@@ -2,7 +2,7 @@
   <div class="w-full my-6 relative">
     <!-- Fake scrollbar container at the top -->
     <div
-	  v-if="view === 'horizontal'"
+      v-if="view === 'horizontal'"
       ref="scrollTop"
       class="overflow-x-scroll scrollbar-thick scrollbar-thumb-black-800 scrollbar-track-gray-300 mb-4"
       @scroll="syncScroll('top')"
@@ -38,12 +38,12 @@
       </div>
 
       <!-- Shadow indicator -->
-      <div
-        v-if="view === 'horizontal' && showRightShadow"
-        class="absolute top-0 right-0 h-full pointer-events-none w-15 transition-opacity duration-300"
-        style="background: linear-gradient(to left, #a4a4a4, transparent)"
-      ></div>
     </div>
+    <div
+      v-if="view === 'horizontal' && showRightShadow"
+      class="absolute mt-10 top-0 right-0 h-full pointer-events-none w-15 transition-opacity duration-300"
+      style="background: linear-gradient(to left, #a4a4a4, transparent)"
+    ></div>
   </div>
 </template>
 
@@ -102,7 +102,11 @@ const showRightShadow = ref(false)
 const updateRightShadow = () => {
   const container = scrollMain.value
   if (!container) return
-  showRightShadow.value = container.scrollLeft + container.clientWidth < container.scrollWidth
+
+  const scrollPosition = container.scrollLeft + container.clientWidth
+  const scrollThreshold = container.scrollWidth * 0.9
+
+  showRightShadow.value = scrollPosition < scrollThreshold
 }
 
 const syncScroll = (source) => {

--- a/dashboard/src/components/schedule/ScheduleView.vue
+++ b/dashboard/src/components/schedule/ScheduleView.vue
@@ -10,7 +10,7 @@
       v-for="(sessions, hall) in schedule"
       :key="hall"
       :class="{
-        'min-w-[720px] flex-shrink-0': view === 'horizontal',
+        'flex-shrink-0 basis-1/2': view === 'horizontal',
       }"
     >
       <SessionListHeader

--- a/dashboard/src/components/schedule/ScheduleView.vue
+++ b/dashboard/src/components/schedule/ScheduleView.vue
@@ -1,7 +1,8 @@
 <template>
-  <div class="w-full my-6">
+  <div class="w-full my-6 relative">
     <!-- Fake scrollbar container at the top -->
     <div
+	  v-if="view === 'horizontal'"
       ref="scrollTop"
       class="overflow-x-scroll scrollbar-thick scrollbar-thumb-black-800 scrollbar-track-gray-300 mb-4"
       @scroll="syncScroll('top')"
@@ -12,14 +13,14 @@
     <!-- original container, now scroll-disabled -->
     <div
       ref="scrollMain"
-      class="flex gap-4 w-full"
+      class="flex gap-4 w-full relative"
       :class="{
         'flex-col': view === 'vertical',
-        'flex-row min-h-[800px]': view === 'horizontal',
+        'flex-row overflow-x-scroll min-h-[800px]': view === 'horizontal',
       }"
-      style="overflow-x: scroll"
       @scroll="syncScroll('main')"
     >
+      <!-- Your sessions -->
       <div
         v-for="(sessions, hall) in schedule"
         :key="hall"
@@ -35,12 +36,19 @@
         />
         <SessionList v-if="!isCollapsed(hall)" :sessions="sessions" :view="view" />
       </div>
+
+      <!-- Shadow indicator -->
+      <div
+        v-if="view === 'horizontal' && showRightShadow"
+        class="absolute top-0 right-0 h-full pointer-events-none w-15 transition-opacity duration-300"
+        style="background: linear-gradient(to left, #a4a4a4, transparent)"
+      ></div>
     </div>
   </div>
 </template>
 
 <script setup>
-import { defineProps, ref, computed, watch, onMounted, nextTick } from 'vue'
+import { defineProps, ref, computed, watch, onMounted, nextTick, onBeforeUnmount } from 'vue'
 import SessionList from '@/components/schedule/SessionList.vue'
 import SessionListHeader from '@/components/schedule/SessionListHeader.vue'
 
@@ -71,7 +79,6 @@ const toggleCollapse = (hall) => {
 }
 
 const isCollapsed = (hall) => {
-  // Collapse only matters in vertical view
   return props.view === 'vertical' && collapsedHalls.value[hall]
 }
 
@@ -84,9 +91,19 @@ watch(
   },
   { immediate: true },
 )
+
 const scrollTop = ref(null)
 const scrollMain = ref(null)
 const scrollWidth = ref(0)
+
+// New reactive state for shadow visibility
+const showRightShadow = ref(false)
+
+const updateRightShadow = () => {
+  const container = scrollMain.value
+  if (!container) return
+  showRightShadow.value = container.scrollLeft + container.clientWidth < container.scrollWidth
+}
 
 const syncScroll = (source) => {
   if (source === 'top') {
@@ -94,12 +111,22 @@ const syncScroll = (source) => {
   } else if (source === 'main') {
     scrollTop.value.scrollLeft = scrollMain.value.scrollLeft
   }
+
+  // After syncing, update shadow visibility
+  updateRightShadow()
 }
 
 onMounted(() => {
   nextTick(() => {
-    // Measure actual scrollable width from scrollMain’s content
     scrollWidth.value = scrollMain.value.scrollWidth
+    updateRightShadow()
   })
+
+  // Update shadow on window resize (optional but recommended)
+  window.addEventListener('resize', updateRightShadow)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', updateRightShadow)
 })
 </script>

--- a/dashboard/src/components/schedule/SessionList.vue
+++ b/dashboard/src/components/schedule/SessionList.vue
@@ -5,7 +5,11 @@
       'h-full': view === 'horizontal',
     }"
   >
-    <div v-for="session in sessions" :key="session.name" class="flex items-center">
+    <div
+      v-for="session in sessions"
+      :key="session.id ?? session.slug ?? session.name"
+      class="flex items-center"
+    >
       <div
         class="relative flex items-center justify-center"
         :class="{

--- a/dashboard/src/components/schedule/SessionList.vue
+++ b/dashboard/src/components/schedule/SessionList.vue
@@ -9,20 +9,20 @@
       <div
         class="relative flex items-center justify-center"
         :class="{
-          'flex-none w-1/12 md:w-1/6': view === 'vertical',
-          'flex-none md:w-1/5': view === 'horizontal',
+          'flex-none w-1/12 md:w-1/5': view === 'vertical',
+          'flex-none md:w-1/6': view === 'horizontal',
         }"
       >
         <div class="absolute inset-0 flex items-center">
           <div class="w-full h-px bg-gray-500"></div>
         </div>
-        <SessionTimeComponent :session="session" class="z-20 mx-5 invisible md:visible shrink-0" />
+        <SessionTimeComponent :session="session" class="z-20 invisible md:visible shrink-0" />
       </div>
       <div
         class="relative flex flex-col items-start"
         :class="{
           'w-full md:w-4/5': view === 'vertical',
-          'w-4/6': view === 'horizontal',
+          'w-full': view === 'horizontal',
         }"
       >
         <SessionTimeComponent

--- a/dashboard/src/components/schedule/SessionListHeader.vue
+++ b/dashboard/src/components/schedule/SessionListHeader.vue
@@ -1,19 +1,16 @@
 <template>
   <div
-    class="w-full flex justify-between px-7 py-3 bg-gray-900 text-white"
+    class="w-auto flex justify-between px-7 py-3 bg-gray-900 text-white cursor-pointer"
     :class="['sticky z-30', view === 'vertical' ? 'top-12' : 'top-0']"
+    @click="collapsible && handleCollapse()"
   >
     <h3 class="text-lg font-medium">{{ title }}</h3>
-    <button
-      v-if="collapsible"
-      class="transition-transform"
-      :class="isCollapsed ? 'rotate-180' : ''"
-      @click="handleCollapse()"
-    >
+    <span v-if="collapsible" class="transition-transform" :class="isCollapsed ? 'rotate-180' : ''">
       <IconCaretDownFilled />
-    </button>
+    </span>
   </div>
 </template>
+
 <script setup>
 import { IconCaretDownFilled } from '@tabler/icons-vue'
 import { defineProps, defineEmits, ref } from 'vue'

--- a/dashboard/src/components/schedule/SessionListHeader.vue
+++ b/dashboard/src/components/schedule/SessionListHeader.vue
@@ -1,14 +1,22 @@
 <template>
-  <div
-    class="w-auto flex justify-between px-7 py-3 bg-gray-900 text-white cursor-pointer"
-    :class="['sticky z-30', view === 'vertical' ? 'top-12' : 'top-0']"
+  <button
+    type="button"
+    class="w-full flex justify-between px-7 py-3 bg-gray-900 text-white"
+    :class="[
+      'sticky z-30',
+      view === 'vertical' ? 'top-12' : 'top-0',
+      collapsible ? 'cursor-pointer' : 'cursor-default',
+    ]"
+    :aria-expanded="collapsible ? !isCollapsed : undefined"
     @click="collapsible && handleCollapse()"
+    @keydown.enter.prevent="collapsible && handleCollapse()"
+    @keydown.space.prevent="collapsible && handleCollapse()"
   >
     <h3 class="text-lg font-medium">{{ title }}</h3>
     <span v-if="collapsible" class="transition-transform" :class="isCollapsed ? 'rotate-180' : ''">
       <IconCaretDownFilled />
     </span>
-  </div>
+  </button>
 </template>
 
 <script setup>
@@ -26,7 +34,7 @@ const props = defineProps({
   },
   view: {
     type: String,
-    required: true,
+    required: false,
     default: 'vertical',
   },
 })
@@ -35,7 +43,8 @@ const emit = defineEmits(['collapse-hall'])
 const isCollapsed = ref(false)
 
 const handleCollapse = () => {
-  emit('collapse-hall')
-  isCollapsed.value = !isCollapsed.value
+  const next = !isCollapsed.value
+  isCollapsed.value = next
+  emit('collapse-hall', next)
 }
 </script>

--- a/dashboard/src/components/schedule/SessionTimeComponent.vue
+++ b/dashboard/src/components/schedule/SessionTimeComponent.vue
@@ -2,8 +2,6 @@
   <div class="px-3 py-2 flex flex-col items-center gap-1 border border-gray-500 bg-white h-fit">
     <div class="flex gap-1 text-sm font-semibold">
       <span>{{ getFormattedTime(session.start_time) }}</span>
-      <span v-if="session.category == 'Break'">-</span>
-      <span v-if="session.category == 'Break'">{{ getFormattedTime(session.end_time) }}</span>
     </div>
     <div
       v-if="session.category !== 'Break'"


### PR DESCRIPTION
## 🚦 Status

- [ ] Draft
- [x] Ready for review

---

## 🔗 Related Issue

Closes / Addresses: #1124 (stage 1 to clear out annoyances from schedule page)
Stage 2 will be to fully re-design based on new design (maybe this week itself or for next year IndiaFoss)

---

## ❗ Problem

<!-- Briefly describe the problem or motivation for this PR -->
Many users claimed annoyance and non-usability of horizontal view.

---

## ✅ Solution

<!-- Describe your solution and what you changed -->
Addressed most of it, made it compact and clear.

---

## 📋 Progress (All must be checked to merge)

- [x] Tested locally

---

## 📝 Changelog

<commit>: <!-- e.g., feat: add user login endpoint -->
<img width="700" height="300" alt="image" src="https://github.com/user-attachments/assets/d77c9106-b683-4564-966f-d9bdcfe8a55f" />

^ Shadow and compact horiz view

<img width="700" height="250" alt="image" src="https://github.com/user-attachments/assets/7b9e1bb8-5ec7-49f6-8271-20f46410aec7" />

^ New popup for downloading ics (no more confusion with filtering of events)

---

## 🖼️ Visualization

<!-- Add screenshots, diagrams, or screen recordings if applicable -->

---

## 🔮 Further Ahead

<!-- Mention any follow-up work or related PRs planned -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calendar download now opens a confirmation modal with Day/Hall selectors.
  * Horizontal schedule view adds a synced top scrollbar and right-edge shadow for scroll cues.
  * Hall headers are now interactive to collapse/expand sections.

* **Style**
  * Adjusted spacing and widths in vertical/horizontal schedule layouts for improved readability.
  * Calendar download button styling and container layout updated.
  * Break sessions now show start time only (end time/dash removed).

* **Accessibility**
  * Hall headers support keyboard activation and reflect expanded/collapsed state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->