### PR TITLE
feat: search support in schedule page

### DIFF
--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -113,6 +113,7 @@ declare module 'vue' {
     ScheduleView: typeof import('./src/components/schedule/ScheduleView.vue')['default']
     ScheduleViewToggle: typeof import('./src/components/schedule/ScheduleViewToggle.vue')['default']
     SearchComplete: typeof import('./src/components/ui/SearchComplete.vue')['default']
+    SearchSession: typeof import('./src/components/schedule/SearchSession.vue')['default']
     SendTestDialog: typeof import('./src/components/mailing/SendTestDialog.vue')['default']
     SessionCard: typeof import('./src/components/schedule/SessionCard.vue')['default']
     SessionDetailForm: typeof import('./src/components/cfp-public/SessionDetailForm.vue')['default']

--- a/dashboard/src/components/schedule/ScheduleDownload.vue
+++ b/dashboard/src/components/schedule/ScheduleDownload.vue
@@ -2,7 +2,7 @@
   <div>
     <!-- Open Modal Button -->
     <button class="flex bg-black text-white px-4 py-2 rounded text-sm" @click="showModal = true">
-      <IconDownload class="w-4 h-4 mr-1" />
+      <IconDownload class="w-auto h-3 mr-1" />
       <span class="hidden md:block uppercase">Download Schedule</span>
     </button>
 

--- a/dashboard/src/components/schedule/ScheduleDownload.vue
+++ b/dashboard/src/components/schedule/ScheduleDownload.vue
@@ -1,8 +1,12 @@
 <template>
   <div>
     <!-- Open Modal Button -->
-    <button class="flex bg-black text-white px-4 py-2 rounded text-sm" @click="showModal = true">
-      <IconDownload class="w-auto h-3 mr-1" />
+    <button
+      class="flex bg-black text-white px-4 py-2 rounded text-sm"
+      @click="showModal = true"
+      aria-label="Download schedule"
+    >
+      <IconDownload class="w-4 h-4 mr-1" />
       <span class="hidden md:block uppercase">Download Schedule</span>
     </button>
 

--- a/dashboard/src/components/schedule/SearchSession.vue
+++ b/dashboard/src/components/schedule/SearchSession.vue
@@ -8,8 +8,8 @@
     />
     <SessionList :sessions="filteredSessions" :view="'vertical'" />
     <div v-if="filteredSessions.length === 0" class="text-gray-500">
-      No sessions found matching "<strong>{{ query }}</strong
-      >"
+      No sessions found matching <strong>{{ query }}</strong
+      >.
     </div>
   </div>
 </template>
@@ -43,15 +43,31 @@ function flattenSchedule(schedule) {
   return all
 }
 
+const allSessions = computed(() => flattenSchedule(props.schedule))
 const filteredSessions = computed(() => {
   const query = props.query.trim().toLowerCase()
   if (!query) return []
 
-  return flattenSchedule(props.schedule).filter((session) => {
+  return allSessions.value.filter((session) => {
     const title = session.title?.toLowerCase() ?? ''
     const name = session.name?.toLowerCase() ?? ''
-    const speakers = (session.cfp_speakers ?? []).map((s) => s.full_name?.toLowerCase()).join(' ')
-    return name.includes(query) || title.includes(query) || speakers.includes(query)
+    const category = session.category?.toLowerCase() ?? ''
+    const speakers = (session.cfp_speakers ?? [])
+      .map((s) =>
+        [
+          s.full_name?.toLowerCase(),
+          s.designation?.toLowerCase(),
+          s.organization?.toLowerCase(),
+        ].join(' '),
+      )
+      .join(' ')
+
+    return (
+      name.includes(query) ||
+      title.includes(query) ||
+      speakers.includes(query) ||
+      category.includes(query)
+    )
   })
 })
 </script>

--- a/dashboard/src/components/schedule/SearchSession.vue
+++ b/dashboard/src/components/schedule/SearchSession.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="space-y-4">
+    <SessionListHeader
+      class="mt-14"
+      :title="`Search Results (${filteredSessions.length})`"
+      :collapsible="false"
+      :view="'vertical'"
+    />
+    <SessionList :sessions="filteredSessions" :view="'vertical'" />
+    <div v-if="filteredSessions.length === 0" class="text-gray-500">
+      No sessions found matching "<strong>{{ query }}</strong
+      >"
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import SessionList from '@/components/schedule/SessionList.vue'
+import SessionListHeader from '@/components/schedule/SessionListHeader.vue'
+
+const props = defineProps({
+  schedule: {
+    type: Object,
+    required: true, // all dates
+  },
+  query: {
+    type: String,
+    required: true,
+  },
+})
+
+// Flatten and filter all sessions
+function flattenSchedule(schedule) {
+  const all = []
+  for (const day of Object.values(schedule ?? {})) {
+    for (const hall of Object.values(day ?? {})) {
+      if (Array.isArray(hall)) {
+        all.push(...hall)
+      }
+    }
+  }
+  return all
+}
+
+const filteredSessions = computed(() => {
+  const query = props.query.trim().toLowerCase()
+  if (!query) return []
+
+  return flattenSchedule(props.schedule).filter((session) => {
+    const title = session.title?.toLowerCase() ?? ''
+    const name = session.name?.toLowerCase() ?? ''
+    const speakers = (session.cfp_speakers ?? []).map((s) => s.full_name?.toLowerCase()).join(' ')
+    return name.includes(query) || title.includes(query) || speakers.includes(query)
+  })
+})
+</script>

--- a/dashboard/src/components/schedule/SearchSession.vue
+++ b/dashboard/src/components/schedule/SearchSession.vue
@@ -7,7 +7,7 @@
       :view="'vertical'"
     />
     <SessionList :sessions="filteredSessions" :view="'vertical'" />
-    <div v-if="filteredSessions.length === 0" class="text-gray-500">
+    <div v-if="filteredSessions.length === 0" class="text-gray-500" aria-live="polite">
       No sessions found matching <strong>{{ query }}</strong
       >.
     </div>
@@ -37,6 +37,8 @@ function flattenSchedule(schedule) {
     for (const hall of Object.values(day ?? {})) {
       if (Array.isArray(hall)) {
         all.push(...hall)
+      } else if (hall && Array.isArray(hall.sessions)) {
+        all.push(...hall.sessions)
       }
     }
   }
@@ -49,25 +51,16 @@ const filteredSessions = computed(() => {
   if (!query) return []
 
   return allSessions.value.filter((session) => {
-    const title = session.title?.toLowerCase() ?? ''
-    const name = session.name?.toLowerCase() ?? ''
-    const category = session.category?.toLowerCase() ?? ''
-    const speakers = (session.cfp_speakers ?? [])
-      .map((s) =>
-        [
-          s.full_name?.toLowerCase(),
-          s.designation?.toLowerCase(),
-          s.organization?.toLowerCase(),
-        ].join(' '),
-      )
-      .join(' ')
-
-    return (
-      name.includes(query) ||
-      title.includes(query) ||
-      speakers.includes(query) ||
-      category.includes(query)
-    )
+    const parts = [
+      session.name,
+      session.title,
+      session.category,
+      ...(session.cfp_speakers ?? []).flatMap((s) => [s.full_name, s.designation, s.organization]),
+    ]
+      .filter(Boolean)
+      .map((s) => String(s).toLowerCase())
+    const haystack = parts.join(' ')
+    return haystack.includes(query)
   })
 })
 </script>

--- a/dashboard/src/pages/schedule/Schedule.vue
+++ b/dashboard/src/pages/schedule/Schedule.vue
@@ -12,7 +12,11 @@
       <div class="flex flex-col sm:flex-row justify-center items-start gap-6 mt-10">
         <input
           v-model="searchQuery"
-          type="text"
+          type="search"
+          aria-label="Search sessions"
+          autocomplete="off"
+          enterkeyhint="search"
+          spellcheck="false"
           placeholder="Search sessions..."
           class="border border-gray-700 rounded text-sm px-3 py-2 w-72 focus:ring-gray-800 focus:border-gray-900"
         />
@@ -20,7 +24,7 @@
       </div>
 
       <ScheduleView
-        v-if="!searchQuery"
+        v-if="!isSearching"
         :view="selectedScheduleView"
         :schedule="selectedSchedule"
         class="my-6"
@@ -55,6 +59,7 @@ const selectedDay = ref(null)
 const selectedSchedule = ref(null)
 const selectedScheduleView = ref(window.innerWidth >= 1024 ? 'horizontal' : 'vertical')
 const searchQuery = ref('')
+const isSearching = computed(() => searchQuery.value.trim().length > 0)
 
 const event = createResource({
   url: 'fossunited.api.dashboard.get_event_from_route',

--- a/dashboard/src/pages/schedule/Schedule.vue
+++ b/dashboard/src/pages/schedule/Schedule.vue
@@ -5,7 +5,11 @@
       <Breadcrumb class="mt-2" :items="breadcrumb_items" />
       <EventHeader :event="event.data" class="my-4 border-b border-gray-900 pb-4" />
       <ScheduleHeader :event="event.data" class="py-2" />
-      <div class="flex justify-between items-end gap-4 flex-wrap">
+      <div
+        class="flex justify-between items-end gap-4 flex-wrap"
+        :class="{ 'opacity-50 pointer-events-none': isSearching }"
+        :aria-disabled="isSearching"
+      >
         <ScheduleDateToggle v-model="selectedDay" :dates="eventDays" class="mt-4" />
         <ScheduleViewToggle v-model="selectedScheduleView" class="mt-4 hidden sm:block" />
       </div>
@@ -15,10 +19,11 @@
           type="search"
           aria-label="Search sessions"
           autocomplete="off"
+          autocapitalize="off"
           enterkeyhint="search"
           spellcheck="false"
           placeholder="Search sessions..."
-          class="border border-gray-700 rounded text-sm px-3 py-2 w-72 focus:ring-gray-800 focus:border-gray-900"
+          class="border border-gray-700 rounded text-sm px-3 py-2 w-full sm:max-w-sm focus:ring-gray-800 focus:border-gray-900"
         />
         <ScheduleDownload :schedule="schedule.data" :event="event.data" />
       </div>

--- a/dashboard/src/pages/schedule/Schedule.vue
+++ b/dashboard/src/pages/schedule/Schedule.vue
@@ -7,10 +7,26 @@
       <ScheduleHeader :event="event.data" class="py-2" />
       <div class="flex justify-between items-end gap-4 flex-wrap">
         <ScheduleDateToggle v-model="selectedDay" :dates="eventDays" class="mt-4" />
-        <ScheduleDownload :schedule="schedule.data" :event="event.data" class="mt-4" />
         <ScheduleViewToggle v-model="selectedScheduleView" class="mt-4 hidden sm:block" />
       </div>
-      <ScheduleView :view="selectedScheduleView" :schedule="selectedSchedule" class="my-6" />
+      <div class="flex flex-col sm:flex-row justify-center items-start gap-6 mt-10">
+        <input
+          v-model="searchQuery"
+          type="text"
+          placeholder="Search sessions..."
+          class="border border-gray-700 rounded text-sm px-3 py-2 w-72 focus:ring-gray-800 focus:border-gray-900"
+        />
+        <ScheduleDownload :schedule="schedule.data" :event="event.data" />
+      </div>
+
+      <ScheduleView
+        v-if="!searchQuery"
+        :view="selectedScheduleView"
+        :schedule="selectedSchedule"
+        class="my-6"
+      />
+
+      <SearchSession v-else :schedule="schedule.data" :query="searchQuery" />
     </div>
   </div>
   <div v-else>
@@ -27,6 +43,7 @@ import ScheduleHeader from '@/components/schedule/ScheduleHeader.vue'
 import ScheduleDateToggle from '@/components/schedule/ScheduleDateToggle.vue'
 import ScheduleViewToggle from '@/components/schedule/ScheduleViewToggle.vue'
 import ScheduleView from '@/components/schedule/ScheduleView.vue'
+import SearchSession from '@/components/schedule/SearchSession.vue'
 import { ref, computed, watch, provide } from 'vue'
 import { createResource, LoadingText, usePageMeta } from 'frappe-ui'
 import { useRoute } from 'vue-router'
@@ -37,6 +54,7 @@ const eventDays = ref([])
 const selectedDay = ref(null)
 const selectedSchedule = ref(null)
 const selectedScheduleView = ref(window.innerWidth >= 1024 ? 'horizontal' : 'vertical')
+const searchQuery = ref('')
 
 const event = createResource({
   url: 'fossunited.api.dashboard.get_event_from_route',


### PR DESCRIPTION
- show flat list of search results for sessions

## 🚦 Status

- [x] Ready for review

---

## 🔗 Related Issue

Closes / Addresses: #1158 

---

## ❗ Problem

<!-- Briefly describe the problem or motivation for this PR -->

Schedule is long that we need search for now.

---

## ✅ Solution

<!-- Describe your solution and what you changed -->

Search schedule session by name and speaker names

Show flat list (vertical) of search results irrespective of view or date chosen

- Any other field ? (i doubt anyone would search with other field in mind)

---

## 📋 Progress (All must be checked to merge)

- [x] Tested locally


---

## 📝 Changelog

<commit>: <!-- e.g., feat: add user login endpoint -->

---

## 🖼️ Visualization

<!-- Add screenshots, diagrams, or screen recordings if applicable -->

https://github.com/user-attachments/assets/38e49764-3474-48bc-af44-7808a68f7828



---

## 🔮 Further Ahead

<!-- Mention any follow-up work or related PRs planned -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session search on the schedule page with live filtering by name, title, category, and speakers.
  * Displays result count and a “No sessions found” message when relevant.
  * Automatically toggles between full schedule view (no query) and search results (with query).

* **Style / Accessibility**
  * Search input and download button are grouped for improved layout.
  * Download button now includes an accessibility label for screen readers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->