### PR TITLE
Fix events timeline as per original issue

### DIFF
--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -238,12 +238,18 @@ def get_main_foss_events():
 def get_grouped_events_by_chapter_type():
     """
     Retrieves FOSS Chapter Events and Hackathons,
-    groups them by their parent Chapter's chapter_type,
+    groups them by custom categories based on chapter_type,
     and then groups each by month and year.
-    Includes a special 'All' group for everything.
+    Includes a special 'All Events' group for everything.
     """
 
-    # Get all events
+    # configurable grouping: view name -> list of chapter types
+    GROUPING_CONFIG = {
+        "default": ["City Community", "Conference", "Virtual", "Something"],
+        "club": ["FOSS Club"],
+    }
+
+    # fetch all events
     events = frappe.get_all(
         EVENT,
         fields=["*"],
@@ -251,7 +257,6 @@ def get_grouped_events_by_chapter_type():
         order_by="event_start_date asc",
     )
 
-    # Get all hackathons
     hackathons = frappe.get_all(
         HACKATHON,
         fields=["*"],
@@ -259,7 +264,7 @@ def get_grouped_events_by_chapter_type():
         order_by="start_date asc",
     )
 
-    # Cache to avoid duplicate DB hits
+    # cache chapter_type lookups to avoid repeated DB calls
     chapter_type_cache = {}
 
     def get_chapter_type(chapter_name):
@@ -271,44 +276,41 @@ def get_grouped_events_by_chapter_type():
         chapter_type_cache[chapter_name] = chapter_type
         return chapter_type
 
-    # Grouped dicts: {chapter_type: [events]}
+    # group events by chapter_type
     event_groups = defaultdict(list)
     hackathon_groups = defaultdict(list)
 
-    # Collect all
     all_events = []
     all_hackathons = []
 
-    # Classify events
     for event in events:
         chapter_type = get_chapter_type(event.get("chapter"))
         event_groups[chapter_type].append(event)
         all_events.append(event)
 
-    # Classify hackathons
     for hackathon in hackathons:
         chapter_type = get_chapter_type(hackathon.get("chapter"))
         hackathon_groups[chapter_type].append(hackathon)
         all_hackathons.append(hackathon)
 
-    # Combine and group
+    # helper: collect events/hackathons for a list of chapter types
+    def collect_events_for_types(types):
+        events = []
+        hackathons = []
+        for chapter_type in types:
+            events.extend(event_groups.get(chapter_type, []))
+            hackathons.extend(hackathon_groups.get(chapter_type, []))
+        return events, hackathons
+
+    # build final result grouped by custom views
     result = {}
 
-    # Individual chapter_type groups
-    all_chapter_types = sorted(set(event_groups) | set(hackathon_groups))
-    for chapter_type in all_chapter_types:
-        grouped = get_month_grouped_events(
-            event_groups.get(chapter_type, []),
-            hackathon_groups.get(chapter_type, []),
-            chapter_type,
-        )
-        result[chapter_type] = grouped
+    for view_name, chapter_types in GROUPING_CONFIG.items():
+        view_events, view_hackathons = collect_events_for_types(chapter_types)
+        result[view_name] = get_month_grouped_events(view_events, view_hackathons)
 
-    result["All Events"] = get_month_grouped_events(
-        all_events,
-        all_hackathons,
-        "All",
-    )
+    # optionally include 'All Events'
+    result["All Events"] = get_month_grouped_events(all_events, all_hackathons)
 
     return result
 
@@ -328,7 +330,7 @@ def get_chapter_details():
     return chapters
 
 
