### PR TITLE
Rsvp toggle

### DIFF
--- a/fossunited/chapters/doctype/foss_event_rsvp/templates/foss_event_rsvp.html
+++ b/fossunited/chapters/doctype/foss_event_rsvp/templates/foss_event_rsvp.html
@@ -140,8 +140,9 @@
         const formData = $('.foss-form-body').serializeArray()
         const data = {}
 
+
         data['linked_rsvp'] = '{{ doc.name }}'
-        data['status'] = 'Accepted' // by default we accept
+        data['confirm_attendance'] = '1' // if they fill, its understood that they confirm
         formData.forEach((field) => {
           data[field.name] = field.value
         })

--- a/fossunited/fossunited/forms.py
+++ b/fossunited/fossunited/forms.py
@@ -29,18 +29,29 @@ def update_submission(doctype, submission, fields, custom):
             frappe.PermissionError,
         )
 
+    # Add authorization check
+    if not check_if_submitter(doctype, submission):
+        frappe.throw(
+            "You are not authorized to update this submission",
+            frappe.PermissionError,
+        )
+
     fields = json.loads(fields)
     custom = json.loads(custom)
-    frappe.db.set_value(doctype, submission, fields)
 
-    doc = frappe.get_doc(doctype, submission).as_dict()
-    for field in doc.custom_answers:
-        frappe.db.set_value(
-            "FOSS Custom Answer",
-            field.name,
-            "response",
-            custom[field.idx - 1]["response"],
-        )
+    doc = frappe.get_doc(doctype, submission)
+
+    # Update main fields
+    for key, value in fields.items():
+        setattr(doc, key, value)
+
+    # Update custom answers
+    for idx, field in enumerate(doc.custom_answers):
+        field.response = custom[idx]["response"]
+
+    doc.save()  # Triggers frappe controller: before_save()
+
+    return {"status": "success"}
 
 
 @frappe.whitelist()

--- a/fossunited/templates/macros/renderfield.html
+++ b/fossunited/templates/macros/renderfield.html
@@ -1,93 +1,216 @@
 {% macro renderfield(field, submission = None) %}
-    <div class="my-4 py-1">
+  <div class="my-4 py-1">
     {% if field.fieldtype == 'Table' %}
-        {% from "fossunited/templates/macros/custom_question.html" import CustomQuestion %}
-        {% if frappe.form_dict['cfp'] %}
-            {% for question in frappe.get_doc("FOSS Event CFP", submission.linked_cfp).custom_questions %}
-                {{ CustomQuestion(question, submission.custom_answers[question.idx - 1]) }}
-            {% endfor %}
-        {% elif frappe.form_dict['rsvp'] %}
-            {% for question in frappe.get_doc("FOSS Event RSVP", submission.linked_rsvp).custom_questions %}
-                {{ CustomQuestion(question, submission.custom_answers[question.idx - 1]) }}
-            {% endfor %}
-        {% endif %}
+      {% from "fossunited/templates/macros/custom_question.html" import CustomQuestion %}
+      {% if frappe.form_dict['cfp'] %}
+        {% for question in frappe.get_doc("FOSS Event CFP", submission.linked_cfp).custom_questions %}
+          {{ CustomQuestion(question, submission.custom_answers[question.idx - 1]) }}
+        {% endfor %}
+      {% elif frappe.form_dict['rsvp'] %}
+        {% for question in frappe.get_doc("FOSS Event RSVP", submission.linked_rsvp).custom_questions %}
+          {{ CustomQuestion(question, submission.custom_answers[question.idx - 1]) }}
+        {% endfor %}
+      {% endif %}
     {% elif field.fieldtype == 'Data' %}
-            <label for="{{field.fieldname}}" class="foss-form-question text-sm">{{field.label}}</label>
-            <input name="{{ field.fieldname }}" data-label="{{ field.label }}" data-type="Data" type="{% if field.fieldname == 'email' %} email {% else %} text {% endif %}" class="form-control text-sm rounded-input" id="{{ field.fieldname }}" value="{{ submission[field.fieldname] or field.value or '' }}" {% if field.read_only %} readonly {% endif %} {% if field.reqd %} required {% endif%}>
+      <label for="{{ field.fieldname }}" class="foss-form-question text-sm"
+        >{{ field.label }}</label
+      >
+      <input
+        name="{{ field.fieldname }}"
+        data-label="{{ field.label }}"
+        data-type="Data"
+        type="{% if field.fieldname == 'email' %}email{% else %}text{% endif %}"
+        class="form-control text-sm rounded-input"
+        id="{{ field.fieldname }}"
+        value="{{ submission[field.fieldname] or field.value or '' }}"
+        {% if field.read_only %}readonly{% endif %}
+        {% if field.reqd %}required{% endif %}
+      />
     {% elif field.fieldtype == 'Select' %}
