### PR TITLE
allow handling mailto protocol for links in text editor component

### DIFF
--- a/dashboard/src/components/ui/TextEditor.vue
+++ b/dashboard/src/components/ui/TextEditor.vue
@@ -274,7 +274,9 @@ const handleLinkInsert = (editor) => {
     return
   }
 
-  if (!newValue.startsWith('http://') && !newValue.startsWith('https://')) {
+  let allowedProtocols = ['http://', 'https://', 'mailto:']
+
+  if (!allowedProtocols.some((proto) => newValue.startsWith(proto))) {
     newValue = `https://${newValue}`
   }
 


### PR DESCRIPTION
- we use custom text editor component, prev every link without https was considered to be converted as https only
  mailto: protocol can be supported so description can have contact us info

closes: #1047 

Note: We actually use custom TextEditor component (ig this was before frappe-ui had it?)

Frappe-ui has it now, so we should switch to that rather than reinventing the wheel.

To work on this, we should remove custom defined component to avoid conflict or clash during build time.

- Future takeaway: #1221 