### PR TITLE
fix teams card height to look equal for all

### DIFF
--- a/fossunited/fossunited/web_template/team_list_section/team_list_section.html
+++ b/fossunited/fossunited/web_template/team_list_section/team_list_section.html
@@ -102,19 +102,21 @@
 
   .teams-container {
     display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-columns: repeat(3, 1fr);
     row-gap: 3rem;
     column-gap: 5rem;
   }
 
   .team-member {
     display: flex;
+    flex-direction: row;
     gap: 3rem;
     border: 1px solid #ccc;
     border-radius: 10px;
     padding: 16px;
     transition: box-shadow 0.3s;
     align-items: center;
+    height: 160px;
   }
 
   .team-member-link:hover .team-member {


### PR DESCRIPTION
- Due to designation appearing in new line, we get unequal height Fixed height to 160px to make it uniform


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardizes the team list to a consistent 3‑column grid for improved readability.
  * Aligns team member items horizontally and sets a uniform card height (160px) for a cleaner layout.
  * Enhances visual consistency and spacing across the team section.
  * Purely visual update with no changes to behavior or data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->