### PR TITLE
Change review status if reviewer has added a review

### DIFF
--- a/dashboard/src/components/reviewers/ProposalDetails.vue
+++ b/dashboard/src/components/reviewers/ProposalDetails.vue
@@ -11,8 +11,8 @@
       </div>
       <div class="flex items-center gap-2">
         <Badge
-          :label="submission.data.status"
-          :theme="getStatusBadgeTheme(submission.data.status)"
+          :label="submission.data.hasReviewed ? 'Reviewed' : submission.data.status"
+          :theme="getStatusBadgeTheme(submission.data.hasReviewed ? 'Yes' : 'No')"
         />
         <span class="text-sm text-gray-600">
           Submitted {{ dayjs(submission.data.creation).fromNow() }}
@@ -50,7 +50,7 @@
 </template>
 <script setup>
 import { createResource, LoadingIndicator, Badge, TabButtons } from 'frappe-ui'
-import { provide, ref, watch } from 'vue'
+import { provide, ref, watch, inject } from 'vue'
 import { useRoute } from 'vue-router'
 import { getStatusBadgeTheme } from '@/helpers/reviewer'
 import { createAbsoluteUrlFromRoute } from '@/helpers/utils'
@@ -107,6 +107,8 @@ const hasAnonymousSpeaker = createResource({
   auto: true,
 })
 
+const session = inject('$session')
+
 const submission = createResource({
   url: 'frappe.client.get',
   makeParams() {
@@ -117,11 +119,14 @@ const submission = createResource({
     }
   },
   transform(data) {
-    if (!data.session_categories) {
-      data.session_categories = []
-    } else {
-      data.session_categories = data.session_categories.split('\n')
-    }
+    // Ensure session_categories is always an array
+    data.session_categories = (data.session_categories ?? '').split('\n').filter(Boolean)
+
+    // Ensure reviews is always an array
+    data.reviews = data.reviews ?? []
+
+    data.hasReviewed = data.reviews.some((review) => review.owner === session.user)
+
     return data
   },
 })

--- a/dashboard/src/components/reviewers/ProposalListItem.vue
+++ b/dashboard/src/components/reviewers/ProposalListItem.vue
@@ -11,7 +11,10 @@
       {{ submission.talk_title }}
     </h4>
     <div class="flex gap-2 items-center !text-sm">
-      <Badge :label="submission.status" :theme="getStatusBadgeTheme(submission.status)" />
+      <Badge
+        :label="submission._is_reviewed === 'Yes' ? 'Reviewed' : submission.status"
+        :theme="getStatusBadgeTheme(submission._is_reviewed || submission.status)"
+      />
       <Badge :label="submission._likes_count" variant="ghost" class="!text-gray-500">
         <template #prefix>
           <IconHeart size="14" />

--- a/dashboard/src/components/reviewers/ProposalsList.vue
+++ b/dashboard/src/components/reviewers/ProposalsList.vue
@@ -6,8 +6,11 @@
         <IconSearch class="w-4" />
       </template>
     </FormControl>
-    <div class="flex flex-wrap justify-between items-center gap-4">
-      <Filter v-model="filters" :docfields="docfields.data" />
+    <div class="flex flex-wrap items-center justify-between gap-4">
+      <div class="flex items-center gap-4">
+        <Filter v-model="filters" :docfields="docfields.data" />
+        <Switch v-model="showNotReviewed" label="Only show not reviewed" />
+      </div>
       <span class="text-xs text-ink-gray-5">Count: {{ cfpSubmissions.data?.length }}</span>
     </div>
   </div>
@@ -36,7 +39,7 @@
 <script setup>
 import ProposalListItem from './ProposalListItem.vue'
 import { defineProps, watch, ref } from 'vue'
-import { createResource, FormControl, LoadingIndicator } from 'frappe-ui'
+import { createResource, FormControl, LoadingIndicator, Switch } from 'frappe-ui'
 import Filter from '../ui/Filter.vue'
 import { getCfpFilterFields, filterSubmissions } from '@/helpers/cfp'
 import { useRoute } from 'vue-router'
@@ -58,6 +61,7 @@ const props = defineProps({
 
 const emit = defineEmits(['open:submission'])
 
+const showNotReviewed = ref(false)
 const searchTitle = ref('')
 const filters = useStorage(`review-filters:${route.params.id}`, {})
 const docfields = await getCfpFilterFields(route.params.id)
@@ -80,19 +84,17 @@ const cfpSubmissions = createResource({
 })
 
 watch(
-  () => filters.value,
-  () => {
-    cfpSubmissions.data = filterSubmissions(cfpSubmissions.originalData, filters.value)
-  },
-  { deep: true },
-)
+  [() => filters.value, () => searchTitle.value, () => showNotReviewed.value],
+  ([newFilters, newTitle, notReviewed]) => {
+    const _filters = {
+      ...newFilters,
+      ...(newTitle ? { talk_title: ['like', newTitle] } : {}),
+      ...(notReviewed ? { _is_not_reviewed: ['=', 'Yes'] } : {}),
+    }
 
-watch(
-  () => searchTitle.value,
-  () => {
-    const _filters = { ...filters.value, talk_title: ['like', `${searchTitle.value}`] }
     cfpSubmissions.data = filterSubmissions(cfpSubmissions.originalData, _filters)
   },
+  { deep: true, immediate: true },
 )
 
 const handleOpenSubmission = (submission) => {

--- a/dashboard/src/helpers/reviewer.js
+++ b/dashboard/src/helpers/reviewer.js
@@ -1,7 +1,9 @@
 export const getStatusBadgeTheme = (status) => {
   switch (status) {
+    case 'Yes':
     case 'Approved':
       return 'green'
+    case 'No':
     case 'Review Pending':
       return 'orange'
     case 'Rejected':


### PR DESCRIPTION
#1035

- Show CFP review status based on reviewer' if they added review or not

- Also give switch to toggle to show only not reviewed CFPs 

We already have frappe filter which is extensive to apply.


https://github.com/user-attachments/assets/084f5e41-3892-4a1c-b7a1-6c13ebe35063


^ demo of reflected changes

- Just that if review is added, then status is shown in green (text: Reviewed), if not its yellow with submission.status as it is

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Track personal review activity with "Reviewed" status indicator on submissions
  * New filter option to display only not-reviewed submissions in the proposals list
  * Enhanced status badge styling to differentiate review states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->