### PR TITLE
update the unit test on concluding events

### DIFF
--- a/fossunited/tests/test_scheduled_tasks.py
+++ b/fossunited/tests/test_scheduled_tasks.py
@@ -23,6 +23,7 @@ class TestScheduledTasks(FrappeTestCase):
         # Event 1 is live and is to end tomorrow
         self.event1 = insert_test_event(
             chapter=self.chapter,
+            status="Live",
             start_date=today.replace(hour=9, minute=00),
             end_date=today.replace(hour=15, minute=30),
         )
@@ -59,15 +60,11 @@ class TestScheduledTasks(FrappeTestCase):
         frappe.delete_doc(EVENT, self.event3.name, force=True)
 
     # Only patching the datetime within the `scheduled_tasks` module
-    @patch("fossunited.scheduled_tasks.datetime")
-    def test_concluded_events(self, mock_datetime):
-        # Set the mock datetime to return a specific date
-        mock_datetime.today.return_value = datetime.today().replace(hour=00, minute=1) + timedelta(
+    @patch("fossunited.scheduled_tasks.now_datetime")
+    def test_concluded_events(self, mock_now_datetime):
+        mock_now_datetime.return_value = datetime.today().replace(hour=0, minute=1) + timedelta(
             days=1
         )
-        mock_datetime.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
-
-        # Call the function to test
         conclude_events()
 
         # Fetch events to check their status


### PR DESCRIPTION
- forgot the impact of changing mock time patch we used datetime before in conclude_events function, but now we use frappe's date_now

- TestScheduledTasks should be working fine now!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated scheduled task tests to use deterministic time, improving reliability and consistency.
  * Expanded validation of event lifecycle: ensures concluded events update related states (e.g., CFP and RSVP) correctly.
  * Clarified test setup to explicitly cover Live, Cancelled, and Concluded scenarios.
  * Simplified mocking approach for clearer, more maintainable test flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->