### PR TITLE
feat: support chapter mailing & handle email_group subcription via user checkbox

### DIFF
--- a/dashboard/src/pages/BuyTickets.vue
+++ b/dashboard/src/pages/BuyTickets.vue
@@ -194,6 +194,13 @@
                   label="Email"
                 />
                 <FormControl
+                  v-model="attendee.subscribe_chapter_mailing"
+                  type="checkbox"
+                  size="sm"
+                  variant="subtle"
+                  label="Yes, I’d like to receive email updates about future events."
+                />
+                <FormControl
                   v-model="attendee.organization"
                   type="text"
                   size="sm"
@@ -524,6 +531,7 @@ watch(
           email: '',
           placeholder: randomPlaceholder,
           designation: '',
+          subscribe_chapter_mailing: true,
           organization: '',
           wants_tshirt: false,
           tshirt_size: 'M',

--- a/fossunited/api/emailing.py
+++ b/fossunited/api/emailing.py
@@ -14,7 +14,8 @@ from fossunited.doctype_ids import (
 )
 
 EMAIL_GROUP_TYPES = Literal[
-    "Chapter Main",
+    "Chapter Event Participants",
+    "Chapter CFP Proposers",
     "Event Participants",
     "CFP Proposers",
     "Accepted Proposers",
@@ -29,7 +30,8 @@ def create_email_group(
     document_type: str = EVENT,
 ):
     """
-    Create an email group linked to the event
+    Ensure an email group exists for the given document.
+    Returns the existing group or creates a new one.
 
     Args:
         type: type of email group
@@ -39,7 +41,7 @@ def create_email_group(
     _doc = frappe.get_doc(document_type, reference_document)
     _chapter = _doc.get("chapter")
 
-    if frappe.db.exists(
+    existing_group = frappe.get_value(
         EMAIL_GROUP,
         {
             "reference_document": reference_document,
@@ -47,21 +49,24 @@ def create_email_group(
             "chapter": _chapter,
             "group_type": type,
         },
-    ):
-        raise frappe.ValidationError("Email Group already exists for this event")
+        "name",
+    )
+    if existing_group:
+        return frappe.get_doc(EMAIL_GROUP, existing_group)
 
-    # This is done to prevent cases when event id and hackathon id are equal
-    group_title = ""
-    if document_type == EVENT:
+    if document_type == CHAPTER:
+        group_title = f"{type}-{reference_document}"
+    elif document_type == EVENT:
         group_title = f"{type}-{reference_document}-Event"
     else:
         group_title = f"{type}-{reference_document}-Hackathon"
 
-    _group_title = group_title[:140]
+    group_title = group_title[:140]
+
     group = frappe.get_doc(
         {
             "doctype": EMAIL_GROUP,
-            "title": _group_title,
+            "title": group_title,
             "chapter": _chapter,
             "reference_document": reference_document,
             "document_type": document_type,
@@ -86,15 +91,18 @@ def add_to_email_group(email_group: str, email: str):
         email_group: id of email group
         email: email to be added to the group
     """
+    logger = frappe.logger("email_group")  # Logs to logs/email_group.log
 
     if not frappe.db.exists(EMAIL_GROUP, email_group):
         frappe.throw("This email group does not exist", frappe.DoesNotExistError)
 
     if frappe.db.exists(EMAIL_MEMBER, {"email_group": email_group, "email": email}):
-        frappe.throw("Email already a part of this email group", frappe.DuplicateEntryError)
+        logger.info(f"Email '{email}' already exists in group '{email_group}'")
+        return
 
     member = frappe.get_doc({"doctype": EMAIL_MEMBER, "email_group": email_group, "email": email})
     member.insert(ignore_permissions=True)
+    logger.info(f"Email '{email}' added to group '{email_group}'")
 
 
 @frappe.whitelist()

--- a/fossunited/api/emailing.py
+++ b/fossunited/api/emailing.py
@@ -105,6 +105,24 @@ def add_to_email_group(email_group: str, email: str):
     logger.info(f"Email '{email}' added to group '{email_group}'")
 
 
+def remove_from_email_group(email_group: str, email: str):
+    """
+    Remove an email from an email group.
+    """
+    logger = frappe.logger("email_group")
+
+    if not frappe.db.exists(EMAIL_GROUP, email_group):
+        frappe.throw("This email group does not exist", frappe.DoesNotExistError)
+
+    member_name = frappe.db.exists(EMAIL_MEMBER, {"email_group": email_group, "email": email})
+    if not member_name:
+        logger.info(f"Email '{email}' not found in group '{email_group}', nothing to remove")
+        return
+
+    frappe.delete_doc(EMAIL_MEMBER, member_name, ignore_permissions=True)
+    logger.info(f"Email '{email}' removed from group '{email_group}'")
+
+
 @frappe.whitelist()
 def create_newsletter_campaign(
     data: dict,

--- a/fossunited/api/emailing.py
+++ b/fossunited/api/emailing.py
@@ -185,15 +185,15 @@ def handle_email_group_subscription(
                 continue
 
             try:
-                if event_group and subscribe_to_event:
+                if subscribe_to_event:
                     add_to_email_group(event_group.name, email)
+                else:
+                    remove_from_email_group(event_group.name, email)
 
                 if subscribe_to_chapter:
                     add_to_email_group(chapter_group.name, email)
                 else:
                     remove_from_email_group(chapter_group.name, email)
-                    remove_from_email_group(event_group.name, email)
-
             except frappe.DuplicateEntryError:
                 continue
 

--- a/fossunited/api/emailing.py
+++ b/fossunited/api/emailing.py
@@ -38,8 +38,14 @@ def create_email_group(
         reference_document: id of the reference document of type document_type
         document_type: type of reference document (default: "FOSS Chapter Event")
     """
-    _doc = frappe.get_doc(document_type, reference_document)
-    _chapter = _doc.get("chapter") or _doc.get("name")
+    try:
+        _doc = frappe.get_doc(document_type, reference_document)
+        _chapter = _doc.get("chapter") or _doc.get("name")
+    except Exception:
+        frappe.log_error(
+            frappe.get_traceback(), "Error fetching reference document for email group"
+        )
+        return None
 
     existing_group = frappe.get_value(
         EMAIL_GROUP,
@@ -76,8 +82,9 @@ def create_email_group(
 
     try:
         group.insert(ignore_permissions=True)
-    except Exception as e:
-        frappe.throw(f"Error while creating email group: {e}", frappe.ValidationError)
+    except Exception:
+        frappe.log_error(frappe.get_traceback(), "Error while creating email group")
+        return None
 
     group.reload()
     return group
@@ -162,6 +169,9 @@ def handle_email_group_subscription(
             document_type=document_type_chapter,
         )
 
+        if not chapter_group:
+            return  # skip silently
+
         event_group = None
         if event and document_type_event:
             event_group = create_email_group(
@@ -171,7 +181,7 @@ def handle_email_group_subscription(
             )
 
         for email in emails:
-            if not email:
+            if not isinstance(email, str) or not email.strip():
                 continue
 
             try:
@@ -182,6 +192,7 @@ def handle_email_group_subscription(
                     add_to_email_group(chapter_group.name, email)
                 else:
                     remove_from_email_group(chapter_group.name, email)
+                    remove_from_email_group(event_group.name, email)
 
             except frappe.DuplicateEntryError:
                 continue

--- a/fossunited/api/emailing.py
+++ b/fossunited/api/emailing.py
@@ -39,7 +39,7 @@ def create_email_group(
         document_type: type of reference document (default: "FOSS Chapter Event")
     """
     _doc = frappe.get_doc(document_type, reference_document)
-    _chapter = _doc.get("chapter")
+    _chapter = _doc.get("chapter") or _doc.get("name")
 
     existing_group = frappe.get_value(
         EMAIL_GROUP,

--- a/fossunited/api/emailing.py
+++ b/fossunited/api/emailing.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, Optional
 
 import frappe
 
@@ -121,6 +121,73 @@ def remove_from_email_group(email_group: str, email: str):
 
     frappe.delete_doc(EMAIL_MEMBER, member_name, ignore_permissions=True)
     logger.info(f"Email '{email}' removed from group '{email_group}'")
+
+
+def handle_email_group_subscription(
+    emails: list[str],
+    chapter: str,
+    event: Optional[str] = None,
+    event_type: str = "Event Participants",
+    chapter_type: str = "Chapter Event Participants",
+    subscribe_to_chapter: bool = True,
+    subscribe_to_event: bool = True,
+    document_type_event: Optional[str] = None,
+    document_type_chapter: str = CHAPTER,
+):
+    """
+    Sync email(s) to event and/or chapter email groups.
+
+    Always adds to event group. Chapter group is conditional.
+
+    Args:
+        emails (list): List of email addresses to process.
+        chapter (str): Chapter name.
+        event (str, optional): Event reference.
+        event_type (str): Event group type.
+        chapter_type (str): Chapter group type.
+        subscribe_to_chapter (bool): Whether to add/remove from chapter group.
+        subscribe_to_event (bool): Whether to add/remove from event group.
+        document_type_event (str): DocType of the event (e.g. "Event", "Hackathon").
+        document_type_chapter (str): DocType of the chapter (default: "Chapter").
+    """
+
+    if not emails or not chapter:
+        return
+
+    try:
+        # Always create chapter group
+        chapter_group = create_email_group(
+            type=chapter_type,
+            reference_document=chapter,
+            document_type=document_type_chapter,
+        )
+
+        event_group = None
+        if event and document_type_event:
+            event_group = create_email_group(
+                type=event_type,
+                reference_document=event,
+                document_type=document_type_event,
+            )
+
+        for email in emails:
+            if not email:
+                continue
+
+            try:
+                if event_group and subscribe_to_event:
+                    add_to_email_group(event_group.name, email)
+
+                if subscribe_to_chapter:
+                    add_to_email_group(chapter_group.name, email)
+                else:
+                    remove_from_email_group(chapter_group.name, email)
+
+            except frappe.DuplicateEntryError:
+                continue
+
+    except Exception:
+        frappe.log_error(frappe.get_traceback(), "sync_email_group_subscription failed")
 
 
 @frappe.whitelist()

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
@@ -4,7 +4,14 @@
 import frappe
 from frappe.website.website_generator import WebsiteGenerator
 
-from fossunited.doctype_ids import CITY_COMMUNITY, EVENT, STUDENT_CLUB, USER_PROFILE
+from fossunited.api.emailing import create_email_group
+from fossunited.doctype_ids import (
+    CHAPTER,
+    CITY_COMMUNITY,
+    EVENT,
+    STUDENT_CLUB,
+    USER_PROFILE,
+)
 
 
 class FOSSChapter(WebsiteGenerator):
@@ -52,6 +59,10 @@ class FOSSChapter(WebsiteGenerator):
         zulip: DF.Data | None
     # end: auto-generated types
 
+    def after_insert(self):
+        if not self.is_external_event:
+            self.create_email_groups()
+
     def before_insert(self):
         self.handle_member_addition()
 
@@ -65,6 +76,13 @@ class FOSSChapter(WebsiteGenerator):
     def on_update(self):
         self.handle_member_addition()
         self.handle_member_removal()
+
+    def create_email_groups(self):
+        for group in [
+            "Chapter Event Participants",
+            "Chapter CFP Proposers",
+        ]:
+            create_email_group(type=group, reference_document=self.name, document_type=CHAPTER)
 
     def handle_member_addition(self):
         # for each member, add roles of 'Chapter Team Member'

--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
@@ -60,8 +60,7 @@ class FOSSChapter(WebsiteGenerator):
     # end: auto-generated types
 
     def after_insert(self):
-        if not self.is_external_event:
-            self.create_email_groups()
+        self.create_email_groups()
 
     def before_insert(self):
         self.handle_member_addition()

--- a/fossunited/chapters/doctype/foss_chapter/test_foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/test_foss_chapter.py
@@ -31,7 +31,8 @@ class TestFOSSChapter(FrappeTestCase):
         new_member = frappe.get_doc(USER_PROFILE, {"user": "test1@example.com"})
 
         chapter.append(
-            "chapter_members", {"chapter_member": new_member.name, "role": "Core Team Member"}
+            "chapter_members",
+            {"chapter_member": new_member.name, "role": "Core Team Member"},
         )
         chapter.save()
 
@@ -52,7 +53,8 @@ class TestFOSSChapter(FrappeTestCase):
         )
         for new_member in new_members:
             chapter.append(
-                "chapter_members", {"chapter_member": new_member.name, "role": "Core Team Member"}
+                "chapter_members",
+                {"chapter_member": new_member.name, "role": "Core Team Member"},
             )
         chapter.save()
 
@@ -91,3 +93,30 @@ class TestFOSSChapter(FrappeTestCase):
         # Then an exception should be raised
         with self.assertRaises(frappe.UniqueValidationError):
             insert_test_chapter(slug=chapter.slug)
+
+    def test_email_groups_are_created_on_chapter_insert(self):
+        expected_group_types = [
+            "Chapter Event Participants",
+            "Chapter CFP Proposers",
+        ]
+
+        for group_type in expected_group_types:
+            self.assertTrue(
+                frappe.db.exists(
+                    "Email Group",
+                    {
+                        "group_type": group_type,
+                        "reference_document": self.chapter.name,
+                        "document_type": CHAPTER,
+                    },
+                ),
+                msg=f"Email Group '{group_type}' not created for event {self.chapter.name}",
+            )
+
+        frappe.db.delete(
+            "Email Group",
+            {
+                "reference_document": self.chapter.name,
+                "document_type": CHAPTER,
+            },
+        )

--- a/fossunited/chapters/doctype/foss_chapter/test_foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/test_foss_chapter.py
@@ -113,10 +113,13 @@ class TestFOSSChapter(FrappeTestCase):
                 msg=f"Email Group '{group_type}' not created for event {self.chapter.name}",
             )
 
-        frappe.db.delete(
+        groups = frappe.get_all(
             "Email Group",
-            {
+            filters={
                 "reference_document": self.chapter.name,
                 "document_type": CHAPTER,
             },
+            pluck="name",
         )
+        for group_name in groups:
+            frappe.delete_doc("Email Group", group_name, force=True)

--- a/fossunited/chapters/doctype/foss_chapter_event/test_foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/test_foss_chapter_event.py
@@ -62,3 +62,32 @@ class TestFOSSChapterEvent(FrappeTestCase):
 
         # Test 3: Same chapter, different slug (should succeed)
         insert_test_event(chapter=original_chapter)
+
+    def test_email_groups_are_created_on_event_insert(self):
+        expected_group_types = [
+            "Event Participants",
+            "CFP Proposers",
+            "Accepted Proposers",
+            "Rejected Proposers",
+        ]
+
+        for group_type in expected_group_types:
+            self.assertTrue(
+                frappe.db.exists(
+                    "Email Group",
+                    {
+                        "group_type": group_type,
+                        "reference_document": self.event.name,
+                        "document_type": EVENT,
+                    },
+                ),
+                msg=f"Email Group '{group_type}' not created for event {self.event.name}",
+            )
+
+        frappe.db.delete(
+            "Email Group",
+            {
+                "reference_document": self.event.name,
+                "document_type": EVENT,
+            },
+        )

--- a/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.py
@@ -78,7 +78,7 @@ class FOSSEventRSVP(WebsiteGenerator):
             {
                 "fieldname": "subscribe_chapter_mailing",
                 "fieldtype": "Check",
-                "label": f"Yes, I’d like to receive email updates about future events from {self.chapter}.",  # noqa: E501
+                "label": f"Yes, I'd like to receive email updates about future events from {self.chapter}.",  # noqa: E501
             },
         ]
         form_fields.extend(self.get_custom_questions())

--- a/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp/foss_event_rsvp.py
@@ -75,6 +75,11 @@ class FOSSEventRSVP(WebsiteGenerator):
                 "options": "\nStudent\nProfessional\nOther",
                 "reqd": 1,
             },
+            {
+                "fieldname": "subscribe_chapter_mailing",
+                "fieldtype": "Check",
+                "label": f"Yes, I’d like to receive email updates about future events from {self.chapter}.",  # noqa: E501
+            },
         ]
         form_fields.extend(self.get_custom_questions())
         context.form_fields = form_fields

--- a/fossunited/chapters/doctype/foss_event_rsvp/templates/foss_event_rsvp.html
+++ b/fossunited/chapters/doctype/foss_event_rsvp/templates/foss_event_rsvp.html
@@ -56,41 +56,7 @@
             %}
               {{ renderfield(field) }}
             {% endfor %}
-            <div class="form-check d-flex align-items-center">
-              <input
-                value="1"
-                class="form-control form-check-input text-sm"
-                type="checkbox"
-                name="confirm_attendance"
-                id="confirm_attendance"
-                required=""
-              />
-              <label
-                class="form-check-label foss-form-question text-sm m-2"
-                for="confirm_attendance"
-              >
-                {{ _("Confirm my attendance for the event.") }}
-              </label>
-            </div>
 
-            <div class="form-check d-flex align-items-center">
-              <input
-                value="1"
-                class="form-control form-check-input text-sm"
-                type="checkbox"
-                name="subscribe_chapter_mailing"
-                id="subscribe_chapter_mailing"
-                required=""
-                checked
-              />
-              <label
-                class="form-check-label foss-form-question text-sm m-2"
-                for="subscribe_chapter_mailing"
-              >
-                Yes, I’d like to receive email updates about future events from
-                {{ event.chapter }}.
-              </label>
-            </div>
           </form>
           <div class="foss-form-buttons">
             <button class="primary-button" type="submit" id="submit-rsvp">
@@ -171,15 +137,11 @@
           return emailRegex.test(email)
         }
 
-        if (!validate_mandatory_fields() || !$('#confirm_attendance').is(':checked')) {
-          frappe.msgprint('Please confirm your attendance for the event!')
-          return
-        }
-
         const formData = $('.foss-form-body').serializeArray()
         const data = {}
 
         data['linked_rsvp'] = '{{ doc.name }}'
+        data['status'] = 'Accepted' // by default we accept
         formData.forEach((field) => {
           data[field.name] = field.value
         })

--- a/fossunited/chapters/doctype/foss_event_rsvp/templates/foss_event_rsvp.html
+++ b/fossunited/chapters/doctype/foss_event_rsvp/templates/foss_event_rsvp.html
@@ -72,6 +72,25 @@
                 {{ _("Confirm my attendance for the event.") }}
               </label>
             </div>
+
+            <div class="form-check d-flex align-items-center">
+              <input
+                value="1"
+                class="form-control form-check-input text-sm"
+                type="checkbox"
+                name="subscribe_chapter_mailing"
+                id="subscribe_chapter_mailing"
+                required=""
+                checked
+              />
+              <label
+                class="form-check-label foss-form-question text-sm m-2"
+                for="subscribe_chapter_mailing"
+              >
+                Yes, I’d like to receive email updates about future events from
+                {{ event.chapter }}.
+              </label>
+            </div>
           </form>
           <div class="foss-form-buttons">
             <button class="primary-button" type="submit" id="submit-rsvp">

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.json
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.json
@@ -134,14 +134,14 @@
    "options": "Pending\nAccepted\nRejected"
   },
   {
-   "default": "1",
+   "default": "0",
    "fieldname": "subscribe_chapter_mailing",
    "fieldtype": "Check",
    "label": "Subscribe to Chapter Mailing?"
   }
  ],
  "links": [],
