### PR TITLE
fix: svg icons for social link based on svgl.app

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
@@ -269,7 +269,7 @@ class FOSSChapter(WebsiteGenerator):
         return members
 
     def get_social_links(self):
-        socials = {}
+        # social fields in order to appear: WYSIWYG
         SOCIAL_LINK_FIELDNAMES = [
             "mastodon",
             "matrix",
@@ -285,14 +285,24 @@ class FOSSChapter(WebsiteGenerator):
             "x",
             "discord",
         ]
-        for k, v in self.as_dict().items():
-            if v and k in SOCIAL_LINK_FIELDNAMES:
-                if k == "matrix":
-                    k = "matrix-light"
-                socials[k] = v
+
+        # map names to svgl.app/library
+        KEY_RENAMES = {
+            "matrix": "matrix-light",
+            "instagram": "instagram-icon",
+            "facebook": "facebook-icon",
+        }
+
+        REVERSE_RENAMES = {v: k for k, v in KEY_RENAMES.items()}
+
+        data = self.as_dict()
+
+        socials = {
+            KEY_RENAMES.get(k, k): v for k, v in data.items() if v and k in SOCIAL_LINK_FIELDNAMES
+        }
 
         def sort_key(item):
-            key = "matrix" if item[0] == "matrix-light" else item[0]
-            return SOCIAL_LINK_FIELDNAMES.index(key)
+            original_key = REVERSE_RENAMES.get(item[0], item[0])
+            return SOCIAL_LINK_FIELDNAMES.index(original_key)
 
         return dict(sorted(socials.items(), key=sort_key))

--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -110,30 +110,41 @@ def get_user_editable_doctype_fields(doctype, docname=None):
 
 
 def get_user_socials(foss_user):
+    """
+    Function to get dict for social svg for profile page.
+    Based on svgl.app/library
+    """
     user = frappe.get_doc(USER_PROFILE, foss_user).as_dict()
     SOCIAL_LINK_FIELDNAMES = [
         "github",
         "gitlab",
+        "mastodon",
+        "bluesky",
+        "devto",
         "x",
         "linkedin",
         "instagram",
-        "mastodon",
         "youtube",
-        "devto",
-        "bluesky",
     ]
 
-    links = {}
-    for field in user:
-        if field in SOCIAL_LINK_FIELDNAMES and user[field]:
-            field1 = field
-            if field == "github":
-                field1 = "github_light"
-            elif field == "devto":
-                field1 = "devto-light"
-            links[field1] = user[field]
+    KEY_RENAMES = {
+        "github": "github_light",
+        "devto": "devto-light",
+        "instagram": "instagram-icon",
+        "facebook": "facebook-icon",
+    }
 
-    return links
+    REVERSE_RENAMES = {v: k for k, v in KEY_RENAMES.items()}
+
+    socials = {
+        KEY_RENAMES.get(k, k): v for k, v in user.items() if k in SOCIAL_LINK_FIELDNAMES and v
+    }
+
+    def sort_key(item):
+        original_key = REVERSE_RENAMES.get(item[0], item[0])
+        return SOCIAL_LINK_FIELDNAMES.index(original_key)
+
+    return dict(sorted(socials.items(), key=sort_key))
 
 
 @frappe.whitelist()


### PR DESCRIPTION
https://github.com/pheralb/svgl/pull/810 changed the icon names for instagram and facebook.

PR to fix the name class via mapping dict keys

- Foss user profile now shows social link in sorted order (foss based appear first and rest follows)

- chapter/event page
<img width="701" height="304" alt="image" src="https://github.com/user-attachments/assets/799812c2-a2a5-4359-b0c2-27c192a36fa6" />

- foss user profile page
<img width="701" height="304" alt="image" src="https://github.com/user-attachments/assets/f5e54c4d-f753-40e5-b766-ac303b8dd363" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Mastodon, Bluesky and Dev.to social links.

* **Refactor**
  * Improved handling and consistent ordering/representation of social links, including refined naming for certain social icons so displayed links appear in a predictable, user-facing order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->