### PR TITLE
validate speaker social link with https prefix

### DIFF
--- a/dashboard/src/components/cfp-public/SpeakerCard.vue
+++ b/dashboard/src/components/cfp-public/SpeakerCard.vue
@@ -4,7 +4,14 @@
       <div class="flex flex-col gap-2 justify-between">
         <div class="flex flex-col gap-1">
           <h5 class="text-lg font-medium">{{ getValue('full_name') }}</h5>
-          <a :href="getValue('social_link')" target="_blank">
+          <a
+            :href="
+              /^https?:\/\//.test(getValue('social_link'))
+                ? getValue('social_link')
+                : 'https://' + getValue('social_link')
+            "
+            target="_blank"
+          >
             <Badge
               :label="getValue('social_link')"
               variant="subtle"


### PR DESCRIPTION
add `https://` if not present for social link

closes #1175 for now

But its a good idea to validate most of the Urls/links in all code
Make a common js function and use it for all link operations