### PR TITLE
Add CFP status filter (dropdown) for public proposals page

### DIFF
--- a/dashboard/src/components/cfp-public/SubmissionsListView.vue
+++ b/dashboard/src/components/cfp-public/SubmissionsListView.vue
@@ -4,7 +4,7 @@ import Filter from '@/components/ui/Filter.vue'
 import { IconSearch } from '@tabler/icons-vue'
 import { createResource, FormControl, LoadingText } from 'frappe-ui'
 import { filterSubmissions } from '@/helpers/cfp'
-import { watch, ref } from 'vue'
+import { watch, ref, computed } from 'vue'
 import { useStorage } from '@vueuse/core'
 import { useRoute } from 'vue-router'
 
@@ -46,47 +46,31 @@ const filterFields = createResource({
   },
 })
 
-watch(
-  () => filters.value,
-  () => {
-    submissions.data = filterSubmissions(submissions.originalData, filters.value)
-  },
-  { deep: true },
-)
+const filteredSubmissions = computed(() => {
+  const search = searchTitle.value.trim().toLowerCase()
+  let result = Array.isArray(submissions.originalData) ? [...submissions.originalData] : []
 
-watch(
-  () => searchTitle.value,
-  () => {
-    const search = searchTitle.value.trim().toLowerCase()
-    let filtered = Array.isArray(submissions.originalData) ? submissions.originalData : []
+  if (filters.value) {
+    result = filterSubmissions(result, filters.value)
+  }
 
-    // Apply basic field filters (status, session_type, etc.)
-    if (filters.value) {
-      filtered = filterSubmissions(filtered, filters.value)
-    }
+  if (search) {
+    result = result.filter(({ talk_title, speaker_name, speakers, _speaker }) => {
+      const titleMatch = talk_title?.toLowerCase().includes(search)
+      const allNames = [
+        ...(speaker_name ? [speaker_name.toLowerCase()] : []),
+        ...((speakers ?? _speaker)?.map((s) => s?.full_name?.toLowerCase() ?? '') ?? []),
+      ]
+      return titleMatch || allNames.some((n) => n.includes(search))
+    })
+  }
 
-    // Apply search on talk title or speaker name
-    if (search) {
-      filtered = filtered.filter((submission) => {
-        const title = submission.talk_title?.toLowerCase() ?? ''
-        // Prefer pre-joined string if present; fallback to array forms.
-        const speakerNameStr = submission.speaker_name?.toLowerCase() ?? ''
-        let speakerMatch = false
-        if (speakerNameStr) {
-          speakerMatch = speakerNameStr.includes(search)
-        } else {
-          const speakersArr = submission.speakers ?? submission._speaker
-          if (Array.isArray(speakersArr)) {
-            speakerMatch = speakersArr.some((s) => s?.full_name?.toLowerCase().includes(search))
-          }
-        }
-        return title.includes(search) || speakerMatch
-      })
-    }
+  return result
+})
 
-    submissions.data = filtered
-  },
-)
+watch(filteredSubmissions, (val) => {
+  submissions.data = val
+})
 </script>
 <template>
   <Suspense>

--- a/dashboard/src/components/cfp-public/SubmissionsListView.vue
+++ b/dashboard/src/components/cfp-public/SubmissionsListView.vue
@@ -2,7 +2,7 @@
 import SubmissionsList from './SubmissionsList.vue'
 import Filter from '@/components/ui/Filter.vue'
 import { IconSearch } from '@tabler/icons-vue'
-import { createResource, FormControl, LoadingText } from 'frappe-ui'
+import { createResource, FormControl, LoadingText, Select } from 'frappe-ui'
 import { filterSubmissions } from '@/helpers/cfp'
 import { watch, ref, computed } from 'vue'
 import { useStorage } from '@vueuse/core'
@@ -12,6 +12,7 @@ const route = useRoute()
 
 const filters = useStorage(`submission-filters:${route.params.route}`, {})
 const searchTitle = ref('')
