### PR TITLE
Add Zulip logo for chapters

### DIFF
--- a/dashboard/src/pages/ChapterDetails.vue
+++ b/dashboard/src/pages/ChapterDetails.vue
@@ -201,6 +201,7 @@
           <template #prefix>
             <IconBrandTelegram class="w-5 text-gray-800" />
           </template>
+        </FormControl>
         <FormControl v-model="chapter.doc.zulip" :type="'url'" size="md" label="Zulip">
           <template #prefix>
             <IconBrandZulip class="w-5 text-gray-800" />

--- a/dashboard/src/pages/ChapterDetails.vue
+++ b/dashboard/src/pages/ChapterDetails.vue
@@ -245,6 +245,7 @@ import {
   IconBrandMastodon,
   IconBrandX,
   IconBrandTelegram,
+  IconBrandZulip,
   IconBrandBluesky,
   IconBrandMatrix,
   IconBrandWhatsapp,

--- a/dashboard/src/pages/ChapterDetails.vue
+++ b/dashboard/src/pages/ChapterDetails.vue
@@ -201,6 +201,10 @@
           <template #prefix>
             <IconBrandTelegram class="w-5 text-gray-800" />
           </template>
+        <FormControl v-model="chapter.doc.zulip" :type="'url'" size="md" label="Zulip">
+          <template #prefix>
+            <IconBrandZulip class="w-5 text-gray-800" />
+          </template>
         </FormControl>
         <FormControl v-model="chapter.doc.bluesky" :type="'url'" size="md" label="Bluesky">
           <template #prefix>

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.json
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.json
@@ -280,7 +280,7 @@
    "link_fieldname": "chapter"
   }
  ],
- "modified": "2025-08-11 12:59:52.035174",
+ "modified": "2025-09-07 09:45:30.000000",
  "modified_by": "Administrator",
  "module": "Chapters",
  "name": "FOSS Chapter",

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.json
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.json
@@ -39,6 +39,7 @@
   "instagram",
   "mastodon",
   "telegram",
+  "zulip",
   "bluesky",
   "whatsapp",
   "discord",
@@ -239,6 +240,12 @@
    "fieldtype": "Data",
    "label": "Telegram",
    "options": "URL"
+  },
+  {
+    "fieldname": "zulip",
+    "fieldtype": "Data",
+    "label": "Zulip",
+    "options": "URL"
   },
   {
    "fieldname": "bluesky",

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
@@ -44,6 +44,7 @@ class FOSSChapter(WebsiteGenerator):
         slug: DF.Data | None
         state: DF.Link | None
         telegram: DF.Data | None
+        zulip: DF.Data | None
         bluesky: DF.Data | None
         whatsapp: DF.Data | None
         x: DF.Data | None
@@ -238,6 +239,7 @@ class FOSSChapter(WebsiteGenerator):
             "matrix",
             "bluesky",
             "telegram",
+            "zulip",
             "github",
             "gitlab",
             "youtube",


### PR DESCRIPTION
## 🚦 Status

- [x] Ready for review

---

## 🔗 Related Issue

Closes / Addresses: #1064

---

## ❗ Problem

<!-- Briefly describe the problem or motivation for this PR -->

I was unable to add Zulip and Bluesky as a support platform for the chapters' pages. Bluesky was addressed via #1079.

---

## ✅ Solution

<!-- Describe your solution and what you changed -->

This PR follows the same format and adds Zulip to the chapter doctype. The Zulip icon was recently included via https://github.com/pheralb/svgl/pull/701.

---

## 📋 Progress (All must be checked to merge)

- [ ] Tested locally

---

## 📝 Changelog

feat: add Zulip icon to chapter details components
chore: update mtime for chapter doctype

---

## 🖼️ Visualization

<!-- Add screenshots, diagrams, or screen recordings if applicable -->

---

## 🔮 Further Ahead

<!-- Mention any follow-up work or related PRs planned -->

N/A



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Zulip as a supported social link for chapters. A new URL input for Zulip now appears in Chapter Details (Socials) with a Zulip icon and consistent styling.
  * Zulip links are included wherever chapter social links are displayed and shared, appearing alongside existing platforms and ordered after Telegram for predictable placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->