- "modified": "2025-10-13 12:21:38.267914",
+ "modified": "2025-10-13 18:31:01.655975",
  "modified_by": "Administrator",
  "module": "Chapters",
  "name": "FOSS Event RSVP Submission",

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.json
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.json
@@ -1,189 +1,197 @@
 {
-  "actions": [],
-  "allow_rename": 1,
-  "creation": "2023-09-04 19:50:13.664495",
-  "default_view": "List",
-  "doctype": "DocType",
-  "editable_grid": 1,
-  "engine": "InnoDB",
-  "field_order": [
-    "section_break_qrdc",
-    "linked_rsvp",
-    "event",
-    "event_name",
-    "column_break_tpys",
-    "submitted_by",
-    "chapter",
-    "status",
-    "standard_questions_section",
-    "name1",
-    "im_a",
-    "column_break_bkxf",
-    "email",
-    "confirm_attendance",
-    "section_break_vzwa",
-    "custom_answers"
-  ],
-  "fields": [
-    {
-      "fieldname": "linked_rsvp",
-      "fieldtype": "Link",
-      "label": "Linked RSVP",
-      "options": "FOSS Event RSVP",
-      "reqd": 1
-    },
-    {
-      "fieldname": "column_break_tpys",
-      "fieldtype": "Column Break"
-    },
-    {
-      "columns": 2,
-      "fieldname": "submitted_by",
-      "fieldtype": "Link",
-      "in_list_view": 1,
-      "in_standard_filter": 1,
-      "label": "Submitted By (User)",
-      "options": "User"
-    },
-    {
-      "fieldname": "section_break_vzwa",
-      "fieldtype": "Section Break",
-      "label": "Custom Answers"
-    },
-    {
-      "fieldname": "custom_answers",
-      "fieldtype": "Table",
-      "label": "Custom Answers",
-      "options": "FOSS Custom Answer"
-    },
-    {
-      "fetch_from": "linked_rsvp.event",
-      "fieldname": "event",
-      "fieldtype": "Data",
-      "in_standard_filter": 1,
-      "label": "Event",
-      "reqd": 1
-    },
-    {
-      "columns": 3,
-      "fetch_from": "linked_rsvp.chapter",
-      "fieldname": "chapter",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "in_standard_filter": 1,
-      "label": "Chapter"
-    },
-    {
-      "fieldname": "standard_questions_section",
-      "fieldtype": "Section Break",
-      "label": "Personal Information"
-    },
-    {
-      "description": "Select your current profession",
-      "fetch_from": ".",
-      "fieldname": "im_a",
-      "fieldtype": "Select",
-      "label": "I'm a",
-      "options": "\nStudent\nProfessional\nFOSS Enthusiast\nOther"
-    },
-    {
-      "fieldname": "column_break_bkxf",
-      "fieldtype": "Column Break"
-    },
-    {
-      "default": "0",
-      "fieldname": "confirm_attendance",
-      "fieldtype": "Check",
-      "label": "Confirm your attendance!"
-    },
-    {
-      "fieldname": "section_break_qrdc",
-      "fieldtype": "Section Break",
-      "label": "Meta Info"
-    },
-    {
-      "columns": 3,
-      "fetch_from": "linked_rsvp.event_name",
-      "fieldname": "event_name",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "in_standard_filter": 1,
-      "label": "Event Name"
-    },
-    {
-      "fetch_from": "submitted_by.full_name",
-      "fetch_if_empty": 1,
-      "fieldname": "name1",
-      "fieldtype": "Data",
-      "label": "Name",
-      "reqd": 1
-    },
-    {
-      "fieldname": "email",
-      "fieldtype": "Data",
-      "label": "Email",
-      "options": "Email",
-      "reqd": 1
-    },
-    {
-      "default": "Pending",
-      "fieldname": "status",
-      "fieldtype": "Select",
-      "label": "Status",
-      "options": "Pending\nAccepted\nRejected"
-    }
-  ],
-  "links": [],
-  "modified": "2024-12-20 15:16:07.795271",
-  "modified_by": "Administrator",
-  "module": "Chapters",
-  "name": "FOSS Event RSVP Submission",
-  "owner": "Administrator",
-  "permissions": [
-    {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "System Manager",
-      "share": 1,
-      "write": 1
-    },
-    {
-      "create": 1,
-      "delete": 1,
-      "read": 1,
-      "role": "Chapter Team Member",
-      "select": 1,
-      "write": 1
-    },
-    {
-      "create": 1,
-      "role": "All"
-    },
-    {
-      "create": 1,
-      "role": "Guest"
-    }
-  ],
-  "sort_field": "modified",
-  "sort_order": "DESC",
-  "states": [
-    {
-      "color": "Yellow",
-      "title": "Pending"
-    },
-    {
-      "color": "Green",
-      "title": "Accepted"
-    },
-    {
-      "color": "Red",
-      "title": "Rejected"
-    }
-  ],
-  "track_changes": 1
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2023-09-04 19:50:13.664495",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_qrdc",
+  "linked_rsvp",
+  "event",
+  "event_name",
+  "column_break_tpys",
+  "submitted_by",
+  "chapter",
+  "status",
+  "standard_questions_section",
+  "name1",
+  "im_a",
+  "column_break_bkxf",
+  "email",
+  "confirm_attendance",
+  "subscribe_chapter_mailing",
+  "section_break_vzwa",
+  "custom_answers"
+ ],
+ "fields": [
+  {
+   "fieldname": "linked_rsvp",
+   "fieldtype": "Link",
+   "label": "Linked RSVP",
+   "options": "FOSS Event RSVP",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_tpys",
+   "fieldtype": "Column Break"
+  },
+  {
+   "columns": 2,
+   "fieldname": "submitted_by",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Submitted By (User)",
+   "options": "User"
+  },
+  {
+   "fieldname": "section_break_vzwa",
+   "fieldtype": "Section Break",
+   "label": "Custom Answers"
+  },
+  {
+   "fieldname": "custom_answers",
+   "fieldtype": "Table",
+   "label": "Custom Answers",
+   "options": "FOSS Custom Answer"
+  },
+  {
+   "fetch_from": "linked_rsvp.event",
+   "fieldname": "event",
+   "fieldtype": "Data",
+   "in_standard_filter": 1,
+   "label": "Event",
+   "reqd": 1
+  },
+  {
+   "columns": 3,
+   "fetch_from": "linked_rsvp.chapter",
+   "fieldname": "chapter",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Chapter"
+  },
+  {
+   "fieldname": "standard_questions_section",
+   "fieldtype": "Section Break",
+   "label": "Personal Information"
+  },
+  {
+   "description": "Select your current profession",
+   "fetch_from": ".",
+   "fieldname": "im_a",
+   "fieldtype": "Select",
+   "label": "I'm a",
+   "options": "\nStudent\nProfessional\nFOSS Enthusiast\nOther"
+  },
+  {
+   "fieldname": "column_break_bkxf",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "confirm_attendance",
+   "fieldtype": "Check",
+   "label": "Confirm your attendance!"
+  },
+  {
+   "fieldname": "section_break_qrdc",
+   "fieldtype": "Section Break",
+   "label": "Meta Info"
+  },
+  {
+   "columns": 3,
+   "fetch_from": "linked_rsvp.event_name",
+   "fieldname": "event_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Event Name"
+  },
+  {
+   "fetch_from": "submitted_by.full_name",
+   "fetch_if_empty": 1,
+   "fieldname": "name1",
+   "fieldtype": "Data",
+   "label": "Name",
+   "reqd": 1
+  },
+  {
+   "fieldname": "email",
+   "fieldtype": "Data",
+   "label": "Email",
+   "options": "Email",
+   "reqd": 1
+  },
+  {
+   "default": "Pending",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "label": "Status",
+   "options": "Pending\nAccepted\nRejected"
+  },
+  {
+   "default": "1",
+   "fieldname": "subscribe_chapter_mailing",
+   "fieldtype": "Check",
+   "label": "Subscribe to Chapter Mailing?"
+  }
+ ],
+ "links": [],
+ "modified": "2025-10-13 12:21:38.267914",
+ "modified_by": "Administrator",
+ "module": "Chapters",
+ "name": "FOSS Event RSVP Submission",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "read": 1,
+   "role": "Chapter Team Member",
+   "select": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "role": "All"
+  },
+  {
+   "create": 1,
+   "role": "Guest"
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [
+  {
+   "color": "Yellow",
+   "title": "Pending"
+  },
+  {
+   "color": "Green",
+   "title": "Accepted"
+  },
+  {
+   "color": "Red",
+   "title": "Rejected"
+  }
+ ],
+ "track_changes": 1
 }

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
@@ -30,6 +30,7 @@ class FOSSEventRSVPSubmission(Document):
         name1: DF.Data
         status: DF.Literal["Pending", "Accepted", "Rejected"]  # noqa: F722, F821
         submitted_by: DF.Link | None
