### PR TITLE
frontend: support licensing for proposals

### DIFF
--- a/dashboard/src/components/cfp-public/ReferencesComponent.vue
+++ b/dashboard/src/components/cfp-public/ReferencesComponent.vue
@@ -5,7 +5,10 @@
       <span class="text-red-500">*</span>
     </label>
     <p class="text-sm text-ink-gray-5">
-      Add links to external resources that will help attendees learn more about the session.
+      Add links to external resources that will help attendees learn more about the session.<br />
+      If this is your first talk, please consider submitting a link to one talk recording of yours.
+      We may use this to understand your presentation style. A mock presentation may be required if
+      this is left empty
     </p>
     <div v-for="(item, index) in references" :key="index" class="flex gap-2 items-center">
       <FormControl

--- a/dashboard/src/components/cfp-public/ReferencesComponent.vue
+++ b/dashboard/src/components/cfp-public/ReferencesComponent.vue
@@ -4,7 +4,7 @@
       Session References
       <span class="text-red-500">*</span>
     </label>
-    <p class="text-sm text-ink-gray-5">
+    <p class="text-sm text-ink-gray-5 leading-relaxed">
       Add links to external resources that will help attendees learn more about the session.<br />
       If this is your first talk, please consider submitting a link to one talk recording of yours.
       We may use this to understand your presentation style. A mock presentation may be required if

--- a/dashboard/src/helpers/cfp.js
+++ b/dashboard/src/helpers/cfp.js
@@ -72,11 +72,33 @@ export const getProposalFormFields = (cfpData) => {
       fieldtype: 'text_editor',
       value: '',
     },
+    {
+      label: 'License',
+      fieldname: 'talk_license',
+      fieldtype: 'text',
+      value: '',
+      description:
+        'Specify the license(s) under which your project/talk is distributed. Examples: MIT License (software), CC BY-SA 4.0 (open data/documentation), CERN OHL-W (open hardware). Refer: https://opensource.org/licenses',
+    },
   ])
 
   let customFields = getCustomQuestions(cfpData.cfp_custom_questions)
 
   baseFields.value.push(...customFields)
+
+  const order = [
+    'talk_title',
+    'session_type',
+    'session_categories',
+    'other_category',
+    'intended_audience',
+    'talk_license',
+    'talk_description',
+    'key_takeaways',
+    'is_first_talk',
+  ]
+
+  baseFields.value.sort((a, b) => order.indexOf(a.fieldname) - order.indexOf(b.fieldname))
 
   return baseFields
 }
@@ -258,9 +280,16 @@ export const getSubmissionConfirmationFields = () => {
       value: false,
     },
     {
-      label:
-        'I am okay with doing a mock presentation of this talk to get better feedback if required',
+      label: 'I can do a mock presentation of this talk if required',
       fieldname: 'mock_presentation_ack',
+      fieldtype: 'checkbox',
+      required: true,
+      value: false,
+    },
+    {
+      label:
+        'I agree that my talk, slides, and related materials may be published under a Creative Commons (CC BY-SA 4.0) license.',
+      fieldname: 'license_ack',
       fieldtype: 'checkbox',
       required: true,
       value: false,

--- a/dashboard/src/helpers/cfp.js
+++ b/dashboard/src/helpers/cfp.js
@@ -83,9 +83,6 @@ export const getProposalFormFields = (cfpData) => {
   ])
 
   let customFields = getCustomQuestions(cfpData.cfp_custom_questions)
-
-  baseFields.value.push(...customFields)
-
   const order = [
     'talk_title',
     'session_type',
@@ -99,6 +96,7 @@ export const getProposalFormFields = (cfpData) => {
   ]
 
   baseFields.value.sort((a, b) => order.indexOf(a.fieldname) - order.indexOf(b.fieldname))
+  baseFields.value.push(...customFields)
 
   return baseFields
 }
