### PR TITLE
add talk video links to schedule and CFP page

### DIFF
--- a/dashboard/src/components/schedule/SessionCard.vue
+++ b/dashboard/src/components/schedule/SessionCard.vue
@@ -31,13 +31,28 @@
         </div>
       </div>
 
-      <button
-        class="px-2 py-1 bg-gray-900 text-white text-xs font-medium rounded-[2px] flex items-center gap-2"
-        @click="downloadSessionIcs()"
-      >
-        <IconCalendarPlus class="w-4 h-4" />
-        <span class="hidden md:block uppercase">Add to Calendar</span>
-      </button>
+      <div class="flex items-center gap-4 ml-auto">
+        <a
+          v-if="PastSession && session.talk_video"
+          :href="session.talk_video"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-gray-600 hover:text-gray-900 flex items-center justify-center"
+          title="Watch on YouTube"
+        >
+          <IconBrandYoutubeFilled class="w-6 h-6" />
+        </a>
+
+        <button
+          v-else-if="!PastSession"
+          class="px-2 py-1 bg-gray-900 text-white text-xs font-medium rounded-[2px] flex items-center gap-2"
+          title="Add to calendar"
+          @click="downloadSessionIcs()"
+        >
+          <IconCalendarPlus class="w-4 h-4" />
+          <span class="hidden md:block uppercase">Add to Calendar</span>
+        </button>
+      </div>
     </div>
     <h3 class="text-lg font-semibold tracking-[-0.18px]">
       {{ session.title }}
@@ -62,7 +77,7 @@
   </a>
 </template>
 <script setup>
-import { IconCalendarPlus } from '@tabler/icons-vue'
+import { IconCalendarPlus, IconBrandYoutubeFilled } from '@tabler/icons-vue'
 import { createEvent } from 'ics'
 import { toast } from 'vue-sonner'
 import { createAbsoluteUrlFromRoute } from '@/helpers/utils'
@@ -149,5 +164,11 @@ const speakers = computed(() => {
   } else {
     return props.session.cfp_speakers
   }
+})
+
+const PastSession = computed(() => {
+  const date = props.session.scheduled_date
+  if (!date) return false
+  return new Date(date) < new Date().setHours(0, 0, 0, 0)
 })
 </script>

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -371,7 +371,4 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
             ["talk_video"],
         )
 
-        if not talk_scheduled:
-            return None
-
-        return talk_scheduled or None
+        return talk_scheduled

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -9,7 +9,7 @@ from frappe.website.website_generator import WebsiteGenerator
 from fossunited.api.emailing import (
     handle_email_group_subscription,
 )
-from fossunited.doctype_ids import CHAPTER, EVENT, EVENT_CFP
+from fossunited.doctype_ids import CHAPTER, EVENT, EVENT_CFP, EVENT_SCHEDULE
 
 
 class FOSSEventCFPSubmission(WebsiteGenerator):
@@ -192,6 +192,7 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         context.likes = self.get_likes()
         context.like = 1 if frappe.session.user in context.likes else 0
         context.like_count = len(context.likes)
+        context.talk_video = self.cfp_get_talk_video()
 
     def get_meta(self, context):
         pagetitle = self.talk_title
@@ -360,3 +361,17 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
             subscribe_to_chapter=frappe.utils.cint(self.subscribe_chapter_mailing) == 1,
             document_type_event=EVENT,
         )
+
+    def cfp_get_talk_video(self) -> str | None:
+        """Return the talk video link if CFP is linked in schedule and has a video."""
+
+        talk_scheduled = frappe.db.get_value(
+            EVENT_SCHEDULE,
+            {"linked_cfp": self.name},
+            ["talk_video"],
+        )
+
+        if not talk_scheduled:
+            return None
+
+        return talk_scheduled or None

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
@@ -49,7 +49,21 @@
       <h1 class="text-3xl font-bold">{{ doc.talk_title }}</h1>
       {{ like_button() }}
     </div>
-    <div class="w-fit">{{ badge(label=doc.status, theme=status_badge_theme[doc.status]) }}</div>
+    <div class="flex items-center gap-2">
+      <div class="w-fit">{{ badge(label=doc.status, theme=status_badge_theme[doc.status]) }}</div>
+
+      {% if talk_video %}
+        <a
+          href="{{ talk_video }}"
+          target="_blank"
+          rel="noopener noreferrer"
+          title="Watch on YouTube"
+          class="inline-flex items-center justify-center text-red-600 hover:text-gray-600 transition-colors"
+        >
+          <i class="ti ti-brand-youtube-filled text-xl"></i>
+        </a>
+      {% endif %}
+    </div>
   </div>
 {% endmacro %}
 