+        subscribe_chapter_mailing: DF.Check
     # end: auto-generated types
 
     def validate(self):

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
@@ -1,5 +1,6 @@
 import frappe
 from frappe.model.document import Document
+from frappe.utils import cint
 
 from fossunited.api.chapter import check_if_chapter_member
 from fossunited.api.emailing import (
@@ -8,6 +9,9 @@ from fossunited.api.emailing import (
     remove_from_email_group,
 )
 from fossunited.doctype_ids import CHAPTER, EVENT, EVENT_RSVP, RSVP_RESPONSE
+
+frappe.utils.logger.set_log_level("DEBUG")
+logger = frappe.logger("rsvp_submission", allow_site=True, file_count=50)
 
 
 class FOSSEventRSVPSubmission(Document):
@@ -49,9 +53,7 @@ class FOSSEventRSVPSubmission(Document):
         self.handle_add_to_email_group()
 
     def before_save(self):
-        if (
-            self.has_value_changed("status") or self.has_value_changed("subscribe_chapter_mailing")
-        ) and not self.is_new():
+        if self.has_value_changed("subscribe_chapter_mailing") and not self.is_new():
             self.handle_add_to_email_group()
 
     def validate_linked_rsvp_exists(self):
@@ -116,47 +118,34 @@ class FOSSEventRSVPSubmission(Document):
         return max_count
 
     def handle_submission_status(self):
-        # Check if the RSVP is accepting all incoming responses
+        if self.status:  # Respect what's set from the web form
+            return
+
         requires_host_approval = bool(
             frappe.db.get_value(EVENT_RSVP, self.linked_rsvp, "requires_host_approval")
         )
 
-        # If requires_host_approval == True, but the status is accepted at time of creation,
-        # Throw a frappe.PermissionError
-        if requires_host_approval and self.status == "Accepted":
-            frappe.throw("Invalid action. Status cannot be `Accepted`.", frappe.PermissionError)
-
-        # If the RSVP requires host approval, set the status to Pending
-        if requires_host_approval:
-            self.status = "Pending"
-            return
-
-        # If the RSVP does not require host approval, set the status to Accepted
-        self.status = "Accepted"
+        self.status = "Pending" if requires_host_approval else "Accepted"
 
     def handle_add_to_email_group(self):
-        # Check if user should be subscribed
-        should_subscribe = self.status == "Accepted" and self.subscribe_chapter_mailing == 1
+        wants_subscription = cint(self.subscribe_chapter_mailing) == 1
 
-        # Create or get the Event Participants group
         event_group = create_email_group(
             type="Event Participants",
             reference_document=self.event,
             document_type=EVENT,
         )
-
-        # Create or get the Chapter Event Participants group
         chapter_group = create_email_group(
             type="Chapter Event Participants",
             reference_document=self.chapter,
             document_type=CHAPTER,
         )
 
-        if should_subscribe:
-            # Add the email to both groups
+        if wants_subscription:
+            logger.info(f"[Email Group] Subscribing {self.email} to {event_group.name}")
             add_to_email_group(event_group.name, self.email)
             add_to_email_group(chapter_group.name, self.email)
         else:
-            # Remove the email from both groups
+            logger.info(f"[Email Group] Unsubscribing {self.email} from {event_group.name}")
             remove_from_email_group(event_group.name, self.email)
             remove_from_email_group(chapter_group.name, self.email)

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
@@ -48,11 +48,7 @@ class FOSSEventRSVPSubmission(Document):
         self.handle_add_to_email_group()
 
     def before_save(self):
-        if (
-            self.is_new()
-            or self.has_value_changed("subscribe_chapter_mailing")
-            or self.has_value_changed("status")
-        ):
+        if self.has_value_changed("subscribe_chapter_mailing") or self.has_value_changed("status"):
             self.handle_add_to_email_group()
 
     def on_trash(self):
@@ -148,6 +144,8 @@ class FOSSEventRSVPSubmission(Document):
     def handle_add_to_email_group(self):
         wants_subscription = cint(self.subscribe_chapter_mailing) == 1
         is_accepted = self.status == "Accepted"
+        if not self.email:
+            return
 
         handle_email_group_subscription(
             emails=[self.email],

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
@@ -3,11 +3,7 @@ from frappe.model.document import Document
 from frappe.utils import cint
 
 from fossunited.api.chapter import check_if_chapter_member
-from fossunited.api.emailing import (
-    add_to_email_group,
-    create_email_group,
-    remove_from_email_group,
-)
+from fossunited.api.emailing import handle_email_group_subscription
 from fossunited.doctype_ids import CHAPTER, EVENT, EVENT_RSVP, RSVP_RESPONSE
 
 logger = frappe.logger("rsvp_submission", allow_site=True, file_count=50)
@@ -52,7 +48,11 @@ class FOSSEventRSVPSubmission(Document):
         self.handle_add_to_email_group()
 
     def before_save(self):
-        if self.has_value_changed("subscribe_chapter_mailing") and not self.is_new():
+        if (
+            self.is_new()
+            or self.has_value_changed("subscribe_chapter_mailing")
+            or self.has_value_changed("status")
+        ):
             self.handle_add_to_email_group()
 
     def on_trash(self):
@@ -149,23 +149,11 @@ class FOSSEventRSVPSubmission(Document):
         wants_subscription = cint(self.subscribe_chapter_mailing) == 1
         is_accepted = self.status == "Accepted"
 
-        event_group = create_email_group(
-            type="Event Participants",
-            reference_document=self.event,
-            document_type=EVENT,
+        handle_email_group_subscription(
+            emails=[self.email],
+            chapter=self.chapter,
+            event=self.event,
+            subscribe_to_chapter=wants_subscription,
+            subscribe_to_event=is_accepted,
+            document_type_event=EVENT,
         )
-        chapter_group = create_email_group(
-            type="Chapter Event Participants",
-            reference_document=self.chapter,
-            document_type=CHAPTER,
-        )
-
-        if wants_subscription and is_accepted:
-            logger.info(f"[Email Group] Subscribing {self.email} to {event_group.name}")
-            add_to_email_group(event_group.name, self.email)
-        elif wants_subscription:
-            add_to_email_group(chapter_group.name, self.email)
-        else:
-            logger.info(f"[Email Group] Unsubscribing {self.email} from {event_group.name}")
-            remove_from_email_group(event_group.name, self.email)
-            remove_from_email_group(chapter_group.name, self.email)

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
@@ -136,7 +136,7 @@ class FOSSEventRSVPSubmission(Document):
 
     def handle_add_to_email_group(self):
         # Check if user should be subscribed
-        should_subscribe = self.status == "Accepted" and self.subscribe_chapter_mailing == "1"
+        should_subscribe = self.status == "Accepted" and self.subscribe_chapter_mailing == 1
 
         # Create or get the Event Participants group
         event_group = create_email_group(

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
@@ -2,7 +2,11 @@ import frappe
 from frappe.model.document import Document
 
 from fossunited.api.chapter import check_if_chapter_member
-from fossunited.api.emailing import add_to_email_group, create_email_group
+from fossunited.api.emailing import (
+    add_to_email_group,
+    create_email_group,
+    remove_from_email_group,
+)
 from fossunited.doctype_ids import CHAPTER, EVENT, EVENT_RSVP, RSVP_RESPONSE
 
 
@@ -45,7 +49,9 @@ class FOSSEventRSVPSubmission(Document):
         self.handle_add_to_email_group()
 
     def before_save(self):
-        if self.has_value_changed("status") and not self.is_new():
+        if (
+            self.has_value_changed("status") or self.has_value_changed("subscribe_chapter_mailing")
+        ) and not self.is_new():
             self.handle_add_to_email_group()
 
     def validate_linked_rsvp_exists(self):
@@ -129,30 +135,28 @@ class FOSSEventRSVPSubmission(Document):
         self.status = "Accepted"
 
     def handle_add_to_email_group(self):
-        if self.status != "Accepted":
-            return
+        # Check if user should be subscribed
+        should_subscribe = self.status == "Accepted" and self.subscribe_chapter_mailing == "1"
 
-        if not frappe.db.exists(
-            "Email Group",
-            {
-                "reference_document": self.event,
-                "document_type": EVENT,
-                "group_type": "Event Participants",
-            },
-        ):
-            create_email_group(
-                type="Event Participants",
-                reference_document=self.event,
-                document_type=EVENT,
-            )
-
-        email_group = frappe.db.get_value(
-            "Email Group",
-            {
-                "reference_document": self.event,
-                "document_type": EVENT,
-                "group_type": "Event Participants",
-            },
-            ["name"],
+        # Create or get the Event Participants group
+        event_group = create_email_group(
+            type="Event Participants",
+            reference_document=self.event,
+            document_type=EVENT,
         )
-        add_to_email_group(email_group, self.email)
+
+        # Create or get the Chapter Event Participants group
+        chapter_group = create_email_group(
+            type="Chapter Event Participants",
+            reference_document=self.chapter,
+            document_type=CHAPTER,
+        )
+
+        if should_subscribe:
+            # Add the email to both groups
+            add_to_email_group(event_group.name, self.email)
+            add_to_email_group(chapter_group.name, self.email)
+        else:
+            # Remove the email from both groups
+            remove_from_email_group(event_group.name, self.email)
+            remove_from_email_group(chapter_group.name, self.email)

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
@@ -118,17 +118,26 @@ class FOSSEventRSVPSubmission(Document):
         return max_count
 
     def handle_submission_status(self):
-        if self.status:  # Respect what's set from the web form
-            return
-
+        # If requires_host_approval == True, but the status is accepted at time of creation,
+        # Throw a frappe.PermissionError
         requires_host_approval = bool(
             frappe.db.get_value(EVENT_RSVP, self.linked_rsvp, "requires_host_approval")
         )
 
-        self.status = "Pending" if requires_host_approval else "Accepted"
+        if requires_host_approval and self.status == "Accepted":
+            frappe.throw("Invalid action. Status cannot be `Accepted`.", frappe.PermissionError)
+
+        # If the RSVP requires host approval, set the status to Pending
+        if requires_host_approval:
+            self.status = "Pending"
+            return
+
+        # If the RSVP does not require host approval, set the status to Accepted
+        self.status = "Accepted"
 
     def handle_add_to_email_group(self):
         wants_subscription = cint(self.subscribe_chapter_mailing) == 1
+        is_accepted = self.status == "Accepted"
 
         event_group = create_email_group(
             type="Event Participants",
@@ -141,9 +150,10 @@ class FOSSEventRSVPSubmission(Document):
             document_type=CHAPTER,
         )
 
-        if wants_subscription:
+        if wants_subscription and is_accepted:
             logger.info(f"[Email Group] Subscribing {self.email} to {event_group.name}")
             add_to_email_group(event_group.name, self.email)
+        elif wants_subscription:
             add_to_email_group(chapter_group.name, self.email)
         else:
             logger.info(f"[Email Group] Unsubscribing {self.email} from {event_group.name}")

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
@@ -55,6 +55,17 @@ class FOSSEventRSVPSubmission(Document):
         if self.has_value_changed("subscribe_chapter_mailing") and not self.is_new():
             self.handle_add_to_email_group()
 
+    def on_trash(self):
+        try:
+            # remove from mailing group as well
+            self.subscribe_chapter_mailing = 0
+            self.handle_add_to_email_group()
+        except Exception:
+            frappe.log_error(
+                frappe.get_traceback(),
+                "Error in on_trash: Unsubscribing from email groups",
+            )
+
     def validate_linked_rsvp_exists(self):
         if not frappe.db.exists(EVENT_RSVP, self.linked_rsvp):
             frappe.throw("Invalid RSVP", frappe.DoesNotExistError)

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
@@ -10,7 +10,6 @@ from fossunited.api.emailing import (
 )
 from fossunited.doctype_ids import CHAPTER, EVENT, EVENT_RSVP, RSVP_RESPONSE
 
-frappe.utils.logger.set_log_level("DEBUG")
 logger = frappe.logger("rsvp_submission", allow_site=True, file_count=50)
 
 

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
@@ -48,19 +48,27 @@ class FOSSEventRSVPSubmission(Document):
         self.handle_add_to_email_group()
 
     def before_save(self):
-        if self.has_value_changed("subscribe_chapter_mailing") or self.has_value_changed("status"):
+        if (
+            self.has_value_changed("subscribe_chapter_mailing")
+            or self.has_value_changed("status")
+            or self.has_value_changed("confirm_attendance")
+        ):
             self.handle_add_to_email_group()
 
     def on_trash(self):
+        # Remove from both event and chapter groups on delete
         try:
-            # remove from mailing group as well
-            self.subscribe_chapter_mailing = 0
-            self.handle_add_to_email_group()
-        except Exception:
-            frappe.log_error(
-                frappe.get_traceback(),
-                "Error in on_trash: Unsubscribing from email groups",
-            )
+            if self.email:
+                handle_email_group_subscription(
+                    emails=[self.email],
+                    chapter=self.chapter,
+                    event=self.event,
+                    subscribe_to_chapter=False,
+                    subscribe_to_event=False,
+                    document_type_event=EVENT,
+                )
+        except frappe.ValidationError as e:
+            frappe.log_error(frappe.get_traceback(), f"on_trash unsubscribe failed: {e}")
 
     def validate_linked_rsvp_exists(self):
         if not frappe.db.exists(EVENT_RSVP, self.linked_rsvp):
@@ -144,6 +152,7 @@ class FOSSEventRSVPSubmission(Document):
     def handle_add_to_email_group(self):
         wants_subscription = cint(self.subscribe_chapter_mailing) == 1
         is_accepted = self.status == "Accepted"
+        is_attending = cint(self.confirm_attendance) == 1
         if not self.email:
             return
 
@@ -152,6 +161,6 @@ class FOSSEventRSVPSubmission(Document):
             chapter=self.chapter,
             event=self.event,
             subscribe_to_chapter=wants_subscription,
-            subscribe_to_event=is_accepted,
+            subscribe_to_event=is_accepted and is_attending,
             document_type_event=EVENT,
         )

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
@@ -58,12 +58,15 @@ class TestFOSSEventRSVPSubmission(FrappeTestCase):
         # Given an RSVP form for an event
         # When an RSVP response is done by a user
         frappe.set_user("Guest")
-        insert_rsvp_submission(linked_rsvp=self.rsvp.name, email=WEBSITE_USER)
+        insert_rsvp_submission(
+            linked_rsvp=self.rsvp.name, email=WEBSITE_USER, subscribe_chapter_mailing=1
+        )
 
         # Then the email should be added to an email group linked to event for participants
         self.assertTrue(
             frappe.db.exists(
-                "Email Group Member", {"email": WEBSITE_USER, "email_group": self.email_group}
+                "Email Group Member",
+                {"email": WEBSITE_USER, "email_group": self.email_group},
             )
         )
 
@@ -112,6 +115,7 @@ class TestFOSSEventRSVPSubmission(FrappeTestCase):
         submission.status = "Accepted"
         # Then it should save without any errors
         submission.save()
+        submission.delete(force=True, ignore_permissions=True)
 
     def test_invalid_status_at_creation(self):
         # Given an rsvp with requires_host_approval = False
@@ -147,6 +151,7 @@ class TestFOSSEventRSVPSubmission(FrappeTestCase):
         # Then the status should change without errors
         submission.status = "Rejected"
         submission.save()
+        submission.delete(force=True, ignore_permissions=True)
 
     def test_add_to_email_on_acceptance(self):
         # Given an RSVP form which requires host approval
@@ -176,6 +181,7 @@ class TestFOSSEventRSVPSubmission(FrappeTestCase):
         # When status is changed to "Accepted"
         frappe.set_user(CORE_TEAM)
         submission.status = "Accepted"
+        submission.subscribe_chapter_mailing = 1
         submission.save()
 
         # Then the email should be added to email group
@@ -188,6 +194,7 @@ class TestFOSSEventRSVPSubmission(FrappeTestCase):
                 },
             )
         )
+        submission.delete(force=True, ignore_permissions=True)
 
     def test_no_add_to_email_on_rejection(self):
         # Given an RSVP form which requires host approval
@@ -229,6 +236,7 @@ class TestFOSSEventRSVPSubmission(FrappeTestCase):
                 },
             )
         )