-        <div class="d-flex flex-column">
-            <label for="{{field.fieldname}}" class="foss-form-question text-sm">{{field.label}}</label>
-            <select data-label="{{ field.label }}" data-type="Select" name="{{ field.fieldname }}" id="{{ field.fieldname }}" class="form-select form-control custom-select text-sm rounded-input w-100 px-3 py-1" {% if field.reqd %} required {% endif%}>
-                {% for option in field.options.splitlines() %}
-                    <option value="{{ option }}" {% if submission[field.fieldname] == option %} selected {% endif %}>{{ option }}</option>
-                {% endfor %}
-            </select>
-        </div>
+      <div class="d-flex flex-column">
+        <label for="{{ field.fieldname }}" class="foss-form-question text-sm"
+          >{{ field.label }}</label
+        >
+        <select
+          data-label="{{ field.label }}"
+          data-type="Select"
+          name="{{ field.fieldname }}"
+          id="{{ field.fieldname }}"
+          class="form-select form-control custom-select text-sm rounded-input w-100 px-3 py-1"
+          {% if field.reqd %}required{% endif %}
+        >
+          {% for option in (field.options or '').splitlines() %}
+            <option
+              value="{{ option }}"
+              {% if (field.get('value') or submission.get(field.fieldname, '')) == option %}selected{% endif %}
+            >
+              {{ option }}
+            </option>
+          {% endfor %}
+        </select>
+      </div>
     {% elif field.fieldtype == 'Check' %}
-        <div class="form-check d-flex align-items-center">
-            <input value="1" data-label="{{ field.label }}" data-type="Check" name="{{ field.fieldname }}" type="checkbox" class="form-control form-check-input text-sm" id="{{ field.fieldname }}" {% if field.reqd %} required {% endif%} {% if field.value == '1' or submission[field.fieldname] == 1 %} checked {% endif %}>
-            <label class="form-check-label foss-form-question text-sm m-2" for="{{ field.fieldname }}">{{ field.label }}</label>
-        </div>
+      <div class="form-check d-flex align-items-center">
+        <input
+          value="1"
+          data-label="{{ field.label }}"
+          data-type="Check"
+          name="{{ field.fieldname }}"
+          type="checkbox"
+          class="form-control form-check-input text-sm"
+          id="{{ field.fieldname }}"
+          {% if field.reqd %}required{% endif %}
+          {% if field.value == '1' or submission[field.fieldname] == 1 %}checked{% endif %}
+        />
+        <label class="form-check-label foss-form-question text-sm m-2" for="{{ field.fieldname }}"
+          >{{ field.label }}</label
+        >
+      </div>
     {% elif field.fieldtype == 'Text Editor' %}
-            <div class="foss-form-question text-sm mb-2">
-                {{ field.label }}
-            </div>
-            <div data-label="{{ field.label }}" data-type="Text Editor" name="{{ field.fieldname }}" id="{{ field.fieldname }}" class="ql-editor-custom" type="text-editor" {% if field.reqd %} required {% endif%}>
-                {{ submission[field.fieldname] or field.value or '' }}
-            </div>
+      <div class="foss-form-question text-sm mb-2">{{ field.label }}</div>
+      <div
+        data-label="{{ field.label }}"
+        data-type="Text Editor"
+        name="{{ field.fieldname }}"
+        id="{{ field.fieldname }}"
+        class="ql-editor-custom"
+        type="text-editor"
+        {% if field.reqd %}required{% endif %}
+      >
+        {{ submission[field.fieldname] or field.value or '' }}
+      </div>
     {% elif field.fieldtype == 'Text' %}
-            <label for="{{ field.fieldname }}" class="foss-form-question text-sm">{{ field.label }}</label>
-            <input data-label="{{ field.label }}" data-type="Text" name="{{ field.fieldname }}" type="text" class="form-control text-sm rounded-input" id="{{ field.fieldname }}" value="{{ submission[field.fieldname] or field.value or '' }}">
+      <label for="{{ field.fieldname }}" class="foss-form-question text-sm"
+        >{{ field.label }}</label
+      >
+      <input
+        data-label="{{ field.label }}"
+        data-type="Text"
+        name="{{ field.fieldname }}"
+        type="text"
+        class="form-control text-sm rounded-input"
+        id="{{ field.fieldname }}"
+        value="{{ submission[field.fieldname] or field.value or '' }}"
+      />
     {% elif field.fieldtype == 'Small Text' %}
