### PR TITLE
UI: hide others review in CFP review tab

### DIFF
--- a/dashboard/src/components/reviewers/ReviewSection.vue
+++ b/dashboard/src/components/reviewers/ReviewSection.vue
@@ -53,20 +53,6 @@
             :theme="getTheme(review.to_approve)"
           />
         </div>
-        <div v-else>
-          <div class="flex justify-between items-center gap-4">
-            <div
-              v-if="review.remarks"
-              class="prose prose-sm max-w-full"
-              v-html="cleanedHTML(review.remarks)"
-            ></div>
-            <span v-else class="text-sm text-gray-600">No Remarks</span>
-          </div>
-          <div class="flex gap-2 items-center">
-            <span class="text-sm">Reviewer #{{ review.idx }}</span>
-            <Badge :label="getLabel(review.to_approve)" :theme="getTheme(review.to_approve)" />
-          </div>
-        </div>
         <hr v-if="index != sortedReviews.length - 1" class="mt-2" />
       </div>
     </div>


### PR DESCRIPTION
- #1004

Why should others review when it can add weight/bias to reviewer

Although in public page they can still see this, ideally that happens for very intentional cases.

Approve-ability index can add weight tho, but at least we reduce influence to some extent.

- TLDR;

Only shows reviewers review if added, if not none!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the review section display to show only the owner's review information, removing non-owner review details from the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->