+        submission.delete(force=True, ignore_permissions=True)
 
     def test_submission_to_unpublished_form(self):
         # Given an rsvp form which is unpublished
@@ -242,3 +250,66 @@ class TestFOSSEventRSVPSubmission(FrappeTestCase):
         frappe.set_user("Guest")
         with self.assertRaises(frappe.ValidationError):
             insert_rsvp_submission(linked_rsvp=rsvp.name)
+
+    def test_email_group_is_not_duplicated(self):
+        frappe.set_user("Guest")
+
+        # First submission
+        sub1 = insert_rsvp_submission(
+            linked_rsvp=self.rsvp.name,
+            email="test@example.com",
+            subscribe_chapter_mailing=1,
+        )
+
+        # Trigger again by second submission
+        sub2 = insert_rsvp_submission(
+            linked_rsvp=self.rsvp.name,
+            email="another@example.com",
+            subscribe_chapter_mailing=1,
+        )
+
+        group_count = frappe.db.count(
+            "Email Group",
+            {
+                "reference_document": self.event.name,
+                "document_type": EVENT,
+                "group_type": "Event Participants",
+            },
+        )
+
+        # Only one email group should exist
+        self.assertEqual(group_count, 1)
+        sub1.delete(force=True, ignore_permissions=True)
+        sub2.delete(force=True, ignore_permissions=True)
+
+    def test_unsubscribe_from_email_group(self):
+        frappe.set_user("Guest")
+
+        # First subscribe
+        submission = insert_rsvp_submission(
+            linked_rsvp=self.rsvp.name,
+            email="unsubscribe@example.com",
+            subscribe_chapter_mailing=True,
+        )
+
+        # Confirm user is added
+        self.assertTrue(
+            frappe.db.exists(
+                "Email Group Member",
+                {"email": "unsubscribe@example.com", "email_group": self.email_group},
+            )
+        )
+
+        # Unsubscribe
+        frappe.set_user(CORE_TEAM)  # So user can update doc
+        submission.subscribe_chapter_mailing = 0
+        submission.save()
+
+        # Confirm user is removed
+        self.assertFalse(
+            frappe.db.exists(
+                "Email Group Member",
+                {"email": "unsubscribe@example.com", "email_group": self.email_group},
+            )
+        )
+        submission.delete(force=True, ignore_permissions=True)

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
@@ -306,6 +306,7 @@ class TestFOSSEventRSVPSubmission(FrappeTestCase):
         # Unsubscribe
         frappe.set_user(CORE_TEAM)  # So user can update doc
         submission.subscribe_chapter_mailing = 0
+        submission.confirm_attendance = 0
         submission.save()
 
         # Confirm user is removed

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
@@ -59,7 +59,10 @@ class TestFOSSEventRSVPSubmission(FrappeTestCase):
         # When an RSVP response is done by a user
         frappe.set_user("Guest")
         insert_rsvp_submission(
-            linked_rsvp=self.rsvp.name, email=WEBSITE_USER, subscribe_chapter_mailing=1
+            linked_rsvp=self.rsvp.name,
+            email=WEBSITE_USER,
+            subscribe_chapter_mailing=1,
+            status="Accepted",
         )
 
         # Then the email should be added to an email group linked to event for participants

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.py
@@ -159,14 +159,16 @@ class FOSSHackathonLocalHost(WebsiteGenerator):
 
     def get_attending_stat(self):
         attending_count = frappe.db.count(
-            HACKATHON_PARTICIPANT, {"localhost": self.name, "localhost_request_status": "Accepted"}
+            HACKATHON_PARTICIPANT,
+            {"localhost": self.name, "localhost_request_status": "Accepted"},
         )
 
         return attending_count
 
     def get_interested_stat(self):
         pending_participants = frappe.db.count(
-            HACKATHON_PARTICIPANT, {"localhost": self.name, "localhost_request_status": "Pending"}
+            HACKATHON_PARTICIPANT,
+            {"localhost": self.name, "localhost_request_status": "Pending"},
         )
         localhost_likes = frappe.db.count(
             "Comment",

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.json
@@ -129,14 +129,14 @@
    "options": "URL"
   },
   {
-   "default": "1",
+   "default": "0",
    "fieldname": "subscribe_chapter_mailing",
    "fieldtype": "Check",
    "label": "Subscribe to Chapter Mailing?"
   }
  ],
  "links": [],
- "modified": "2025-10-13 16:09:11.412173",
+ "modified": "2025-10-14 16:06:43.666875",
  "modified_by": "Administrator",
  "module": "FOSS Hackathon",
  "name": "FOSS Hackathon Participant",

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.json
@@ -1,182 +1,190 @@
 {
-  "actions": [],
-  "allow_rename": 1,
-  "autoname": "hash",
-  "creation": "2024-05-24 21:24:15.111949",
-  "doctype": "DocType",
-  "engine": "InnoDB",
-  "field_order": [
-    "meta_section",
-    "hackathon",
-    "column_break_pxgj",
-    "user",
-    "participant_details_section",
-    "user_profile",
-    "full_name",
-    "email",
-    "is_student",
-    "organization",
-    "column_break_hkri",
-    "git_profile",
-    "localhost_tab",
-    "wants_to_attend_locally",
-    "section_break_pijd",
-    "localhost",
-    "column_break_wclx",
-    "localhost_request_status"
-  ],
-  "fields": [
-    {
-      "fieldname": "participant_details_section",
-      "fieldtype": "Section Break",
-      "label": "Details"
-    },
-    {
-      "fieldname": "user_profile",
-      "fieldtype": "Link",
-      "label": "User Profile",
-      "options": "FOSS User Profile"
-    },
-    {
-      "fieldname": "email",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "label": "Email",
-      "options": "Email",
-      "reqd": 1
-    },
-    {
-      "default": "0",
-      "fieldname": "is_student",
-      "fieldtype": "Check",
-      "label": "Is Student?"
-    },
-    {
-      "fieldname": "organization",
-      "fieldtype": "Data",
-      "label": "Organization / Institute"
-    },
-    {
-      "fieldname": "column_break_hkri",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "hackathon",
-      "fieldtype": "Link",
-      "label": "Hackathon",
-      "options": "FOSS Hackathon",
-      "reqd": 1
-    },
-    {
-      "fieldname": "meta_section",
-      "fieldtype": "Section Break",
-      "label": "Meta"
-    },
-    {
-      "fieldname": "full_name",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "label": "Full Name",
-      "reqd": 1
-    },
-    {
-      "fieldname": "localhost_tab",
-      "fieldtype": "Tab Break",
-      "label": "LocalHost"
-    },
-    {
-      "default": "0",
-      "fieldname": "wants_to_attend_locally",
-      "fieldtype": "Check",
-      "label": "Wants to attend locally?"
-    },
-    {
-      "fieldname": "section_break_pijd",
-      "fieldtype": "Section Break"
-    },
-    {
-      "fieldname": "localhost",
-      "fieldtype": "Link",
-      "label": "LocalHost",
-      "options": "FOSS Hackathon LocalHost"
-    },
-    {
-      "fieldname": "column_break_wclx",
-      "fieldtype": "Column Break"
-    },
-    {
-      "default": "Pending",
-      "fieldname": "localhost_request_status",
-      "fieldtype": "Select",
-      "label": "LocalHost Request Status",
-      "options": "Pending\nPending Confirmation\nAccepted\nRejected"
-    },
-    {
-      "fieldname": "column_break_pxgj",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "user",
-      "fieldtype": "Link",
-      "label": "User",
-      "options": "User"
-    },
-    {
-      "fieldname": "git_profile",
-      "fieldtype": "Data",
-      "label": "Git Profile",
-      "options": "URL"
-    }
-  ],
-  "links": [],
-  "modified": "2024-12-29 17:10:32.240540",
-  "modified_by": "Administrator",
-  "module": "FOSS Hackathon",
-  "name": "FOSS Hackathon Participant",
-  "naming_rule": "Random",
-  "owner": "Administrator",
-  "permissions": [
-    {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "System Manager",
-      "share": 1,
-      "write": 1
-    },
-    {
-      "create": 1,
-      "read": 1,
-      "role": "All",
-      "write": 1
-    },
-    {
-      "read": 1,
-      "role": "Localhost Organizer",
-      "select": 1,
-      "write": 1
-    },
-    {
-      "email": 1,
-      "export": 1,
-      "permlevel": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "Localhost Organizer",
-      "share": 1,
-      "write": 1
-    }
-  ],
-  "search_fields": "hackathon, email, user_profile",
-  "show_title_field_in_link": 1,
-  "sort_field": "modified",
-  "sort_order": "DESC",
-  "states": [],
-  "title_field": "full_name",
-  "track_changes": 1
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "hash",
+ "creation": "2024-05-24 21:24:15.111949",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "meta_section",
+  "hackathon",
+  "column_break_pxgj",
+  "user",
+  "participant_details_section",
+  "user_profile",
+  "full_name",
+  "email",
+  "is_student",
+  "subscribe_chapter_mailing",
+  "column_break_hkri",
+  "organization",
+  "git_profile",
+  "localhost_tab",
+  "wants_to_attend_locally",
+  "section_break_pijd",
+  "localhost",
+  "column_break_wclx",
+  "localhost_request_status"
+ ],
+ "fields": [
+  {
+   "fieldname": "participant_details_section",
+   "fieldtype": "Section Break",
+   "label": "Details"
+  },
+  {
+   "fieldname": "user_profile",
+   "fieldtype": "Link",
+   "label": "User Profile",
+   "options": "FOSS User Profile"
+  },
+  {
+   "fieldname": "email",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Email",
+   "options": "Email",
+   "reqd": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_student",
+   "fieldtype": "Check",
+   "label": "Is Student?"
+  },
+  {
+   "fieldname": "organization",
+   "fieldtype": "Data",
+   "label": "Organization / Institute"
+  },
+  {
+   "fieldname": "column_break_hkri",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "hackathon",
+   "fieldtype": "Link",
+   "label": "Hackathon",
+   "options": "FOSS Hackathon",
+   "reqd": 1
+  },
+  {
+   "fieldname": "meta_section",
+   "fieldtype": "Section Break",
+   "label": "Meta"
+  },
+  {
+   "fieldname": "full_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Full Name",
+   "reqd": 1
+  },
+  {
+   "fieldname": "localhost_tab",
+   "fieldtype": "Tab Break",
+   "label": "LocalHost"
+  },
+  {
+   "default": "0",
+   "fieldname": "wants_to_attend_locally",
+   "fieldtype": "Check",
+   "label": "Wants to attend locally?"
+  },
+  {
+   "fieldname": "section_break_pijd",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "localhost",
+   "fieldtype": "Link",
+   "label": "LocalHost",
+   "options": "FOSS Hackathon LocalHost"
+  },
+  {
+   "fieldname": "column_break_wclx",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "Pending",
+   "fieldname": "localhost_request_status",
+   "fieldtype": "Select",
+   "label": "LocalHost Request Status",
+   "options": "Pending\nPending Confirmation\nAccepted\nRejected"
+  },
+  {
+   "fieldname": "column_break_pxgj",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "label": "User",
+   "options": "User"
+  },
+  {
+   "fieldname": "git_profile",
+   "fieldtype": "Data",
+   "label": "Git Profile",
+   "options": "URL"
+  },
+  {
+   "default": "1",
+   "fieldname": "subscribe_chapter_mailing",
+   "fieldtype": "Check",
+   "label": "Subscribe to Chapter Mailing?"
+  }
+ ],
+ "links": [],
+ "modified": "2025-10-13 16:09:11.412173",
+ "modified_by": "Administrator",
+ "module": "FOSS Hackathon",
+ "name": "FOSS Hackathon Participant",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "read": 1,
+   "role": "All",
+   "write": 1
+  },
+  {
+   "read": 1,
+   "role": "Localhost Organizer",
+   "select": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "permlevel": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Localhost Organizer",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "search_fields": "hackathon, email, user_profile",
+ "show_title_field_in_link": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "full_name",
+ "track_changes": 1
 }

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -4,8 +4,16 @@
 import frappe
 from frappe.model.document import Document
 