-            <label for="{{ field.fieldname }}" class="foss-form-question text-sm">{{ field.label }}</label>
-            <textarea data-label="{{ field.label }}" data-type="Small Text" name="{{ field.fieldname }}" class="form-control text-sm rounded-input" id="{{ field.fieldname }}" rows="3" {% if field.reqd %} required {% endif%}>{{ submission[field.fieldname] or field.value or ''}}</textarea>
+      <label for="{{ field.fieldname }}" class="foss-form-question text-sm"
+        >{{ field.label }}</label
+      >
+      <textarea
+        data-label="{{ field.label }}"
+        data-type="Small Text"
+        name="{{ field.fieldname }}"
+        class="form-control text-sm rounded-input"
+        id="{{ field.fieldname }}"
+        rows="3"
+        {% if field.reqd %}required{% endif %}
+      >
+{{ submission[field.fieldname] or field.value or '' }}</textarea
+      >
     {% elif field.fieldtype == 'Long Text' %}
-            <label for="{{ field.fieldname }}" class="foss-form-question text-sm">{{ field.label }}</label>
-            <textarea data-label="{{ field.label }}" data-type="Long Text" name="{{ field.fieldname }}" class="form-control text-sm rounded-input" id="{{ field.fieldname }}" rows="6" {% if field.reqd %} required {% endif%}>{{ submission[field.fieldname] or field.value or ''}}</textarea>
+      <label for="{{ field.fieldname }}" class="foss-form-question text-sm"
+        >{{ field.label }}</label
+      >
+      <textarea
+        data-label="{{ field.label }}"
+        data-type="Long Text"
+        name="{{ field.fieldname }}"
+        class="form-control text-sm rounded-input"
+        id="{{ field.fieldname }}"
+        rows="6"
+        {% if field.reqd %}required{% endif %}
+      >
+{{ submission[field.fieldname] or field.value or '' }}</textarea
+      >
     {% elif field.fieldtype == 'Date' %}
-            <label for="{{ field.fieldname }}" class="foss-form-question text-sm">{{ field.label }}</label>
-            <input data-label="{{ field.label }}" name="{{ field.fieldname }}" type="date" class="form-control text-sm rounded-input" id="{{ field.fieldname }}" value="{{ submission[field.fieldname] }}">
+      <label for="{{ field.fieldname }}" class="foss-form-question text-sm"
+        >{{ field.label }}</label
+      >
+      <input
+        data-label="{{ field.label }}"
+        name="{{ field.fieldname }}"
+        type="date"
+        class="form-control text-sm rounded-input"
+        id="{{ field.fieldname }}"
+        value="{{ submission[field.fieldname] }}"
+      />
     {% elif field.fieldtype == 'Time' %}
-            <label for="{{ field.fieldname }}" class="foss-form-question text-sm">{{ field.label }}</label>
-            <input data-label="{{ field.label }}" name="{{ field.fieldname }}" type="time" class="form-control text-sm rounded-input" id="{{ field.fieldname }}" value="{{ submission[field.fieldname] }}">
+      <label for="{{ field.fieldname }}" class="foss-form-question text-sm"
+        >{{ field.label }}</label
+      >
+      <input
+        data-label="{{ field.label }}"
+        name="{{ field.fieldname }}"
+        type="time"
+        class="form-control text-sm rounded-input"
+        id="{{ field.fieldname }}"
+        value="{{ submission[field.fieldname] }}"
+      />
     {% elif field.fieldtype == 'Datetime' %}
-            <label for="{{ field.fieldname }}" class="foss-form-question text-sm">{{ field.label }}</label>
-            <input data-label="{{ field.label }}" name="{{ field.fieldname }}" type="datetime-local" class="form-control text-sm rounded-input" id="{{ field.fieldname }}" value="{{ submission[field.fieldname] }}">
+      <label for="{{ field.fieldname }}" class="foss-form-question text-sm"
+        >{{ field.label }}</label
+      >
+      <input
+        data-label="{{ field.label }}"
+        name="{{ field.fieldname }}"
+        type="datetime-local"
+        class="form-control text-sm rounded-input"
+        id="{{ field.fieldname }}"
+        value="{{ submission[field.fieldname] }}"
+      />
     {% elif field.fieldtype == 'Link' %}
-            <label for="{{ field.fieldname }}" class="foss-form-question text-sm">{{ field.label }}</label>
-            <input data-label="{{ field.label }}" name="{{ field.fieldname }}" type="url" class="form-control text-sm rounded-input" id="{{ field.fieldname }}" value="{{ submission[field.fieldname] }}">
+      <label for="{{ field.fieldname }}" class="foss-form-question text-sm"
+        >{{ field.label }}</label
+      >
+      <input
+        data-label="{{ field.label }}"
+        name="{{ field.fieldname }}"
+        type="url"
+        class="form-control text-sm rounded-input"
+        id="{{ field.fieldname }}"
+        value="{{ submission[field.fieldname] }}"
+      />
     {% elif field.fieldtype == 'Currency' %}