--- a/fossunited/fossunited/doctype/foss_event_schedule/foss_event_schedule.json
+++ b/fossunited/fossunited/doctype/foss_event_schedule/foss_event_schedule.json
@@ -1,116 +1,129 @@
 {
-  "actions": [],
-  "allow_rename": 1,
-  "creation": "2023-08-22 00:12:45.713314",
-  "doctype": "DocType",
-  "editable_grid": 1,
-  "engine": "InnoDB",
-  "field_order": [
-    "linked_cfp_section",
-    "linked_cfp",
-    "section_break_ojro",
-    "title",
-    "category",
-    "other_category",
-    "hall",
-    "speakers",
-    "section_break_cmsn",
-    "scheduled_date",
-    "column_break_iitq",
-    "start_time",
-    "end_time"
-  ],
-  "fields": [
-    {
-      "fieldname": "section_break_cmsn",
-      "fieldtype": "Section Break",
-      "label": "Timings"
-    },
-    {
-      "columns": 1,
-      "fieldname": "start_time",
-      "fieldtype": "Time",
-      "in_list_view": 1,
-      "label": "Start Time"
-    },
-    {
-      "fieldname": "column_break_iitq",
-      "fieldtype": "Column Break"
-    },
-    {
-      "columns": 1,
-      "fieldname": "end_time",
-      "fieldtype": "Time",
-      "in_list_view": 1,
-      "label": "End Time"
-    },
-    {
-      "columns": 2,
-      "fieldname": "scheduled_date",
-      "fieldtype": "Date",
-      "in_list_view": 1,
-      "label": "Scheduled Date"
-    },
-    {
-      "fieldname": "linked_cfp_section",
-      "fieldtype": "Section Break",
-      "label": "Linked CFP"
-    },
-    {
-      "columns": 1,
-      "fieldname": "linked_cfp",
-      "fieldtype": "Link",
-      "label": "Linked CFP",
-      "options": "FOSS Event CFP Submission"
-    },
-    {
-      "fieldname": "section_break_ojro",
-      "fieldtype": "Section Break"
-    },
-    {
-      "description": "Format \n<pre>{\n  \"speakers\": [\n    {\n        \"name\": \"Test Name\",\n        \"designation\": \"Software Engineer\",\n        \"organization\": \"FOSS United\",\n        \"profile\": \"\",\n        \"image\": \"\"\n    }\n  ]\n}\n</pre>\n",
-      "fieldname": "speakers",
-      "fieldtype": "JSON",
-      "label": "Speakers"
-    },
-    {
-      "fieldname": "category",
-      "fieldtype": "Select",
-      "in_list_view": 1,
-      "label": "Category",
-      "options": "Talk\nLightning Talk\nWorkshop\nPanel Discussion\nOpening Note\nBreak\nOther"
-    },
-    {
-      "depends_on": "eval:doc.category=='Other'",
-      "fieldname": "other_category",
-      "fieldtype": "Data",
-      "label": "Other Category"
-    },
-    {
-      "columns": 2,
-      "fetch_from": "linked_cfp.talk_title",
-      "fetch_if_empty": 1,
-      "fieldname": "title",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "label": "Title"
-    },
-    {
-      "fieldname": "hall",
-      "fieldtype": "Data",
-      "label": "Hall"
-    }
-  ],
-  "index_web_pages_for_search": 1,
-  "istable": 1,
-  "links": [],
-  "modified": "2024-08-31 17:12:36.763381",
-  "modified_by": "Administrator",
-  "module": "FOSSUnited",
-  "name": "FOSS Event Schedule",
-  "owner": "Administrator",
-  "permissions": [],
-  "sort_field": "modified",
-  "sort_order": "DESC",
-  "states": []
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2023-08-22 00:12:45.713314",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "linked_cfp_section",
+  "linked_cfp",
+  "section_break_ojro",
+  "title",
+  "hall",
+  "talk_video",
+  "category",
+  "other_category",
+  "section_break_s3gt",
+  "speakers",
+  "section_break_cmsn",
+  "scheduled_date",
+  "column_break_iitq",
+  "start_time",
+  "end_time"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_cmsn",
+   "fieldtype": "Section Break",
+   "label": "Timings"
+  },
+  {
+   "columns": 1,
+   "fieldname": "start_time",
+   "fieldtype": "Time",
+   "in_list_view": 1,
+   "label": "Start Time"
+  },
+  {
+   "fieldname": "column_break_iitq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "columns": 1,
+   "fieldname": "end_time",
+   "fieldtype": "Time",
+   "in_list_view": 1,
+   "label": "End Time"
+  },
+  {
+   "columns": 2,
+   "fieldname": "scheduled_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Scheduled Date"
+  },
+  {
+   "fieldname": "linked_cfp_section",
+   "fieldtype": "Section Break",
+   "label": "Linked CFP"
+  },
+  {
+   "columns": 1,
+   "fieldname": "linked_cfp",
+   "fieldtype": "Link",
+   "label": "Linked CFP",
+   "options": "FOSS Event CFP Submission"
+  },
+  {
+   "fieldname": "section_break_ojro",
+   "fieldtype": "Section Break"
+  },
+  {
+   "description": "Format \n<pre>{\n  \"speakers\": [\n    {\n        \"name\": \"Test Name\",\n        \"designation\": \"Software Engineer\",\n        \"organization\": \"FOSS United\",\n        \"profile\": \"\",\n        \"image\": \"\"\n    }\n  ]\n}\n</pre>\n",
+   "fieldname": "speakers",
+   "fieldtype": "JSON",
+   "label": "Speakers"
+  },
+  {
+   "fieldname": "category",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Category",
+   "options": "Talk\nLightning Talk\nWorkshop\nPanel Discussion\nOpening Note\nBreak\nOther"
+  },
+  {
+   "depends_on": "eval:doc.category=='Other'",
+   "fieldname": "other_category",
+   "fieldtype": "Data",
+   "label": "Other Category"
+  },
+  {
+   "columns": 2,
+   "fetch_from": "linked_cfp.talk_title",
+   "fetch_if_empty": 1,
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Title"
+  },
+  {
+   "fieldname": "hall",
+   "fieldtype": "Data",
+   "label": "Hall"
+  },
+  {
+   "fieldname": "talk_video",
+   "fieldtype": "Data",
+   "label": "Talk video",
+   "options": "URL"
+  },
+  {
+   "fieldname": "section_break_s3gt",
+   "fieldtype": "Section Break"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-11-10 12:45:18.707352",
+ "modified_by": "Administrator",
+ "module": "FOSSUnited",
+ "name": "FOSS Event Schedule",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
 }

