### PR TITLE
New event type

### DIFF
--- a/dashboard/src/pages/CreateEventForm.vue
+++ b/dashboard/src/pages/CreateEventForm.vue
@@ -17,10 +17,10 @@
           <div class="my-1 grid sm:grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-6">
             <FormControl
               v-model="temp_event.event_type"
-              :type="'select'"
+              type="select"
               :options="eventTypeOptions.data"
               size="md"
-              label="Event Type&ast;"
+              label="Event Type*"
             />
             <FormControl
               v-model="temp_event.event_name"
@@ -159,14 +159,17 @@ const chapter = createDocumentResource({
   name: route.params.id,
 })
 
-const eventTypeOptions = createListResource({
-  doctype: 'FOSS Event Type',
-  fields: ['name'],
+const eventTypeOptions = createResource({
+  url: 'fossunited.fossunited.utils.get_select_field_options',
+  makeParams() {
+    return {
+      doctype_name: 'FOSS Chapter Event',
+      fieldname: 'event_type',
+    }
+  },
   auto: true,
   transform(data) {
-    return data.map((d) => {
-      return { label: d.name, value: d.name }
-    })
+    return data.map((opt) => ({ label: opt, value: opt }))
   },
 })
 

--- a/dashboard/src/pages/EventDetails.vue
+++ b/dashboard/src/pages/EventDetails.vue
@@ -201,7 +201,13 @@
 import EventHeader from '@/components/EventHeader.vue'
 import TextEditor from '@/components/ui/TextEditor.vue'
 import CopyToClipboardButton from '@/components/CopyToClipboardButton.vue'
-import { createDocumentResource, createListResource, FileUploader, FormControl } from 'frappe-ui'
+import {
+  createDocumentResource,
+  createListResource,
+  createResource,
+  FileUploader,
+  FormControl,
+} from 'frappe-ui'
 import { useRoute } from 'vue-router'
 import { toast } from 'vue-sonner'
 import { createAbsoluteUrlFromRoute } from '@/helpers/utils'
@@ -242,14 +248,17 @@ const setBannerImage = (file) => {
   }
 }
 
-const eventTypeOptions = createListResource({
-  doctype: 'FOSS Event Type',
-  fields: ['name'],
+const eventTypeOptions = createResource({
+  url: 'fossunited.fossunited.utils.get_select_field_options',
+  makeParams() {
+    return {
+      doctype_name: 'FOSS Chapter Event',
+      fieldname: 'event_type',
+    }
+  },
   auto: true,
   transform(data) {
-    return data.map((d) => {
-      return { label: d.name, value: d.name }
-    })
+    return data.map((opt) => ({ label: opt, value: opt }))
   },
 })
 

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
@@ -104,11 +104,11 @@
   },
   {
    "fieldname": "event_type",
-   "fieldtype": "Link",
+   "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Event Type",
    "mandatory_depends_on": "eval:doc.is_external_event == 0",
-   "options": "FOSS Event Type"
+   "options": "Meet Up\nConference\nWorkshop\nBirds Of Feathers\nHackathon\nLinux Installation Party"
   },
   {
    "fieldname": "chapter_information_section",
@@ -531,7 +531,7 @@
    "link_fieldname": "event"
   }
  ],
- "modified": "2025-08-17 12:01:27.933102",
+ "modified": "2025-10-07 16:50:15.974998",
  "modified_by": "Administrator",
  "module": "Chapters",
  "name": "FOSS Chapter Event",
@@ -569,6 +569,7 @@
    "select": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "event_permalink, chapter",
  "show_title_field_in_link": 1,
  "sort_field": "modified",

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -434,7 +434,7 @@ class FOSSChapterEvent(WebsiteGenerator):
         if frappe.db.exists(EVENT_CFP, {"event": self.name}):
             cfp_form = frappe.get_doc(EVENT_CFP, {"event": self.name})
             cfp_status_block |= {
-                "form_route": cfp_form.route,
+                "form_route": cfp_form.get("route") or f"{self.route}/cfp",
                 "has_doc": True,
                 "block_heading": "Call for Proposal (CFP) Form is Live!",
                 "docname": cfp_form.name,

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -41,7 +41,7 @@ class FOSSChapterEvent(WebsiteGenerator):
         from fossunited.chapters.doctype.foss_event_community_partner.foss_event_community_partner import (  # noqa: E501
             FOSSEventCommunityPartner,
         )
-        from fossunited.fossunited.doctype.event_project_showcase.event_project_showcase import (  # noqa: E501
+        from fossunited.fossunited.doctype.event_project_showcase.event_project_showcase import (
             EventProjectShowcase,
         )
         from fossunited.fossunited.doctype.foss_event_field.foss_event_field import (
@@ -73,7 +73,14 @@ class FOSSChapterEvent(WebsiteGenerator):
         event_permalink: DF.Data | None
         event_schedule: DF.Table[FOSSEventSchedule]
         event_start_date: DF.Datetime
-        event_type: DF.Link | None
+        event_type: DF.Literal[
+            "Meet Up",  # noqa: F722, F821
+            "Conference",  # noqa: F722, F821
+            "Workshop",  # noqa: F722, F821
+            "Birds Of Feathers",  # noqa: F722, F821
+            "Hackathon",  # noqa: F722, F821
+            "Linux Installation Party",  # noqa: F722, F821
+        ]
         external_event_url: DF.Data | None
         hall_options: DF.SmallText | None
         has_external_webpage: DF.Check
@@ -99,10 +106,10 @@ class FOSSChapterEvent(WebsiteGenerator):
         show_schedule: DF.Check
         show_speakers: DF.Check
         sponsor_list: DF.Table[FOSSEventSponsor]
-        status: DF.Literal["Draft", "Live", "Concluded", "Cancelled"]  # noqa: F821
+        status: DF.Literal["Draft", "Live", "Concluded", "Cancelled"]  # noqa: F722, F821
         t_shirt_price: DF.Currency
         ticket_form_description: DF.MarkdownEditor | None
-        tickets_status: DF.Literal["Live", "Closed"]  # noqa: F821
+        tickets_status: DF.Literal["Live", "Closed"]  # noqa: F722, F821
         tiers: DF.Table[FOSSTicketTier]
     # end: auto-generated types
 

--- a/fossunited/chapters/doctype/foss_event_rsvp/templates/foss_event_rsvp.html
+++ b/fossunited/chapters/doctype/foss_event_rsvp/templates/foss_event_rsvp.html
@@ -2,7 +2,7 @@
 {% block meta_block %}
   <meta name="title" content="{{ event.event_name }}" />
   {% if doc.is_published %}
-    {% if event.event_type in ['Meetup', 'City Meetup', 'FOSS Meetup'] %}
+    {% if event.event_type in ['Meet Up'] %}
       <meta
         property="og:title"
         content="🔴 RSVP form is live! - {{ event.event_name }}, {{ event.chapter_name | title }}"
@@ -16,7 +16,7 @@
       content="RSVP is coming soon! - {{ event.event_name }}, {{ event.chapter_name | title }}"
     />
   {% endif %}
-  {% if event.event_type in ['Meetup', 'City Meetup', 'FOSS Meetup'] %}
+  {% if event.event_type in ['Meet Up'] %}
     <meta
       property="og:description"
       content="RSVP forms are live for {{ event.event_name }} {{ event.event_start_date.strftime('%B') }} - {{ event.chapter_name | title }}"

--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -422,3 +422,18 @@ def get_foss_profile(email):
         as_dict=1,
     )
     return profile
+
+
+@frappe.whitelist(allow_guest=True)
+def get_select_field_options(doctype_name, fieldname):
+    """
+    Return options for a Select field in a Doctype as a list of strings.
+    """
+    meta = frappe.get_meta(doctype_name)
+    field = meta.get_field(fieldname)
+    if not field or field.fieldtype != "Select":
+        return []
+
+    # Options are stored as newline-separated string in `field.options`
+    options = field.options.split("\n") if field.options else []
+    return options

--- a/fossunited/patches.txt
+++ b/fossunited/patches.txt
@@ -8,3 +8,4 @@ fossunited.patches.v1_0.duplicate_event_name_to_reference_field  #31-12-2024
 fossunited.patches.v1_0.handle_sharing_all_existing_profiles
 fossunited.patches.v1_0.migrate_old_cfps_to_new_schema
 fossunited.patches.v1_0.convert_lead_to_core_team_chapters
+fossunited.patches.v1_0.convert_event_type_new_option

--- a/fossunited/patches/v1_0/convert_event_type_new_option.py
+++ b/fossunited/patches/v1_0/convert_event_type_new_option.py
@@ -20,14 +20,17 @@ def execute():
     # update documents with new values
     for old_value, new_value in mapping.items():
         try:
-            frappe.db.set_value(
-                doctype,
-                {"event_type": old_value},
-                fieldname,
-                new_value,
-                update_modified=False,
-            )
-            print(f"Updated '{old_value}' → '{new_value}'")
+            event_names = frappe.get_all(doctype, filters={fieldname: old_value}, pluck="name")
+            for name in event_names:
+                frappe.db.set_value(
+                    doctype,
+                    name,
+                    fieldname,
+                    new_value,
+                    update_modified=False,
+                )
+            if event_names:
+                print(f"Updated {len(event_names)} record(s) from '{old_value}' → '{new_value}'")
         except Exception as e:
             print(f"Error updating '{old_value}': {str(e)}")
             frappe.log_error(f"Event type migration error: {str(e)}")

--- a/fossunited/patches/v1_0/convert_event_type_new_option.py
+++ b/fossunited/patches/v1_0/convert_event_type_new_option.py
@@ -11,6 +11,7 @@ def execute():
     mapping = {
         "City Meetup": "Meet Up",
         "FOSS Meetup": "Meet Up",
+        "Meetup": "Meet Up",
         "CityFOSS Conference": "Conference",
         "FOSS Hack": "Hackathon",
     }
@@ -18,14 +19,19 @@ def execute():
     print("\n--- Starting Event Type Migration ---\n")
     # update documents with new values
     for old_value, new_value in mapping.items():
-        frappe.db.set_value(
-            doctype,
-            {"event_type": old_value},
-            fieldname,
-            new_value,
-            update_modified=False,
-        )
-        print(f"Updated '{old_value}' → '{new_value}'")
+        try:
+            frappe.db.set_value(
+                doctype,
+                {"event_type": old_value},
+                fieldname,
+                new_value,
+                update_modified=False,
+            )
+            print(f"Updated '{old_value}' → '{new_value}'")
+        except Exception as e:
+            print(f"Error updating '{old_value}': {str(e)}")
+            frappe.log_error(f"Event type migration error: {str(e)}")
+
     # change fieldtype from Link to Select and set new options
     docfield = frappe.get_doc("DocField", {"parent": doctype, "fieldname": fieldname})
 

--- a/fossunited/patches/v1_0/convert_event_type_new_option.py
+++ b/fossunited/patches/v1_0/convert_event_type_new_option.py
@@ -1,0 +1,49 @@
+import frappe
+
+from fossunited.doctype_ids import EVENT
+
+
+def execute():
+    doctype = EVENT
+    fieldname = "event_type"
+
+    # map old values to new ones
+    mapping = {
+        "City Meetup": "Meet Up",
+        "FOSS Meetup": "Meet Up",
+        "CityFOSS Conference": "Conference",
+        "FOSS Hack": "Hackathon",
+    }
+
+    print("\n--- Starting Event Type Migration ---\n")
+    # update documents with new values
+    for old_value, new_value in mapping.items():
+        frappe.db.set_value(
+            doctype,
+            {"event_type": old_value},
+            fieldname,
+            new_value,
+            update_modified=False,
+        )
+        print(f"Updated '{old_value}' → '{new_value}'")
+    # change fieldtype from Link to Select and set new options
+    docfield = frappe.get_doc("DocField", {"parent": doctype, "fieldname": fieldname})
+
+    docfield.fieldtype = "Select"
+    docfield.options = "\n".join(
+        [
+            "Meet Up",
+            "Conference",
+            "Workshop",
+            "Birds Of Feathers",
+            "Hackathon",
+            "Linux Installation Party",
+        ]
+    )
+    docfield.save()
+    print("Updated fieldtype to 'Select' with new options")
+
+    # rebuild schema and clear cache
+    frappe.clear_cache(doctype=doctype)
+    frappe.db.commit()
+    print("\nEvent Type migration completed.\n")

--- a/fossunited/tests/utils.py
+++ b/fossunited/tests/utils.py
@@ -129,7 +129,7 @@ def insert_test_event(chapter: dict, **kwargs):
         chapter (dict, optional): chapter to associate the event with.
                 If not provided, a new test chapter will be generated.
         event_name (str, optional): Name of the event. Defaults to random text.
-        event_type (str, optional): Type of event. Defaults to "FOSS Meetup".
+        event_type (str, optional): Type of event. Defaults to "Hackathon".
         start_date (datetime, optional): Event start date. Defaults to today.
         end_date (datetime, optional): Event end date. Defaults to next day.
         status (str, optional): Event status. Defaults to "Live".
@@ -173,7 +173,7 @@ def insert_test_event(chapter: dict, **kwargs):
             "event_name": kwargs.get("event_name", fake.text(max_nb_chars=20).strip()),
             "event_permalink": kwargs.get("event_permalink", fake.slug().replace("-", "_")),
             "status": kwargs.get("status", "Live"),
-            "event_type": kwargs.get("event_type", "FOSS Meetup"),
+            "event_type": kwargs.get("event_type", "Hackathon"),
             "event_start_date": kwargs.get("start_date", datetime.today() + timedelta(days=1)),
             "event_end_date": kwargs.get("end_date", datetime.today() + timedelta(days=2)),
             "event_description": kwargs.get(


### PR DESCRIPTION
## 🚦 Status

- [ ] Draft
- [x] Ready for review

---

## 🔗 Related Issue

Closes / Addresses: #1187 

---

## ❗ Problem

<!-- Briefly describe the problem or motivation for this PR -->
Simplify event type to new scheme (more sensible names)

---

## ✅ Solution

<!-- Describe your solution and what you changed -->

1. Apply new schema for options
2. Move `event_type` field from link (doctype) to simple Select option
  - Add api to get these options dynamically into vue page (event create form & edit details page)
  
3. Migration patch to convert old schema types to new option names

---

## 📋 Progress (All must be checked to merge)

- [x] Tested locally

---

## 📝 Changelog

<commit>: <!-- e.g., feat: add user login endpoint -->

---

## 🖼️ Visualization

<!-- Add screenshots, diagrams, or screen recordings if applicable -->

---

## 🔮 Further Ahead

<!-- Mention any follow-up work or related PRs planned -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Event Type is now a Select with fixed options (Meet Up, Conference, Workshop, Birds Of Feathers, Hackathon, Linux Installation Party).
  - Event Type options now load dynamically from an API for consistent dropdowns.

- **Bug Fixes**
  - Label corrected to display "Event Type*".
  - RSVP meta tags now trigger only for "Meet Up" events.

- **Chores**
  - Migration added to convert existing events to the new Event Type values.

- **Tests**
  - Test helper default event type updated to "Hackathon".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->