-def process_event(event, event_list, chapter=""):
+def process_event(event, event_list):
     """
     Processes a single event or hackathon, adding it to the upcoming or past events list based on
     the current date.
@@ -347,23 +349,23 @@ def process_event(event, event_list, chapter=""):
     event["_sort_dt"] = start_dt
 
     if end_dt >= now:
-        event_list[f"Upcoming {chapter} Events"].append(event)
+        event_list["Upcoming Events"].append(event)
     else:
-        event_list[f"Past {chapter} Events"].append(event)
+        event_list["Past Events"].append(event)
 
 
-def get_month_grouped_events(events, hackathons, chapter=""):
+def get_month_grouped_events(events, hackathons):
     """
     Groups events and hackathons by month and year, ensuring they are sorted chronologically
     within each group.
     """
-    grouped_events = {f"Upcoming {chapter} Events": [], f"Past {chapter} Events": []}
+    grouped_events = {"Upcoming Events": [], "Past Events": []}
 
     for event in events:
-        process_event(event, grouped_events, chapter)
+        process_event(event, grouped_events)
 
     for hackathon in hackathons:
-        process_event(hackathon, grouped_events, chapter)
+        process_event(hackathon, grouped_events)
 
     month_grouped_events = {key: {} for key in grouped_events}
 
@@ -377,7 +379,7 @@ def get_month_grouped_events(events, hackathons, chapter=""):
             month_grouped_events[key][month_year] = list(month_year_events)
 
     for key in month_grouped_events:
-        if key == f"Upcoming {chapter} Events":
+        if key == "Upcoming Events":
             sorted_month_years = sorted(
                 month_grouped_events[key].keys(),
                 key=lambda x: datetime.strptime(x, "%B %Y"),

--- a/fossunited/fossunited/web_template/events_timeline/events_timeline.html
+++ b/fossunited/fossunited/web_template/events_timeline/events_timeline.html
@@ -2,14 +2,13 @@
 {% from "fossunited/templates/macros/hackathon_card.html" import hackathon_card %}
 {% set grouped_events = get_grouped_events_by_chapter_type() %}
 
-{% macro render_event_groups(grouped_events, chapter="All Events") %}
+{% macro render_event_groups(grouped_events, chapter="default") %}
   {% for group, events in (grouped_events.get(chapter) or {}).items() %}
     {% set is_past = group.startswith('Past ') %}
-    {% set base_group = group.replace('Upcoming ', '').replace('Past ', '').replace(' FOSS', '').replace(' Events', '') %}
 
     {% if is_past %}
       <details role="region">
-        <summary class="select-theme">Show Past {{ base_group }} Events</summary>
+        <summary class="select-theme">Show Past Events</summary>
     {% endif %}
 
     <div class="event-group" role="region">
@@ -18,7 +17,7 @@
       {% for month, month_events in events.items() %}
         <h4
           class="event-month"
-          v-show="(mustAttendOnly, searchText, cityChapter, filterEvent, $el?.nextElementSibling?.style?.display !== 'none')"
+          v-show="(mustAttendOnly, searchText, cityChapter, $el?.nextElementSibling?.style?.display !== 'none')"
         >
           {{ month }}
         </h4>
@@ -26,7 +25,7 @@
         <div
           class="events-grid-4"
           role="group"
-          v-show="(mustAttendOnly, searchText, cityChapter, filterEvent, $el?.children.length > 0)"
+          v-show="(mustAttendOnly, searchText, cityChapter, $el?.children.length > 0)"
         >
           {% for event in month_events %}
             {% set raw_date = event.event_start_date or event.start_date %}
@@ -218,22 +217,18 @@
         Filter the events to show only those marked as must-attend.
       </p>
 
-      <div id="event-filter-select" class="must-attend-checkbox">
-        <select
-          id="filterEvent"
-          v-model="filterEvent"
-          class="select-theme"
-          aria-describedby="filter-event-desc"
-        >
-          {% for chapter_type in grouped_events.keys() %}
-            <option value="{{ chapter_type }}">{{ chapter_type }}</option>
-          {% endfor %}
-        </select>
-        <label for="filterEvent">Filter Events</label>
-      </div>
-      <p id="filter-event-desc" class="sr-only">
-        Filter events by chapter type or show all events.
-      </p>
+	  <div class="must-attend-checkbox">
+		<label for="show-fossclub-checkbox">Show Club Events</label>
+		<input
+		  type="checkbox"
+		  id="show-fossclub-checkbox"
+		  v-model="showFossClub"
+		  aria-describedby="show-fossclub-desc"
+		  />
+	  </div>
+	  <p id="show-fossclub-desc" class="sr-only">
+		Toggle to view FOSS Club events. When off, shows rest all Events.
+	  </p>
 
       <!-- City Chapter selector -->
       <div class="must-attend-checkbox">
@@ -262,18 +257,20 @@
       <i class="ti ti-download"></i>
     </button>
 
-    {% for chapter in grouped_events.keys() %}
-      <div v-show="filterEvent === '{{ chapter }}'">
-        {{ render_event_groups(grouped_events, chapter) }}
-      </div>
-    {% endfor %}
+	<div v-show="!showFossClub">
+	  {{ render_event_groups(grouped_events, "default") }}
+	</div>
+
+	<div v-show="showFossClub">
+	  {{ render_event_groups(grouped_events, "club") }}
+	</div>
 
     <script>
       PetiteVue.createApp({
         searchText: '',
         mustAttendOnly: false,
         cityChapter: 'All Cities',
-        filterEvent: 'All Events',
+        showFossClub: false,
         canShow(eventName, eventDate, eventMustAttend, eventCityChapter) {
           if (this.mustAttendOnly && !eventMustAttend) {
             return false

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -1500,12 +1500,14 @@ h6 {
 }
 
 .event-card--title {
-  width: 15.625rem;
   height: 3.125rem;
   flex-shrink: 0;
   font-size: var(--text-lg);
   font-weight: 600;
   letter-spacing: -0.045rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .event-card--location-section {
@@ -1531,7 +1533,7 @@ h6 {
   border-radius: 8px;
   border: 2px solid hsl(var(--clr-open-gray-100));
   transition: border 0.2s ease-in-out;
-  background: #FFF;
+  background: #fff;
 }
 
 .talk-card:hover {
@@ -1572,7 +1574,7 @@ h6 {
 }
 
 .talk-card--title {
-  color: #1A1A1A;
+  color: #1a1a1a;
   font-family: Inter;
   font-size: 16px;
   font-style: normal;
@@ -1588,7 +1590,7 @@ h6 {
   align-items: center;
   gap: 5px;
   border-radius: 8px;
-  background: #F1F1F1;
+  background: #f1f1f1;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
@@ -1597,7 +1599,7 @@ h6 {
 
 .talk-card--location-date {
   align-items: center;
-  color: #4B4B4B;
+  color: #4b4b4b;
   font-family: Inter;
   font-size: 14px;
   font-style: normal;
@@ -1612,7 +1614,7 @@ h6 {
   align-items: center;
   gap: 5px;
   border-radius: 8px;
-  background: rgba(8, 183, 79, 0.10);
+  background: rgba(8, 183, 79, 0.1);
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
@@ -1620,7 +1622,7 @@ h6 {
 }
 
 .chapter-volunteer-card--role {
-  color: #08B74F;
+  color: #08b74f;
   font-family: Inter;
   font-size: 12px;
   font-style: normal;

--- a/fossunited/templates/macros/event_card.html
+++ b/fossunited/templates/macros/event_card.html
@@ -21,7 +21,7 @@
             <span>{{ chapter.chapter_name | truncate(25, True, '...', 0) }}</span>
           {% else %}
             <span class="fff-forward"
-              >{{ (chapter.city.upper() if chapter.city else '') | truncate(25, True, '...', 0) }}</span
+              >{{ (chapter.city.upper() if chapter.city else chapter.chapter_name) | truncate(25, True, '...', 0) }}</span
             >
           {% endif %}
         </div>


### PR DESCRIPTION
## 🚦 Status

- [ ] Draft
- [x] Ready for review

---

## 🔗 Related Issue

Closes / Addresses: #1097 
- revisiting the issue to fix back timeline as initially intended

---

## ❗ Problem

We gave dropdown filter, but we had simply wanted only a checkbox to either show Only club events or by default show the rest.

---

## ✅ Solution

We had grouping code, so we did not remove them, since in future can be re-used to extend more.

Kinda grouped events as "default" to include rest, and "club" for all club based.

---

## 📋 Progress (All must be checked to merge)

- [x] Tested locally

---

## 📝 Changelog

<commit>: <!-- e.g., feat: add user login endpoint -->

---

## 🖼️ Visualization

<!-- Add screenshots, diagrams, or screen recordings if applicable -->

https://github.com/user-attachments/assets/8e7714c6-7195-410c-9bcc-2db5cd601ade

^ Note: Also includes chapter name for "Conference" and "virtual" if city is not set. So we can show it as mini banner

---

## 🔮 Further Ahead

<!-- Mention any follow-up work or related PRs planned -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced unified event views with “Upcoming Events” and “Past Events.”
  - Added a “Show Club Events” toggle to filter the timeline by club events.

- Bug Fixes
  - Event cards now display a chapter fallback name when city is unavailable.

- Style
  - Long event titles are truncated with an ellipsis for cleaner cards.
  - Minor color and formatting adjustments for visual consistency.

- Refactor
  - Simplified timeline rendering and labels (e.g., “Show Past Events”) for a clearer browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->