### PR TITLE
doctype: add link field to stack

### DIFF
--- a/fossunited/stack/doctype/stack/stack.json
+++ b/fossunited/stack/doctype/stack/stack.json
@@ -1,61 +1,74 @@
 {
-  "actions": [],
-  "allow_rename": 1,
-  "autoname": "hash",
-  "creation": "2024-11-07 12:26:04.097329",
-  "doctype": "DocType",
-  "engine": "InnoDB",
-  "field_order": ["title", "category", "icon"],
-  "fields": [
-    {
-      "fieldname": "category",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "label": "Category",
-      "reqd": 1
-    },
-    {
-      "fieldname": "icon",
-      "fieldtype": "Attach Image",
-      "label": "Icon",
-      "reqd": 1
-    },
-    {
-      "fieldname": "title",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "label": "Title",
-      "reqd": 1
-    }
-  ],
-  "index_web_pages_for_search": 1,
-  "links": [],
-  "modified": "2024-11-08 13:03:03.615834",
-  "modified_by": "Administrator",
-  "module": "Stack",
-  "name": "Stack",
-  "naming_rule": "Random",
-  "owner": "Administrator",
-  "permissions": [
-    {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "System Manager",
-      "share": 1,
-      "write": 1
-    },
-    {
-      "read": 1,
-      "role": "All"
-    }
-  ],
-  "sort_field": "creation",
-  "sort_order": "DESC",
-  "states": [],
-  "title_field": "title"
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "hash",
+ "creation": "2024-11-07 12:26:04.097329",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "title",
+  "link",
+  "category",
+  "icon"
+ ],
+ "fields": [
+  {
+   "fieldname": "category",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Category",
+   "reqd": 1
+  },
+  {
+   "fieldname": "icon",
+   "fieldtype": "Attach Image",
+   "label": "Icon",
+   "reqd": 1
+  },
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Title",
+   "reqd": 1
+  },
+  {
+   "fieldname": "link",
+   "fieldtype": "Data",
+   "label": "Link",
+   "options": "URL",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-10-14 13:43:44.934216",
+ "modified_by": "Administrator",
+ "module": "Stack",
+ "name": "Stack",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "read": 1,
+   "role": "All"
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "title"
 }

--- a/fossunited/stack/doctype/stack/stack.py
+++ b/fossunited/stack/doctype/stack/stack.py
@@ -16,6 +16,7 @@ class Stack(Document):
 
         category: DF.Data
         icon: DF.AttachImage
+        link: DF.Data
         title: DF.Data
     # end: auto-generated types
 

--- a/fossunited/stack/utils.py
+++ b/fossunited/stack/utils.py
@@ -4,7 +4,9 @@ import frappe
 
 
 def get_stack_dict():
-    stacks = frappe.get_all(doctype="Stack", fields=["title", "icon", "category"], page_length=999)
+    stacks = frappe.get_all(
+        doctype="Stack", fields=["title", "icon", "category", "link"], page_length=999
+    )
 
     stack_dict = defaultdict(list)
 

--- a/fossunited/stack/web_template/stack___items/stack___items.html
+++ b/fossunited/stack/web_template/stack___items/stack___items.html
@@ -10,11 +10,14 @@
 {% endmacro %}
 
 {% macro stack_item(item) %}
-  <div class="flex gap-3 p-3 items-center justify-center border rounded-sm bg-gray-50">
-    <img src="{{ item.icon }}" class=" w-7 h-7  aspect-square object-contain" />
-    <span class="text-base font-medium text-gray-800">{{ item.title }}</span>
-  </div>
+  <a href="{{ item.link or '#' }}" target="_blank" rel="noopener noreferrer" class="no-underline">
+    <div class="flex gap-3 p-3 items-center justify-center border rounded-sm bg-gray-50 hover:bg-gray-200 transition">
+      <img src="{{ item.icon }}" class="w-7 h-7 aspect-square object-contain" />
+      <span class="text-base font-medium text-gray-800">{{ item.title }}</span>
+    </div>
+  </a>
 {% endmacro %}
+
 
 <div class="flex flex-col gap-4 my-12">
   {% set stack_dict = get_stack_dict() %}


### PR DESCRIPTION
We've stack doctype for a page to show some FOSS stack we use as individual and as organization (team) 

This page can be improved alot, but as intended we will list of projects we use in uniform manner.

This PR adds link fields to each card 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Stack items now support a Link field, enabling direct navigation to internal or external URLs and opening in a new tab.

- **UI/UX**
  - Each Stack item is rendered as a clickable element with hover highlighting to indicate interactivity.
  - Existing layout and content presentation are preserved while improving access to linked resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->