@@ -288,7 +286,7 @@ export const getSubmissionConfirmationFields = () => {
     },
     {
       label:
-        'I agree that my talk, slides, and related materials may be published under a Creative Commons (CC BY-SA 4.0) license.',
+        'I agree that my talk, slides, and related materials will be published under a Creative Commons (CC BY-SA 4.0) license if my proposal is accepted.',
       fieldname: 'license_ack',
       fieldtype: 'checkbox',
       required: true,

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.json
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.json
@@ -28,7 +28,7 @@
   "talk_title",
   "session_type",
   "is_first_talk",
-  "talk_reference",
+  "talk_license",
   "references",
   "session_categories",
   "categories_preview",
@@ -151,13 +151,6 @@
    "label": "Status",
    "options": "Review Pending\nScreening\nApproved\nRejected\nWithdrawn",
    "permlevel": 2
-  },
-  {
-   "description": "Link relevant references for your talk.",
-   "fieldname": "talk_reference",
-   "fieldtype": "Data",
-   "label": "Session Reference",
-   "options": "URL"
   },
   {
    "fieldname": "section_break_ilij",
@@ -342,12 +335,18 @@
    "fieldname": "subscribe_chapter_mailing",
    "fieldtype": "Check",
    "label": "Subscribe to Chapter Mailing?"
+  },
+  {
+   "description": "License for the talk/project.",
+   "fieldname": "talk_license",
+   "fieldtype": "Data",
+   "label": "Talk License"
   }
  ],
  "has_web_view": 1,
  "is_published_field": "is_published",
  "links": [],
- "modified": "2025-10-31 14:50:44.288866",
+ "modified": "2025-11-10 18:27:38.862779",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "FOSS Event CFP Submission",

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -30,7 +30,7 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         from fossunited.fossunited.doctype.foss_custom_answer.foss_custom_answer import (
             FOSSCustomAnswer,
         )
-        from fossunited.fossunited.doctype.foss_event_cfp_review.foss_event_cfp_review import (  # noqa: E501
+        from fossunited.fossunited.doctype.foss_event_cfp_review.foss_event_cfp_review import (
             FOSSEventCFPReview,
         )
 
@@ -45,8 +45,8 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         event_name: DF.Data | None
         first_name: DF.Data | None
         full_name: DF.Data | None
-        intended_audience: DF.Literal["Beginner", "Intermediate", "Advanced"]  # noqa: F821
-        is_first_talk: DF.Literal["Yes", "No"]  # noqa: F821
+        intended_audience: DF.Literal["Beginner", "Intermediate", "Advanced"]
+        is_first_talk: DF.Literal["Yes", "No"]
         is_published: DF.Check
         is_withdrawn: DF.Check
         key_takeaways: DF.TextEditor | None
@@ -61,19 +61,19 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         route: DF.Data | None
         session_categories: DF.Text | None
         session_type: DF.Literal[
-            "Talk",  # noqa: F821
-            "Lightning Talk",  # noqa: F722
-            "Panel Discussion",  # noqa: F821, F722
-            "Birds of Feather(BoF)",  # noqa: F722
-            "Workshop",  # noqa: F821
-            "Invited Talk",  # noqa: F821, F722
+            "Talk",
+            "Lightning Talk",
+            "Panel Discussion",
+            "Birds of Feather(BoF)",
+            "Workshop",
+            "Invited Talk",
         ]
         speakers: DF.Table[CFPSubmissionSpeaker]
-        status: DF.Literal["Review Pending", "Screening", "Approved", "Rejected", "Withdrawn"]  # noqa: F821, F722
+        status: DF.Literal["Review Pending", "Screening", "Approved", "Rejected", "Withdrawn"]
         submitted_by: DF.Link
         subscribe_chapter_mailing: DF.Check
         talk_description: DF.TextEditor
-        talk_reference: DF.Data | None
+        talk_license: DF.Data | None
         talk_title: DF.Data
         unsure_reviews: DF.Data | None
     # end: auto-generated types


### PR DESCRIPTION
- Will fix #1238 & #1256

- Removed deprecated talk_reference field and moved it as talk_license for users to input license for their talk/topic

- Show checkbox for agreement on publishing their content in CC license

- Inform users to also submit previous talk sample link as "references"
  ^ I'm not sure if we really need to add another field in backend for this, since we have references and multiple links can be expected, we can simply let them add more as references.
  Good for reviewer as well as public viewers.

### Future uptakes

- Remove "Session Category" from everything to complete #1242

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Talk License field to capture presentation licensing information
  * Added license acknowledgement checkbox for speaker confirmation
  * Improved guidance for first-time speakers to submit a recording link

* **Documentation**
  * Refined mock-presentation acknowledgement wording for clarity
  * Reordered and organized proposal form fields for a clearer submission flow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->