### PR TITLE
fix event route feedback UI in create event form

### DIFF
--- a/dashboard/src/pages/CreateEventForm.vue
+++ b/dashboard/src/pages/CreateEventForm.vue
@@ -262,7 +262,7 @@ const sluggify = (text) => {
 
 const getEventLink = () => {
   const slug = sluggify(temp_event.event_permalink || '')
-  const baseRoute = chapter.data?.route ? `${chapter.data.route}/events` : ''
+  const baseRoute = chapter.doc?.route ? `${chapter.doc?.route}` : ''
   const event_route = createAbsoluteUrlFromRoute(`${baseRoute}/${slug}`)
   return event_route.replace(/(^\w+:|^)\/\//, '')
 }


### PR DESCRIPTION

closes #1180 

Missed addressing correct route var
Thanks harsh!


<img width="750" height="250" alt="image" src="https://github.com/user-attachments/assets/3cadfdac-09cc-483d-b41f-1e656cd271ec" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event links in Create Event now use the chapter’s route as the base path, ensuring correct URLs without redundant segments. Slug handling and absolute URL generation remain unchanged. Users will see accurate links when previewing or sharing event pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->