### PR TITLE
update teams page to include past employee + volunteers

### DIFF
--- a/fossunited/fossunited/web_template/team_list_section/team_list_section.html
+++ b/fossunited/fossunited/web_template/team_list_section/team_list_section.html
@@ -47,9 +47,8 @@
   ["in", ["Fellow", "Intern"]]}, order_by ='full_name', limit_page_length=0)
 %}
 {%
-  set volunteers = frappe.get_all("FOSS United Team", fields=["full_name",
-  "username", "headshot", "designation"], filters={"is_active": 1, "org_role":
-  "Volunteer"}, order_by ='full_name', limit_page_length=0)
+  set pastMembers = frappe.get_all("FOSS United Team", fields=["full_name",
+  "username", "headshot", "designation"], filters={"is_active": 0,}, order_by ='full_name', limit_page_length=0)
 %}
 <style>
   .team-member-link {
@@ -171,7 +170,7 @@
       {{ render_team_section("Governing Board", GovBoardMembers, '<a href="/blog/organization/meet-the-first-ever-elected-community-governance-board-foss-united" class="blog-link">View Blog Post</a>') }}
       {{ render_team_section("Full-time and Part-time Staff", staff) }}
       {{ render_team_section("Fellows and Interns", fellowsInterns) }}
-      {{ render_team_section("Active and Part-time Volunteers", volunteers) }}
+      {{ render_team_section("Past Employees and Volunteers", pastMembers) }}
     </div>
   </div>
 </div>

--- a/fossunited/fossunited/web_template/team_list_section/team_list_section.html
+++ b/fossunited/fossunited/web_template/team_list_section/team_list_section.html
@@ -170,7 +170,10 @@
       {{ render_team_section("Governing Board", GovBoardMembers, '<a href="/blog/organization/meet-the-first-ever-elected-community-governance-board-foss-united" class="blog-link">View Blog Post</a>') }}
       {{ render_team_section("Full-time and Part-time Staff", staff) }}
       {{ render_team_section("Fellows and Interns", fellowsInterns) }}
-      {{ render_team_section("Past Employees and Volunteers", pastMembers) }}
+      <details>
+        <summary class="h5">Past Employees and Volunteers</summary>
+        {{ render_team_section("", pastMembers) }}
+      </details>
     </div>
   </div>
 </div>


### PR DESCRIPTION

Add all inactive members as Past employee and Volunteers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Team page now lists past employees and volunteers instead of active volunteers.
  * Section title updated to “Past Employees and Volunteers.”
  * The past members list is presented in a collapsible details block for easier browsing.
  * Profile details (name, username, photo, designation), ordering and pagination are preserved; other team sections remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->