-from fossunited.api.emailing import add_to_email_group, create_email_group
-from fossunited.doctype_ids import EMAIL_GROUP, HACKATHON, HACKATHON_LOCALHOST
+from fossunited.api.emailing import (
+    add_to_email_group,
+    create_email_group,
+    remove_from_email_group,
+)
+from fossunited.doctype_ids import (
+    CHAPTER,
+    HACKATHON,
+    HACKATHON_LOCALHOST,
+)
 
 
 class FOSSHackathonParticipant(Document):
@@ -27,13 +35,15 @@ class FOSSHackathonParticipant(Document):
             "Pending", "Pending Confirmation", "Accepted", "Rejected"  # noqa: F722, F821
         ]
         organization: DF.Data | None
+        subscribe_chapter_mailing: DF.Check
         user: DF.Link | None
         user_profile: DF.Link | None
         wants_to_attend_locally: DF.Check
     # end: auto-generated types
 
     def after_insert(self):
-        self.add_to_email_group()
+        if self.has_value_changed("subscribe_chapter_mailing"):
+            self.handle_add_to_email_group()
 
     def before_save(self):
         if self.has_value_changed("wants_to_attend_locally"):
@@ -46,32 +56,33 @@ class FOSSHackathonParticipant(Document):
         if self.wants_to_attend_locally and not self.localhost:
             frappe.throw("No LocalHost value provided", frappe.ValidationError)
 
-    def add_to_email_group(self):
-        if not frappe.db.exists(
-            EMAIL_GROUP,
-            {
-                "document_type": HACKATHON,
-                "reference_document": self.hackathon,
-                "group_type": "Event Participants",
-            },
-        ):
-            create_email_group(
-                type="Event Participants",
-                reference_document=self.hackathon,
-                document_type=HACKATHON,
-            )
+    def handle_add_to_email_group(self):
+        # Check if user should be subscribed
+        should_subscribe = self.subscribe_chapter_mailing == 1
 
-        email_group = frappe.db.get_value(
-            "Email Group",
-            {
-                "reference_document": self.hackathon,
-                "document_type": HACKATHON,
-                "group_type": "Event Participants",
-            },
-            ["name"],
+        # Create or get the Event Participants group
+        hackathon_group = create_email_group(
+            type="Event Participants",
+            reference_document=self.hackathon,
+            document_type=HACKATHON,
         )
 
-        add_to_email_group(email_group, self.email)
+        # Create or get the Chapter Event Participants group
+        event_doc = frappe.get_doc(HACKATHON, self.hackathon)
+        chapter_group = create_email_group(
+            type="Chapter Event Participants",
+            reference_document=event_doc.chapter,
+            document_type=CHAPTER,
+        )
+
+        if should_subscribe:
+            # Add the email to both groups
+            add_to_email_group(hackathon_group.name, self.email)
+            add_to_email_group(chapter_group.name, self.email)
+        else:
+            # Remove the email from both groups
+            remove_from_email_group(hackathon_group.name, self.email)
+            remove_from_email_group(chapter_group.name, self.email)
 
     def update_request_status(self):
         self.localhost_request_status = "Pending"
@@ -100,7 +111,8 @@ class FOSSHackathonParticipant(Document):
 
         if (self.localhost == prev_doc.localhost) and self.localhost_request_status == "Rejected":
             frappe.throw(
-                "You have already been rejected from this localhost.", frappe.PermissionError
+                "You have already been rejected from this localhost.",
+                frappe.PermissionError,
             )
 
         self.localhost_request_status = "Pending"

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -42,8 +42,7 @@ class FOSSHackathonParticipant(Document):
     # end: auto-generated types
 
     def after_insert(self):
-        if self.has_value_changed("subscribe_chapter_mailing"):
-            self.handle_add_to_email_group()
+        self.handle_add_to_email_group()
 
     def before_save(self):
         if self.has_value_changed("wants_to_attend_locally"):
@@ -58,9 +57,20 @@ class FOSSHackathonParticipant(Document):
         if self.wants_to_attend_locally and not self.localhost:
             frappe.throw("No LocalHost value provided", frappe.ValidationError)
 
+    def on_trash(self):
+        try:
+            # remove from mailing group as well
+            self.subscribe_chapter_mailing = 0
+            self.handle_add_to_email_group()
+        except Exception:
+            frappe.log_error(
+                frappe.get_traceback(),
+                "Error in on_trash: Unsubscribing from email groups",
+            )
+
     def handle_add_to_email_group(self):
         # Check if user should be subscribed
-        should_subscribe = self.subscribe_chapter_mailing == 1
+        should_subscribe = frappe.utils.cint(self.subscribe_chapter_mailing) == 1
 
         # Create or get the Event Participants group
         hackathon_group = create_email_group(

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -4,13 +4,8 @@
 import frappe
 from frappe.model.document import Document
 
-from fossunited.api.emailing import (
-    add_to_email_group,
-    create_email_group,
-    remove_from_email_group,
-)
+from fossunited.api.emailing import handle_email_group_subscription
 from fossunited.doctype_ids import (
-    CHAPTER,
     HACKATHON,
     HACKATHON_LOCALHOST,
 )
@@ -70,31 +65,17 @@ class FOSSHackathonParticipant(Document):
 
     def handle_add_to_email_group(self):
         # Check if user should be subscribed
-        should_subscribe = frappe.utils.cint(self.subscribe_chapter_mailing) == 1
-
-        # Create or get the Event Participants group
-        hackathon_group = create_email_group(
-            type="Event Participants",
-            reference_document=self.hackathon,
-            document_type=HACKATHON,
-        )
-
-        # Create or get the Chapter Event Participants group
+        wants_subscription = frappe.utils.cint(self.subscribe_chapter_mailing) == 1
         event_doc = frappe.get_doc(HACKATHON, self.hackathon)
-        chapter_group = create_email_group(
-            type="Chapter Event Participants",
-            reference_document=event_doc.chapter,
-            document_type=CHAPTER,
-        )
 
-        if should_subscribe:
-            # Add the email to both groups
-            add_to_email_group(hackathon_group.name, self.email)
-            add_to_email_group(chapter_group.name, self.email)
-        else:
-            # Remove the email from both groups
-            remove_from_email_group(hackathon_group.name, self.email)
-            remove_from_email_group(chapter_group.name, self.email)
+        handle_email_group_subscription(
+            emails=[self.email],
+            chapter=event_doc.chapter,
+            event=self.hackathon,
+            subscribe_to_chapter=wants_subscription,
+            subscribe_to_event=wants_subscription,
+            document_type_event=HACKATHON,
+        )
 
     def update_request_status(self):
         self.localhost_request_status = "Pending"

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -51,6 +51,8 @@ class FOSSHackathonParticipant(Document):
         self.handle_localhost_rejection()
         if self.has_value_changed("localhost"):
             self.update_request_status()
+        if self.has_value_changed("subscribe_chapter_mailing"):
+            self.handle_add_to_email_group()
 
     def validate(self):
         if self.wants_to_attend_locally and not self.localhost:

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/test_foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/test_foss_hackathon_participant.py
@@ -186,3 +186,9 @@ class TestFOSSHackathonParticipant(FrappeTestCase):
         )
 
         participant.delete(force=True, ignore_permissions=True)
+        self.assertFalse(
+            frappe.db.exists(
+                EMAIL_MEMBER,
+                {"email_group": email_group_id, "email": frappe.session.user},
+            )
+        )

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/test_foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/test_foss_hackathon_participant.py
@@ -57,11 +57,12 @@ class TestFOSSHackathonParticipant(FrappeTestCase):
         frappe.set_user(self.PARTICIPANT_2)
 
         # Given a hackathon
-        # When a participant registers for this hackathon
+        # When a participant registers for this hackathon and subscribes for mailing
         participant = insert_test_hackathon_participant(
             hackathon_id=self.hackathon.name,
             email=frappe.session.user,
             user=frappe.session.user,
+            subscribe_chapter_mailing=1,
         )
 
         email_group_id = frappe.db.get_value(
@@ -113,3 +114,75 @@ class TestFOSSHackathonParticipant(FrappeTestCase):
         # Then a permission error should be thrown
         with self.assertRaises(frappe.PermissionError):
             self.participant_1.save()
+
+    def test_remove_from_email_group_on_unsubscribe(self):
+        frappe.set_user(self.PARTICIPANT_2)
+
+        # Participant subscribes to email group
+        participant = insert_test_hackathon_participant(
+            hackathon_id=self.hackathon.name,
+            email=frappe.session.user,
+            user=frappe.session.user,
+            subscribe_chapter_mailing=1,
+        )
+
+        email_group_id = frappe.db.get_value(
+            EMAIL_GROUP,
+            {
+                "document_type": HACKATHON,
+                "reference_document": self.hackathon.name,
+                "group_type": "Event Participants",
+            },
+            "name",
+        )
+
+        self.assertTrue(
+            frappe.db.exists(
+                EMAIL_MEMBER,
+                {"email_group": email_group_id, "email": frappe.session.user},
+            )
+        )
+
+        # Participant unsubscribes (update subscription flag)
+        participant.subscribe_chapter_mailing = 0
+        participant.save()
+
+        # Ensure email is removed from the group
+        self.assertFalse(
+            frappe.db.exists(
+                EMAIL_MEMBER,
+                {"email_group": email_group_id, "email": frappe.session.user},
+            )
+        )
+
+        participant.delete(force=True, ignore_permissions=True)
+
+    def test_email_group_cleanup_on_participant_deletion(self):
+        frappe.set_user(self.PARTICIPANT_2)
+
+        # Step 1: Register with mailing subscription
+        participant = insert_test_hackathon_participant(
+            hackathon_id=self.hackathon.name,
+            email=frappe.session.user,
+            user=frappe.session.user,
+            subscribe_chapter_mailing=1,
+        )
+
+        email_group_id = frappe.db.get_value(
+            EMAIL_GROUP,
+            {
+                "document_type": HACKATHON,
+                "reference_document": self.hackathon.name,
+                "group_type": "Event Participants",
+            },
+            "name",
+        )
+
+        self.assertTrue(
+            frappe.db.exists(
+                EMAIL_MEMBER,
+                {"email_group": email_group_id, "email": frappe.session.user},
+            )
+        )
+
+        participant.delete(force=True, ignore_permissions=True)

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.json
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.json
@@ -346,7 +346,7 @@
  "has_web_view": 1,
  "is_published_field": "is_published",
  "links": [],
- "modified": "2025-10-13 16:26:04.767625",
+ "modified": "2025-10-13 17:10:24.035388",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "FOSS Event CFP Submission",

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.json
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.json
@@ -23,6 +23,7 @@
   "event",
   "event_name",
   "submitted_by",
+  "subscribe_chapter_mailing",
   "about_talk_section",
   "talk_title",
   "session_type",
@@ -334,12 +335,18 @@
    "fieldname": "is_withdrawn",
    "fieldtype": "Check",
    "label": "Is Withdrawn?"
+  },
+  {
+   "default": "1",
+   "fieldname": "subscribe_chapter_mailing",
+   "fieldtype": "Check",
+   "label": "Subscribe to Chapter Mailing?"
   }
  ],
  "has_web_view": 1,
  "is_published_field": "is_published",
  "links": [],
- "modified": "2025-08-19 21:25:18.448437",
+ "modified": "2025-10-13 16:26:04.767625",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "FOSS Event CFP Submission",
@@ -408,6 +415,7 @@
    "share": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "submitted_by, event, event_name, chapter",
  "show_title_field_in_link": 1,
  "sort_field": "modified",

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -6,7 +6,11 @@ import textwrap
 import frappe
 from frappe.website.website_generator import WebsiteGenerator
 
-from fossunited.api.emailing import add_to_email_group, create_email_group
+from fossunited.api.emailing import (
+    add_to_email_group,
+    create_email_group,
+    remove_from_email_group,
+)
 from fossunited.doctype_ids import CHAPTER, EVENT, EVENT_CFP
 
 
@@ -92,7 +96,8 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         self.validate_session_type_permissions()
 
     def after_insert(self):
-        self.handle_email_group("CFP Proposers")
+        if self.has_value_changed("subscribe_chapter_mailing"):
+            self.handle_email_group("CFP Proposers")
 
     def set_route(self):
         event_route = frappe.db.get_value(EVENT, self.event, "route")
