### PR TITLE
show date and hall when searching schedule

### DIFF
--- a/dashboard/src/components/schedule/SearchSession.vue
+++ b/dashboard/src/components/schedule/SearchSession.vue
@@ -33,12 +33,20 @@ const props = defineProps({
 // Flatten and filter all sessions
 function flattenSchedule(schedule) {
   const all = []
-  for (const day of Object.values(schedule ?? {})) {
-    for (const hall of Object.values(day ?? {})) {
-      if (Array.isArray(hall)) {
-        all.push(...hall)
-      } else if (hall && Array.isArray(hall.sessions)) {
-        all.push(...hall.sessions)
+  for (const [date, day] of Object.entries(schedule ?? {})) {
+    for (const [hallName, hall] of Object.entries(day ?? {})) {
+      const sessions = Array.isArray(hall)
+        ? hall
+        : hall && Array.isArray(hall.sessions)
+          ? hall.sessions
+          : []
+
+      for (const session of sessions) {
+        all.push({
+          ...session,
+          _date: date,
+          _hall: hallName,
+        })
       }
     }
   }

--- a/dashboard/src/components/schedule/SessionCard.vue
+++ b/dashboard/src/components/schedule/SessionCard.vue
@@ -16,6 +16,19 @@
         >
           {{ getDuration() }}
         </div>
+        <div
+          v-if="session._date"
+          class="px-2 py-1 bg-blue-100 text-blue-900 text-xs font-medium rounded-[2px] flex items-center"
+        >
+          {{ session._date }}
+        </div>
+
+        <div
+          v-if="session._hall"
+          class="px-2 py-1 bg-purple-100 text-purple-900 text-xs font-medium rounded-[2px] flex items-center"
+        >
+          {{ session._hall }}
+        </div>
       </div>
 
       <button


### PR DESCRIPTION
- Completes #1158


Added date and hall info to show while searching

- Since search shows flat list, we need info on date and hall name.

date in blue | and hall in purple

<img width="800" height="250" alt="image" src="https://github.com/user-attachments/assets/11898bf2-4aeb-4b93-a80b-d47619f8e3ec" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session cards now display date and hall badges (when available) alongside duration, with distinct colors for quick scanning. This makes it easier to see when and where sessions occur at a glance.
* **Refactor**
  * Reworked schedule data normalization to produce a uniform flat list of sessions with contextual metadata, improving the consistency and accuracy of search and filtering. No changes to user interactions beyond clearer results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->