### PR TITLE
doctype: only permit team to modify their free ticket codes

### DIFF
--- a/fossunited/fossunited/doctype/event_free_ticket_applications/event_free_ticket_applications.py
+++ b/fossunited/fossunited/doctype/event_free_ticket_applications/event_free_ticket_applications.py
@@ -42,14 +42,14 @@ class EventFreeTicketApplications(Document):
         coupon_data = frappe.db.get_value(
             FREE_TICKET_CODE,
             self.coupon_id,
-            ["max_count", "used_count", "tier", "other_tier"],
+            ["max_count", "used_count", "tier", "other_tier", "is_used"],
             as_dict=True,
         )
 
         if not coupon_data:
             frappe.throw("Coupon not found or inactive.")
 
-        if coupon_data.used_count >= coupon_data.max_count:
+        if coupon_data.is_used or (coupon_data.used_count >= coupon_data.max_count):
             frappe.throw("Reached max count of coupon usage.")
 
         return coupon_data

--- a/fossunited/fossunited/doctype/event_free_ticket_code/event_free_ticket_code.py
+++ b/fossunited/fossunited/doctype/event_free_ticket_code/event_free_ticket_code.py
@@ -53,6 +53,10 @@ class EventFreeTicketCode(Document):
         if check_if_chapter_or_event_core_member(self.event):
             return True
 
+        frappe.log_error(
+            title="Permission Denied: Free Ticket Code Modification",
+            message=f"User {user} attempted to modify free ticket code for event {self.event}",
+        )
         frappe.throw(
             "You are not allowed to modify free ticket codes for this event.",
             frappe.PermissionError,

--- a/fossunited/fossunited/doctype/event_free_ticket_code/event_free_ticket_code.py
+++ b/fossunited/fossunited/doctype/event_free_ticket_code/event_free_ticket_code.py
@@ -1,8 +1,10 @@
 # Copyright (c) 2025, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
+
+from fossunited.api.chapter import check_if_chapter_or_event_core_member
 
 
 class EventFreeTicketCode(Document):
@@ -32,4 +34,26 @@ class EventFreeTicketCode(Document):
         ]
         used_count: DF.Int
     # end: auto-generated types
-    pass
+
+    def on_trash(self):
+        self.permit_only_team()
+
+    def before_save(self):
+        self.permit_only_team()
+
+    def permit_only_team(self):
+        """Allow only event/chapter team members to modify."""
+
+        user = frappe.session.user
+        roles = frappe.get_roles(user)
+
+        if "System Manager" in roles or "Administrator" in roles:
+            return True
+
+        if check_if_chapter_or_event_core_member(self.event):
+            return True
+
+        frappe.throw(
+            "You are not allowed to modify free ticket codes for this event.",
+            frappe.PermissionError,
+        )


### PR DESCRIPTION
- for #1259 

- To let only chapter team or desk users to modify free ticket codes.

- we make this to avoid modifying other free ticket codes 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Permission-based controls for modifying or deleting event free ticket codes — only administrators and authorized core team members can make changes; unauthorized attempts are blocked with an error.
* **Bug Fixes**
  * Added validation to prevent using already-used or fully redeemed free ticket codes, stopping duplicate or over-limit redemptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->