### PR TITLE
backend: add virtual to Chapter type

### DIFF
--- a/dashboard/src/pages/ChapterDetails.vue
+++ b/dashboard/src/pages/ChapterDetails.vue
@@ -130,7 +130,7 @@
           />
         </div>
       </div>
-      <div v-if="chapter.doc.chapter_type === 'City Community'">
+      <div v-if="['City Community', 'FOSS Club'].includes(chapter.doc.chapter_type)">
         <div class="font-semibold text-gray-800 border-b-2 pb-2">Location</div>
         <div class="p-2 my-1 grid grid-cols-1 md:grid-cols-2 gap-4">
           <FormControl

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.json
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.json
@@ -31,16 +31,16 @@
   "google_map_link",
   "socials_section",
   "email",
-  "x",
-  "linkedin",
-  "matrix",
-  "column_break_fifp",
-  "facebook",
-  "instagram",
   "mastodon",
   "telegram",
-  "zulip",
   "bluesky",
+  "matrix",
+  "x",
+  "column_break_fifp",
+  "facebook",
+  "linkedin",
+  "instagram",
+  "zulip",
   "whatsapp",
   "discord",
   "chapter_members_section",
@@ -59,7 +59,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Chapter Type",
-   "options": "City Community\nFOSS Club\nConference",
+   "options": "City Community\nFOSS Club\nConference\nVirtual",
    "reqd": 1
   },
   {
@@ -75,13 +75,14 @@
    "fieldname": "city",
    "fieldtype": "Link",
    "label": "City",
+   "mandatory_depends_on": "eval:doc.chapter_type==='City Community'",
    "options": "City"
   },
   {
    "fieldname": "state",
    "fieldtype": "Link",
    "label": "State",
-   "mandatory_depends_on": "eval:doc.chapter_type!='Conference'",
+   "mandatory_depends_on": "eval:doc.chapter_type==='City Community'",
    "options": "State"
   },
   {
@@ -98,7 +99,7 @@
    "label": "Basic Information"
   },
   {
-   "depends_on": "eval:doc.chapter_type!='Conference' ",
+   "depends_on": "eval:doc.chapter_type==='City Community'",
    "fieldname": "location_section",
    "fieldtype": "Section Break",
    "label": "Location"
@@ -242,10 +243,10 @@
    "options": "URL"
   },
   {
-    "fieldname": "zulip",
-    "fieldtype": "Data",
-    "label": "Zulip",
-    "options": "URL"
+   "fieldname": "zulip",
+   "fieldtype": "Data",
+   "label": "Zulip",
+   "options": "URL"
   },
   {
    "fieldname": "bluesky",
@@ -280,7 +281,7 @@
    "link_fieldname": "chapter"
   }
  ],
- "modified": "2025-09-07 09:45:30.000000",
+ "modified": "2025-10-07 10:45:37.496671",
  "modified_by": "Administrator",
  "module": "Chapters",
  "name": "FOSS Chapter",
@@ -315,6 +316,7 @@
   }
  ],
  "route": "c",
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.json
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.json
@@ -75,14 +75,14 @@
    "fieldname": "city",
    "fieldtype": "Link",
    "label": "City",
-   "mandatory_depends_on": "eval:doc.chapter_type==='City Community'",
+   "mandatory_depends_on": "eval:['City Community', 'FOSS Club'].includes(doc.chapter_type)",
    "options": "City"
   },
   {
    "fieldname": "state",
    "fieldtype": "Link",
    "label": "State",
-   "mandatory_depends_on": "eval:doc.chapter_type==='City Community'",
+   "mandatory_depends_on": "eval:['City Community', 'FOSS Club'].includes(doc.chapter_type)",
    "options": "State"
   },
   {
@@ -99,7 +99,7 @@
    "label": "Basic Information"
   },
   {
-   "depends_on": "eval:doc.chapter_type==='City Community'",
+   "depends_on": "eval:['City Community', 'FOSS Club'].includes(doc.chapter_type)",
    "fieldname": "location_section",
    "fieldtype": "Section Break",
    "label": "Location"
@@ -122,6 +122,7 @@
    "fieldname": "institution_name",
    "fieldtype": "Link",
    "label": "Institution Name",
+   "mandatory_depends_on": "eval: doc.chapter_type==='FOSS Club'",
    "options": "Institute"
   },
   {
@@ -281,7 +282,7 @@
    "link_fieldname": "chapter"
   }
  ],
- "modified": "2025-10-07 10:45:37.496671",
+ "modified": "2025-10-07 23:15:33.866231",
  "modified_by": "Administrator",
  "module": "Chapters",
  "name": "FOSS Chapter",

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
@@ -22,11 +22,14 @@ class FOSSChapter(WebsiteGenerator):
 
         about_chapter: DF.TextEditor | None
         banner_image: DF.AttachImage | None
+        bluesky: DF.Data | None
         chapter_logo: DF.AttachImage | None
         chapter_members: DF.Table[FOSSChapterLeadTeamMember]
         chapter_name: DF.Data
-        chapter_status: DF.Literal["Active", "Inactive", "Defunct", "Independent", "New"]  # noqa: F722, F821
-        chapter_type: DF.Literal["City Community", "FOSS Club", "Conference"]  # noqa: F722, F821
+        chapter_status: DF.Literal[
+            "Active", "Inactive", "Defunct", "Independent", "New"  # noqa: F722, F821
+        ]
+        chapter_type: DF.Literal["City Community", "FOSS Club", "Conference", "Virtual"]  # noqa: F722, F821
         city: DF.Link | None
         country: DF.Link | None
         discord: DF.Data | None
@@ -44,10 +47,9 @@ class FOSSChapter(WebsiteGenerator):
         slug: DF.Data | None
         state: DF.Link | None
         telegram: DF.Data | None
-        zulip: DF.Data | None
-        bluesky: DF.Data | None
         whatsapp: DF.Data | None
         x: DF.Data | None
+        zulip: DF.Data | None
     # end: auto-generated types
 
     def before_insert(self):


### PR DESCRIPTION
- Make location (section) only display and mandate for "City Community"
- Clubs will have Institute displayed
- Rest can only have social links

@rahulporuri 

Tagging in case if more customization is needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “Virtual” as a Chapter Type option.
  - Introduced Mastodon, Telegram, and Bluesky social fields; socials reordered (X, LinkedIn and Zulip positions adjusted).

- **Chores**
  - City and State are now required for City Community and FOSS Club; Location section shown for both.
  - Institution name now required for FOSS Club.
  - Minor public metadata/formatting updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->