### PR TITLE
frontend: manage event free ticket code in dashboard

### DIFF
--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -45,6 +45,8 @@ declare module 'vue' {
     FossClubIcon: typeof import('./src/components/icons/FossClubIcon.vue')['default']
     FossClubLogo: typeof import('./src/components/FossClubLogo.vue')['default']
     FossUnitedLogo: typeof import('./src/components/FossUnitedLogo.vue')['default']
+    FreeTicketCodeDialog: typeof import('./src/components/event/FreeTicketCodeDialog.vue')['default']
+    FreeTicketCodeSection: typeof import('./src/components/event/FreeTicketCodeSection.vue')['default']
     GuidelineSection: typeof import('./src/components/cfp-public/GuidelineSection.vue')['default']
     HackathonAttendanceMode: typeof import('./src/components/hackathon/HackathonAttendanceMode.vue')['default']
     HackathonParticipantHeader: typeof import('./src/components/hackathon/HackathonParticipantHeader.vue')['default']

--- a/dashboard/src/components/event/FreeTicketCodeDialog.vue
+++ b/dashboard/src/components/event/FreeTicketCodeDialog.vue
@@ -16,10 +16,15 @@
           readonly
         />
         <FormControl v-model="code.full_name" label="Full Name" />
-        <FormControl v-model="code.mapped_email" label="Email &ast;" type="email" />
+        <FormControl
+          v-model="code.mapped_email"
+          label="Email *"
+          type="email"
+          placeholder="john@fossunited.org"
+        />
         <FormControl
           v-model="code.tier"
-          label="Tier &ast;"
+          label="Tier *"
           type="select"
           :options="[
             { label: 'Volunteer', value: 'Volunteer' },
@@ -33,7 +38,13 @@
         />
         <FormControl v-model="code.company" label="Organization" />
         <FormControl v-if="code.tier === 'Other'" v-model="code.other_tier" label="Other Tier" />
-        <FormControl v-model="code.max_count" label="Max Count &ast;" type="number" :max="30" />
+        <FormControl
+          v-model="code.max_count"
+          label="Max Count *"
+          type="number"
+          :min="1"
+          :max="30"
+        />
       </div>
       <ErrorMessage :message="errorMessages" />
     </template>

--- a/dashboard/src/components/event/FreeTicketCodeDialog.vue
+++ b/dashboard/src/components/event/FreeTicketCodeDialog.vue
@@ -8,6 +8,13 @@
   >
     <template #body-content>
       <div class="flex flex-col gap-4">
+        <FormControl
+          v-if="!inCreateMode"
+          v-model="code.name"
+          label="Coupon ID"
+          type="text"
+          readonly
+        />
         <FormControl v-model="code.full_name" label="Full Name" />
         <FormControl v-model="code.mapped_email" label="Email &ast;" type="email" />
         <FormControl
@@ -81,6 +88,7 @@ const showDialog = defineModel({
 })
 
 const code = reactive({
+  name: '',
   full_name: '',
   mapped_email: '',
   tier: '',
@@ -92,6 +100,7 @@ const code = reactive({
 watch(
   () => props.row,
   (row) => {
+    code.name = row.name || ''
     code.full_name = row.full_name || ''
     code.mapped_email = row.mapped_email || ''
     code.tier = row.tier || ''

--- a/dashboard/src/components/event/FreeTicketCodeDialog.vue
+++ b/dashboard/src/components/event/FreeTicketCodeDialog.vue
@@ -98,20 +98,29 @@ const showDialog = defineModel({
   default: false,
 })
 
-const code = reactive({
-  name: '',
+const defaultCode = {
   full_name: '',
   mapped_email: '',
   tier: '',
   company: '',
   other_tier: '',
   max_count: 1,
-})
+}
+
+const code = reactive({ ...defaultCode })
+
+const resetCode = () => {
+  Object.assign(code, defaultCode)
+}
 
 watch(
   () => props.row,
   (row) => {
     code.name = row.name || ''
+    if (!row || !Object.keys(row).length) {
+      resetCode()
+      return
+    }
     code.full_name = row.full_name || ''
     code.mapped_email = row.mapped_email || ''
     code.tier = row.tier || ''
@@ -151,9 +160,10 @@ const createCode = createResource({
   },
   onSuccess() {
     toast.success('Free code created successfully')
+    emit('refresh')
     showDialog.value = false
-    // Trigger refresh of parent list
-    window.location.reload()
+    resetCode()
+    errorMessages.value = ''
   },
   onError(error) {
     errorMessages.value = error.message
@@ -178,8 +188,9 @@ const updateCode = createResource({
   },
   onSuccess() {
     toast.success('Free code updated successfully')
+    emit('refresh')
     showDialog.value = false
-    window.location.reload()
+    errorMessages.value = ''
   },
   onError(error) {
     errorMessages.value = error.message
@@ -196,8 +207,10 @@ const deleteCode = createResource({
   },
   onSuccess() {
     toast.info('Free code deleted successfully')
+    emit('refresh')
     showDialog.value = false
-    window.location.reload()
+    resetCode()
+    errorMessages.value = ''
   },
   onError(error) {
     errorMessages.value = error.message

--- a/dashboard/src/components/event/FreeTicketCodeDialog.vue
+++ b/dashboard/src/components/event/FreeTicketCodeDialog.vue
@@ -1,0 +1,210 @@
+<template>
+  <Dialog
+    v-model="showDialog"
+    :options="{
+      title: inCreateMode ? 'Create Free Code' : 'Edit Free Code',
+      width: 'md',
+    }"
+  >
+    <template #body-content>
+      <div class="flex flex-col gap-4">
+        <FormControl v-model="code.full_name" label="Full Name" />
+        <FormControl v-model="code.mapped_email" label="Email &ast;" type="email" />
+        <FormControl
+          v-model="code.tier"
+          label="Tier &ast;"
+          type="select"
+          :options="[
+            { label: 'Volunteer', value: 'Volunteer' },
+            { label: 'Speaker/Workshop Host', value: 'Speaker/Workshop Host' },
+            { label: 'Community Partner', value: 'Community Partner' },
+            { label: 'Sponsor', value: 'Sponsor' },
+            { label: 'Diversity Scholar', value: 'Diversity Scholar' },
+            { label: 'Booth Manager', value: 'Booth Manager' },
+            { label: 'Other', value: 'Other' },
+          ]"
+        />
+        <FormControl v-model="code.company" label="Organization" />
+        <FormControl v-if="code.tier === 'Other'" v-model="code.other_tier" label="Other Tier" />
+        <FormControl v-model="code.max_count" label="Max Count &ast;" type="number" :max="30" />
+      </div>
+      <ErrorMessage :message="errorMessages" />
+    </template>
+    <template #actions>
+      <div class="grid grid-cols-3 gap-2 items-center">
+        <Button
+          v-if="!inCreateMode"
+          class="w-full"
+          icon="trash"
+          theme="red"
+          @click="handleDelete"
+        />
+        <Button class="w-full" label="Cancel" @click="showDialog = false" />
+        <Button
+          v-if="inCreateMode"
+          class="w-full"
+          variant="solid"
+          label="Create"
+          @click="handleCreate"
+        />
+        <Button v-else class="w-full" variant="solid" label="Save" @click="handleSave" />
+      </div>
+    </template>
+  </Dialog>
+</template>
+
+<script setup>
+import { defineProps, defineModel, watch, reactive, ref } from 'vue'
+import { Dialog, FormControl, ErrorMessage, Button, createResource } from 'frappe-ui'
+import { toast } from 'vue-sonner'
+
+const props = defineProps({
+  event: {
+    type: Object,
+    required: true,
+  },
+  inCreateMode: {
+    type: Boolean,
+    default: false,
+  },
+  row: {
+    type: Object,
+    default: () => ({}),
+  },
+})
+
+const emit = defineEmits(['refresh'])
+
+const showDialog = defineModel({
+  type: Boolean,
+  default: false,
+})
+
+const code = reactive({
+  full_name: '',
+  mapped_email: '',
+  tier: '',
+  company: '',
+  other_tier: '',
+  max_count: 1,
+})
+
+watch(
+  () => props.row,
+  (row) => {
+    code.full_name = row.full_name || ''
+    code.mapped_email = row.mapped_email || ''
+    code.tier = row.tier || ''
+    code.company = row.company || ''
+    code.other_tier = row.other_tier || ''
+    code.max_count = row.max_count || 1
+  },
+  { immediate: true },
+)
+
+const errorMessages = ref('')
+
+const validateFields = () => {
+  const errors = []
+  if (!code.mapped_email) errors.push('Email is required.')
+  if (!code.tier) errors.push('Tier is required.')
+  if (!code.max_count || code.max_count < 1) errors.push('Max count must be at least 1.')
+  if (code.max_count > 30) errors.push('Max count cannot exceed 30.')
+  return errors
+}
+
+const createCode = createResource({
+  url: 'frappe.client.insert',
+  makeParams() {
+    return {
+      doc: {
+        doctype: 'Event Free Ticket Code',
+        event: props.event.data.name,
+        full_name: code.full_name,
+        mapped_email: code.mapped_email,
+        tier: code.tier,
+        company: code.company,
+        other_tier: code.other_tier,
+        max_count: code.max_count,
+      },
+    }
+  },
+  onSuccess() {
+    toast.success('Free code created successfully')
+    showDialog.value = false
+    // Trigger refresh of parent list
+    window.location.reload()
+  },
+  onError(error) {
+    errorMessages.value = error.message
+  },
+})
+
+const updateCode = createResource({
+  url: 'frappe.client.set_value',
+  makeParams() {
+    return {
+      doctype: 'Event Free Ticket Code',
+      name: props.row.name,
+      fieldname: {
+        full_name: code.full_name,
+        mapped_email: code.mapped_email,
+        tier: code.tier,
+        company: code.company,
+        other_tier: code.other_tier,
+        max_count: code.max_count,
+      },
+    }
+  },
+  onSuccess() {
+    toast.success('Free code updated successfully')
+    showDialog.value = false
+    window.location.reload()
+  },
+  onError(error) {
+    errorMessages.value = error.message
+  },
+})
+
+const deleteCode = createResource({
+  url: 'frappe.client.delete',
+  makeParams() {
+    return {
+      doctype: 'Event Free Ticket Code',
+      name: props.row.name,
+    }
+  },
+  onSuccess() {
+    toast.info('Free code deleted successfully')
+    showDialog.value = false
+    window.location.reload()
+  },
+  onError(error) {
+    errorMessages.value = error.message
+  },
+})
+
+const handleCreate = () => {
+  const errors = validateFields()
+  if (errors.length) {
+    errorMessages.value = errors.join(' ')
+    return
+  }
+  errorMessages.value = ''
+  createCode.fetch()
+}
+
+const handleSave = () => {
+  const errors = validateFields()
+  if (errors.length) {
+    errorMessages.value = errors.join(' ')
+    return
+  }
+  errorMessages.value = ''
+  updateCode.fetch()
+}
+
+const handleDelete = () => {
+  deleteCode.fetch()
+}
+</script>

--- a/dashboard/src/components/event/FreeTicketCodeSection.vue
+++ b/dashboard/src/components/event/FreeTicketCodeSection.vue
@@ -1,0 +1,131 @@
+<template>
+  <FreeTicketCodeDialog
+    v-model="showDialog"
+    :event="event"
+    :in-create-mode="inCreateMode"
+    :row="selectedRow"
+    @refresh="freeCodes.fetch()"
+  />
+  <div>
+    <div class="prose w-full mb-4">
+      <h2 class="mb-1">Free Ticket Codes</h2>
+      <p class="text-sm">Manage free ticket codes for this event.</p>
+      <Button variant="solid" label="Add Code" icon-left="plus" @click="handleCreate" />
+    </div>
+
+    <ListView
+      v-if="freeCodes.data && freeCodes.data.length > 0"
+      v-model:rows="groupedRows"
+      class="mt-4 min-h-[300px]"
+      :columns="[
+        { label: 'Full Name', key: 'full_name', icon: 'user' },
+        { label: 'Email', key: 'mapped_email', icon: 'at-sign' },
+        { label: 'Used / Max', key: 'usage', icon: 'check-circle' },
+        { label: 'Tier', key: 'tier', icon: 'award' },
+        { label: 'Organization', key: 'company', icon: 'briefcase' },
+      ]"
+      row-key="name"
+      :options="{
+        emptyState: {
+          title: 'No Free Codes',
+          description: 'No free ticket codes have been added yet.',
+        },
+        selectable: false,
+        showTooltip: true,
+        resizeColumn: true,
+        onRowClick: (row) => handleEdit(row),
+      }"
+    >
+      <template #cell="{ item, row, column }">
+        <div v-if="column.key === 'usage'">
+          <span
+            class="px-2 py-1 rounded text-sm font-medium"
+            :class="
+              row.used_count >= row.max_count
+                ? 'bg-red-100 text-red-700'
+                : 'bg-green-100 text-green-700'
+            "
+          >
+            {{ row.used_count }} / {{ row.max_count }}
+          </span>
+        </div>
+        <div v-else>
+          <span class="text-base">{{ item }}</span>
+        </div>
+      </template>
+    </ListView>
+  </div>
+</template>
+
+<script setup>
+import { defineProps, ref, watchEffect } from 'vue'
+import { createResource, ListView, Button } from 'frappe-ui'
+import FreeTicketCodeDialog from '@/components/event/FreeTicketCodeDialog.vue'
+import { useRoute } from 'vue-router'
+
+const props = defineProps({
+  event: {
+    type: Object,
+    required: true,
+  },
+})
+
+const route = useRoute()
+const showDialog = ref(false)
+const inCreateMode = ref(false)
+const selectedRow = ref({})
+const groupedRows = ref([])
+
+const freeCodes = createResource({
+  url: 'fossunited.api.tickets.get_event_free_codes',
+  makeParams() {
+    return {
+      event: route.params.id,
+    }
+  },
+  auto: true,
+})
+
+watchEffect(() => {
+  const rows = Array.isArray(freeCodes.data) ? freeCodes.data : []
+
+  // Group by tier
+  const groups = {}
+
+  rows.forEach((code) => {
+    const tier = code.tier || 'Other'
+    if (!groups[tier]) {
+      groups[tier] = []
+    }
+
+    // Transform row data with bg_color for usage
+    groups[tier].push({
+      ...code,
+      usage: {
+        label: `${code.used_count || 0} / ${code.max_count || 0}`,
+        color: code.used_count >= code.max_count ? 'red' : 'green',
+        // ^ does not apply in grouping view? so using v-if span method
+      },
+    })
+  })
+
+  // Convert to array format for ListView
+  groupedRows.value = Object.entries(groups).map(([tier, tierRows]) => ({
+    group: tier,
+    collapsed: false,
+    rows: tierRows,
+  }))
+})
+
+const handleEdit = (row) => {
+  inCreateMode.value = false
+  selectedRow.value = row
+  showDialog.value = true
+}
+
+const handleCreate = () => {
+  selectedRow.value = {}
+  inCreateMode.value = true
+  showDialog.value = true
+}
+</script>

--- a/dashboard/src/components/event/FreeTicketCodeSection.vue
+++ b/dashboard/src/components/event/FreeTicketCodeSection.vue
@@ -19,6 +19,7 @@
       class="mt-4 min-h-[300px]"
       :columns="[
         { label: 'Full Name', key: 'full_name', icon: 'user' },
+        { label: 'Coupon ID', key: 'name' },
         { label: 'Email', key: 'mapped_email', icon: 'at-sign' },
         { label: 'Used / Max', key: 'usage', icon: 'check-circle' },
         { label: 'Tier', key: 'tier', icon: 'award' },

--- a/dashboard/src/components/event/FreeTicketCodeSection.vue
+++ b/dashboard/src/components/event/FreeTicketCodeSection.vue
@@ -10,7 +10,7 @@
     <div class="prose w-full mb-4">
       <h2 class="mb-1">Free Ticket Codes</h2>
       <p class="text-sm">Manage free ticket codes for this event.</p>
-      <Button variant="solid" label="Add Code" icon-left="plus" @click="handleCreate" />
+      <Button variant="solid" label="Create Free Coupon" icon-left="plus" @click="handleCreate" />
     </div>
 
     <ListView

--- a/dashboard/src/components/event/FreeTicketCodeSection.vue
+++ b/dashboard/src/components/event/FreeTicketCodeSection.vue
@@ -81,7 +81,7 @@ const freeCodes = createResource({
   url: 'fossunited.api.tickets.get_event_free_codes',
   makeParams() {
     return {
-      event: route.params.id,
+      event: props.event.name || route.params.id,
     }
   },
   auto: true,

--- a/dashboard/src/components/event/TicketCustomFieldDialog.vue
+++ b/dashboard/src/components/event/TicketCustomFieldDialog.vue
@@ -40,7 +40,7 @@
       <ErrorMessage :message="errorMessages" />
     </template>
     <template #actions>
-      <div class="flex gap-2 items-center">
+      <div class="grid grid-cols-3 gap-2 items-center">
         <Button
           v-if="!inCreateMode"
           class="w-fit px-2"

--- a/dashboard/src/pages/EventTicketManage.vue
+++ b/dashboard/src/pages/EventTicketManage.vue
@@ -40,12 +40,15 @@
 
     <!-- Custom Fields -->
     <TicketCustomFieldsSection :event="event" />
+
+    <FreeTicketCodeSection :event="event" />
   </div>
 </template>
 <script setup>
 import TicketTierSection from '@/components/event/TicketTierSection.vue'
 import TicketTshirtSection from '@/components/event/TicketTshirtSection.vue'
 import TicketCustomFieldsSection from '@/components/event/TicketCustomFieldsSection.vue'
+import FreeTicketCodeSection from '@/components/event/FreeTicketCodeSection.vue'
 import { createResource } from 'frappe-ui'
 import { useRoute } from 'vue-router'
 

--- a/fossunited/api/emailing.py
+++ b/fossunited/api/emailing.py
@@ -577,10 +577,10 @@ def get_sending_status(campaign_id: str) -> dict:
         dict: of stats of format
         ```
         {
-            'sent': int,
-            'error': int,
-            'total': int,
-            'emails_queued': int,
+            "sent": int,
+            "error": int,
+            "total": int,
+            "emails_queued": int,
         }
         ```
     """

--- a/fossunited/api/tickets.py
+++ b/fossunited/api/tickets.py
@@ -392,3 +392,30 @@ def get_free_pass_insights(event_id: str) -> dict:
     )
 
     return stats
+
+
+@frappe.whitelist()
+def get_event_free_codes(event):
+    """Get all free ticket codes for an event"""
+
+    if not has_valid_permission(event):
+        frappe.throw("You are not authorized to view the tickets for this event")
+
+    codes = frappe.get_all(
+        "Event Free Ticket Code",
+        filters={"event": event},
+        fields=[
+            "name",
+            "full_name",
+            "mapped_email",
+            "tier",
+            "company",
+            "other_tier",
+            "used_count",
+            "max_count",
+            "is_used",
+        ],
+        order_by="tier asc, creation desc",
+    )
+
+    return codes


### PR DESCRIPTION
- completes #999 
- Goes after #1259 

- Add two new components to manage and create free ticket codes for any events in tickets (page)

- Should we show coupon ID as well?
  Since some complain are like "we did not get email" or just to nudge people organizers can ping them with coupon ID to claim


https://github.com/user-attachments/assets/21181bfc-149e-43de-b7c4-6c7412b4a180

- TLDR; as simple as desk creation, this page lets organizers to manage free code management for an event


TLDR;

- Able to manage free ticket codes via dashboard itself
- Only max_count to only 1-30 

### further ahead TODO
- make email message generic on ticket claim
- make web form generic for claiming ticket
- make sure ticket transfer also applies the same

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Free ticket code management: create, edit, delete free-ticket codes with tier, email mapping and usage limits.
  * Codes listed in a grouped-by-tier view with per-code usage indicators and create/edit flows.

* **UI**
  * Adjusted dialog action layout for improved button alignment.

* **Documentation**
  * Minor docstring formatting update in emailing utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->