### PR TITLE
format CFP review content in pages

### DIFF
--- a/dashboard/src/components/event/cfp/SubmissionReviews.vue
+++ b/dashboard/src/components/event/cfp/SubmissionReviews.vue
@@ -42,7 +42,11 @@ const getTheme = (status) => {
     <div class="flex flex-col">
       <div v-for="review in reviews" :key="review.name" class="flex flex-col gap-1 border-b py-3">
         <div class="flex justify-between items-center gap-4">
-          <div v-if="review.remarks" class="text-base" v-html="cleanedHTML(review.remarks)"></div>
+          <div
+            v-if="review.remarks"
+            class="prose prose-sm"
+            v-html="cleanedHTML(review.remarks)"
+          ></div>
           <span v-else class="text-base text-gray-600">No Remarks</span>
         </div>
         <div class="flex gap-2 items-center">

--- a/dashboard/src/components/reviewers/ReviewSection.vue
+++ b/dashboard/src/components/reviewers/ReviewSection.vue
@@ -36,7 +36,7 @@
         <div v-if="isReviewOwner(review)" class="p-4 border rounded flex flex-col gap-2">
           <h5 class="text-base font-semibold">Your Review</h5>
           <div class="flex justify-between items-center gap-4">
-            <div v-if="review.remarks" class="text-base" v-html="review.remarks"></div>
+            <div v-if="review.remarks" class="prose prose-sm" v-html="review.remarks"></div>
             <span v-else class="text-sm text-gray-600">No Remarks</span>
             <div class="flex items-center gap-2">
               <Button label="Edit" @click="editReview(review)" />
@@ -53,7 +53,7 @@
           <div class="flex justify-between items-center gap-4">
             <div
               v-if="review.remarks"
-              class="text-base"
+              class="prose prose-sm"
               v-html="cleanedHTML(review.remarks)"
             ></div>
             <span v-else class="text-sm text-gray-600">No Remarks</span>

--- a/dashboard/src/components/reviewers/ReviewSection.vue
+++ b/dashboard/src/components/reviewers/ReviewSection.vue
@@ -36,7 +36,11 @@
         <div v-if="isReviewOwner(review)" class="p-4 border rounded flex flex-col gap-2">
           <h5 class="text-base font-semibold">Your Review</h5>
           <div class="flex justify-between items-center gap-4">
-            <div v-if="review.remarks" class="prose prose-sm" v-html="review.remarks"></div>
+            <div
+              v-if="review.remarks"
+              class="prose prose-sm max-w-full"
+              v-html="review.remarks"
+            ></div>
             <span v-else class="text-sm text-gray-600">No Remarks</span>
             <div class="flex items-center gap-2">
               <Button label="Edit" @click="editReview(review)" />
@@ -53,7 +57,7 @@
           <div class="flex justify-between items-center gap-4">
             <div
               v-if="review.remarks"
-              class="prose prose-sm"
+              class="prose prose-sm max-w-full"
               v-html="cleanedHTML(review.remarks)"
             ></div>
             <span v-else class="text-sm text-gray-600">No Remarks</span>

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
@@ -178,7 +178,7 @@
 
 {% macro review_card(review) %}
   <div class="flex flex-col gap-1 my-2">
-    <div class="text-base">{{ review.remarks }}</div>
+    <div class="prose prose-sm">{{ review.remarks | escape }}</div>
     <div class="flex gap-2 items-center">
       <span class="text-sm">Reviewer #{{ review.idx }}</span>
       <i class="ti ti-circle-filled text-[8px] text-gray-400"></i>


### PR DESCRIPTION
- #1036

We had to simply add tailwindcss typography class "prose" to it so text is rendered as intended.

This is in public CFP detail page:

<img width="500" height="400" alt="image" src="https://github.com/user-attachments/assets/78b05531-ac77-404e-81e6-1c2ed32dbb80" />


This is in CFP reviewer dashboard page:

<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/88407169-4b0f-4bda-b49a-b51020df7345" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined typography for reviewer remarks across multiple views for improved consistency and readability.
* **Bug Fixes**
  * Remarks rendering now properly sanitizes/escapes content to prevent display of unsafe HTML.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->