-            <label for="{{ field.fieldname }}" class="foss-form-question text-sm">{{ field.label }}</label>
-            <input data-label="{{ field.label }}" name="{{ field.fieldname }}" type="number" class="form-control text-sm rounded-input" id="{{ field.fieldname }}" value="{{ submission[field.fieldname] }}">
+      <label for="{{ field.fieldname }}" class="foss-form-question text-sm"
+        >{{ field.label }}</label
+      >
+      <input
+        data-label="{{ field.label }}"
+        name="{{ field.fieldname }}"
+        type="number"
+        class="form-control text-sm rounded-input"
+        id="{{ field.fieldname }}"
+        value="{{ submission[field.fieldname] }}"
+      />
     {% endif %}
 
     {% if field.description %}
-    <div class="mt-1"></div>
-    <small>{{ field.description }}</small>
+      <div class="mt-1"></div>
+      <small>{{ field.description }}</small>
     {% endif %}
-    </div>
+  </div>
 
-    {% if field.fieldtype == 'Text Editor' %}
+  {% if field.fieldtype == 'Text Editor' %}
     <script src="//cdn.quilljs.com/1.3.6/quill.js"></script>
     <script>
-        var toolbarOptions = [
-        [{ 'header': [1, 2, 3, 4, 5, 6, false] }],
+      var toolbarOptions = [
+        [{ header: [1, 2, 3, 4, 5, 6, false] }],
         ['bold', 'italic', 'underline', 'strike'],
         ['blockquote', 'code-block'],
-        [{ 'list': 'ordered'}, { 'list': 'bullet' }],
-        [{ 'script': 'sub'}, { 'script': 'super' }],
-        [{ 'indent': '-1'}, { 'indent': '+1' }],
-        [{ 'direction': 'rtl' }],
-        [{ 'color': [] }, { 'background': [] }],
-        [{ 'align': [] }],
-        ['clean']
-        ];
-        var quill = new Quill('#{{ field.fieldname }}', {
-            modules: {
-                toolbar: toolbarOptions
-            },
-            theme: 'snow'
-        });
+        [{ list: 'ordered' }, { list: 'bullet' }],
+        [{ script: 'sub' }, { script: 'super' }],
+        [{ indent: '-1' }, { indent: '+1' }],
+        [{ direction: 'rtl' }],
+        [{ color: [] }, { background: [] }],
+        [{ align: [] }],
+        ['clean'],
+      ]
+      var quill = new Quill('#{{ field.fieldname }}', {
+        modules: {
+          toolbar: toolbarOptions,
+        },
+        theme: 'snow',
+      })
     </script>
-    {% endif %}
+  {% endif %}
 {% endmacro %}

--- a/fossunited/templates/macros/renderfield.html
+++ b/fossunited/templates/macros/renderfield.html
@@ -2,11 +2,11 @@
   <div class="my-4 py-1">
     {% if field.fieldtype == 'Table' %}
       {% from "fossunited/templates/macros/custom_question.html" import CustomQuestion %}
-      {% if frappe.form_dict['cfp'] %}
+      {% if frappe.form_dict.get('cfp') %}
         {% for question in frappe.get_doc("FOSS Event CFP", submission.linked_cfp).custom_questions %}
           {{ CustomQuestion(question, submission.custom_answers[question.idx - 1]) }}
         {% endfor %}
-      {% elif frappe.form_dict['rsvp'] %}
+      {% elif frappe.form_dict.get('rsvp') %}
         {% for question in frappe.get_doc("FOSS Event RSVP", submission.linked_rsvp).custom_questions %}
           {{ CustomQuestion(question, submission.custom_answers[question.idx - 1]) }}
         {% endfor %}
@@ -39,10 +39,13 @@
           class="form-select form-control custom-select text-sm rounded-input w-100 px-3 py-1"
           {% if field.reqd %}required{% endif %}
         >
-          {% for option in (field.options or '').splitlines() %}
+          {% set field_value = field.get('value') if field else '' %}
+          {% set submission_value = submission.get(field.fieldname) if submission else '' %}
+          {% for raw in (field.options or '').splitlines() %}
+            {% set option = raw.strip() %}
             <option
               value="{{ option }}"
