### PR TITLE
backend: keep name+email blank for guest in RSVP submission

### DIFF
--- a/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.py
@@ -46,6 +46,7 @@ class FOSSEventRSVP(WebsiteGenerator):
         context.event = frappe.get_doc(EVENT, self.event)
         context.event_name = self.event_name
         context.event_date = context.event.event_start_date.strftime("%B %d, %Y")
+        is_guest = frappe.session.user in ("Guest", "Administrator")
 
         form_fields = [
             {
@@ -53,14 +54,18 @@ class FOSSEventRSVP(WebsiteGenerator):
                 "fieldtype": "Data",
                 "label": "Full Name",
                 "reqd": 1,
-                "value": frappe.get_value("User", frappe.session.user, "full_name"),
+                "value": ""
+                if is_guest
+                else (frappe.get_value("User", frappe.session.user, "full_name") or ""),
             },
             {
                 "fieldname": "email",
                 "fieldtype": "Data",
                 "label": "Email",
                 "reqd": 1,
-                "value": frappe.get_value("User", frappe.session.user, "email"),
+                "value": ""
+                if is_guest
+                else (frappe.get_value("User", frappe.session.user, "email") or ""),
             },
             {
                 "fieldname": "im_a",


### PR DESCRIPTION
- The auto pre-fills based on frappe.session.user, so we will mitigate user moving on with "guest@example.com"

- And this was not as placeholder text, this was direct as inputted text

Fixes #1197 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RSVP form now adapts to session status: signed-in users have name and email pre-filled; guests see empty name and email fields to enter manually.
  * Improves clarity during RSVP by reflecting whether you’re logged in or browsing as a guest.
  * No other form behavior or fields were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->