### PR TITLE
rss: remove newsletters from rss feed

### DIFF
--- a/fossunited/www/rss.py
+++ b/fossunited/www/rss.py
@@ -39,43 +39,16 @@ def get_context(context):
         limit=20,
     )
 
-    news_list = frappe.get_all(
-        "Newsletter",
-        fields=[
-            "name",
-            "modified",
-            "subject",
-            "sender_name",
-            "sender_email",
-            "route",
-            "message_md",
-            "message",
-            "message_html",
-            "content_type",
-        ],
-        filters={"email_sent": 1},
-        order_by="modified desc",
-        limit=20,
-    )
-
-    for blog in blog_list + news_list:
+    for blog in blog_list:
         blog.link = urljoin(host, blog.route)
         blog.title = escape_html(
             getattr(blog, "title", None) or getattr(blog, "subject", "") or ""
         )
-        blog.author = escape_html(
-            getattr(blog, "blogger", None)
-            or (
-                f"{blog.sender_name} <{blog.sender_email}>" if hasattr(blog, "sender_name") else ""
-            )
-        )
+        blog.author = escape_html(getattr(blog, "blogger", None) or "")
         blog.published_date = format_datetime(
             datetime.combine(getattr(blog, "published_on", None) or blog.modified, time())
         )
-        prefix = "message_" if blog.route.startswith("newsletters/") else "content_"
-        attr = {"Markdown": prefix + "md", "HTML": prefix + "html"}.get(
-            blog.content_type, prefix.rstrip("_")
-        )
+        attr = {"Markdown": "content_md", "HTML": "content_html"}.get(blog.content_type, "content")
         value = getattr(blog, attr)
         if blog.content_type == "Markdown":
             blog_content = markdown(re.sub(r"(?i)</?br\s*/?>", "\n", value))
@@ -83,7 +56,7 @@ def get_context(context):
             blog_content = value
         blog.content = f"<![CDATA[{blog_content}]]>"
 
-    all_items = blog_list + news_list
+    all_items = blog_list
     if all_items:
         modified = format_datetime(max(blog["modified"] for blog in all_items))
     else:
@@ -101,7 +74,7 @@ def get_context(context):
         "title": title,
         "description": description,
         "modified": modified,
-        "items": blog_list + news_list,
+        "items": blog_list,
         "link": host + "/blog",
         "feed_url": host + "/rss.xml",
     }


### PR DESCRIPTION
- users can use discourse forum rss feeds for more content
- we will explicitly only publish blog posts for rss


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RSS feed now includes only Blog Posts; Newsletter items are excluded.
  * Feed metadata (e.g., last-modified) and payload reflect Blog Post activity only.
  * Feed entries surface links, titles, authors, publish dates, and content sourced exclusively from Blog Posts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->