@@ -338,28 +343,19 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
             self.handle_email_group("Rejected Proposers")
 
     def handle_email_group(self, type) -> None:
-        if not frappe.db.exists(
-            "Email Group",
-            {
-                "reference_document": self.event,
-                "document_type": EVENT,
-                "group_type": type,
-            },
-        ):
-            create_email_group(
-                type=type,
-                reference_document=self.event,
-                document_type=EVENT,
-            )
+        should_subscribe = self.subscribe_chapter_mailing == 1
 
-        email_group = frappe.db.get_value(
-            "Email Group",
-            {
-                "reference_document": self.event,
-                "document_type": EVENT,
-                "group_type": type,
-            },
-            ["name"],
+        # Create or get the Event Participants group
+        event_group = create_email_group(
+            type=type,
+            reference_document=self.event,
+            document_type=EVENT,
+        )
+
+        chapter_group = create_email_group(
+            type="Chapter CFP Proposers",
+            reference_document=self.chapter,
+            document_type=CHAPTER,
         )
 
         for speaker in self.speakers:
@@ -367,6 +363,11 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
                 continue
 
             try:
-                add_to_email_group(email_group, speaker.email)
+                if should_subscribe:
+                    add_to_email_group(event_group, speaker.email)
+                    add_to_email_group(chapter_group, speaker.email)
+                else:
+                    remove_from_email_group(event_group, speaker.email)
+                    remove_from_email_group(chapter_group, speaker.email)
             except frappe.DuplicateEntryError:
                 continue

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -73,6 +73,7 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         speakers: DF.Table[CFPSubmissionSpeaker]
         status: DF.Literal["Review Pending", "Screening", "Approved", "Rejected", "Withdrawn"]  # noqa: F821, F722
         submitted_by: DF.Link | None
+        subscribe_chapter_mailing: DF.Check
         talk_description: DF.TextEditor
         talk_reference: DF.Data | None
         talk_title: DF.Data

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -93,6 +93,8 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
                 self.status = "Review Pending"
         self.set_route()
         self.set_scores()
+        if self.has_value_changed("subscribe_chapter_mailing"):
+            self.handle_email_group("CFP Proposers")
         self.handle_status_change()
         self.validate_session_type_permissions()
 

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -97,8 +97,8 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         self.validate_session_type_permissions()
 
     def after_insert(self):
-        if self.has_value_changed("subscribe_chapter_mailing"):
-            self.handle_email_group("CFP Proposers")
+        # Always handle initial subscription on insert
+        self.handle_email_group("CFP Proposers")
 
     def set_route(self):
         event_route = frappe.db.get_value(EVENT, self.event, "route")

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -352,6 +352,10 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
             event=self.event,
             event_type=email_group_type,
             chapter_type="Chapter CFP Proposers",
+            # NOTE: We mandate subscribe to event mailing cause,
+            # ideally CFPs would require some communication to occur by team
+            # Again, event is temporary for event_duration. Hope logic sounds intentional?
+            # if not, please do raise an issue!
             subscribe_to_event=True,
             subscribe_to_chapter=frappe.utils.cint(self.subscribe_chapter_mailing) == 1,
             document_type_event=EVENT,

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -364,10 +364,10 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
 
             try:
                 if should_subscribe:
-                    add_to_email_group(event_group, speaker.email)
-                    add_to_email_group(chapter_group, speaker.email)
+                    add_to_email_group(event_group.name, speaker.email)
+                    add_to_email_group(chapter_group.name, speaker.email)
                 else:
-                    remove_from_email_group(event_group, speaker.email)
-                    remove_from_email_group(chapter_group, speaker.email)
+                    remove_from_email_group(event_group.name, speaker.email)
+                    remove_from_email_group(chapter_group.name, speaker.email)
             except frappe.DuplicateEntryError:
                 continue

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -7,9 +7,7 @@ import frappe
 from frappe.website.website_generator import WebsiteGenerator
 
 from fossunited.api.emailing import (
-    add_to_email_group,
-    create_email_group,
-    remove_from_email_group,
+    handle_email_group_subscription,
 )
 from fossunited.doctype_ids import CHAPTER, EVENT, EVENT_CFP
 
@@ -93,10 +91,10 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
                 self.status = "Review Pending"
         self.set_route()
         self.set_scores()
-        if self.has_value_changed("subscribe_chapter_mailing"):
-            self.handle_email_group("CFP Proposers")
         self.handle_status_change()
         self.validate_session_type_permissions()
+        if self.has_value_changed("subscribe_chapter_mailing"):
+            self.handle_email_group("CFP Proposers")
 
     def after_insert(self):
         # Always handle initial subscription on insert
@@ -345,32 +343,16 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         if self.status == "Rejected":
             self.handle_email_group("Rejected Proposers")
 
-    def handle_email_group(self, type) -> None:
-        should_subscribe = frappe.utils.cint(self.subscribe_chapter_mailing) == 1
+    def handle_email_group(self, email_group_type) -> None:
+        emails = [s.email for s in self.speakers if s.email]
 
-        # Create or get the Event Participants group
-        event_group = create_email_group(
-            type=type,
-            reference_document=self.event,
-            document_type=EVENT,
+        handle_email_group_subscription(
+            emails=emails,
+            chapter=self.chapter,
+            event=self.event,
+            event_type=email_group_type,
+            chapter_type="Chapter CFP Proposers",
+            subscribe_to_event=True,
+            subscribe_to_chapter=frappe.utils.cint(self.subscribe_chapter_mailing) == 1,
+            document_type_event=EVENT,
         )
-
-        chapter_group = create_email_group(
-            type="Chapter CFP Proposers",
-            reference_document=self.chapter,
-            document_type=CHAPTER,
-        )
-
-        for speaker in self.speakers:
-            if not speaker.email:
-                continue
-
-            try:
-                if should_subscribe:
-                    add_to_email_group(event_group.name, speaker.email)
-                    add_to_email_group(chapter_group.name, speaker.email)
-                else:
-                    remove_from_email_group(event_group.name, speaker.email)
-                    remove_from_email_group(chapter_group.name, speaker.email)
-            except frappe.DuplicateEntryError:
-                continue

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -344,7 +344,7 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
             self.handle_email_group("Rejected Proposers")
 
     def handle_email_group(self, type) -> None:
-        should_subscribe = self.subscribe_chapter_mailing == 1
+        should_subscribe = frappe.utils.cint(self.subscribe_chapter_mailing) == 1
 
         # Create or get the Event Participants group
         event_group = create_email_group(

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/test_foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/test_foss_event_cfp_submission.py
@@ -150,6 +150,20 @@ class TestFOSSEventCFPSubmission(FrappeTestCase):
             self.assertTrue(
                 self.is_added_to_email_group(self.event.name, speaker.email, "CFP Proposers")
             )
+        chapter_group = frappe.db.get_value(
+            "Email Group",
+            {
+                "reference_document": self.chapter.name,
+                "document_type": "FOSS Chapter",
+                "group_type": "Chapter CFP Proposers",
+            },
+        )
+        self.assertFalse(
+            frappe.db.exists(
+                "Email Group Member",
+                {"email": speaker.email, "email_group": chapter_group},
+            )
+        )
 
     def test_status_change_no_add_when_unsubscribed(self):
         # Given a submission with mailing unsubscribed
@@ -195,3 +209,7 @@ class TestFOSSEventCFPSubmission(FrappeTestCase):
                     {"email": speaker.email, "email_group": chapter_group},
                 )
             )
+        # still present in event CFP Proposers
+        self.assertTrue(
+            self.is_added_to_email_group(self.event.name, speaker.email, "CFP Proposers")
+        )

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/test_foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/test_foss_event_cfp_submission.py
@@ -3,6 +3,7 @@ from faker import Faker
 from frappe.tests.utils import FrappeTestCase
 
 from fossunited.doctype_ids import (
+    CHAPTER,
     EVENT,
     PROPOSAL,
 )
@@ -155,16 +156,19 @@ class TestFOSSEventCFPSubmission(FrappeTestCase):
             "Email Group",
             {
                 "reference_document": self.chapter.name,
-                "document_type": "FOSS Chapter",
+                "document_type": CHAPTER,
                 "group_type": "Chapter CFP Proposers",
             },
         )
-        self.assertFalse(
-            frappe.db.exists(
-                "Email Group Member",
-                {"email": speaker.email, "email_group": chapter_group},
+        submission.delete(force=True, ignore_permissions=True)
+
+        for sp in submission.speakers:
+            self.assertFalse(
+                frappe.db.exists(
+                    "Email Group Member",
+                    {"email": sp.email, "email_group": chapter_group},
+                )
             )
-        )
 
     def test_status_change_no_add_when_unsubscribed(self):
         # Given a submission with mailing unsubscribed
@@ -200,7 +204,7 @@ class TestFOSSEventCFPSubmission(FrappeTestCase):
                 "Email Group",
                 {
                     "reference_document": self.chapter.name,
-                    "document_type": "FOSS Chapter",
+                    "document_type": CHAPTER,
                     "group_type": "Chapter CFP Proposers",
                 },
             )
@@ -210,7 +214,8 @@ class TestFOSSEventCFPSubmission(FrappeTestCase):
                     {"email": speaker.email, "email_group": chapter_group},
                 )
             )
-        # still present in event CFP Proposers
-        self.assertTrue(
-            self.is_added_to_email_group(self.event.name, speaker.email, "CFP Proposers")
-        )
+        # should still present in event CFP Proposers
+        for sp in self.submission.speakers:
+            self.assertTrue(
+                self.is_added_to_email_group(self.event.name, sp.email, "CFP Proposers")
+            )

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/test_foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/test_foss_event_cfp_submission.py
@@ -126,3 +126,72 @@ class TestFOSSEventCFPSubmission(FrappeTestCase):
         return bool(
             frappe.db.exists("Email Group Member", {"email": email, "email_group": email_group})
         )
+
+    def test_no_email_group_when_unsubscribed(self):
+        # Given a CFP form and submission
+        speakers = [
+            {
+                "full_name": fake.name(),
+                "email": "nosubscribe@example.com",
+                "designation": fake.job(),
+                "organization": fake.company(),
+                "bio": "Test Submission",
+            }
+        ]
+        submission = insert_cfp_submission(
+            linked_cfp=self.cfp.name,
+            event=self.event.name,
+            speakers=speakers,
+            subscribe_chapter_mailing=0,
+        )
+
+        # They should must be added to CFP Proposers group by default
+        for speaker in submission.speakers:
+            self.assertTrue(
+                self.is_added_to_email_group(self.event.name, speaker.email, "CFP Proposers")
+            )
+
+    def test_status_change_no_add_when_unsubscribed(self):
+        # Given a submission with mailing unsubscribed
+        self.submission.subscribe_chapter_mailing = 0
+        self.submission.save()
+
+        frappe.set_user(CoreTeam)
+        self.submission.status = "Approved"
+        self.submission.save()
+
+        for speaker in self.submission.speakers:
+            self.assertFalse(
+                self.is_added_to_email_group(self.event.name, speaker.email, "Accepted Proposers")
+            )
+
+    def test_removal_from_email_group_on_unsubscribe(self):
+        # Given a submission with subscription enabled
+        self.assertEqual(self.submission.subscribe_chapter_mailing, 1)
+
+        for speaker in self.submission.speakers:
+            self.assertTrue(
+                self.is_added_to_email_group(self.event.name, speaker.email, "CFP Proposers")
+            )
+
+        # When user unsubscribes & is rejected
+        self.submission.subscribe_chapter_mailing = 0
+        self.submission.status = "Rejected"
+        self.submission.save()
+
+        # they should not be in chapter group, can be in cfp proposers group
+        for speaker in self.submission.speakers:
+            chapter_group = frappe.db.get_value(
+                "Email Group",
+                {
+                    "reference_document": self.chapter.name,
+                    "document_type": "FOSS Chapter",
+                    "group_type": "Chapter CFP Proposers",
+                },
+            )
+            self.assertFalse(
+                frappe.db.exists(
+                    "Email Group Member",
+                    {"email": speaker.email, "email_group": chapter_group},
+                )
+            )

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/test_foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/test_foss_event_cfp_submission.py
@@ -142,8 +142,9 @@ class TestFOSSEventCFPSubmission(FrappeTestCase):
             linked_cfp=self.cfp.name,
             event=self.event.name,
             speakers=speakers,
-            subscribe_chapter_mailing=0,
         )
+        submission.subscribe_chapter_mailing = 0
+        submission.save()
 
         # They should must be added to CFP Proposers group by default
         for speaker in submission.speakers:
@@ -175,7 +176,7 @@ class TestFOSSEventCFPSubmission(FrappeTestCase):
         self.submission.save()
 
         for speaker in self.submission.speakers:
-            self.assertFalse(
+            self.assertTrue(
                 self.is_added_to_email_group(self.event.name, speaker.email, "Accepted Proposers")
             )
 

--- a/fossunited/setup.py
+++ b/fossunited/setup.py
@@ -163,7 +163,7 @@ def get_custom_fields():
                 "fieldname": "group_type",
                 "fieldtype": "Select",
                 "label": "Group Type",
-                "options": "Chapter Main\nEvent Participants\nCFP Proposers\nAccepted Proposers\nRejected Proposers\nOther",  # noqa: E501
+                "options": "Chapter Event Participants\nChapter CFP Proposers\nEvent Participants\nCFP Proposers\nAccepted Proposers\nRejected Proposers\nOther",  # noqa: E501
                 "default": "Other",
                 "insert_after": "event",
             },

--- a/fossunited/tests/test_emailing.py
+++ b/fossunited/tests/test_emailing.py
@@ -4,7 +4,9 @@ from frappe.tests.utils import FrappeTestCase
 
 from fossunited.api.emailing import (
     add_to_email_group,
+    create_email_group,
     create_newsletter_campaign,
+    remove_from_email_group,
     send_campaign,
     send_test_email,
 )
