### PR TITLE
add safe check for foss profile activity merging hackathon details

### DIFF
--- a/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.py
@@ -180,8 +180,9 @@ class FOSSUserProfile(WebsiteGenerator):
             filters={"email": self.email},
             page_length=9999,
         )
+
         for val in hackathon_ids:
-            attended_hack.append(
+            hackathon_data = (
                 frappe.db.get_value(
                     HACKATHON,
                     fieldname=[
@@ -197,20 +198,25 @@ class FOSSUserProfile(WebsiteGenerator):
                     filters={"name": val.hackathon},
                     as_dict=1,
                 )
-                | (  # Add localhost details if he attended a localhost
-                    frappe.db.get_value(
-                        HACKATHON_LOCALHOST,
-                        fieldname=[
-                            "localhost_name",
-                            "location",
-                        ],
-                        filters={"name": val.localhost},
-                        as_dict=1,
-                    )
-                    if val.localhost != ""
-                    else {"localhost_name": "", "location": ""}
-                )
+                or {}
             )
+
+            # Add localhost details if he attended a localhost
+            localhost_data = (
+                frappe.db.get_value(
+                    HACKATHON_LOCALHOST,
+                    fieldname=[
+                        "localhost_name",
+                        "location",
+                    ],
+                    filters={"name": val.localhost},
+                    as_dict=1,
+                )
+                if val.localhost
+                else {"localhost_name": "", "location": ""}
+            ) or {}
+
+            attended_hack.append({**hackathon_data, **localhost_data})
 
         # CFP Proposals submitted, and how many of those were approved
         cfps = []


### PR DESCRIPTION
<img width="700" height="270" alt="image" src="https://github.com/user-attachments/assets/1f6455ab-4731-44f2-8c5b-7528e2da6a4b" />

^ Error for users when they add themself to hackathon. We did not handle merging the two data types properly.

Both should be dict, but in prev case, one was dict and other was None type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable display of hackathon attendance details, ensuring localhost name and location appear correctly even when some data is missing.
* **Refactor**
  * Streamlined and clarified data handling for user hackathon activity with explicit defaults, reducing edge-case errors and improving robustness.
* **Documentation**
  * Added inline comments to clarify how localhost details are enriched in hackathon activity data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->