-              {% if (field.get('value') or submission.get(field.fieldname, '')) == option %}selected{% endif %}
+              {% if (submission_value or field_value) == option %}selected{% endif %}
             >
               {{ option }}
             </option>

--- a/fossunited/www/rsvp/submission/edit.html
+++ b/fossunited/www/rsvp/submission/edit.html
@@ -20,6 +20,15 @@
           {% endfor %}
         </form>
         <div class="foss-form-buttons">
+          {% if submission.confirm_attendance %}
+            <button class="danger-button" id="toggle-rsvp" data-new-status="0">
+              {{ _("I can't attend the Event!") }}
+            </button>
+          {% else %}
+            <button class="secondary-button" id="toggle-rsvp" data-new-status="1">
+              {{ _("I'll attend the Event!") }}
+            </button>
+          {% endif %}
           <button class="primary-button" type="submit" id="update-rsvp" disabled="">
             {{ _("Update RSVP Form") }}
           </button>
@@ -55,6 +64,13 @@
 
       $('#update-rsvp').on('click', (e) => {
         update_rsvp()
+      })
+      $('#toggle-rsvp').on('click', function (e) {
+        e.preventDefault()
+
+        const newStatus = $(this).data('new-status')
+
+        update_rsvp({ confirm_attendance: newStatus })
       })
     })
 
@@ -102,7 +118,7 @@
       })
     }
 
-    function update_rsvp() {
+    function update_rsvp(override_fields = {}) {
       let formFields = document.querySelectorAll(
         '.form-control:not(.custom-question), [type="text-editor"]',
       )
@@ -130,6 +146,12 @@
 
       // removing empty string keys
       submission = Object.fromEntries(Object.entries(submission).filter(([k, v]) => k !== ''))
+
+      // Merge overrides (like confirm_attendance: 0)
+      submission = {
+        ...submission,
+        ...override_fields,
+      }
 
       frappe.call({
         method: 'fossunited.fossunited.forms.update_submission',

--- a/fossunited/www/rsvp/submission/edit.py
+++ b/fossunited/www/rsvp/submission/edit.py
@@ -9,6 +9,7 @@ def get_context(context):
     context.event = frappe.get_doc(EVENT, context.submission.event)
     frappe.form_dict["rsvp"] = frappe.form_dict.submission
     frappe.form_dict["doctype"] = RSVP_RESPONSE
+    context.confirm_attendance = context.submission.confirm_attendance
     context.form_fields = get_form_fields(context.submission.doctype, context.submission)
     context.no_cache = 1
 
@@ -22,6 +23,12 @@ def get_form_fields(doctype, submission):
             continue
         if field["fieldtype"] == "Section Break":
             current_section = field["label"]
+            continue
+        if field["fieldname"] == "subscribe_chapter_mailing":
+            field["label"] = (
+                f"Yes, I'd like to receive updates about future events from {submission.chapter}."
+            )
+        if field["fieldname"] == "confirm_attendance":
             continue
         if current_section in ["Meta Info", "Custom Answers"]:
             continue


### PR DESCRIPTION
## 🚦 Status

- [ ] Draft
- [x] Ready for review

---

## 🔗 Related Issue

Closes / Addresses: #1044 & #1185 (partially)

---

## ❗ Problem

<!-- Briefly describe the problem or motivation for this PR -->

Rsvp update does not trigger frappe controller and UN-Rsvp does not have visual feedback on edit form

---

## ✅ Solution

<!-- Describe your solution and what you changed -->

Improve Toggling RSVP (confirm attendance) status via button

---

## 📋 Progress (All must be checked to merge)

- [x] Tested locally

---

## 📝 Changelog

- About higher LOC change: It is due to prettier formatting on `fossunited/templates/macros/renderfield.html` file

It was horribly in single line, prettier moves code to be structure so new lines came (hence increase in LOC for this PR)

Only change I did on renderfield was to handle select option with value for logged-in users

---

## 🖼️ Visualization

<!-- Add screenshots, diagrams, or screen recordings if applicable -->

https://github.com/user-attachments/assets/7bf9a642-812b-4526-b113-1d0a8f125a42



---

## 🔮 Further Ahead

<!-- Mention any follow-up work or related PRs planned -->

- Apply filter for rsvp insights to act based on confirm_attendance


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RSVP toggle added to quickly switch between “I’ll attend” and “I can’t attend,” sending an explicit attendance confirmation field.
  * Subscription label now includes the chapter name for clearer context.

* **Bug Fixes**
  * Enforced submitter-only updates to prevent unauthorized RSVP changes.
  * Form submissions now reliably apply override fields (e.g., attendance) when updating.

* **Style**
  * Unified form markup and field layouts for consistent appearance and improved select handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->