### PR TITLE
Vale docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,11 +13,11 @@ fossunited/public/dist
 /fossunited/www/dashboard.html
 /development/fossu-bench/
 
-.docs/styles/*
-!.docs/styles/config/
+docs/styles/*
+!docs/styles/config/
 
-.docs/styles/config/*
-!.docs/styles/config/vocabularies/
+docs/styles/config/*
+!docs/styles/config/vocabularies/
 
-.docs/styles/config/vocabularies/*
-!.docs/styles/config/vocabularies/base
+docs/styles/config/vocabularies/*
+!docs/styles/config/vocabularies/base

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,11 @@ fossunited/public/dist
 /fossunited/www/dashboard.html
 /development/fossu-bench/
 
+.docs/styles/*
+!.docs/styles/config/
+
+.docs/styles/config/*
+!.docs/styles/config/vocabularies/
+
+.docs/styles/config/vocabularies/*
+!.docs/styles/config/vocabularies/base

--- a/.vale.ini
+++ b/.vale.ini
@@ -6,5 +6,5 @@ Packages = RedHat, proselint, write-good, alex, Joblint
 
 Vocab = base
 
-[*.{md,org,txt}]
+[*.{md,org}]
 BasedOnStyles = Vale, RedHat, proselint, write-good, alex, Joblint

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,8 +1,10 @@
-StylesPath = styles
+StylesPath = docs/styles
 
 MinAlertLevel = suggestion
 
-Packages = RedHat, proselint, write-good, alex, Joblint, Microsoft, Google
+Packages = RedHat, proselint, write-good, alex, Joblint
 
-[*.{md,rst,org,txt}]
-BasedOnStyles = Vale, RedHat, Google, Microsoft, proselint, write-good, alex, Joblint
+Vocab = base
+
+[*.{md,org,txt}]
+BasedOnStyles = Vale, RedHat, proselint, write-good, alex, Joblint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
 ## Introduction
 
-Thank you for showing interest for contributing in our new FOSS United Platform which we are building for the FOSS Community all over India. You can always take a look at what are the current issues we are working on. There are a lot of ways you can contribute to our platform including requesting Documentation, Bug Reports or Feature Requests and help us make our platform efficient and better at performance
+Thank you for showing interest for contributing in our new FOSS United Platform which we are building for the FOSS Community all over India. You can always take a look at what are the current issues we are working on. Help us make our platform better by requesting documentation, reporting bugs, or suggesting new features. Every contribution improves performance and usability.
 
 ### Bug Report Guidelines
 
-- If you have some query, before asking a question we would suggest you to go through [dontasktoask](https://dontasktoask.com).
+- If you have some query, before asking a question we would suggest you to go through [dont-ask-to-ask](https://dontasktoask.com).
 - Description Questions: If the question is a bit complicated, then the use of application oriented approach might help make it more descriptive.
 
 ### Issue Creation Guidelines

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <div align="center">
-    <img alt="fossunited logo" src=".github/logo.png" width="150px" height="120px">
+    <img alt="FOSS United logo" src=".github/logo.png" width="150px" height="120px">
 </div>
 
 ## The FOSS United Platform
 
-Repo for the website and open-source platform of FOSS United. The whole platform is being built on [Frappe](https://frappe.io).
+Project repo for the website and open-source platform of FOSS United. The whole platform is being built on [Frappe](https://frappe.io).
 
 ## Installation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,8 @@
 #### Reporting a Vulnerability
 
-If you find a (suspected) vulnerability in the code or the behavior of the application that is not very critical then create an [issue on the repository](https://github.com/fossunited/fossunited/issues) with all the possible details. An issue on the GitHub repo should be created only if the vulnerability or bug is not very critical.
+If you find a (suspected) vulnerability in the code or the behavior of the application that is not critical then create an [issue on the repository](https://github.com/fossunited/fossunited/issues) with all the possible details. An issue on the GitHub repo should be created only if the vulnerability or bug is not critical.
 
-In case, the (suspected) Bug or Vulnerability is very critical and may leak data, then please send us an email at security@fossunited.org and the team shall get back to you within 12-24 hours. Furthermore, a resolution timeline will be shared in the same thread.
+In case, the (suspected) Bug or Vulnerability is critical and may leak data, then please send us an email at security@fossunited.org and the team shall get back to you within 12-24 hours. Furthermore, a resolution timeline will be shared in the same thread.
 
 Please include the following things in your report:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 If you find a (suspected) vulnerability in the code or the behavior of the application that is not critical then create an [issue on the repository](https://github.com/fossunited/fossunited/issues) with all the possible details. An issue on the GitHub repo should be created only if the vulnerability or bug is not critical.
 
-In case, the (suspected) Bug or Vulnerability is critical and may leak data, then please send us an email at security@fossunited.org and the team shall get back to you within 12-24 hours. Furthermore, a resolution timeline will be shared in the same thread.
+In case the (suspected) bug or vulnerability is critical and may leak data, then please send us an email at mailto:security@fossunited.org and the team shall get back to you within 12-24 hours. Furthermore, a resolution timeline will be shared in the same thread.
 
 Please include the following things in your report:
 

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -29,7 +29,7 @@ In a development environment, you need to put the below key-value pair in your `
 "ignore_csrf": 1
 ```
 
-This will prevent `CSRFToken` errors while using the vite dev server. In production environment, the `csrf_token` is attached to the `window` object in `index.html` for you.
+This will prevent `CSRFToken` errors while using the Vite development server. In production environment, the `csrf_token` is attached to the `window` object in `index.html` for you.
 
 The Vite dev server will start on the port `8080`. This can be changed from `vite.config.js`.
 The development server is configured to proxy your frappe app (usually running on port `8000`). If you have a site named `todo.test`, open `http://todo.test:8080` in your browser. If you see a button named "Click to send 'ping' request", congratulations!

--- a/docs/docs/attend-event.md
+++ b/docs/docs/attend-event.md
@@ -4,16 +4,16 @@
 attendees to RSVP for the event. This helps the event organizers plan
 accordingly e.g. purchase snacks and beverages.
 
-## RSVPing to an event
+## RSVP-ing to an event
 
-**NOTE:** RSVP-ing to an event does not require you to have a Profile.
+**Note:** RSVP-ing to an event does not require you to have a Profile.
 
 - Visit the RSVP tab for the event and click on the `"RSVP for the event"`
   green button
 
 ![RSVP to a meetup](./assets/meetup-event.png)
 
-- Fill in the form with the necessary information. Please note that if you are
+- Complete the form with the necessary information. Please note that if you are
   logged in, the Platform will auto-fill some of the information i.e. the Full
   Name and Email fields.
 
@@ -22,10 +22,10 @@ accordingly e.g. purchase snacks and beverages.
 - You should receive an email from FOSS United after you successfully submit
   the form.
 
-**NOTE:** Please note that some of the events might need additional
-information from the participants e.g. phone numbers. This is because some of
+**Note:** Please note that some of the events might need additional
+information from the participants e.g. mobile phone numbers. This is because some of
 the venue partners where the meetups are organized might require the attendees
-to provide their phone numbers to enter the building or office premises.
+to provide their mobile phone numbers to enter the building or office premises.
 
 ## Updating your RSVP
 
@@ -39,7 +39,7 @@ prevents wasting time, energy, money, and food.
 
 ![Visit RSVP tab for RSVP'ed event](./assets/rsvp-update.png)
 
-- Uncheck the `"Confirm your attendance!"` field from the RSVP form and click
+- Clear the `"Confirm your attendance!"` field from the RSVP form and click
   on the `"Update RSVP Form"` button.
 
-![Uncheck RSVP](./assets/rsvp-submission-update.png)
+![Clear RSVP](./assets/rsvp-submission-update.png)

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -36,7 +36,7 @@ We had Successfully Concluded our 5th Edition of IndiaFOSS (2025) on 20-21 Sept.
 - [#1118](https://github.com/fossunited/fossunited/pull/1118) Make ticket transfer page public
   We noticed that not everyone who bought ticket had FossUnited account, so with added security tests, we made Ticket transfer page public to avoid exploits.
 - [#1147](https://github.com/fossunited/fossunited/pull/1147) Added QR code scanner for Ticket Check-ins
-  Implemented a QR code based quick check-in scanner to log check-in details. Both pages `/dashboard/event/.../quick-checkin` and `/dashboard/event/.../checkins` utilize this component to scan QR.
+  Implemented a QR code based quick check-in scanner to log check-in details. Both pages `/dashboard/event/.../quick-checkin` and `/dashboard/event/.../checkins` use this component to scan QR.
 
 #### Event Schedule
 Could not complete the Schedule re-design, so added some features to enhance UX.
@@ -44,7 +44,7 @@ Could not complete the Schedule re-design, so added some features to enhance UX.
 - [#1126](https://github.com/fossunited/fossunited/pull/1126) Search by Speaker in proposal (CFP) page
   Although it has a frappe filter to narrow, it would be convenient to just type and search by speaker name.
 - [#1132](https://github.com/fossunited/fossunited/issues/1132) Fix Event Schedule ICS download
-  Due to some events having end datetime > start datetime, the API was throwing an error.
+  Due to some events having end `datetime` > start `datetime`, the API was throwing an error.
 - [#1158](https://github.com/fossunited/fossunited/issues/1158) Search support in Schedule page
   Search whole Event schedule in flat List based on Talk Title, Speaker name, Designation and category. Also card shows Hall and Date as Indicator
 - [#1151](https://github.com/fossunited/fossunited/issues/1151) Schedule Download formats
@@ -55,8 +55,8 @@ Could not complete the Schedule re-design, so added some features to enhance UX.
 ### New Contributor Spotlight
 - [@agriyakhetarpal](https://github.com/agriyakhetarpal) made their first contribution:
   - [#1142](https://github.com/fossunited/fossunited/pull/1142): Added Zulip logo for chapters
-    With merge of Zulip into svgl, we now have zulip support into socials link for Chapter Info.
-  - Related [PR](https://github.com/fossunited/fossunited/pull/1146) on adding Bluesky and dev.to logo for Foss user profile page
+    With merge of Zulip into svgl, we now have Zulip support into socials link for Chapter Info.
+  - Related [PR](https://github.com/fossunited/fossunited/pull/1146) on adding Bluesky and dev.to logo for FOSS user profile page
 
 - [@arunppsg](https://github.com/arunppsg) made their first contribution:
   - [#1167](https://github.com/fossunited/fossunited/pull/1167): Added more docs
@@ -74,7 +74,7 @@ Could not complete the Schedule re-design, so added some features to enhance UX.
 
 Hi everyone,
 
-I'm **Dilip G** (aka *Zororg* on Telegram, or with username `@idlip`), the new Developer for FOSS United. First month on board, after Harsh Tandiya as Developer.
+I'm **Dilip G** (also known as *Zororg* on Telegram, or with username `@idlip`), the new Developer for FOSS United. First month on board, after Harsh Tandiya as Developer.
 This is my first monthly tech report as part of the FOSS United team. I'd love your feedback on the format, content, or anything you'd like to see added in future changelogs. You can share your suggestions via GitHub Issues or drop me an email; whichever works best for you.
 
 ---
@@ -149,7 +149,7 @@ The FOSS United platform was mostly under maintenance mode during this period. T
 ### PR Highlights
 
 #### Setup with NixOS
-- [#1068](https://github.com/fossunited/fossunited/issues/1068) Doc and guide on setting up FossUnited platform with Nixos. I plan to extend this further more.
+- [#1068](https://github.com/fossunited/fossunited/issues/1068) Doc and guide on setting up FossUnited platform with NixOS. I plan to extend this further more.
 
 #### Job Management
 - [#1077](https://github.com/fossunited/fossunited/pull/1077) Added date of posting for each job card and closing for expired ones

--- a/docs/docs/code-contributions.md
+++ b/docs/docs/code-contributions.md
@@ -3,11 +3,11 @@
 Code contributions are usually what people refer to when they mean
 contributing to a FOSS project and we are glad to receive code contributions.
 If you are not sure where to start, we can recommend looking into the codebase
-to identify untested code and add unittests. Testing ensures that the Platform
-is robust and works as expected and unittests, integration tests, end-to-end
+to identify untested code and add unit tests. Testing ensures that the Platform
+is robust and works as expected and unit tests, integration tests, end-to-end
 tests, API tests, and more are welcome code contributions.
 
-You could also look at the issue board to identify issues that you would like
+You could also look at the issue board to identify issues that you want
 to pick up. You don't have to ask us if you want to pick up an issue - as long
 as someone isn't already working on the issue, feel free to pick it up and
 open a Pull Request addressing the issue. The existing contributors usually

--- a/docs/docs/create-event.md
+++ b/docs/docs/create-event.md
@@ -10,7 +10,7 @@
 
 - Please provide the requested information in the form
 
-| Create event                                      | (...)                                                |
+| Create event                                      | (…)                                                |
 | ------------------------------------------------- | ---------------------------------------------------- |
 | ![Create event I](./assets/create-event-form.png) | ![Create event II](./assets/create-event-form-2.png) |
 
@@ -20,7 +20,7 @@
     e.g. `"FOSS Meetup Hyderabad"`
   - Please use `YYYY-MMM` for the `"Event Permalink"` e.g. `2024-nov`
   - Please use `"Live"` as the `"Event Status"`
-  - Please select the start datetime and the end datetime for the event
+  - Please select the start date & time and the end date & time for the event
 
 After an event is created successfully, you should be able to see it in the
 `"Manage Chapter"` page.
@@ -41,10 +41,10 @@ the `"Update Details"` button.
 After an event has concluded, please update the `"Event Status"` from `"Live"`
 to `"Concluded"`.
 
-**NOTE:** The event will not be displayed under the `"Past Events"` section of
+**Note:** The event will not be displayed under the `"Past Events"` section of
 the chapter page unless the `"Event Status"` is updated. We have observed
 events "disappear" from the public pages of chapters because the
 `"Event Status"` doesn't get updated and the events aren't displayed under
-`"Upcoming Events"` because the datetime for the event is in the past.
+`"Upcoming Events"` because the date & time for the event is in the past.
 
 ![concluded event](./assets/concluded-event.png)

--- a/docs/docs/create-profile.md
+++ b/docs/docs/create-profile.md
@@ -8,11 +8,11 @@
 - In the `"login"` page, use the `"Sign up"` button at the bottom to create a
   Profile
 
-![Signup for a Profile](./assets/signup.png)
+![Sign-up for a Profile](./assets/signup.png)
 
 - Please provide your name or an alias and an email address.
 
-  **NOTE:** Please note that it is not possible to change the email address
+  **Note:** Please note that it is not possible to change the email address
   associated with your Profile once it is created. The name or alias can be
   updated.
 

--- a/docs/docs/delete-data.md
+++ b/docs/docs/delete-data.md
@@ -1,6 +1,6 @@
 # Delete personal data
 
-If you would like us to delete your data that is saved on the FOSS United
+If you want us to delete your data that is saved on the FOSS United
 Foundation systems, including Personally Identifiable Information (PII),
 please submit your email address on the
 [Delete Data](https://fossunited.org/request-for-account-deletion/new) page.

--- a/docs/docs/development.md
+++ b/docs/docs/development.md
@@ -121,7 +121,7 @@ Or use [uv](https://github.com/astral-sh/uv) as an alternative Python package ma
 
 ## Useful Links
 
-* [FOSS United GitHub Repo](https://github.com/fossunited/fossunited)
+* [FOSS United GitHub repo](https://github.com/fossunited/fossunited)
 * [Frappe Docs](https://frappeframework.com/docs/)
 * [Create a Site Guide](https://frappeframework.com/docs/user/en/tutorial/create-a-site)
 

--- a/docs/docs/event-cfp.md
+++ b/docs/docs/event-cfp.md
@@ -8,7 +8,7 @@ event.
 - Please open the CFP tab under the Event page and click on the
   `"Create Form"` button
 
-![cfp page](./assets/create-cfp.png)
+![CFP page](./assets/create-cfp.png)
 
 - Provide the necessary information for the CFP form and click on the
   `"Create"` button, If necessary please use the `"Add Custom Field"` button
@@ -18,28 +18,28 @@ event.
 
 | Create CFP form                                    | Standard fields                                    | Custom fields                                                   |
 | -------------------------------------------------- | -------------------------------------------------- | --------------------------------------------------------------- |
-| ![create cfp form](./assets/create-cfp-form-1.png) | ![standard fields](./assets/create-cfp-form-2.png) | ![custom fields](./assets/create-rsvp-form-custom-question.png) |
+| ![create CFP form](./assets/create-cfp-form-1.png) | ![standard fields](./assets/create-cfp-form-2.png) | ![custom fields](./assets/create-rsvp-form-custom-question.png) |
 
 - Once created, the Event page on the Dashboard should reflect the fact that
   the CFP is "live"
 
-![cfp live](./assets/cfp-live.png)
+![CFP live](./assets/cfp-live.png)
 
 ## Update the CFP
 
 - If necessary, you can use the `"Web Form"` tab to update the form e.g.
   allow proposal edits, allow only talk proposals
 
-![update rsvp](./assets/update-cfp-form.png)
+![update RSVP](./assets/update-cfp-form.png)
 
 ## Close the CFP
 
 - The CFP form can be unpublished and the CFP tab on the event page can be
   hidden if necessary e.g. deadline for the CFP is past
 
-| Hide CFP Tab                               | Unpublish CFP form                                     |
+| Hide CFP Tab                               | Un-publish CFP form                                     |
 | ------------------------------------------ | ------------------------------------------------------ |
-| ![hide cfp tab](./assets/hide-cfp-tab.png) | ![unpublish cfp form](./assets/unpublish-cfp-form.png) |
+| ![hide CFP tab](./assets/hide-cfp-tab.png) | ![un-publish CFP form](./assets/unpublish-cfp-form.png) |
 
 ## Download proposal info
 
@@ -48,6 +48,6 @@ event.
 
 ![CFP Insights](./assets/cfp-insights.png)
 
-**NOTE:** Please note that responses to custom fields in the CFP form cannot
+**Note:** Please note that responses to custom fields in the CFP form cannot
 be downloaded using the `"Download"` button on the `"Insights"` tab. Please
 reach out to the Foundation if and when that information is required.

--- a/docs/docs/event-proposals.md
+++ b/docs/docs/event-proposals.md
@@ -11,20 +11,20 @@ have a Profile.
 
 ## What to Propose?
 
-FOSS United encourages a healthy-mix of talks on
+FOSS United encourages a healthy mix of talks on
 
-- Broad computing/tech principles and concepts (e.g.: distributed computing, UI/UX stuff, queues etc).
+- Broad computing/tech principles and concepts (e.g.: distributed computing, UI/UX stuff, queues, etc).
 This is great to intro first principles to a beginner audience.
 - People's personal projects and their journeys (technical + non-technical process and experience).
 No to-do projects, but decent, unique projects.
 - Fun technical stuff, like your hobby projects, projects which you tinkered on or even algorithms
-- Technical (language constructs, database etc)
+- Technical (language constructs, database, etc)
 - Incidental (design, philosophy, legalese, policy)
 
 ### What proposals are not acceptable?
 
 - Proposals from organisations which seem to promote a certain product with overt commercial interest.
-- Proposals from influences and content creators whose primary incentive seem to be promoting themselves or their social media profiles.
+- Proposals from influencers and content creators whose primary incentive seem to be promoting themselves or their social media profiles.
 
 ## Submit a Proposal
 
@@ -35,7 +35,7 @@ No to-do projects, but decent, unique projects.
 ![CFP tab for meetup](./assets/cfp-meetup.png)
 
 - Please complete the requested details on the `"Call for Proposal!"` form. If
-  you are logged-in, the Platform will auto-fill some of the information on
+  you are logged in, the Platform will auto-fill some of the information on
   the form i.e. Full Name, Email. Before submitting, we request you to read
   the [guidelines for proposals](https://forum.fossunited.org/t/talk-proposal-guidelines-for-a-foss-conference-meetup/1923)
 

--- a/docs/docs/event-proposals.md
+++ b/docs/docs/event-proposals.md
@@ -6,25 +6,25 @@ Community to submit proposals e.g. talk proposals, workshop proposals. As the
 scheduled date of the event approaches, the organizers choose the final sessions
 from the submitted proposals with help from reviewers.
 
-**NOTE:** Submitting a proposal to a FOSS United event does not require you to
+**Note:** Submitting a proposal to a FOSS United event does not require you to
 have a Profile.
 
 ## What to Propose?
 
-FOSSUnited encourages a healthy-mix of talks on
+FOSS United encourages a healthy-mix of talks on
 
-- Broad computing/tech principles and concepts (eg: distributed computing, UI/UX stuff, queues etc).
+- Broad computing/tech principles and concepts (e.g.: distributed computing, UI/UX stuff, queues etc).
 This is great to intro first principles to a beginner audience.
 - People's personal projects and their journeys (technical + non-technical process and experience).
 No to-do projects, but decent, unique projects.
 - Fun technical stuff, like your hobby projects, projects which you tinkered on or even algorithms
-- Very technical (language constructs, database etc)
+- Technical (language constructs, database etc)
 - Incidental (design, philosophy, legalese, policy)
 
 ### What proposals are not acceptable?
 
 - Proposals from organisations which seem to promote a certain product with overt commercial interest.
-- Proposals from influencers and content creators whose primary incentive seem to be promoting themselves or their social media profiles.
+- Proposals from influences and content creators whose primary incentive seem to be promoting themselves or their social media profiles.
 
 ## Submit a Proposal
 
@@ -34,15 +34,15 @@ No to-do projects, but decent, unique projects.
 
 ![CFP tab for meetup](./assets/cfp-meetup.png)
 
-- Please fill in the requested details on the `"Call for Proposal!"` form. If
+- Please complete the requested details on the `"Call for Proposal!"` form. If
   you are logged-in, the Platform will auto-fill some of the information on
   the form i.e. Full Name, Email. Before submitting, we request you to read
   the [guidelines for proposals](https://forum.fossunited.org/t/talk-proposal-guidelines-for-a-foss-conference-meetup/1923)
 
-**NOTE:** Please note some of the events might need additional information
+**Note:** Please note some of the events might need additional information
 from the proposers.
 
-| CFP form                               | (...)                                   |
+| CFP form                               | (…)                                   |
 | -------------------------------------- | --------------------------------------- |
 | ![CFP form I](./assets/cfp-form-1.png) | ![CFP form II](./assets/cfp-form-2.png) |
 

--- a/docs/docs/event-rsvp.md
+++ b/docs/docs/event-rsvp.md
@@ -17,7 +17,7 @@ event.
 
 | Create RSVP Form                                | Standard fields                                   | Custom fields                                                      |
 | ----------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------ |
-| ![create RSVP I](./assets/create-rsvp-form.png) | ![create RSVP I](./assets/create-rsvp-form-2.png) | ![add custom field](./assets/create-rsvp-form-custom-question.png) |
+| ![create RSVP I](./assets/create-rsvp-form.png) | ![create RSVP II](./assets/create-rsvp-form-2.png) | ![add custom field](./assets/create-rsvp-form-custom-question.png) |
 
 - Once created, the Event page on the Dashboard should reflect the fact that
   the RSVP is "live"

--- a/docs/docs/event-rsvp.md
+++ b/docs/docs/event-rsvp.md
@@ -1,4 +1,4 @@
-# Manage event RSVPs
+# Manage event RSVP
 
 ## Create RSVP form
 
@@ -8,37 +8,37 @@ event.
 - Please open the RSVP page under the Event page and click on the
   `"Create RSVP Form"` button
 
-![rsvp page](./assets/create-rsvp.png)
+![RSVP page](./assets/create-rsvp.png)
 
 - Provide the necessary information for the RSVP form and click on the
   `"Create"` button. If necessary please use the `"Add Custom Field"` under
   the `"Custom Fields"` section of the form to request additional information
-  from the attendees e.g. phone numbers
+  from the attendees e.g. mobile phone numbers
 
 | Create RSVP Form                                | Standard fields                                   | Custom fields                                                      |
 | ----------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------ |
-| ![create rsvp I](./assets/create-rsvp-form.png) | ![create rsvp I](./assets/create-rsvp-form-2.png) | ![add custom field](./assets/create-rsvp-form-custom-question.png) |
+| ![create RSVP I](./assets/create-rsvp-form.png) | ![create RSVP I](./assets/create-rsvp-form-2.png) | ![add custom field](./assets/create-rsvp-form-custom-question.png) |
 
 - Once created, the Event page on the Dashboard should reflect the fact that
   the RSVP is "live"
 
-![rsvp live](./assets/rsvp-live.png)
+![RSVP live](./assets/rsvp-live.png)
 
 ## Update RSVP form
 
 - If necessary, you can use the `"Web Form"` tab to update the form e.g.
   allow RSVP edits, increase Max RSVP count.
 
-![update rsvp](./assets/update-rsvp-form.png)
+![update RSVP](./assets/update-rsvp-form.png)
 
-## Unpublish RSVP form
+## Un-publish RSVP form
 
 - The RSVP form can be unpublished and the RSVP tab on the event page can be
   hidden if necessary e.g. Max RSVP count has been reached
 
-| Hide RSVP Tab                                | Unpublish RSVP form                                      |
+| Hide RSVP Tab                                | Un-publish RSVP form                                      |
 | -------------------------------------------- | -------------------------------------------------------- |
-| ![hide rsvp tab](./assets/hide-rsvp-tab.png) | ![unpublish rsvp form](./assets/unpublish-rsvp-form.png) |
+| ![hide RSVP tab](./assets/hide-rsvp-tab.png) | ![un-publish RSVP form](./assets/unpublish-rsvp-form.png) |
 
 ## Download RSVP info
 
@@ -47,6 +47,6 @@ event.
 
 ![RSVP Insights](./assets/rsvp-insights.png)
 
-**NOTE:** Please note that responses to custom fields in the RSVP form cannot
+**Note:** Please note that responses to custom fields in the RSVP form cannot
 be downloaded using the `"Download"` button on the `"Insights"` tab. Please
 reach out to the Foundation if and when that information is required.

--- a/docs/docs/event-schedule.md
+++ b/docs/docs/event-schedule.md
@@ -1,6 +1,6 @@
 # Creating the event schedule
 
 After the review volunteers submit reviews for the event proposals, the event
-volunteers have the responsiblity to select the final talks for the event.
+volunteers have the responsibility to select the final talks for the event.
 
 (To be completed)

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,6 +1,6 @@
 # FOSS United Platform
 
-The FOSS United platform is an open source community management platform built with [Frappe Framework](https://frappeframework.com/). The platform serves as central hub of FOSS United's community activities like hosting events etc.,
+The FOSS United platform is an open source community management platform built with [Frappe Framework](https://frappeframework.com/). The platform serves as central hub of FOSS United community activities like hosting events etc.,
 
 This guide provides an overview of the platform's architecture, features, and how to get started with development.
 

--- a/docs/docs/manage-profile.md
+++ b/docs/docs/manage-profile.md
@@ -7,9 +7,9 @@
 - Click on the `"Edit Profile"` button to add or change information about
   yourself
 
-**NOTE:** Toggling the `"Make Profile Private"` button will prevent people
+**Note:** Toggling the `"Make Profile Private"` button will prevent people
 from seeing your information on the Platform
 
-| Edit Profile                                 | (...)                                                    |
+| Edit Profile                                 | (…)                                                    |
 | -------------------------------------------- | -------------------------------------------------------- |
 | ![Edit Profile I](./assets/edit-profile.png) | ![Edit Profile II](./assets/edit-profile-additional.png) |

--- a/docs/docs/project-management.md
+++ b/docs/docs/project-management.md
@@ -18,7 +18,7 @@ at the moment and known issues about the project are tracked using the GitHub
 
 Apart from documentation, another way to get involved with the project is with
 Project Management. For example, we need users of the Platform to discover and
-report bugs in the project. We need volunteers to keep an eye on the issue
+report bugs in the project. We need volunteers to report on the issue
 board and respond to new issues from the Community. Reproducing issues or
 responding to the issues with request for additional information to aid in
 reproduction of the issue are incredibly valuable ways to contribute to the

--- a/docs/docs/request-data.md
+++ b/docs/docs/request-data.md
@@ -1,6 +1,6 @@
 # Request personal data
 
-If you would like to request your Personally Identifiable Information (PII)
+If you want to request your Personally Identifiable Information (PII)
 that is saved on the FOSS United Foundation systems, please submit your email
 address on the [Request Data](https://fossunited.org/request-data/new) page.
 

--- a/docs/docs/reviewing-proposals.md
+++ b/docs/docs/reviewing-proposals.md
@@ -31,13 +31,13 @@ Once you're added as a reviewer, you should be able to see a new
 
 ![review proposal](./assets/review-proposal.png)
 
-**NOTE:** We humbly request the reviewers to provide constructive criticism of
-the proposals. One word reviews are stronlgy discouraged. Almost all proposals
+**Note:** We humbly request the reviewers to provide constructive criticism of
+the proposals. One word reviews are strongly discouraged. Almost all proposals
 can be improved in some way or another and it is the reviewers' responsibility
 to provide this necessary feedback to the proposers. There exists an
 equilibrium between the proposers and the reviewers - if the reviewers are
 unnecessarily harsh, proposers become demotivated over time and the likelihood
-of repeat proposals from the same proposer goes down. On the other hand, if
+of repeat proposals from the same proposer goes down. However, if
 the reviewers approve all proposals without providing meaningful feedback, the
 proposers don't have any incentive to improve their proposals over time, also
 leading to fewer sound proposals. The long-term quality of proposals and talks

--- a/docs/docs/social-media.md
+++ b/docs/docs/social-media.md
@@ -6,5 +6,5 @@ event details on social media—with or without them—is important as it helps 
 the word about open-source and about the organisation.
 
 While preparing posters, stick with the standard FOSS United templates, color schemes and fonts.
-You can also refer to the template created by FOSS United's Chennai team
+You can also refer to the template created by FOSS United Chennai team
 [here](https://forum.fossunited.org/t/foss-united-events-design-templates/2820) for reference.

--- a/docs/docs/volunteering.md
+++ b/docs/docs/volunteering.md
@@ -12,7 +12,7 @@ handle logistics of the event on the ground, communicate what went well
 and what did not with the rest of the Community, and more.
 
 Volunteering is not to be taken lightly. Volunteers in the Community routinely
-spend 10-20+ hours every month. As volunteers, you are held to a higher
+outlay 10-20+ hours every month. As volunteers, you are held to a higher
 standard than the rest of the Community, given your ability to mould and drive
 the Community.
 

--- a/docs/styles/config/vocabularies/base/accept.txt
+++ b/docs/styles/config/vocabularies/base/accept.txt
@@ -1,0 +1,6 @@
+Hackathon
+RSVP'ed
+listmonk
+uv
+repo
+hackathons

--- a/docs/styles/config/vocabularies/base/accept.txt
+++ b/docs/styles/config/vocabularies/base/accept.txt
@@ -4,3 +4,14 @@ listmonk
 uv
 repo
 hackathons
+freecodecamp
+Orgmode
+Zulip
+svgl
+Bluesky
+Arun
+Dilip
+NixOS
+Tandiya
+Zororg
+scrollbar

--- a/docs/styles/config/vocabularies/base/accept.txt
+++ b/docs/styles/config/vocabularies/base/accept.txt
@@ -18,3 +18,4 @@ scrollbar
 Vue
 Vite
 dev
+influencers

--- a/docs/styles/config/vocabularies/base/accept.txt
+++ b/docs/styles/config/vocabularies/base/accept.txt
@@ -15,3 +15,6 @@ NixOS
 Tandiya
 Zororg
 scrollbar
+Vue
+Vite
+dev


### PR DESCRIPTION
should fix all `vale` spelling/grammar lint by pre-commit CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Standardized wording, capitalization, and note styling across many guides (RSVP, profiles, events, CFP, proposals, schedule).
  - Clarified contribution, review, volunteering, data request/deletion, and changelog guidance.
  - Fixed typos; improved alt text, phrasing, accessibility, and security severity wording.

- Chores
  - Updated linting/writing tool configuration and trimmed style packages.
  - Adjusted ignore rules for documentation styling assets and added new accepted vocabulary terms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->