### PR TITLE
add missing doc for event permalink field

### DIFF
--- a/dashboard/src/pages/CreateEventForm.vue
+++ b/dashboard/src/pages/CreateEventForm.vue
@@ -34,7 +34,9 @@
               size="md"
               label="Event Permalink&ast;"
               description="This text will be added to the event URL, creating a link in the format: <event-page>/<event-permalink>. Use '-' instead of spaces."
+              @input="onPermalinkInput"
             />
+
             <FormControl
               :value="getEventLink()"
               size="md"
@@ -42,6 +44,7 @@
               :disabled="true"
               description="The event URL will appear as shown above, using the structure: <event-page>/<event-permalink>."
             />
+
             <FormControl
               v-model="temp_event.status"
               :type="'select'"
@@ -243,10 +246,23 @@ const getFormError = () => {
   return errors
 }
 
+const onPermalinkInput = (event) => {
+  const input = event.target.value
+  temp_event.event_permalink = input.replace(/\s+/g, '-')
+}
+
+const sluggify = (text) => {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '') // remove punctuation
+    .trim()
+    .replace(/[\s_-]+/g, '-') // collapse spaces and underscores
+    .replace(/^-+|-+$/g, '') // trim leading/trailing hyphens
+}
+
 const getEventLink = () => {
-  let event_route = createAbsoluteUrlFromRoute(
-    chapter.doc?.route + '/' + temp_event.event_permalink,
-  )
+  const slug = sluggify(temp_event.event_permalink || '')
+  const event_route = createAbsoluteUrlFromRoute(chapter.data?.route + '/' + slug)
   return event_route.replace(/(^\w+:|^)\/\//, '')
 }
 

--- a/dashboard/src/pages/CreateEventForm.vue
+++ b/dashboard/src/pages/CreateEventForm.vue
@@ -33,7 +33,7 @@
               :type="'text'"
               size="md"
               label="Event Permalink&ast;"
-              description="This text will be added to the event URL, creating a link in the format: <event-page>/<event-permalink>"
+              description="This text will be added to the event URL, creating a link in the format: <event-page>/<event-permalink>. Use '-' instead of spaces."
             />
             <FormControl
               :value="getEventLink()"

--- a/dashboard/src/pages/CreateEventForm.vue
+++ b/dashboard/src/pages/CreateEventForm.vue
@@ -247,8 +247,8 @@ const getFormError = () => {
 }
 
 const onPermalinkInput = (event) => {
-  const input = event.target.value
-  temp_event.event_permalink = input.replace(/\s+/g, '-')
+  const input = event.target?.value ?? ''
+  temp_event.event_permalink = sluggify(input)
 }
 
 const sluggify = (text) => {
@@ -262,7 +262,8 @@ const sluggify = (text) => {
 
 const getEventLink = () => {
   const slug = sluggify(temp_event.event_permalink || '')
-  const event_route = createAbsoluteUrlFromRoute(chapter.data?.route + '/' + slug)
+  const baseRoute = chapter.data?.route ? `${chapter.data.route}/events` : ''
+  const event_route = createAbsoluteUrlFromRoute(`${baseRoute}/${slug}`)
   return event_route.replace(/(^\w+:|^)\/\//, '')
 }
 

--- a/dashboard/src/pages/EventDetails.vue
+++ b/dashboard/src/pages/EventDetails.vue
@@ -71,6 +71,7 @@
           size="md"
           label="Event Permalink"
           description="This text will be added to the event URL, creating a link in the format: <event-page>/<event-permalink>. Use '-' instead of spaces."
+          @input="onPermalinkInput"
         />
         <div class="flex flex-col gap-2">
           <FormControl
@@ -265,10 +266,23 @@ const updateDetails = () => {
     })
 }
 
+const sluggify = (text) => {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    .replace(/[\s_-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+const onPermalinkInput = (eventInput) => {
+  const input = eventInput.target.value
+  event.doc.event_permalink = input.replace(/\s+/g, '-')
+}
+
 const getEventLink = () => {
-  let event_route = createAbsoluteUrlFromRoute(
-    chapter.data?.route + '/' + event.doc.event_permalink,
-  )
+  const slug = sluggify(event.doc.event_permalink || '')
+  const event_route = createAbsoluteUrlFromRoute(chapter.data?.route + '/' + slug)
   return event_route.replace(/(^\w+:|^)\/\//, '')
 }
 </script>

--- a/dashboard/src/pages/EventDetails.vue
+++ b/dashboard/src/pages/EventDetails.vue
@@ -70,6 +70,7 @@
           :type="'text'"
           size="md"
           label="Event Permalink"
+          description="This text will be added to the event URL, creating a link in the format: <event-page>/<event-permalink>. Use '-' instead of spaces."
         />
         <div class="flex flex-col gap-2">
           <FormControl
@@ -78,6 +79,7 @@
             type="url"
             size="md"
             label="Event Link"
+            description="The event URL will appear as shown above, using the structure: <event-page>/<event-permalink>."
           >
             <template #suffix>
               <CopyToClipboardButton :value="getEventLink()" />

--- a/dashboard/src/pages/EventDetails.vue
+++ b/dashboard/src/pages/EventDetails.vue
@@ -276,8 +276,8 @@ const sluggify = (text) => {
 }
 
 const onPermalinkInput = (eventInput) => {
-  const input = eventInput.target.value
-  event.doc.event_permalink = input.replace(/\s+/g, '-')
+  const input = eventInput.target?.value ?? ''
+  event.doc.event_permalink = sluggify(input)
 }
 
 const getEventLink = () => {


### PR DESCRIPTION
Missed adding permalink docs to Events detail page (events edit page)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live permalink normalization: spaces are replaced with hyphens as you type and the displayed event URL uses a slugified permalink so the link reflects a URL-friendly route.

* **Documentation**
  * Added/updated helper text on Event Permalink and Event Link fields explaining hyphen usage and how the displayed URL is formed for consistent guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->