### PR TITLE
make ticket transfer process api public

### DIFF
--- a/fossunited/api/tickets.py
+++ b/fossunited/api/tickets.py
@@ -54,7 +54,7 @@ def create_transfer_request(ticket: str, receiver_details: dict):
     return transfer_request
 
 
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
 def get_transfer_doc_validity(transfer_id: str):
     """
     Check the validity of transfer doc/id
@@ -64,7 +64,7 @@ def get_transfer_doc_validity(transfer_id: str):
     return bool(is_valid_id)
 
 
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
 def get_transfer_details(id: str):
     """
     Get the transfer doc
@@ -78,7 +78,7 @@ def get_transfer_details(id: str):
     return doc
 
 
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
 def change_transfer_status(transfer_id: str, status: str):
     """
     Change the status of the transfer request


### PR DESCRIPTION
The ticket transfer approval and rejection page was not working due to some api having permission error.

Since these are just ticket transfer api, made it to allow guest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Guest users can now check the validity of a ticket transfer via public API (no login required).
  * Guest users can view ticket transfer details via public API.
  * Guest users can update the status of a ticket transfer via public API when provided with a valid transfer reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->