### PR TITLE
dashboard: Show rsvp insights with grouping based on confirm_attendance

### DIFF
--- a/dashboard/src/pages/EventRsvpInsights.vue
+++ b/dashboard/src/pages/EventRsvpInsights.vue
@@ -67,7 +67,7 @@ const submissions = createResource({
   url: 'fossunited.api.chapter.get_submissions_with_answers',
   params: {
     event_id: route.params.id,
-    answers: false,
+    full_answers: false,
   },
   auto: true,
 })
@@ -92,11 +92,13 @@ const listColumns = computed(() => {
 const groupedRows = ref([])
 
 watchEffect(() => {
+  const rows = Array.isArray(submissions.data) ? submissions.data : []
   const attending = []
   const notAttending = []
 
-  for (const row of submissions.data) {
-    if (row.confirm_attendance) {
+  for (const row of rows) {
+    const isAttending = Boolean(Number(row?.confirm_attendance || 0))
+    if (isAttending) {
       attending.push(row)
     } else {
       notAttending.push(row)

--- a/dashboard/src/pages/EventRsvpInsights.vue
+++ b/dashboard/src/pages/EventRsvpInsights.vue
@@ -2,34 +2,36 @@
   <div v-if="submissions.data && rsvp_form.data" class="px-4 py-8 md:p-8 flex flex-col gap-4">
     <div class="flex flex-col gap-4 mt-5">
       <div class="flex items-center justify-between">
-        <div class="font-semibold text-gray-800">
-          Attendees
-          <span class="text-gray-700 text-base font-normal">
-            ({{ submissions.data.length }}/{{ rsvp_form.data.max_rsvp_count }})
-          </span>
-        </div>
+        <div class="font-semibold text-gray-800">Attendees</div>
         <Button size="md" icon-left="download" @click="downloadAttendeeList2">Download</Button>
       </div>
 
       <ListView
+        v-model:rows="groupedRows"
         :columns="listColumns"
-        :rows="submissions.data"
         row-key="name"
         :options="{
           selectable: false,
+          showTooltip: true,
           resizeColumn: true,
           emptyState: {
             description: 'No one has RSVPed for the event yet.',
           },
         }"
-      />
+      >
+        <template #group-header="{ group }">
+          <span class="text-base font-medium leading-6 text-ink-gray-9">
+            {{ group.group }} ({{ group.rows.length }})
+          </span>
+        </template>
+      </ListView>
     </div>
   </div>
 </template>
 
 <script setup>
 import { useRoute } from 'vue-router'
-import { inject, ref, computed } from 'vue'
+import { inject, ref, computed, watchEffect } from 'vue'
 import { createListResource, createResource, ListView, Button } from 'frappe-ui'
 
 const route = useRoute()
@@ -65,7 +67,7 @@ const submissions = createResource({
   url: 'fossunited.api.chapter.get_submissions_with_answers',
   params: {
     event_id: route.params.id,
-    full: false,
+    answers: false,
   },
   auto: true,
 })
@@ -77,7 +79,7 @@ const listColumns = computed(() => {
   if (Array.isArray(submissions.data)) {
     submissions.data.forEach((submission) => {
       Object.keys(submission).forEach((key) => {
-        if (!columns.has(key)) {
+        if (key !== 'confirm_attendance' && !columns.has(key)) {
           columns.set(key, { key, label: key }) // Use key as label directly
         }
       })
@@ -85,6 +87,34 @@ const listColumns = computed(() => {
   }
 
   return Array.from(columns.values())
+})
+
+const groupedRows = ref([])
+
+watchEffect(() => {
+  const attending = []
+  const notAttending = []
+
+  for (const row of submissions.data) {
+    if (row.confirm_attendance) {
+      attending.push(row)
+    } else {
+      notAttending.push(row)
+    }
+  }
+
+  groupedRows.value = [
+    {
+      group: 'Attending event',
+      collapsed: false,
+      rows: attending,
+    },
+    {
+      group: 'Not attending',
+      collapsed: true,
+      rows: notAttending,
+    },
+  ]
 })
 
 const downloadAttendeeList2 = () => {

--- a/dashboard/src/pages/EventRsvpInsights.vue
+++ b/dashboard/src/pages/EventRsvpInsights.vue
@@ -49,7 +49,7 @@ const rsvp_form = createResource({
 
 const isEventLead = ref(false)
 const event_lead = createResource({
-  url: 'fossunited.api.chapter.check_if_event_lead',
+  url: 'fossunited.api.chapter.check_if_chapter_or_event_core_member',
   makeParams() {
     return {
       event: route.params.id,

--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -78,6 +78,21 @@ def check_if_event_lead(event: str) -> bool:
 
 
 @frappe.whitelist(allow_guest=True)
+def check_if_chapter_or_event_core_member(event: str) -> bool:
+    """
+    A common function to check if user is either chapter or event member to give some access.
+    This API function is intended to only apply for cases where every time event is created
+    they would not add themselves to event_members table
+    """
+    event_doc = frappe.get_doc(EVENT, event, ["name"])
+    chapter_id = event_doc.chapter
+    is_team = bool(
+        check_if_event_lead(event) or check_if_chapter_member(chapter_id, frappe.session.user)
+    )
+    return is_team
+
+
+@frappe.whitelist(allow_guest=True)
 def generate_ics(event_ids):
     """
     Return ICS event for the event ids provided
@@ -157,7 +172,7 @@ def get_submissions_with_answers(event_id: str, full: bool = False) -> list[dict
         limit_page_length=9999,
     )
 
-    if not check_if_event_lead(event_id):
+    if not check_if_chapter_or_event_core_member(event_id):
         for s in submissions:
             s["email"] = mask_email(s.get("email"))
             s.pop("name", None)

--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -151,14 +151,14 @@ def generate_ics(event_ids):
 @frappe.whitelist()
 def get_submissions_with_answers(
     event_id: str,
-    answers: bool = False,
+    full_answers: bool = False,
 ) -> list[dict]:
     """
     Provide RSVP submission with answers for EventInsights.
 
     Args:
         event_id (str): Event ID
-        answers (bool): If True, return full question labels and responses;
+        full_answers (bool): If True, return full question labels and responses;
                      otherwise truncate for UI display. Applicable for csv export/download.
     Returns:
         List of submission dicts with custom field answers for core team members.
@@ -186,7 +186,7 @@ def get_submissions_with_answers(
     if not submission_ids:
         return submissions
 
-    answers = frappe.get_all(
+    answers_rows = frappe.get_all(
         RSVP_CUSTOM_FIELD,
         filters={
             "parent": ["in", submission_ids],
@@ -199,7 +199,7 @@ def get_submissions_with_answers(
     )
 
     answers_by_parent = {}
-    for a in answers:
+    for a in answers_rows:
         answers_by_parent.setdefault(a["parent"], []).append(a)
 
     for s in submissions:
@@ -210,7 +210,7 @@ def get_submissions_with_answers(
             response = a.get("response")
             if response is None:
                 response = ""
-            if not answers:
+            if not full_answers:
                 response = _truncate_label(str(response), 30)
 
             s[f"{key}"] = response
@@ -218,7 +218,7 @@ def get_submissions_with_answers(
             # Truncate label if not full
             raw_label = a.get("question")
             label = "" if raw_label is None else str(raw_label)
-            if not answers:
+            if not full_answers:
                 label = _truncate_label(label, 30)
 
         s.pop("name", None)
@@ -237,7 +237,7 @@ def _safe_column_key(label: str) -> str:
     - Converts the label to lowercase.
     - Prefixes the key with an underscore if it starts with a dangerous character
       (i.e., '=', '+', '-', '@') to prevent CSV injection.
-    - Truncates the key to a maximum of 80 characters.
+    - Truncates the key to a maximum of 50 characters.
 
     Args:
         label (str): The original label to sanitize.
@@ -310,7 +310,7 @@ def download_attendee_list_csv(event_id: str) -> str:
     import re
 
     # Get full submission data (each is a dict)
-    submissions = get_submissions_with_answers(event_id, answers=True)
+    submissions = get_submissions_with_answers(event_id, full_answers=True)
 
     if not submissions:
         return ""

--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -149,13 +149,16 @@ def generate_ics(event_ids):
 
 
 @frappe.whitelist()
-def get_submissions_with_answers(event_id: str, full: bool = False) -> list[dict]:
+def get_submissions_with_answers(
+    event_id: str,
+    answers: bool = False,
+) -> list[dict]:
     """
     Provide RSVP submission with answers for EventInsights.
 
     Args:
         event_id (str): Event ID
-        full (bool): If True, return full question labels and responses;
+        answers (bool): If True, return full question labels and responses;
                      otherwise truncate for UI display. Applicable for csv export/download.
     Returns:
         List of submission dicts with custom field answers for core team members.
@@ -167,7 +170,7 @@ def get_submissions_with_answers(event_id: str, full: bool = False) -> list[dict
     submissions = frappe.get_all(
         RSVP_RESPONSE,
         filters={"event": event_id},
-        fields=["name", "name1", "email", "im_a"],
+        fields=["name", "confirm_attendance", "name1", "email", "im_a"],
         order_by="creation asc",
         limit_page_length=9999,
     )
@@ -207,7 +210,7 @@ def get_submissions_with_answers(event_id: str, full: bool = False) -> list[dict
             response = a.get("response")
             if response is None:
                 response = ""
-            if not full:
+            if not answers:
                 response = _truncate_label(str(response), 30)
 
             s[f"{key}"] = response
@@ -215,7 +218,7 @@ def get_submissions_with_answers(event_id: str, full: bool = False) -> list[dict
             # Truncate label if not full
             raw_label = a.get("question")
             label = "" if raw_label is None else str(raw_label)
-            if not full:
+            if not answers:
                 label = _truncate_label(label, 30)
 
         s.pop("name", None)
@@ -307,7 +310,7 @@ def download_attendee_list_csv(event_id: str) -> str:
     import re
 
     # Get full submission data (each is a dict)
-    submissions = get_submissions_with_answers(event_id, full=True)
+    submissions = get_submissions_with_answers(event_id, answers=True)
 
     if not submissions:
         return ""

--- a/fossunited/tests/test_rsvp_insights_field.py
+++ b/fossunited/tests/test_rsvp_insights_field.py
@@ -69,7 +69,7 @@ class TestGetSubmissionsWithAnswersAPI(FrappeTestCase):
 
     def test_non_event_core_team_masks_email(self):
         frappe.set_user(self.volunteer_user)
-        result = get_submissions_with_answers(self.event.name, full=False)
+        result = get_submissions_with_answers(self.event.name, full_answers=False)
         self.assertTrue(result)
         # Check email is masked: basic pattern check
         self.assertIn("@", result[0]["email"])
@@ -77,14 +77,14 @@ class TestGetSubmissionsWithAnswersAPI(FrappeTestCase):
 
     def test_event_core_team_full_email(self):
         frappe.set_user(self.core_team_email)
-        result = get_submissions_with_answers(self.event.name, full=False)
+        result = get_submissions_with_answers(self.event.name, full_answers=False)
         self.assertTrue(result)
         self.assertIn("@", result[0]["email"])
         self.assertEqual(result[0]["email"], "alicewonderland@example.com")
 
     def test_event_core_team_gets_full_answers(self):
         frappe.set_user(self.core_team_email)
-        result = get_submissions_with_answers(self.event.name, full=True)
+        result = get_submissions_with_answers(self.event.name, full_answers=True)
         self.assertIn("whats_your_goal", result[0])
         self.assertEqual(
             result[0]["whats_your_goal"],
@@ -103,10 +103,10 @@ class TestGetSubmissionsWithAnswersAPI(FrappeTestCase):
             email="bob@example.com",
             custom_answers=[{"question": long_q, "response": long_r}],
         )
-        result = get_submissions_with_answers(self.event.name, full=False)
+        result = get_submissions_with_answers(self.event.name, full_answers=False)
         for s in result:
             for key, val in s.items():
-                if key.startswith(""):
+                if key not in ["name1", "email", "im_a", "confirm_attendance"]:
                     self.assertLessEqual(len(val), 52)
 
     def test_no_truncation_when_full_true(self):
@@ -121,7 +121,7 @@ class TestGetSubmissionsWithAnswersAPI(FrappeTestCase):
         )
         self._extra_responses.append(_charlie.name)
 
-        result = get_submissions_with_answers(self.event.name, full=True)
+        result = get_submissions_with_answers(self.event.name, full_answers=True)
         found = False
         for s in result:
             if s.get("email") == "charlie@example.com":


### PR DESCRIPTION
## 🚦 Status

- [ ] Draft
- [x] Ready for review

---

## 🔗 Related Issue

Closes / Addresses: #1185 (completes now)

---

## ❗ Problem

<!-- Briefly describe the problem or motivation for this PR -->
Since we introduced UI for RSVP edit form to un-rsvp (not attend) or re-attend, we should adhere to it for team members to group based on this status

---

## ✅ Solution

<!-- Describe your solution and what you changed -->

- ListView has grouping feature, and we can use it to show two group in toggle collapsible button

- By default "attending" will be shown and "not attending" will be hidden

- This should help with count of how many are confirming.
- The count also reflects based on grouping based. + removed overall count from header

Note: Csv would still show first column for attendance, so team/users can filter based on it as well.

---

## 📋 Progress (All must be checked to merge)

- [x] Tested locally
- [ ] 

---

## 📝 Changelog

<commit>: <!-- e.g., feat: add user login endpoint -->

---

## 🖼️ Visualization

<!-- Add screenshots, diagrams, or screen recordings if applicable -->

https://github.com/user-attachments/assets/cf574075-d952-416a-b95c-4a8421152549



---

## 🔮 Further Ahead

<!-- Mention any follow-up work or related PRs planned -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Grouped attendee view in RSVP insights showing "Attending" and "Not attending" sections with counts and collapsible groups.

* **Improvements**
  * Tooltips added for clearer guidance in the attendees list.
  * Cleaner "Attendees" header formatting.
  * Attendee exports/CSV handling improved to better include full answers when requested.
  * Access checks updated to recognize event leads and chapter core members.

* **Tests**
  * Test suite updated to reflect renamed export parameter and adjusted assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->