### PR TITLE
show info error on free tier ticket transfer

### DIFF
--- a/dashboard/src/pages/TicketTransfer.vue
+++ b/dashboard/src/pages/TicketTransfer.vue
@@ -169,6 +169,13 @@ const ticket = createResource({
     }
   },
   onSuccess(data) {
+    if (data.tier && data.tier.toLowerCase().includes('free pass')) {
+      ticketValidateError.value =
+        'Free Pass tickets cannot be transferred. Please contact us via email.'
+      ticket.data = null // Clear ticket data to prevent showing
+      return
+    }
+
     event.fetch()
     receiver.wants_tshirt = data.wants_tshirt
     if (data.tshirt_size) {


### PR DESCRIPTION

---

## 🔗 Related Issue

Closes / Addresses: #1143

---

## ❗ Problem

<!-- Briefly describe the problem or motivation for this PR -->
The UX is not good if someone is trying to transfer a Free Pass ticket.
We can warn them, and then they can reach out to us via email to resolve on that.

---

## ✅ Solution

<!-- Describe your solution and what you changed -->

Simple error if tier is found to be a free pass

---

## 📋 Progress (All must be checked to merge)

- [x] Tested locally

---

## 📝 Changelog

<commit>: <!-- e.g., feat: add user login endpoint -->

---

## 🖼️ Visualization

<!-- Add screenshots, diagrams, or screen recordings if applicable -->
<img width="1060" height="391" alt="image" src="https://github.com/user-attachments/assets/268c0535-b476-4891-9c76-c57564301f36" />


---

## 🔮 Further Ahead

<!-- Mention any follow-up work or related PRs planned -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents transferring Free Pass tickets by adding a validation guard.
  * Displays a clear error message when a Free Pass ticket is scanned for transfer.
  * Hides blocked ticket details from the UI to avoid confusion.
  * Skips any follow-up updates (e.g., preferences) when the transfer is blocked.
  * Leaves the normal transfer flow unchanged for eligible tickets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->