### PR TITLE
fix event banner to show as it is without crop

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
+++ b/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
@@ -23,11 +23,13 @@
 {% macro header() %}
   <div class="container header-section-parent">
     <div class="header-section event-header">
-      <img
-        src="{{ doc.banner_image or '/assets/fossunited/images/defaults/event_banner.png' }}"
-        alt="Cover Image"
-        class="foss-banner-image header--banner"
-      />
+	  <div class="foss-banner-wrapper">
+		<img
+		  src="{{ doc.banner_image or '/assets/fossunited/images/defaults/event_banner.png' }}"
+		  alt="Cover Image"
+		  class="foss-banner-image"
+		  />
+	  </div>
       <div class="header--title-cta-parent">
         <div>
           {% if doc.chapter %}
@@ -59,12 +61,12 @@
             </a>
           {% endif %}
           {% if doc.is_paid_event %}
-            <button
-              class="primary-button ticket-button"
-              onClick="window.location.href='/dashboard/buy-tickets?event={{ doc.name }}'"
+            <a
+              class="primary-button"
+              href="/dashboard/buy-tickets?event={{ doc.name }}"
             >
               Buy Ticket
-            </button>
+            </a>
           {% endif %}
         </div>
       </div>
@@ -76,7 +78,7 @@
           background='hsl(var(--clr-foss-mint-100))', icon='star-filled')
         }}{% endif %}
       </div>
-      <div class="header-section--socials-event">
+      <div class="header-section--socials-event ml-5 md:ml-0">
         {% for (k,v) in social_links.items() %}
         <a href="{{ v }}" aria-label="{{ k|title }} for {{ doc.chapter_name }} chapter.">
           <img src="https://svgl.app/library/{{ k }}.svg" alt="{{ k|title }}" />

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -1357,11 +1357,17 @@ h6 {
   aspect-ratio: 1;
 }
 
+.foss-banner-wrapper {
+  display: grid;
+  place-items: center;
+}
 .foss-banner-image {
   width: 100%;
-  height: 18.75rem;
-  object-fit: cover;
+  height: auto;
+  display: block;
   border-radius: 1rem;
+  object-fit: contain;
+  object-position: center;
 }
 
 .buttons-group {


### PR DESCRIPTION
- make buy ticket button aligned with other button

- might fix #1048

Let the users take their choice of width/crop of image.
Site does not add hard rule to crop for width. It just fits now.


https://github.com/user-attachments/assets/4cbc17fd-e758-47ae-bbf6-e969023bb8cf


I've not tested much with all banners, but should work fine. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated event banner visuals to prevent cropping and scale responsively.
  * Simplified Buy Ticket button styling for a cleaner look.
  * Improved spacing of social links with responsive margins.

* **Refactor**
  * Reworked banner structure to use a dedicated wrapper and image class for more consistent layout across devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->