### PR TITLE
fix: remove csv metadata for downloading schedule

### DIFF
--- a/fossunited/api/schedule.py
+++ b/fossunited/api/schedule.py
@@ -286,9 +286,6 @@ def format_schedule_data(format, doc, sessions, metadata):
     elif format == "csv":
         output = io.StringIO()
         writer = csv.writer(output, quoting=csv.QUOTE_ALL, lineterminator="\r\n")
-        for k, v in metadata.items():
-            writer.writerow([cleanse_csv_cell(k), cleanse_csv_cell(v)])
-        writer.writerow([])
         writer.writerow(
             [
                 "Title",


### PR DESCRIPTION
- file format would not be parsed properly
- No need to pollute file with metadata

closes: #1218 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CSV exports now have a cleaner structure with metadata rows and blank separators removed, providing improved alignment and a more standard file format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->