--- a/fossunited/fossunited/doctype/foss_event_schedule/foss_event_schedule.py
+++ b/fossunited/fossunited/doctype/foss_event_schedule/foss_event_schedule.py
@@ -14,13 +14,13 @@ class FOSSEventSchedule(Document):
         from frappe.types import DF
 
         category: DF.Literal[
-            "Talk",  # noqa: F821
-            "Lightning Talk",  # noqa: F722, F821
-            "Workshop",  # noqa: F821
-            "Panel Discussion",  # noqa: F722, F821
-            "Opening Note",  # noqa: F722, F821
-            "Break",  # noqa: F821
-            "Other",  # noqa: F821
+            "Talk",
+            "Lightning Talk",
+            "Workshop",
+            "Panel Discussion",
+            "Opening Note",
+            "Break",
+            "Other",
         ]
         end_time: DF.Time | None
         hall: DF.Data | None
@@ -32,6 +32,7 @@ class FOSSEventSchedule(Document):
         scheduled_date: DF.Date | None
         speakers: DF.JSON | None
         start_time: DF.Time | None
+        talk_video: DF.Data | None
         title: DF.Data | None
     # end: auto-generated types
 


### PR DESCRIPTION
- completed #785 

Implementatin:

- Doctype: Add an `talk_video` field to schedule data so it can be showed in schedule page
- Schedule page shows the Youtube icon for video link

- In CFP fetch linked schedule data and get video link to show in those public CFP pages.

- Show Video link only if event is concluded and remove add to calendar button.

NOTE: After implementation, its a manual work to add each YT link to schedule items.

Future plans:
- Maybe we can embed the video as iframe so directly in page it can play.
- Maybe add metadata in CFP page to inform in which day, event and hall it happened
  ^ But again users would have found this CFP only via schedule or event page

Render in schedule page (Note: will change soon on re-design)

<img width="1000" height="500" alt="image" src="https://github.com/user-attachments/assets/f80bb95a-4fdf-4056-b2cd-47ec939d4483" />

rendering in CFP page:

<img width="600" height="160" alt="image" src="https://github.com/user-attachments/assets/de8a566f-4eb0-43c4-8deb-2f54907747be" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions can include a "Talk video" URL and this is exposed where relevant.
  * Past sessions show a clickable YouTube link when a talk video is available.

* **UI Updates**
  * Replaced the standalone "Add to Calendar" button with a right-aligned contextual control group that shows either a YouTube link (past) or the "Add to Calendar" action (upcoming).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->