### PR TITLE
enhance mobile QR scan UX

### DIFF
--- a/dashboard/src/components/event/QRTicketScanner.vue
+++ b/dashboard/src/components/event/QRTicketScanner.vue
@@ -3,25 +3,33 @@
     v-if="modelValue"
     :class="[
       isFullscreen
-        ? 'fixed inset-10 sm:inset-10 z-50 bg-black flex rounded-[30px] items-center justify-center overflow-hidden'
+        ? 'fixed inset-0 z-50 bg-black/90 flex items-center justify-center overflow-hidden p-4 md:p-8'
         : 'relative my-4 mx-auto border border-gray-300 w-full max-w-md',
     ]"
   >
     <!-- Close Button -->
     <button
+      type="button"
+      aria-label="Close scanner"
+      title="Close"
       @click="emit('update:modelValue', false)"
-      class="absolute top-2 right-2 text-white text-6xl bg-red-500 font-bold bg-black bg-opacity-50 rounded-full w-9 h-9 flex items-center justify-center z-50"
+      class="absolute top-3 right-3 z-50 grid place-items-center w-10 h-10 rounded-full bg-red-600/60 text-white text-xl hover:bg-black/70 focus:outline-none focus:ring-2 focus:ring-white/70"
     >
-      ✕
+      <span aria-hidden="true">✕</span>
     </button>
 
     <!-- Camera wrapper with aspect ratio preserved -->
     <div
-      :class="[isFullscreen ? 'w-full max-w-md aspect-video' : 'w-full aspect-video']"
+      :class="[
+        isFullscreen
+          ? 'w-[80vw] h-[80vh] max-w-[864px] aspect-video rounded-2xl'
+          : 'w-full aspect-video rounded-xl',
+      ]"
       class="relative bg-black"
     >
       <qrcode-stream
         :constraints="{ facingMode: 'environment' }"
+        :paused="processing || !modelValue"
         @detect="onDetect"
         @camera-on="onCameraOn"
         @error="onError"
@@ -54,7 +62,7 @@
 
 <script setup>
 import { QrcodeStream } from 'vue-qrcode-reader'
-import { ref, computed, watch, onMounted } from 'vue'
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import { toast } from 'vue-sonner'
 
 // Props
@@ -74,8 +82,12 @@ const emit = defineEmits(['update:modelValue', 'scanned'])
 const processing = ref(false)
 const isMobile = ref(false)
 
