### PR TITLE
Auto speaker

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -222,10 +222,10 @@ class FOSSChapterEvent(WebsiteGenerator):
 
     def get_context(self, context):
         context.chapter = frappe.get_doc(CHAPTER, self.chapter)
-        context.nav_items = self.get_navbar_items()
         context.sponsors_dict = self.get_sponsors()
         context.volunteers = self.get_volunteers()
         context.speakers, context.submissions = self.get_speakers()
+        context.nav_items = self.get_navbar_items(context.speakers)
         context.rsvp_status_block = self.get_rsvp_status_block()
         context.cfp_status_block = self.get_cfp_status_block()
         context.user_cfp_submissions = self.get_user_cfp_submissions()
@@ -259,7 +259,7 @@ class FOSSChapterEvent(WebsiteGenerator):
 
         return pagetitle, description, image
 
-    def get_navbar_items(self):
+    def get_navbar_items(self, speakers=None):
         navbar_items = [
             "event_information",
             "speakers",
@@ -271,8 +271,8 @@ class FOSSChapterEvent(WebsiteGenerator):
         if is_user_team_member(self.chapter, frappe.session.user):
             return navbar_items
 
-        speakers, submissions = self.get_speakers()
-
+        if speakers is None:
+            speakers, _ = self.get_speakers()
         if not self.show_speakers or not speakers:
             navbar_items.remove("speakers")
         if not self.show_rsvp or self.is_paid_event:

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -271,7 +271,9 @@ class FOSSChapterEvent(WebsiteGenerator):
         if is_user_team_member(self.chapter, frappe.session.user):
             return navbar_items
 
-        if not self.show_speakers:
+        speakers, submissions = self.get_speakers()
+
+        if not self.show_speakers or not speakers:
             navbar_items.remove("speakers")
         if not self.show_rsvp or self.is_paid_event:
             navbar_items.remove("rsvp")

--- a/fossunited/scheduled_tasks.py
+++ b/fossunited/scheduled_tasks.py
@@ -35,6 +35,7 @@ def conclude_events():
             doc.status = "Concluded"
             doc.show_rsvp = 0
             doc.show_cfp = 0
+            doc.show_speakers = 1
             doc.save(ignore_permissions=True)
 
             rsvps = frappe.get_all(EVENT_RSVP, filters={"event": doc.name}, fields=["name"])
@@ -73,7 +74,7 @@ def update_past_job_status():
 
             # Send notification email after successful update
             if job_doc.mail:
-                cc_email = ["developers@fossunited.org"]
+                cc_email = ["foundation@fossunited.org"]
                 subject = (
                     f"Job Posting Auto-Expiry Notice: "
                     f"{frappe.utils.escape_html(job_doc.name)} | "
@@ -84,11 +85,11 @@ def update_past_job_status():
                     f"<p>Dear {frappe.utils.escape_html(job_doc.company_name)},</p>"
                     f"<p>Your job posting titled"
                     f"<strong>{frappe.utils.escape_html(job_doc.job_title)}</strong> "
-                    f"has not been updated in over 90 days and "
+                    f"has been up for 90 days and "
                     f"will now be automatically marked as "
                     f"<strong>Expired</strong>.</p>"
-                    f"<p>If you wish to keep this job open, please update the job post.</p>"
-                    f"<p>Regards,<br>FossUnited Team</p>"
+                    f"<p>If you wish to keep this job open, please reply over this email.</p>"
+                    f"<p>Regards,<br>FOSS United Team</p>"
                 )
                 frappe.sendmail(
                     recipients=[job_doc.mail],


### PR DESCRIPTION
#1053 

- Show speaker tab in events page only if speakers list is not empty

- Auto enable speakers tab when concluding events.

- Also format email message to be sensible. (did we get any email?)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced speaker visibility logic—speakers section now displays only when speakers exist, in addition to the configured display setting.
  * Concluded events now automatically enable speaker information display.
  * Job posting status notification emails updated with new recipient address and clarified 90-day duration messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->