### PR TITLE
show only conf and city chapter events on main /events page

### DIFF
--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -207,19 +207,25 @@ def get_main_foss_events():
             "event_end_date": [">=", frappe.utils.now()],
         },
         order_by="event_start_date",
+        page_length=100,
     )
 
     allowed_types = {"City Community", "Conference"}
-    chapter_type_cache = {}
     filtered_events = []
 
+    chapters = list({e.get("chapter") for e in events if e.get("chapter")})
+    chapter_type_map = {}
+    if chapters:
+        rows = frappe.db.get_all(
+            CHAPTER,
+            filters={"name": ["in", chapters]},
+            fields=["name", "chapter_type"],
+        )
+        chapter_type_map = {r.name: r.chapter_type for r in rows}
+
     for event in events:
-        chapter = event.get("chapter")
-        if not chapter:
-            continue
-        if chapter not in chapter_type_cache:
-            chapter_type_cache[chapter] = frappe.db.get_value(CHAPTER, chapter, "chapter_type")
-        if chapter_type_cache[chapter] in allowed_types:
+        ctype = chapter_type_map.get(event.get("chapter"))
+        if ctype in allowed_types:
             filtered_events.append(event)
 
     return filtered_events[:12]

--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -193,6 +193,38 @@ def validate_profile_completion():
     )
 
 
+def get_main_foss_events():
+    """
+    Get main foss events to be shown for grid page in /events
+    only for City chapters and Conferences
+    """
+    events = frappe.get_all(
+        EVENT,
+        fields=["*"],
+        filters={
+            "status": "Live",
+            "is_published": 1,
+            "event_end_date": [">=", frappe.utils.now()],
+        },
+        order_by="event_start_date",
+    )
+
+    allowed_types = {"City Community", "Conference"}
+    chapter_type_cache = {}
+    filtered_events = []
+
+    for event in events:
+        chapter = event.get("chapter")
+        if not chapter:
+            continue
+        if chapter not in chapter_type_cache:
+            chapter_type_cache[chapter] = frappe.db.get_value(CHAPTER, chapter, "chapter_type")
+        if chapter_type_cache[chapter] in allowed_types:
+            filtered_events.append(event)
+
+    return filtered_events[:12]
+
+
 def get_grouped_events_by_chapter_type():
     """
     Retrieves FOSS Chapter Events and Hackathons,

--- a/fossunited/fossunited/web_template/upcoming_foss_events_section/upcoming_foss_events_section.html
+++ b/fossunited/fossunited/web_template/upcoming_foss_events_section/upcoming_foss_events_section.html
@@ -23,7 +23,7 @@
     flex-direction: column;
     gap: 1rem;
   }
-  .upcoming-events-header h4{
+  .upcoming-events-header h4 {
     font-size: var(--text-2xl);
     font-weight: var(--fw-semibold);
   }
@@ -54,13 +54,15 @@
     </div>
 
     {% from "fossunited/templates/macros/event_card.html" import event_card %}
-
-	{% set events = get_main_foss_events() %}
+    {% set events = get_main_foss_events() %}
 
     {% if events | length %}
       <div class="events-grid-4">{% for event in events %}{{ event_card(event) }}{% endfor %}</div>
     {% else %}
-      <p>No upcoming events.</p>
+      <p>
+        No upcoming events.
+        <a class="view-events-link" href="{{ view_events_link }}">Browse all events ↗</a>
+      </p>
     {% endif %}
   </div>
 </div>

--- a/fossunited/fossunited/web_template/upcoming_foss_events_section/upcoming_foss_events_section.html
+++ b/fossunited/fossunited/web_template/upcoming_foss_events_section/upcoming_foss_events_section.html
@@ -54,18 +54,9 @@
     </div>
 
     {% from "fossunited/templates/macros/event_card.html" import event_card %}
-    {%
-      set events = frappe.get_all(
-      "FOSS Chapter Event",
-      fields=["*"],
-      filters={
-        "status": "Live",
-        "is_published": 1,
-        "event_end_date": ['>=', frappe.utils.now()],
-      },
-      page_length=12,
-      order_by='event_start_date')
-    %}
+
+	{% set events = get_main_foss_events() %}
+
     {% if events | length %}
       <div class="events-grid-4">{% for event in events %}{{ event_card(event) }}{% endfor %}</div>
     {% else %}

--- a/fossunited/hooks.py
+++ b/fossunited/hooks.py
@@ -50,6 +50,7 @@ jinja = {
         "fossunited.fossunited.utils.get_grouped_events_by_chapter_type",
         "fossunited.fossunited.utils.get_chapter_details",
         "fossunited.stack.utils.get_stack_dict",
+        "fossunited.fossunited.utils.get_main_foss_events",
     ],
     "filters": [
         "fossunited.fossunited.utils.make_badge",


### PR DESCRIPTION
- Previously only focused on de-cluttering timeline
- But main page should also be focused on important events

## 🚦 Status

- [x] Ready for review

---

## 🔗 Related Issue

Closes / Addresses: #1144

---

## ❗ Problem

<!-- Briefly describe the problem or motivation for this PR -->
Again, Foss club events clutter the main page as well
Prev only did on events/timeline page.

---

## ✅ Solution

<!-- Describe your solution and what you changed -->
Moved the direct simple call to `utils.py` to handle the events filter only for conf and chapter type and to show only 12

---

## 📋 Progress (All must be checked to merge)

- [x] Tested locally

---

## 📝 Changelog

<commit>: <!-- e.g., feat: add user login endpoint -->

---

## 🖼️ Visualization

<!-- Add screenshots, diagrams, or screen recordings if applicable -->
I dont have much events locally made to show, should see it in live action.

---

## 🔮 Further Ahead

<!-- Mention any follow-up work or related PRs planned -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upcoming Events now highlights main FOSS events from city communities and conferences, ordered by start date and capped at 12 for a cleaner, more relevant view.
  * Adds a “Browse all events” link and a clear multi-line “No upcoming events.” message when none are found.

* **Improvements**
  * Centralized event retrieval for more consistent rendering and responsiveness of the events section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->