### PR TITLE
fix: auto set event for redeem-claim if not given based on coupon code

### DIFF
--- a/fossunited/fossunited/doctype/event_free_ticket_applications/event_free_ticket_applications.py
+++ b/fossunited/fossunited/doctype/event_free_ticket_applications/event_free_ticket_applications.py
@@ -26,6 +26,12 @@ class EventFreeTicketApplications(Document):
 
     def before_insert(self):
         """Executed automatically before inserting the document."""
+        if not self.event and self.coupon_id:
+            event = frappe.db.get_value(FREE_TICKET_CODE, self.coupon_id, "event")
+            if not event:
+                frappe.throw("Selected coupon has no linked event. Please contact organizers")
+            self.event = event
+
         coupon_data = self.validate_coupon()
         ticket_tier = self.get_ticket_tier(coupon_data)
         self.create_free_ticket(ticket_tier)


### PR DESCRIPTION
- it helps us to make web form be generic to all paid events

- So if they submit coupon_id and fill their details, backend will link it to event and ticket is done.
- as simple!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Free ticket applications now include enhanced validation to ensure selected coupons have a properly linked event. Clear error messages are displayed if coupon validation fails.

* **New Features**
  * Coupon usage tracking is now automated to update in real-time whenever free tickets are issued through valid coupons, ensuring accurate quota management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->