+const statusFilter = ref('')
 
 const props = defineProps({
   eventId: {
@@ -46,12 +47,35 @@ const filterFields = createResource({
   },
 })
 
+const statusOptions = computed(() => {
+  const data = filterFields.data
+  if (!data || !Array.isArray(data)) return []
+
+  const statusField = data.find((field) => field.fieldname === 'status')
+  if (!statusField) return []
+
+  const options = [
+    { label: 'All', value: '' },
+    ...statusField.options.split('\n').map((option) => ({
+      label: option,
+      value: option,
+    })),
+  ]
+
+  return options
+})
+
 const filteredSubmissions = computed(() => {
   const search = searchTitle.value.trim().toLowerCase()
+  const status = statusFilter.value
   let result = Array.isArray(submissions.originalData) ? [...submissions.originalData] : []
 
   if (filters.value) {
     result = filterSubmissions(result, filters.value)
+  }
+
+  if (status) {
+    result = result.filter((item) => item.status === status)
   }
 
   if (search) {
@@ -81,7 +105,10 @@ watch(filteredSubmissions, (val) => {
             <IconSearch class="w-4" />
           </template>
         </FormControl>
-        <Filter v-if="filterFields.data" v-model="filters" :docfields="filterFields.data" />
+        <div class="flex items-end gap-2">
+          <Select v-model="statusFilter" :options="statusOptions" />
+          <Filter v-if="filterFields.data" v-model="filters" :docfields="filterFields.data" />
+        </div>
       </div>
       <SubmissionsList v-model="submissions.data" />
       <div

--- a/dashboard/src/components/cfp-public/SubmissionsListView.vue
+++ b/dashboard/src/components/cfp-public/SubmissionsListView.vue
@@ -12,15 +12,13 @@ const route = useRoute()
 
 const filters = useStorage(`submission-filters:${route.params.route}`, {})
 const searchTitle = ref('')
-const statusFilter = ref('')
 
 const props = defineProps({
-  eventId: {
-    type: String,
-    required: true,
-  },
+  eventId: { type: String, required: true },
+  statusFilter: { type: String, default: '' },
 })
 
+const filteredStatus = ref(props.statusFilter)
 const submissions = createResource({
   url: 'fossunited.api.proposal.get_event_proposals',
   params: {
@@ -67,7 +65,7 @@ const statusOptions = computed(() => {
 
 const filteredSubmissions = computed(() => {
   const search = searchTitle.value.trim().toLowerCase()
-  const status = statusFilter.value
+  const status = filteredStatus.value
   let result = Array.isArray(submissions.originalData) ? [...submissions.originalData] : []
 
   if (filters.value) {
@@ -92,6 +90,13 @@ const filteredSubmissions = computed(() => {
   return result
 })
 
+watch(
+  () => props.statusFilter,
+  (newVal) => {
+    filteredStatus.value = newVal
+  },
+)
+
 watch(filteredSubmissions, (val) => {
   submissions.data = val
 })
@@ -106,7 +111,7 @@ watch(filteredSubmissions, (val) => {
           </template>
         </FormControl>
         <div class="flex items-end gap-2">
-          <Select v-model="statusFilter" :options="statusOptions" />
+          <Select v-model="filteredStatus" :options="statusOptions" />
           <Filter v-if="filterFields.data" v-model="filters" :docfields="filterFields.data" />
         </div>
       </div>

--- a/dashboard/src/components/event/cfp/InsightsGrid.vue
+++ b/dashboard/src/components/event/cfp/InsightsGrid.vue
@@ -21,6 +21,13 @@ const insights = createResource({
   auto: true,
 })
 
+const emit = defineEmits(['select-insight'])
+
+function handleClick(label) {
+  const filterValue = label === 'Total' ? '' : label
+  emit('select-insight', filterValue)
+}
+
 const getClasses = {
   'Total Submissions': 'md:col-span-2 lg:col-span-1',
 }
@@ -36,6 +43,7 @@ const getClasses = {
         :class="getClasses[insight.label]"
         :title="insight.label"
         :value="insight.count"
+        @click="() => handleClick(insight.label)"
       >
         <template v-if="insight.today" #post-value>
           <Badge class="w-fit" theme="green">

--- a/dashboard/src/pages/events/AllProposals.vue
+++ b/dashboard/src/pages/events/AllProposals.vue
@@ -27,6 +27,12 @@ const cfpData = createResource({
   },
 })
 
+const insightFilter = ref('')
+
+function updateStatusFilter(selectedLabel) {
+  insightFilter.value = selectedLabel
+}
+
 const breadcrumb_items = ref([
   {
     label: 'Events',
@@ -66,7 +72,7 @@ usePageMeta(() => {
       </EventHeader>
     </div>
     <FormCard :cfp="cfpData.data" />
-    <InsightsGrid :event-id="cfpData.data.event.name" />
-    <SubmissionsListView :event-id="cfpData.data.event.name" />
+    <InsightsGrid :event-id="cfpData.data.event.name" @select-insight="updateStatusFilter" />
+    <SubmissionsListView :event-id="cfpData.data.event.name" :status-filter="insightFilter" />
   </NarrowLayout>
 </template>


### PR DESCRIPTION
- on #1082 

We provide simply another select filter to choose narrow based on status of proposals

- I'm skipping feature on "Clicking grid to filter"
  although its nice, the code would need to be applied for 3 files (since files are split into components) and would not makes sense to maintain in future.

EDIT: Got it working in simple method using emit of value. yay!

https://github.com/user-attachments/assets/4a206380-98fd-430b-856f-3ad6a7181929



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a status filter dropdown to the submissions list so users can filter by status alongside existing filters and text search.
  * Insight cards are now clickable to apply quick filters (including an "All" option) to the submissions list.
  * Insights and the submissions list are dynamically linked so selecting an insight updates the list in real time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->