@@ -27,6 +29,7 @@ class TestEmailing(FrappeTestCase):
         frappe.set_user("Administrator")
         frappe.delete_doc(CHAPTER, self.chapter.name, force=True)
         frappe.delete_doc(EVENT, self.event.name, force=True)
+        frappe.delete_doc("Email Group", {"reference_document": self.event.name})
 
     def setup_campaign(self):
         email_group = frappe.get_doc(
@@ -38,7 +41,11 @@ class TestEmailing(FrappeTestCase):
             },
         )
 
-        recipient_emails = ["test2@example.com", "test3@example.com", "test5@example.com"]
+        recipient_emails = [
+            "test2@example.com",
+            "test3@example.com",
+            "test5@example.com",
+        ]
         for email in recipient_emails:
             add_to_email_group(email_group.name, email)
 
@@ -74,3 +81,71 @@ class TestEmailing(FrappeTestCase):
         frappe.set_user(self.core_team_email)
 
         send_campaign(self.newsletter.name)
+
+    def test_create_email_group_creates_group(self):
+        group = create_email_group(
+            type="Event Participants",
+            reference_document=self.event.name,
+            document_type=self.event.doctype,
+        )
+
+        self.assertTrue(frappe.db.exists("Email Group", group.name))
+        self.assertEqual(group.reference_document, self.event.name)
+        self.assertEqual(group.document_type, self.event.doctype)
+        self.assertEqual(group.chapter, self.chapter.name)
+
+    def test_create_email_group_returns_existing(self):
+        # First call creates it
+        group1 = create_email_group(
+            type="Event Participants",
+            reference_document=self.event.name,
+            document_type=self.event.doctype,
+        )
+
+        # Second call should not create a new one
+        group2 = create_email_group(
+            type="Event Participants",
+            reference_document=self.event.name,
+            document_type=self.event.doctype,
+        )
+
+        self.assertEqual(group1.name, group2.name)
+
+        count = frappe.db.count("Email Group", {"name": group1.name})
+        self.assertEqual(count, 1)
+
+    def test_add_to_email_group_adds_member(self):
+        group = create_email_group(
+            type="Event Participants",
+            reference_document=self.event.name,
+            document_type=self.event.doctype,
+        )
+        email = "added@example.com"
+        add_to_email_group(group.name, email)
+
+        self.assertTrue(
+            frappe.db.exists("Email Group Member", {"email": email, "email_group": group.name})
+        )
+
+    def test_remove_from_email_group_removes_member(self):
+        group = create_email_group(
+            type="Event Participants",
+            reference_document=self.event.name,
+            document_type=self.event.doctype,
+        )
+        email = "remove@example.com"
+        add_to_email_group(group.name, email)
+
+        self.assertTrue(
+            frappe.db.exists("Email Group Member", {"email": email, "email_group": group.name})
+        )
+
+        remove_from_email_group(group.name, email)
+
+        self.assertFalse(
+            frappe.db.exists("Email Group Member", {"email": email, "email_group": group.name})
+        )
+
+    def test_add_to_nonexistent_email_group_raises(self):
+        with self.assertRaises(frappe.DoesNotExistError):
+            add_to_email_group("non-existent-group", "test@example.com")

--- a/fossunited/tests/test_emailing.py
+++ b/fossunited/tests/test_emailing.py
@@ -29,7 +29,14 @@ class TestEmailing(FrappeTestCase):
         frappe.set_user("Administrator")
         frappe.delete_doc(CHAPTER, self.chapter.name, force=True)
         frappe.delete_doc(EVENT, self.event.name, force=True)
-        frappe.delete_doc("Email Group", {"reference_document": self.event.name})
+        # Delete all email groups for the event
+        groups = frappe.get_all(
+            "Email Group",
+            filters={"reference_document": self.event.name},
+            pluck="name",
+        )
+        for group_name in groups:
+            frappe.delete_doc("Email Group", group_name, force=True)
 
     def setup_campaign(self):
         email_group = frappe.get_doc(

--- a/fossunited/tests/utils.py
+++ b/fossunited/tests/utils.py
@@ -390,6 +390,7 @@ def insert_rsvp_submission(linked_rsvp: str, **kwargs):
         confirm_attendance (int, optional): Attendance confirmation status.
                                             Defaults to 1 (confirmed).
         custom_answers (list, optional): Answers to custom RSVP questions.
+        "subscribe_chapter_mailing": kwargs.get("subscribe_chapter_mailing"),
         **kwargs: Additional arguments to be passed to the RSVP submission.
 
     Returns:

--- a/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.json
+++ b/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.json
@@ -158,14 +158,14 @@
    "label": "Tshirt Delivered?"
   },
   {
-   "default": "1",
+   "default": "0",
    "fieldname": "subscribe_chapter_mailing",
    "fieldtype": "Check",
    "label": "Subscribe to Mailing Group?"
   }
  ],
  "links": [],
- "modified": "2025-10-13 15:16:53.771108",
+ "modified": "2025-10-15 12:51:09.109565",
  "modified_by": "Administrator",
  "module": "Ticketing",
  "name": "FOSS Event Ticket",

--- a/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.json
+++ b/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.json
@@ -1,185 +1,192 @@
 {
-  "actions": [],
-  "allow_rename": 1,
-  "creation": "2024-04-27 12:37:58.593416",
-  "doctype": "DocType",
-  "engine": "InnoDB",
-  "field_order": [
-    "section_break_pvar",
-    "is_transfer_ticket",
-    "section_break_ogof",
-    "event",
-    "full_name",
-    "designation",
-    "column_break_dnhv",
-    "tier",
-    "email",
-    "organization",
-    "payment_details_section",
-    "razorpay_payment",
-    "column_break_uihi",
-    "customer",
-    "additional_details_section",
-    "wants_tshirt",
-    "tshirt_delivered",
-    "column_break_qbfj",
-    "tshirt_size",
-    "section_break_tzsu",
-    "custom_fields",
-    "section_break_ueio",
-    "check_ins"
-  ],
-  "fields": [
-    {
-      "fieldname": "full_name",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "label": "Full Name",
-      "reqd": 1
-    },
-    {
-      "fieldname": "column_break_dnhv",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "email",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "label": "Email",
-      "options": "Email",
-      "reqd": 1
-    },
-    {
-      "fieldname": "payment_details_section",
-      "fieldtype": "Section Break",
-      "label": "Payment Details"
-    },
-    {
-      "fieldname": "razorpay_payment",
-      "fieldtype": "Link",
-      "label": "Razorpay Payment",
-      "options": "Razorpay Payment",
-      "read_only": 1
-    },
-    {
-      "fieldname": "column_break_uihi",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fetch_from": "razorpay_payment.email",
-      "fieldname": "customer",
-      "fieldtype": "Data",
-      "label": "Customer"
-    },
-    {
-      "fieldname": "event",
-      "fieldtype": "Link",
-      "label": "Event",
-      "options": "FOSS Chapter Event",
-      "reqd": 1,
-      "search_index": 1
-    },
-    {
-      "fieldname": "tier",
-      "fieldtype": "Data",
-      "label": "Tier"
-    },
-    {
-      "fieldname": "additional_details_section",
-      "fieldtype": "Section Break",
-      "label": "Additional Details"
-    },
-    {
-      "fieldname": "column_break_qbfj",
-      "fieldtype": "Column Break"
-    },
-    {
-      "default": "0",
-      "fieldname": "wants_tshirt",
-      "fieldtype": "Check",
-      "label": "Wants T Shirt?",
-      "read_only": 1
-    },
-    {
-      "depends_on": "eval:doc.wants_tshirt==1",
-      "fieldname": "tshirt_size",
-      "fieldtype": "Data",
-      "label": "T Shirt Size"
-    },
-    {
-      "fieldname": "section_break_tzsu",
-      "fieldtype": "Section Break"
-    },
-    {
-      "fieldname": "custom_fields",
-      "fieldtype": "Table",
-      "label": "Custom Fields",
-      "options": "FOSS Ticket Custom Field"
-    },
-    {
-      "fieldname": "designation",
-      "fieldtype": "Data",
-      "label": "Designation"
-    },
-    {
-      "fieldname": "organization",
-      "fieldtype": "Data",
-      "label": "Organization / College"
-    },
-    {
-      "fieldname": "section_break_pvar",
-      "fieldtype": "Section Break"
-    },
-    {
-      "default": "0",
-      "fieldname": "is_transfer_ticket",
-      "fieldtype": "Check",
-      "label": "Is Transfer Ticket?"
-    },
-    {
-      "fieldname": "section_break_ogof",
-      "fieldtype": "Section Break"
-    },
-    {
-      "fieldname": "section_break_ueio",
-      "fieldtype": "Section Break"
-    },
-    {
-      "fieldname": "check_ins",
-      "fieldtype": "Table",
-      "label": "Check Ins",
-      "options": "Event Check In"
-    },
-    {
-      "default": "0",
-      "fieldname": "tshirt_delivered",
-      "fieldtype": "Check",
-      "label": "Tshirt Delivered?"
-    }
-  ],
-  "links": [],
-  "modified": "2025-07-24 15:11:26.187693",
-  "modified_by": "Administrator",
-  "module": "Ticketing",
-  "name": "FOSS Event Ticket",
-  "owner": "Administrator",
-  "permissions": [
-    {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "System Manager",
-      "share": 1,
-      "write": 1
-    }
-  ],
-  "row_format": "Dynamic",
-  "sort_field": "creation",
-  "sort_order": "DESC",
-  "states": [],
-  "title_field": "full_name"
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-04-27 12:37:58.593416",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_pvar",
+  "is_transfer_ticket",
+  "section_break_ogof",
+  "event",
+  "full_name",
+  "designation",
+  "column_break_dnhv",
+  "tier",
+  "email",
+  "subscribe_chapter_mailing",
+  "organization",
+  "payment_details_section",
+  "razorpay_payment",
+  "column_break_uihi",
+  "customer",
+  "additional_details_section",
+  "wants_tshirt",
+  "tshirt_delivered",
+  "column_break_qbfj",
+  "tshirt_size",
+  "section_break_tzsu",
+  "custom_fields",
+  "section_break_ueio",
+  "check_ins"
+ ],
+ "fields": [
+  {
+   "fieldname": "full_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Full Name",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_dnhv",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "email",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Email",
+   "options": "Email",
+   "reqd": 1
+  },
+  {
+   "fieldname": "payment_details_section",
+   "fieldtype": "Section Break",
+   "label": "Payment Details"
+  },
+  {
+   "fieldname": "razorpay_payment",
+   "fieldtype": "Link",
+   "label": "Razorpay Payment",
+   "options": "Razorpay Payment",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_uihi",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "razorpay_payment.email",
+   "fieldname": "customer",
+   "fieldtype": "Data",
+   "label": "Customer"
+  },
+  {
+   "fieldname": "event",
+   "fieldtype": "Link",
+   "label": "Event",
+   "options": "FOSS Chapter Event",
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "tier",
+   "fieldtype": "Data",
+   "label": "Tier"
+  },
+  {
+   "fieldname": "additional_details_section",
+   "fieldtype": "Section Break",
+   "label": "Additional Details"
+  },
+  {
+   "fieldname": "column_break_qbfj",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "wants_tshirt",
+   "fieldtype": "Check",
+   "label": "Wants T Shirt?",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.wants_tshirt==1",
+   "fieldname": "tshirt_size",
+   "fieldtype": "Data",
+   "label": "T Shirt Size"
+  },
+  {
+   "fieldname": "section_break_tzsu",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "custom_fields",
+   "fieldtype": "Table",
+   "label": "Custom Fields",
+   "options": "FOSS Ticket Custom Field"
+  },
+  {
+   "fieldname": "designation",
+   "fieldtype": "Data",
+   "label": "Designation"
+  },
+  {
+   "fieldname": "organization",
+   "fieldtype": "Data",
+   "label": "Organization / College"
+  },
+  {
+   "fieldname": "section_break_pvar",
+   "fieldtype": "Section Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_transfer_ticket",
+   "fieldtype": "Check",
+   "label": "Is Transfer Ticket?"
+  },
+  {
+   "fieldname": "section_break_ogof",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "section_break_ueio",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "check_ins",
+   "fieldtype": "Table",
+   "label": "Check Ins",
+   "options": "Event Check In"
+  },
+  {
+   "default": "0",
+   "fieldname": "tshirt_delivered",
+   "fieldtype": "Check",
+   "label": "Tshirt Delivered?"
+  },
+  {
+   "default": "1",
+   "fieldname": "subscribe_chapter_mailing",
+   "fieldtype": "Check",
+   "label": "Subscribe to Mailing Group?"
+  }
+ ],
+ "links": [],
+ "modified": "2025-10-13 15:16:53.771108",
+ "modified_by": "Administrator",
+ "module": "Ticketing",
+ "name": "FOSS Event Ticket",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "full_name"
 }

--- a/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
@@ -28,7 +28,9 @@ class FOSSEventTicket(Document):
     if TYPE_CHECKING:
         from frappe.types import DF
 
-        from fossunited.fossunited.doctype.event_check_in.event_check_in import EventCheckIn
+        from fossunited.fossunited.doctype.event_check_in.event_check_in import (
+            EventCheckIn,
+        )
         from fossunited.ticketing.doctype.foss_ticket_custom_field.foss_ticket_custom_field import (  # noqa: E501
             FOSSTicketCustomField,
         )
@@ -88,6 +90,7 @@ class FOSSEventTicket(Document):
 
     def after_insert(self):
         self.check_max_tickets()
+        self.handle_add_to_email_group()
 
     def before_save(self):
         if self.has_value_changed("subscribe_chapter_mailing"):