-onMounted(() => {
+const updateIsMobile = () => {
   isMobile.value = window.innerWidth < 768 // Tailwind 'md' breakpoint
+}
+onMounted(() => {
+  updateIsMobile()
+  window.addEventListener('resize', updateIsMobile, { passive: true })
 })
 
 const isFullscreen = computed(() => {
@@ -114,8 +126,8 @@ function onDetect(detectedCodes) {
     if (!scannedId || !/^[A-Za-z0-9_-]{6,}$/.test(scannedId)) {
       throw new Error('Invalid scanned ID')
     }
-    emit('update:modelValue', false)
     emit('scanned', scannedId)
+    emit('update:modelValue', false)
   } catch (err) {
     toast.error('Invalid QR code or format')
     processing.value = false
@@ -137,6 +149,7 @@ function onError(error) {
     StreamApiNotSupportedError: 'Browser lacks required APIs',
   }
   toast.error(map[error?.name] || `Camera error: ${error?.message || 'Unknown'}`)
+  processing.value = false
   emit('update:modelValue', false)
 }
 
@@ -146,4 +159,15 @@ watch(
     if (visible) processing.value = false
   },
 )
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', updateIsMobile)
+})
 </script>
+<style scoped>
+:deep(video) {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+</style>

--- a/dashboard/src/components/event/QRTicketScanner.vue
+++ b/dashboard/src/components/event/QRTicketScanner.vue
@@ -1,38 +1,92 @@
 <template>
   <div
     v-if="modelValue"
-    class="my-4 mx-auto border border-gray-300"
-    :style="{ width: '100%', maxWidth: '24rem' }"
+    :class="[
+      isFullscreen
+        ? 'fixed inset-10 sm:inset-10 z-50 bg-black flex rounded-[30px] items-center justify-center overflow-hidden'
+        : 'relative my-4 mx-auto border border-gray-300 w-full max-w-md',
+    ]"
   >
-    <qrcode-stream
-      :constraints="{ facingMode: 'environment' }"
-      @detect="onDetect"
-      @camera-on="onCameraOn"
-      @error="onError"
-    />
+    <!-- Close Button -->
+    <button
+      @click="emit('update:modelValue', false)"
+      class="absolute top-2 right-2 text-white text-6xl bg-red-500 font-bold bg-black bg-opacity-50 rounded-full w-9 h-9 flex items-center justify-center z-50"
+    >
+      ✕
+    </button>
+
+    <!-- Camera wrapper with aspect ratio preserved -->
+    <div
+      :class="[isFullscreen ? 'w-full max-w-md aspect-video' : 'w-full aspect-video']"
+      class="relative bg-black"
+    >
+      <qrcode-stream
+        :constraints="{ facingMode: 'environment' }"
+        @detect="onDetect"
+        @camera-on="onCameraOn"
+        @error="onError"
+        class="absolute top-0 left-0 w-full h-full object-cover"
+      />
+
+      <!-- Corner overlay box -->
+      <div
+        v-if="showOverlay"
+        class="absolute inset-0 flex items-center justify-center pointer-events-none z-20"
+      >
+        <div class="relative w-3/4 max-w-xs h-40">
+          <div
+            class="absolute top-0 left-0 w-6 h-6 border-t-4 border-l-4 border-green-400 rounded-tl-md"
+          ></div>
+          <div
+            class="absolute top-0 right-0 w-6 h-6 border-t-4 border-r-4 border-green-400 rounded-tr-md"
+          ></div>
+          <div
+            class="absolute bottom-0 left-0 w-6 h-6 border-b-4 border-l-4 border-green-400 rounded-bl-md"
+          ></div>
+          <div
+            class="absolute bottom-0 right-0 w-6 h-6 border-b-4 border-r-4 border-green-400 rounded-br-md"
+          ></div>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup>
 import { QrcodeStream } from 'vue-qrcode-reader'
-import { ref, watch } from 'vue'
+import { ref, computed, watch, onMounted } from 'vue'
 import { toast } from 'vue-sonner'
 
 // Props
 const props = defineProps({
   modelValue: Boolean,
+  fullscreen: {
+    type: Boolean,
+    default: undefined,
+  },
+  showOverlay: {
+    type: Boolean,
+    default: true, // Show scan box by default
+  },
 })
 
-// Emits
 const emit = defineEmits(['update:modelValue', 'scanned'])
 const processing = ref(false)
+const isMobile = ref(false)
+
+onMounted(() => {
+  isMobile.value = window.innerWidth < 768 // Tailwind 'md' breakpoint
+})
+
+const isFullscreen = computed(() => {
+  return props.fullscreen !== undefined ? props.fullscreen : isMobile.value
+})
 
 function extractTicketId(input) {
   const s = String(input || '').trim()
   if (!s) return ''
   try {
     const u = new URL(s)
-    // Allow-list hosts; accept subdomains of these
     const allowedHosts = ['fossunited.org', 'fossunited.com', 'fossunited.in']
     const host = u.hostname.toLowerCase()
     const isAllowed = allowedHosts.some((h) => host === h || host.endsWith('.' + h))
@@ -50,39 +104,28 @@ function extractTicketId(input) {
   }
 }
 
-// Parse and validate scanned QR content
 function onDetect(detectedCodes) {
   const rawValue = detectedCodes[0]?.rawValue
-  if (!rawValue) return
-  if (processing.value) return
+  if (!rawValue || processing.value) return
   processing.value = true
 
-  if (import.meta?.env?.DEV) console.log('Scanned:', rawValue)
-
-  let scannedId
-
   try {
-    scannedId = extractTicketId(rawValue)
-
-    // Optionally validate scannedId format here, e.g. alphanumeric min length
+    const scannedId = extractTicketId(rawValue)
     if (!scannedId || !/^[A-Za-z0-9_-]{6,}$/.test(scannedId)) {
-      throw new Error('Invalid scanned ID format')
+      throw new Error('Invalid scanned ID')
     }
-
-    emit('update:modelValue', false) // Close scanner
-    emit('scanned', scannedId) // Emit normalized ID
+    emit('update:modelValue', false)
+    emit('scanned', scannedId)
   } catch (err) {
     toast.error('Invalid QR code or format')
     processing.value = false
   }
 }
 
-// Optional: camera success hook
 function onCameraOn() {
-  // Add torch support or loading state if needed
+  // Camera ready
 }
 
-// Handle camera access errors
 function onError(error) {
   console.error('Camera error:', error)
   const map = {
@@ -100,10 +143,7 @@ function onError(error) {
 watch(
   () => props.modelValue,
   (visible) => {
-    if (visible) {
-      // Reset internal state each time scanner is shown
-      processing.value = false
-    }
+    if (visible) processing.value = false
   },
 )
 </script>


### PR DESCRIPTION
- Added a popup window to occupy 80% screen for camera to scan Also overlay box as indicator (technically it does not play any role)

- Simply improved UX for mobile by making big screen camera default on mobile device

There was no delay with inline or this popup, so hopefully it won't slow

<img width="250" height="450" alt="image" src="https://github.com/user-attachments/assets/04afa6ff-6b80-47e1-8524-1455c9ddd543" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fullscreen QR ticket scanner with responsive layout (auto on mobile or toggle).
  * Close button to dismiss the scanner.
  * Camera view preserves aspect ratio and includes an optional corner overlay to highlight the scan area (overlay enabled by default).
  * Scanning pauses while processing or when scanner is hidden.

* **Bug Fixes**
  * Prevents duplicate scan handling and improves scanned-ID validation.
  * Clearer "Invalid scanned ID" message.
  * Automatically closes scanner on camera errors and resets processing when reopened.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->