### PR TITLE
Minor fix

### DIFF
--- a/dashboard/src/components/schedule/ScheduleHeader.vue
+++ b/dashboard/src/components/schedule/ScheduleHeader.vue
@@ -5,13 +5,14 @@
       <div class="prose">
         <h1 class="font-bond">Schedule</h1>
       </div>
-      <div class="text-base text-gray-700" v-html="event.schedule_page_description"></div>
+      <div class="text-base text-gray-700" v-html="sanitizedScheduleDesc"></div>
     </div>
   </div>
 </template>
 <script setup>
 import ScheduleHeroIcon from '@/components/icons/ScheduleHeroIcon.vue'
-import { defineProps } from 'vue'
+import { defineProps, computed } from 'vue'
+import DOMPurify from 'dompurify'
 
 const props = defineProps({
   event: {
@@ -19,4 +20,8 @@ const props = defineProps({
     required: true,
   },
 })
+
+const sanitizedScheduleDesc = computed(() =>
+  DOMPurify.sanitize(props.event?.schedule_page_description ?? ''),
+)
 </script>

--- a/dashboard/src/components/schedule/ScheduleHeader.vue
+++ b/dashboard/src/components/schedule/ScheduleHeader.vue
@@ -5,9 +5,7 @@
       <div class="prose">
         <h1 class="font-bond">Schedule</h1>
       </div>
-      <div class="text-base text-gray-700">
-        {{ event.schedule_page_description }}
-      </div>
+      <div class="text-base text-gray-700" v-html="event.schedule_page_description"></div>
     </div>
   </div>
 </template>

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
@@ -184,6 +184,8 @@ class FOSSChapter(WebsiteGenerator):
                 "banner_image",
                 "must_attend",
                 "event_location",
+                "external_event_url",
+                "has_external_webpage",
             ],
             order_by="event_start_date asc",
             page_length=6,

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
@@ -184,6 +184,7 @@ class FOSSChapter(WebsiteGenerator):
                 "banner_image",
                 "must_attend",
                 "event_location",
+                "is_external_event",
                 "external_event_url",
                 "has_external_webpage",
             ],


### PR DESCRIPTION
- Minor enhancement

- make schedule page description to render html as well
  Before everything was shown as plain text only (no link clickable)

- Add external event webpage URL for event card to show (had issue with tech4good URL not showing in c/indiafoss page)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upcoming events can now display external event links and indicate when an event has an external webpage, matching past events.

* **Improvements**
  * Event descriptions in the schedule header now support sanitized rich text/HTML (links, emphasis, lists) for clearer, more engaging presentation.
  * Consistent event detail fields across upcoming and past events improve reliability and user expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->