--- a/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
@@ -6,8 +6,12 @@ from typing import TYPE_CHECKING
 import frappe
 from frappe.model.document import Document
 
-from fossunited.api.emailing import add_to_email_group, create_email_group
-from fossunited.doctype_ids import EVENT, EVENT_TICKET
+from fossunited.api.emailing import (
+    add_to_email_group,
+    create_email_group,
+    remove_from_email_group,
+)
+from fossunited.doctype_ids import CHAPTER, EVENT, EVENT_TICKET
 
 if TYPE_CHECKING:
     from fossunited.payments.doctype.razorpay_payment.razorpay_payment import (
@@ -39,6 +43,7 @@ class FOSSEventTicket(Document):
         is_transfer_ticket: DF.Check
         organization: DF.Data | None
         razorpay_payment: DF.Link | None
+        subscribe_chapter_mailing: DF.Check
         tier: DF.Data | None
         tshirt_delivered: DF.Check
         tshirt_size: DF.Data | None
@@ -82,37 +87,39 @@ class FOSSEventTicket(Document):
             frappe.throw("Ticket sale are closed for this event!", frappe.PermissionError)
 
     def after_insert(self):
-        self.handle_add_to_email_group()
         self.check_max_tickets()
 
-    def handle_add_to_email_group(self):
-        if not frappe.db.exists(
-            "Email Group",
-            {
-                "reference_document": self.event,
-                "document_type": EVENT,
-                "group_type": "Event Participants",
-            },
-        ):
-            create_email_group(
-                type="Event Participants",
-                reference_document=self.event,
-                document_type=EVENT,
-            )
+    def before_save(self):
+        if self.has_value_changed("subscribe_chapter_mailing"):
+            self.handle_add_to_email_group()
 
-        email_group = frappe.db.get_value(
-            "Email Group",
-            {
-                "reference_document": self.event,
-                "document_type": EVENT,
-                "group_type": "Event Participants",
-            },
-            ["name"],
+    def handle_add_to_email_group(self):
+        # Check if user should be subscribed
+        should_subscribe = self.subscribe_chapter_mailing == 1
+
+        # Create or get the Event Participants group
+        event_group = create_email_group(
+            type="Event Participants",
+            reference_document=self.event,
+            document_type=EVENT,
         )
-        try:
-            add_to_email_group(email_group, self.email)
-        except frappe.DuplicateEntryError:
-            pass
+
+        # Create or get the Chapter Event Participants group
+        event_doc = frappe.get_doc(EVENT, self.event)
+        chapter_group = create_email_group(
+            type="Chapter Event Participants",
+            reference_document=event_doc.chapter,
+            document_type=CHAPTER,
+        )
+
+        if should_subscribe:
+            # Add the email to both groups
+            add_to_email_group(event_group.name, self.email)
+            add_to_email_group(chapter_group.name, self.email)
+        else:
+            # Remove the email from both groups
+            remove_from_email_group(event_group.name, self.email)
+            remove_from_email_group(chapter_group.name, self.email)
 
     def is_ticket_live(self):
         tickets_status = frappe.db.get_value(

--- a/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
@@ -98,6 +98,8 @@ class FOSSEventTicket(Document):
 
     def handle_add_to_email_group(self):
         # Check if user should be subscribed
+        if not self.email:
+            return
         should_subscribe = frappe.utils.cint(self.subscribe_chapter_mailing) == 1
 
         # Create or get the Event Participants group

--- a/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
@@ -6,12 +6,8 @@ from typing import TYPE_CHECKING
 import frappe
 from frappe.model.document import Document
 
-from fossunited.api.emailing import (
-    add_to_email_group,
-    create_email_group,
-    remove_from_email_group,
-)
-from fossunited.doctype_ids import CHAPTER, EVENT, EVENT_TICKET
+from fossunited.api.emailing import handle_email_group_subscription
+from fossunited.doctype_ids import EVENT, EVENT_TICKET
 
 if TYPE_CHECKING:
     from fossunited.payments.doctype.razorpay_payment.razorpay_payment import (
@@ -100,31 +96,17 @@ class FOSSEventTicket(Document):
         # Check if user should be subscribed
         if not self.email:
             return
-        should_subscribe = frappe.utils.cint(self.subscribe_chapter_mailing) == 1
+        wants_subscription = frappe.utils.cint(self.subscribe_chapter_mailing) == 1
 
-        # Create or get the Event Participants group
-        event_group = create_email_group(
-            type="Event Participants",
-            reference_document=self.event,
-            document_type=EVENT,
-        )
-
-        # Create or get the Chapter Event Participants group
         event_doc = frappe.get_doc(EVENT, self.event)
-        chapter_group = create_email_group(
-            type="Chapter Event Participants",
-            reference_document=event_doc.chapter,
-            document_type=CHAPTER,
+        handle_email_group_subscription(
+            emails=[self.email],
+            chapter=event_doc.chapter,
+            event=self.event,
+            subscribe_to_chapter=wants_subscription,
+            subscribe_to_event=wants_subscription,
+            document_type_event=EVENT,
         )
-
-        if should_subscribe:
-            # Add the email to both groups
-            add_to_email_group(event_group.name, self.email)
-            add_to_email_group(chapter_group.name, self.email)
-        else:
-            # Remove the email from both groups
-            remove_from_email_group(event_group.name, self.email)
-            remove_from_email_group(chapter_group.name, self.email)
 
     def is_ticket_live(self):
         tickets_status = frappe.db.get_value(

--- a/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
@@ -98,7 +98,7 @@ class FOSSEventTicket(Document):
 
     def handle_add_to_email_group(self):
         # Check if user should be subscribed
-        should_subscribe = self.subscribe_chapter_mailing == 1
+        should_subscribe = frappe.utils.cint(self.subscribe_chapter_mailing) == 1
 
         # Create or get the Event Participants group
         event_group = create_email_group(

--- a/fossunited/ticketing/doctype/foss_event_ticket/test_foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/test_foss_event_ticket.py
@@ -156,8 +156,9 @@ class TestFOSSEventTicket(FrappeTestCase):
 
         attendee_email = "test4@example.com"
         # When a ticket is created with attendee's email
-        insert_test_ticket(event=self.event.name, email=attendee_email)
-
+        ticket = insert_test_ticket(event=self.event.name, email=attendee_email)
+        ticket.subscribe_chapter_mailing = 1
+        ticket.save()
         # Then the email should be added to an email group linked to event for participants
         email_group = frappe.db.get_value(
             "Email Group",
@@ -174,12 +175,15 @@ class TestFOSSEventTicket(FrappeTestCase):
                 {"email": attendee_email, "email_group": email_group},
             )
         )
+        ticket.delete(force=True)
 
     def test_remove_from_email_group_on_unsubscribe(self):
         attendee_email = "test4@example.com"
 
         # Given: Ticket created with subscription ON (default behavior)
         ticket = insert_test_ticket(event=self.event.name, email=attendee_email)
+        ticket.subscribe_chapter_mailing = 1
+        ticket.save()
 
         email_group_id = frappe.db.get_value(
             "Email Group",

--- a/fossunited/ticketing/doctype/foss_event_ticket/test_foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/test_foss_event_ticket.py
@@ -198,6 +198,23 @@ class TestFOSSEventTicket(FrappeTestCase):
             )
         )
 
+        # Verify initial membership in Chapter Event Participants group
+        chapter_group_id = frappe.db.get_value(
+            "Email Group",
+            {
+                "reference_document": self.chapter.name,
+                "document_type": CHAPTER,
+                "group_type": "Chapter Event Participants",
+            },
+            "name",
+        )
+        self.assertTrue(
+            frappe.db.exists(
+                "Email Group Member",
+                {"email": attendee_email, "email_group": chapter_group_id},
+            )
+        )
+
         # When: Ticket is updated to unsubscribe
         ticket.subscribe_chapter_mailing = 0
         ticket.save()
@@ -211,15 +228,6 @@ class TestFOSSEventTicket(FrappeTestCase):
         )
 
         # Also verify removal from Chapter Event Participants group
-        chapter_group_id = frappe.db.get_value(
-            "Email Group",
-            {
-                "reference_document": self.chapter.name,
-                "document_type": CHAPTER,
-                "group_type": "Chapter Event Participants",
-            },
-            "name",
-        )
         self.assertFalse(
             frappe.db.exists(
                 "Email Group Member",

--- a/fossunited/ticketing/doctype/foss_event_ticket/test_foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/test_foss_event_ticket.py
@@ -4,7 +4,11 @@ from frappe.tests.utils import FrappeTestCase
 
 from fossunited.api.checkins import checkin_attendee
 from fossunited.doctype_ids import CHAPTER, EVENT, EVENT_TICKET
-from fossunited.tests.utils import insert_test_chapter, insert_test_event, insert_test_ticket
+from fossunited.tests.utils import (
+    insert_test_chapter,
+    insert_test_event,
+    insert_test_ticket,
+)
 
 
 class TestFOSSEventTicket(FrappeTestCase):
@@ -166,6 +170,81 @@ class TestFOSSEventTicket(FrappeTestCase):
 
         self.assertTrue(
             frappe.db.exists(
-                "Email Group Member", {"email": attendee_email, "email_group": email_group}
+                "Email Group Member",
+                {"email": attendee_email, "email_group": email_group},
             )
         )
+
+    def test_remove_from_email_group_on_unsubscribe(self):
+        attendee_email = "test4@example.com"
+
+        # Given: Ticket created with subscription ON (default behavior)
+        ticket = insert_test_ticket(event=self.event.name, email=attendee_email)
+
+        email_group_id = frappe.db.get_value(
+            "Email Group",
+            {
+                "reference_document": self.event.name,
+                "document_type": EVENT,
+                "group_type": "Event Participants",
+            },
+            "name",
+        )
+
+        self.assertTrue(
+            frappe.db.exists(
+                "Email Group Member",
+                {"email": attendee_email, "email_group": email_group_id},
+            )
+        )
+
+        # When: Ticket is updated to unsubscribe
+        ticket.subscribe_chapter_mailing = 0
+        ticket.save()
+
+        # Then: Email should be removed from email group
+        self.assertFalse(
+            frappe.db.exists(
+                "Email Group Member",
+                {"email": attendee_email, "email_group": email_group_id},
+            )
+        )
+
+        ticket.delete(force=True)
+
+    def test_resub_from_email_group(self):
+        attendee_email = "test4@example.com"
+
+        # Insert with default subscription (subscribe_chapter_mailing=1)
+        ticket = insert_test_ticket(event=self.event.name, email=attendee_email)
+
+        ticket.subscribe_chapter_mailing = 0
+        ticket.handle_add_to_email_group()
+        ticket.save()
+
+        email_group_id = frappe.db.get_value(
+            "Email Group",
+            {
+                "reference_document": self.event.name,
+                "document_type": EVENT,
+                "group_type": "Event Participants",
+            },
+            "name",
+        )
+
+        self.assertFalse(
+            frappe.db.exists(
+                "Email Group Member",
+                {"email": attendee_email, "email_group": email_group_id},
+            )
+        )
+        ticket.subscribe_chapter_mailing = 1
+        ticket.save()
+        self.assertTrue(
+            frappe.db.exists(
+                "Email Group Member",
+                {"email": attendee_email, "email_group": email_group_id},
+            )
+        )
+
+        ticket.delete(force=True)

--- a/fossunited/ticketing/doctype/foss_event_ticket/test_foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/test_foss_event_ticket.py
@@ -210,6 +210,23 @@ class TestFOSSEventTicket(FrappeTestCase):
             )
         )
 
+        # Also verify removal from Chapter Event Participants group
+        chapter_group_id = frappe.db.get_value(
+            "Email Group",
+            {
+                "reference_document": self.chapter.name,
+                "document_type": CHAPTER,
+                "group_type": "Chapter Event Participants",
+            },
+            "name",
+        )
+        self.assertFalse(
+            frappe.db.exists(
+                "Email Group Member",
+                {"email": attendee_email, "email_group": chapter_group_id},
+            )
+        )
+
         ticket.delete(force=True)
 
     def test_resub_from_email_group(self):


### PR DESCRIPTION
## 🚦 Status

- [x] Draft
- [ ] Ready for review

---

## 🔗 Related Issue

Closes / Addresses: #1176 & #1012

---

## ❗ Problem

<!-- Briefly describe the problem or motivation for this PR -->
A chapter level mailing (newsletter) to send out mail to past participants and CFP proposers.

This must act upon based on users preference (choice via checkbox)

---

## ✅ Solution

<!-- Describe your solution and what you changed -->
Handle adding and removing from email group of user (email) from various event and doctype.

Usually un-subscribe link is sent via newsletter to get them removed from group, but we also have checkbox option to update on the same.



---

## 📋 Progress (All must be checked to merge)

- [ ] Tested locally (PENDING)
- [ ] Write unit tests
- [ ] Connect control handling via desk, user email (footer) and also via edit form (rsvp, cfp..)

---

## 📝 Changelog

<commit>: <!-- e.g., feat: add user login endpoint -->

---

## 🖼️ Visualization

<!-- Add screenshots, diagrams, or screen recordings if applicable -->

---

## 🔮 Further Ahead

<!-- Mention any follow-up work or related PRs planned -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Per-attendee "Subscribe to Chapter Mailing?" checkbox added to tickets, RSVPs, CFP submissions, hackathon participant and attendee forms.

- **Changes**
  - Chapters and events automatically create relevant mailing groups on creation.
  - RSVP confirmation UI removed; submissions default to Accepted unless host approval is required.
  - Unified, idempotent subscription workflow that syncs event and chapter subscriptions and unsubscribes on change/delete; operations are logged.

- **Tests**
  - New tests for group creation, idempotency, subscribe/unsubscribe flows and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->