### PR TITLE
wrap the route component if exceed the width

### DIFF
--- a/dashboard/src/components/CopyToClipboardComponent.vue
+++ b/dashboard/src/components/CopyToClipboardComponent.vue
@@ -1,10 +1,18 @@
 <template>
   <Tooltip class="w-fit" :text="tooltip_label" :placement="'top'">
-    <Button class="w-fit my-2 font-mono" size="md" icon-left="copy" @click="copyRouteToClipboard">
-      {{ props.route }}
+    <Button
+      class="w-fit my-2 font-mono text-left"
+      size="md"
+      icon-left="copy"
+      @click="copyRouteToClipboard"
+    >
+      <span class="break-all whitespace-normal block">
+        {{ props.route }}
+      </span>
     </Button>
   </Tooltip>
 </template>
+
 <script setup>
 import { Tooltip } from 'frappe-ui'
 import { ref, defineProps } from 'vue'


### PR DESCRIPTION
- closes #1179

Simply wrap the url based on width.

Fix on mobile as well.

<img width="1470" height="537" alt="image" src="https://github.com/user-attachments/assets/c76d076d-c448-42f5-9b2b-7f9dfa5598b1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved Copy to Clipboard button presentation: left-aligned text with better wrapping for long routes to prevent overflow.
  * Enhanced readability on smaller screens without changing copy behavior or icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->