### PR TITLE
feat: Add Bluesky as an option for user profiles, and include Dev.to in user profile headers

### DIFF
--- a/dashboard/src/pages/MyProfile.vue
+++ b/dashboard/src/pages/MyProfile.vue
@@ -186,6 +186,7 @@
             <FormControl v-model="profile_dict.devto" type="url" label="Dev.to" />
             <FormControl v-model="profile_dict.medium" type="url" label="Medium" />
             <FormControl v-model="profile_dict.mastodon" type="url" label="Mastodon" />
+            <FormControl v-model="profile_dict.bluesky" type="url" label="Bluesky" />
             <ErrorMessage class="col-span-2" :message="updateErrors" />
             <div class="hidden md:block"></div>
             <div class="flex justify-end">
@@ -230,6 +231,7 @@ const profile_dict = reactive({
   devto: '',
   medium: '',
   mastodon: '',
+  bluesky: '',
 })
 
 const profile = createResource({
@@ -358,6 +360,7 @@ const updateProfileErrors = () => {
     devto: profile_dict.devto,
     medium: profile_dict.medium,
     mastodon: profile_dict.mastodon,
+    bluesky: profile_dict.bluesky,
   }
   Object.keys(socials).forEach((key) => {
     const url = socials[key]

--- a/fossunited/api/dashboard.py
+++ b/fossunited/api/dashboard.py
@@ -121,7 +121,7 @@ def get_session_user_profile():
             "gitlab",
             "linkedin",
             "mastodon",
-            "mastodon",
+            "bluesky",
             "x",
             "instagram",
             "devto",

--- a/fossunited/api/profile.py
+++ b/fossunited/api/profile.py
@@ -125,6 +125,7 @@ def update_profile(fields_dict):
             "devto": fields_dict.get("devto"),
             "medium": fields_dict.get("medium"),
             "mastodon": fields_dict.get("mastodon"),
+            "bluesky": fields_dict.get("bluesky"),
         }
 
         profile = frappe.get_doc(USER_PROFILE, user_doc.name)

--- a/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.json
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.json
@@ -301,7 +301,7 @@
   "index_web_pages_for_search": 1,
   "is_published_field": "is_published",
   "links": [],
-  "modified": "2025-06-10 16:36:59.223147",
+  "modified": "2025-09-08 18:12:00.000000",
   "modified_by": "Administrator",
   "module": "FOSS Profiles",
   "name": "FOSS User Profile",

--- a/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.json
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.json
@@ -36,6 +36,7 @@
     "gitlab",
     "linkedin",
     "mastodon",
+    "bluesky",
     "medium",
     "column_break_hmr6",
     "x",
@@ -208,6 +209,12 @@
       "fieldname": "mastodon",
       "fieldtype": "Data",
       "label": "Mastodon",
+      "options": "URL"
+    },
+    {
+      "fieldname": "bluesky",
+      "fieldtype": "Data",
+      "label": "Bluesky",
       "options": "URL"
     },
     {

--- a/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.py
@@ -69,6 +69,7 @@ class FOSSUserProfile(WebsiteGenerator):
         is_published: DF.Check
         linkedin: DF.Data | None
         mastodon: DF.Data | None
+        bluesky: DF.Data | None
         medium: DF.Data | None
         profile_photo: DF.AttachImage | None
         projects: DF.Table[FOSSUserProjects]

--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -110,6 +110,8 @@ def get_user_socials(foss_user):
         "instagram",
         "mastodon",
         "youtube",
+        "devto",
+        "bluesky",
     ]
 
     links = {}

--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -120,6 +120,8 @@ def get_user_socials(foss_user):
             field1 = field
             if field == "github":
                 field1 = "github_light"
+            elif field == "devto":
+                field1 = "devto-light"
             links[field1] = user[field]
 
     return links


### PR DESCRIPTION
## 🚦 Status

- [x] Ready for review

---

## 🔗 Related Issue

Closes / Addresses: As a follow-up to #1064

---

## ❗ Problem

<!-- Briefly describe the problem or motivation for this PR -->

Building on #1142, this PR adds the Bluesky social media platform as an option for user profiles, as discussed in https://github.com/fossunited/fossunited/pull/1142#issuecomment-3263768701.

---

## ✅ Solution

<!-- Describe your solution and what you changed -->

I updated the user profile doctype to include Bluesky as an option (a logo for it already exists and is being used), and I updated the user profile API files as needed.

---

## 📋 Progress (All must be checked to merge)

- [ ] Tested locally
- [ ] 

---

## 📝 Changelog

<commit>: <!-- e.g., feat: add user login endpoint -->

- feat: Add Bluesky for user profile doctype
- feat: add `FormControl` element for Bluesky
- feat: Add `bluesky` to API pages
- chore: Update mtime for user profile doctype update

---

## 🖼️ Visualization

<!-- Add screenshots, diagrams, or screen recordings if applicable -->

---

## 🔮 Further Ahead

<!-- Mention any follow-up work or related PRs planned -->

N/A



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Bluesky to Social Links in the profile editor with validation and save support.
  - Profile data now includes Bluesky across the app for consistent display and updates.
  - Session profile responses now include YouTube for more complete social info.
  - Social link extraction expanded to include Dev.to and Bluesky.

- **Chores**
  - Updated types/schema to support the new Bluesky field without changing runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->