### PR TITLE
utils: sort stack category dict in chronology (a-z)

### DIFF
--- a/fossunited/stack/utils.py
+++ b/fossunited/stack/utils.py
@@ -1,4 +1,4 @@
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 
 import frappe
 
@@ -8,9 +8,25 @@ def get_stack_dict():
         doctype="Stack", fields=["title", "icon", "category", "link"], page_length=999
     )
 
+    # Group items by category
     stack_dict = defaultdict(list)
-
     for item in stacks:
         stack_dict[item.category].append(item)
 
-    return stack_dict
+    # Sort categories alphabetically (case-insensitive), with "Past Utilities" at the end
+    sorted_categories = sorted(
+        [cat for cat in stack_dict if cat.lower() != "past utilities"],
+        key=lambda x: x.lower(),
+    )
+    if "Past Utilities" in stack_dict:
+        sorted_categories.append("Past Utilities")
+
+    # Create an OrderedDict to maintain sorted order
+    sorted_stack_dict = OrderedDict()
+
+    for category in sorted_categories:
+        # Sort items in each category by title (case-insensitive)
+        sorted_items = sorted(stack_dict[category], key=lambda x: x.title.lower())
+        sorted_stack_dict[category] = sorted_items
+
+    return sorted_stack_dict

--- a/fossunited/stack/utils.py
+++ b/fossunited/stack/utils.py
@@ -13,13 +13,18 @@ def get_stack_dict():
     for item in stacks:
         stack_dict[item.category].append(item)
 
-    # Sort categories alphabetically (case-insensitive), with "Past Utilities" at the end
+    # Sort categories alphabetically (case-insensitive), with "Not actively used" at the end
+    past_utilities_key = None
+    for cat in stack_dict:
+        if cat.lower() == "not actively used":
+            past_utilities_key = cat
+            break
     sorted_categories = sorted(
-        [cat for cat in stack_dict if cat.lower() != "past utilities"],
+        [cat for cat in stack_dict if cat != past_utilities_key],
         key=lambda x: x.lower(),
     )
-    if "Past Utilities" in stack_dict:
-        sorted_categories.append("Past Utilities")
+    if past_utilities_key:
+        sorted_categories.append(past_utilities_key)
 
     # Create an OrderedDict to maintain sorted order
     sorted_stack_dict = OrderedDict()


### PR DESCRIPTION
- it would look out of order if its not sorted :-)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Utilities are grouped by category and shown in a consistent, case-insensitive alphabetical order.
  - Items within each category are sorted case-insensitively for easier scanning.
  - The "Not actively used" category (when present) is always placed at the end for clearer separation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->