### PR TITLE
fix event concluding scheduler

### DIFF
--- a/fossunited/scheduled_tasks.py
+++ b/fossunited/scheduled_tasks.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 
 import frappe
+from frappe.utils import now_datetime
 
 from fossunited.doctype_ids import (
     EVENT,
@@ -14,45 +15,45 @@ from fossunited.doctype_ids import (
 
 def conclude_events():
     """
-    Get all the events which have ended (end_date < today) and set their status to concluded
+    Get all the events which have ended (end_date < today) and set their status to concluded.
+    Also hide RSVP/CFP if present.
     """
+
     events = frappe.db.get_all(
         EVENT,
         {
-            "status": ["in", ["Live", "Cancelled"]],
-            "event_end_date": ["<", datetime.today()],
+            "status": "Live",
+            "event_end_date": ["<", now_datetime()],
         },
         ["name", "status", "event_end_date", "event_start_date"],
         page_length=999,
     )
 
     for event in events:
-        doc = frappe.get_doc(EVENT, event.name)
-        if doc.status == "Live":
-            doc.status = "Concluded"
-        else:
-            doc.status = "Cancelled"
-
-        doc.show_rsvp = 0
-        doc.show_cfp = 0
-
         try:
-            # Fetch linked RSVP/CFP by `event` (link to Event name) and update if present
+            doc = frappe.get_doc(EVENT, event.name)
+            doc.status = "Concluded"
+            doc.show_rsvp = 0
+            doc.show_cfp = 0
             doc.save(ignore_permissions=True)
-            past_rsvp = frappe.get_doc(EVENT_RSVP, {"event_name": doc.event_name})
-            if past_rsvp:
+
+            # Safely update RSVP if exists
+            if frappe.db.exists(EVENT_RSVP, {"event_name": doc.event_name}):
+                past_rsvp = frappe.get_doc(EVENT_RSVP, {"event_name": doc.event_name})
                 past_rsvp.is_published = 0
                 past_rsvp.save(ignore_permissions=True)
-            past_cfp = frappe.get_doc(EVENT_CFP, {"event_name": doc.event_name})
-            if past_cfp:
+
+            # Safely update CFP if exists
+            if frappe.db.exists(EVENT_CFP, {"event_name": doc.event_name}):
+                past_cfp = frappe.get_doc(EVENT_CFP, {"event_name": doc.event_name})
                 past_cfp.status = "Closed"
                 past_cfp.save(ignore_permissions=True)
-        except Exception as e:
+
+        except Exception:
             frappe.log_error(
-                frappe.get_traceback(),
-                f"Error while concluding events through scheduler- ID:{doc.name}\nError:{str(e)}",
+                title=f"Error concluding event: {event.name}",
+                message=frappe.get_traceback(),
             )
-            continue
 
 
 def update_past_job_status():
@@ -73,7 +74,6 @@ def update_past_job_status():
             job_doc = frappe.get_doc(JOB, jobs.name)
             job_doc.status = JOB_STATUS_EXPIRED
             job_doc.save(ignore_permissions=True)
-            frappe.db.commit()
 
             # Send notification email after successful update
             if job_doc.mail:

--- a/fossunited/scheduled_tasks.py
+++ b/fossunited/scheduled_tasks.py
@@ -37,17 +37,13 @@ def conclude_events():
             doc.show_cfp = 0
             doc.save(ignore_permissions=True)
 
-            # Safely update RSVP if exists
-            if frappe.db.exists(EVENT_RSVP, {"event_name": doc.event_name}):
-                past_rsvp = frappe.get_doc(EVENT_RSVP, {"event_name": doc.event_name})
-                past_rsvp.is_published = 0
-                past_rsvp.save(ignore_permissions=True)
+            rsvps = frappe.get_all(EVENT_RSVP, filters={"event": doc.name}, fields=["name"])
+            for r in rsvps:
+                frappe.db.set_value(EVENT_RSVP, r.name, "is_published", 0)
 
-            # Safely update CFP if exists
-            if frappe.db.exists(EVENT_CFP, {"event_name": doc.event_name}):
-                past_cfp = frappe.get_doc(EVENT_CFP, {"event_name": doc.event_name})
-                past_cfp.status = "Closed"
-                past_cfp.save(ignore_permissions=True)
+            cfps = frappe.get_all(EVENT_CFP, filters={"event": doc.name}, fields=["name"])
+            for c in cfps:
+                frappe.db.set_value(EVENT_CFP, c.name, "status", "Closed")
 
         except Exception:
             frappe.log_error(

--- a/fossunited/tests/test_scheduled_tasks.py
+++ b/fossunited/tests/test_scheduled_tasks.py
@@ -88,8 +88,8 @@ class TestScheduledTasks(FrappeTestCase):
 
         # Second event should not change it's status, since it was cancelled
         self.assertEqual(self.event2.status, "Cancelled")
-        self.assertEqual(self.event2_cfp.status, "Closed")
-        self.assertEqual(self.event2_rsvp.is_published, 0)
+        self.assertEqual(self.event2_cfp.status, "Live")
+        self.assertEqual(self.event2_rsvp.is_published, 1)
 
         # Third event is still live, since its end_date > mock date set here
         self.assertEqual(self.event3.status, "Live")


### PR DESCRIPTION
- due to Rsvp or cfp not found, the scheduler had errors without updating any events

- Related to #1080 

I guess i noticed it that time, but overlooked it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatically hides RSVP and closes CFP when an event concludes.

- Bug Fixes
  - Events now conclude only when currently live and after their end time, preventing ended events from appearing active.

- Reliability
  - More robust handling and logging around event conclusion to reduce failures; safer updates with fewer redundant commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->