### PR TITLE
dashboard: enhance modifying schedule for events

### DIFF
--- a/dashboard/src/components/event/schedule/ModifyScheduleItem.vue
+++ b/dashboard/src/components/event/schedule/ModifyScheduleItem.vue
@@ -70,6 +70,8 @@ const handleCfpChange = (cfpName) => {
   const cfp = allCfpSubmissions.data.find((c) => c.name === cfpValue)
 
   if (cfp) {
+    // Update the linked_cfp value properly
+    selectedScheduleItem.value.linked_cfp = cfpValue
     selectedScheduleItem.value.title = cfp.talk_title
     selectedScheduleItem.value.category = cfp.session_type
     // Only set talk_video if it exists and current value is empty
@@ -130,6 +132,11 @@ const handleSave = () => {
   toast.info('Schedule updated')
 }
 
+const handleDelete = () => {
+  emit('delete:schedule', selectedScheduleItem.value)
+  showDeleteConfirmation.value = false
+}
+
 const showDeleteConfirmation = ref(false)
 
 // Keyboard shortcut
@@ -185,7 +192,12 @@ onUnmounted(() => window.removeEventListener('keydown', saveShortcut))
           variant="outline"
           description="Choose a proposal from approved submissions"
           :options="getLinkedCfpOptions"
-          @update:model-value="handleCfpChange"
+          @update:model-value="
+            (value) => {
+              selectedScheduleItem.linked_cfp = value
+              handleCfpChange(value)
+            }
+          "
         >
           <template #item-prefix="{ selected }">
             <div class="flex gap-2 items-center">
@@ -205,6 +217,7 @@ onUnmounted(() => window.removeEventListener('keydown', saveShortcut))
           required
         />
 
+        <!-- Other Category (conditional) -->
         <FormControl
           v-if="selectedScheduleItem.category === 'Other'"
           v-model="selectedScheduleItem.other_category"
@@ -213,6 +226,7 @@ onUnmounted(() => window.removeEventListener('keydown', saveShortcut))
           required
         />
 
+        <!-- Title -->
         <FormControl
           v-model="selectedScheduleItem.title"
           label="Title"
@@ -220,6 +234,7 @@ onUnmounted(() => window.removeEventListener('keydown', saveShortcut))
           required
         />
 
+        <!-- Hall -->
         <FormControl
           v-model="selectedScheduleItem.hall"
           label="Hall"
@@ -229,6 +244,7 @@ onUnmounted(() => window.removeEventListener('keydown', saveShortcut))
           required
         />
 
+        <!-- Date and Time -->
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-2">
           <FormControl
             v-model="selectedScheduleItem.scheduled_date"
@@ -250,15 +266,17 @@ onUnmounted(() => window.removeEventListener('keydown', saveShortcut))
           />
         </div>
 
+        <!-- Talk Video -->
         <FormControl
           v-model="selectedScheduleItem.talk_video"
           label="Talk Video Link"
-          type="url"
+          type="text"
           variant="outline"
         />
       </div>
     </div>
 
+    <!-- Actions -->
     <div class="flex flex-col gap-4">
       <ErrorMessage v-if="errorMessages" class="mt-2" :message="errorMessages" />
 

--- a/dashboard/src/components/event/schedule/ModifyScheduleItem.vue
+++ b/dashboard/src/components/event/schedule/ModifyScheduleItem.vue
@@ -1,15 +1,14 @@
 <script setup>
 import { IconCircleCheckFilled } from '@tabler/icons-vue'
 import { Badge, FormControl, Dialog, ErrorMessage } from 'frappe-ui'
-import { computed, inject, watch, onMounted, ref, onUnmounted } from 'vue'
+import { computed, inject, ref, onMounted, onUnmounted } from 'vue'
 import { toast } from 'vue-sonner'
 
 const event = inject('event')
 const emit = defineEmits(['update:schedule', 'delete:schedule'])
-
 const selectedScheduleItem = defineModel({ type: Object, required: true })
 
-const scheduleCategories = [
+const SCHEDULE_CATEGORIES = [
   'Talk',
   'Lightning Talk',
   'Workshop',
@@ -19,9 +18,13 @@ const scheduleCategories = [
   'Other',
 ]
 
+const CATEGORIES_WITHOUT_CFP = ['Opening Note', 'Break']
+const CATEGORIES_REQUIRING_CFP = ['Lightning Talk', 'Workshop', 'Panel Discussion']
+
 const allCfpSubmissions = inject('allCfpSubmissions')
 const linkedCfpSubmissions = inject('linkedCfpSubmissions')
 
+// Computed properties
 const getLinkedCfpOptions = computed(() => {
   return allCfpSubmissions.data
     .filter(
@@ -29,42 +32,91 @@ const getLinkedCfpOptions = computed(() => {
         !linkedCfpSubmissions.value.includes(cfp.name) ||
         cfp.name === selectedScheduleItem.value.linked_cfp,
     )
-    .map((cfp) => {
-      return {
-        label: cfp.talk_title,
-        value: cfp.name,
-      }
-    })
+    .map((cfp) => ({
+      label: cfp.talk_title,
+      value: cfp.name,
+    }))
 })
 
-watch(
-  () => selectedScheduleItem.value.linked_cfp,
-  (newValue) => {
-    if (
-      selectedScheduleItem.value.category === 'Opening Note' ||
-      selectedScheduleItem.value.category === 'Break'
-    ) {
-      return
-    }
+const getHallOptions = computed(() => {
+  if (!event.doc.hall_options) return ['']
 
-    if (!newValue) {
-      selectedScheduleItem.value.title = ''
-      selectedScheduleItem.value.category = ''
-      return
-    }
+  const options = event.doc.hall_options
+    .split('\n')
+    .map((option) => option.trim())
+    .filter(Boolean)
 
-    if (typeof newValue == 'object') {
-      newValue = newValue.value
-    }
+  return ['', ...options]
+})
 
-    const target = allCfpSubmissions.data.find((cfp) => cfp.name === newValue)
-
-    selectedScheduleItem.value.title = target.talk_title
-    selectedScheduleItem.value.category = target.session_type
-  },
+const showCfpField = computed(
+  () => !CATEGORIES_WITHOUT_CFP.includes(selectedScheduleItem.value.category),
 )
 
+// Handle CFP selection
+const handleCfpChange = (cfpName) => {
+  if (CATEGORIES_WITHOUT_CFP.includes(selectedScheduleItem.value.category)) {
+    return
+  }
+
+  if (!cfpName) {
+    selectedScheduleItem.value.title = ''
+    selectedScheduleItem.value.category = ''
+    selectedScheduleItem.value.talk_video = ''
+    return
+  }
+
+  const cfpValue = typeof cfpName === 'object' ? cfpName.value : cfpName
+  const cfp = allCfpSubmissions.data.find((c) => c.name === cfpValue)
+
+  if (cfp) {
+    selectedScheduleItem.value.title = cfp.talk_title
+    selectedScheduleItem.value.category = cfp.session_type
+    // Only set talk_video if it exists and current value is empty
+    if (cfp.talk_video && !selectedScheduleItem.value.talk_video) {
+      selectedScheduleItem.value.talk_video = cfp.talk_video
+    }
+  }
+}
+
+// Validation
 const errorMessages = ref('')
+
+const validateScheduleItem = () => {
+  const errors = []
+  const item = selectedScheduleItem.value
+
+  if (!item.title) errors.push('Title is required')
+  if (!item.category) errors.push('Category is required')
+  if (!item.hall) errors.push('Hall is required')
+  if (!item.scheduled_date) errors.push('Date is required')
+  if (!item.start_time) errors.push('Start Time is required')
+  if (!item.end_time) errors.push('End Time is required')
+
+  // Clear linked_cfp for categories that don't need it
+  if (CATEGORIES_WITHOUT_CFP.includes(item.category)) {
+    item.linked_cfp = ''
+  }
+
+  // Require linked_cfp for specific categories
+  if (CATEGORIES_REQUIRING_CFP.includes(item.category) && !item.linked_cfp) {
+    errors.push('Linked Proposal is required')
+  }
+
+  // Validate time order
+  if (item.start_time && item.end_time) {
+    const [startHour, startMin] = item.start_time.split(':').map(Number)
+    const [endHour, endMin] = item.end_time.split(':').map(Number)
+
+    if (endHour < startHour || (endHour === startHour && endMin <= startMin)) {
+      errors.push('End Time must be after Start Time')
+    }
+  }
+
+  return errors
+}
+
+// Actions
 const handleSave = () => {
   const errors = validateScheduleItem()
 
@@ -74,109 +126,32 @@ const handleSave = () => {
   }
 
   errorMessages.value = ''
-
   emit('update:schedule', selectedScheduleItem.value)
   toast.info('Schedule updated')
 }
 
-watch(
-  () => selectedScheduleItem.value,
-  () => {
-    errorMessages.value = ''
-  },
-)
-
-const validateScheduleItem = () => {
-  const errors = []
-  if (!selectedScheduleItem.value.title) {
-    errors.push('Title is required')
-  }
-
-  if (!selectedScheduleItem.value.category) {
-    errors.push('Category is required')
-  }
-
-  if (
-    selectedScheduleItem.value.category === 'Opening Note' ||
-    selectedScheduleItem.value.category === 'Break'
-  ) {
-    selectedScheduleItem.value.linked_cfp = ''
-  }
-
-  if (!['Talk', 'Other', 'Opening Note', 'Break'].includes(selectedScheduleItem.value.category)) {
-    if (!selectedScheduleItem.value.linked_cfp) {
-      errors.push('Linked Proposal is required')
-    }
-  }
-
-  if (!selectedScheduleItem.value.hall) {
-    errors.push('Hall value is required')
-  }
-
-  if (!selectedScheduleItem.value.scheduled_date) {
-    errors.push('Date is required')
-  }
-
-  if (!selectedScheduleItem.value.start_time) {
-    errors.push('Start Time is required')
-  }
-
-  if (!selectedScheduleItem.value.end_time) {
-    errors.push('End Time is required')
-  }
-
-  // Validate that end time is not before start time
-  if (selectedScheduleItem.value.start_time && selectedScheduleItem.value.end_time) {
-    // Compare as "HH:mm"
-    const [startHour, startMinute] = selectedScheduleItem.value.start_time.split(':').map(Number)
-    const [endHour, endMinute] = selectedScheduleItem.value.end_time.split(':').map(Number)
-    if (endHour < startHour || (endHour === startHour && endMinute < startMinute)) {
-      errors.push('End Time cannot be before Start Time')
-    }
-  }
-
-  return errors
-}
-
 const showDeleteConfirmation = ref(false)
 
+// Keyboard shortcut
 const saveShortcut = (e) => {
-  if ((e.ctrlKey || e.metaKey) && e.key == 's') {
+  if ((e.ctrlKey || e.metaKey) && e.key === 's') {
     e.preventDefault()
     handleSave()
   }
 }
 
-onMounted(() => {
-  window.addEventListener('keydown', saveShortcut)
-})
-
-onUnmounted(() => {
-  window.removeEventListener('keydown', saveShortcut)
-})
-
-const getHallOptions = computed(() => {
-  if (!event.doc.hall_options) {
-    return []
-  }
-
-  let options = event.doc.hall_options.split('\n').map((option) => option.trim())
-  options.unshift('')
-
-  return options
-})
+onMounted(() => window.addEventListener('keydown', saveShortcut))
+onUnmounted(() => window.removeEventListener('keydown', saveShortcut))
 </script>
+
 <template>
   <Dialog
     v-model="showDeleteConfirmation"
     class="z-50"
     :options="{
       title: 'Delete Schedule',
-      message: `Are you sure you want to delete this schedule? This action cannot be undone.`,
-      icon: {
-        name: 'trash',
-        appearance: 'danger',
-      },
+      message: 'Are you sure you want to delete this schedule? This action cannot be undone.',
+      icon: { name: 'trash', appearance: 'danger' },
       actions: [
         {
           label: 'Delete',
@@ -188,28 +163,29 @@ const getHallOptions = computed(() => {
         },
         {
           label: 'Cancel',
-          onClick: () => (showDeleteConfirmation.value = false),
+          onClick: () => (showDeleteConfirmation = false),
         },
       ],
     }"
   />
+
   <div class="flex flex-col gap-2 justify-between h-full">
     <div class="flex flex-col gap-2">
       <div class="prose">
         <h3>Modify Schedule</h3>
       </div>
+
       <div class="my-2 flex flex-col gap-4">
+        <!-- Linked Proposal (CFP) -->
         <FormControl
-          v-if="
-            selectedScheduleItem.category !== 'Opening Note' &&
-            selectedScheduleItem.category !== 'Break'
-          "
-          v-model="selectedScheduleItem.linked_cfp"
+          v-if="showCfpField"
+          :model-value="selectedScheduleItem.linked_cfp"
           label="Linked Proposal"
           type="autocomplete"
           variant="outline"
-          description="Choose a proposal from the following list of approved proposals"
+          description="Choose a proposal from approved submissions"
           :options="getLinkedCfpOptions"
+          @update:model-value="handleCfpChange"
         >
           <template #item-prefix="{ selected }">
             <div class="flex gap-2 items-center">
@@ -218,14 +194,17 @@ const getHallOptions = computed(() => {
             </div>
           </template>
         </FormControl>
+
+        <!-- Category -->
         <FormControl
           v-model="selectedScheduleItem.category"
           label="Category"
-          :options="scheduleCategories"
           type="select"
           variant="outline"
+          :options="SCHEDULE_CATEGORIES"
           required
         />
+
         <FormControl
           v-if="selectedScheduleItem.category === 'Other'"
           v-model="selectedScheduleItem.other_category"
@@ -233,44 +212,56 @@ const getHallOptions = computed(() => {
           variant="outline"
           required
         />
+
         <FormControl
           v-model="selectedScheduleItem.title"
           label="Title"
           variant="outline"
           required
         />
+
         <FormControl
           v-model="selectedScheduleItem.hall"
           label="Hall"
-          variant="outline"
           type="select"
+          variant="outline"
           :options="getHallOptions"
           required
         />
+
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-2">
           <FormControl
             v-model="selectedScheduleItem.scheduled_date"
-            variant="outline"
             label="Date"
             type="date"
+            variant="outline"
           />
           <FormControl
             v-model="selectedScheduleItem.start_time"
-            variant="outline"
             label="Start Time"
             type="time"
+            variant="outline"
           />
           <FormControl
             v-model="selectedScheduleItem.end_time"
-            variant="outline"
             label="End Time"
             type="time"
+            variant="outline"
           />
         </div>
+
+        <FormControl
+          v-model="selectedScheduleItem.talk_video"
+          label="Talk Video Link"
+          type="url"
+          variant="outline"
+        />
       </div>
     </div>
+
     <div class="flex flex-col gap-4">
-      <ErrorMessage class="mt-2" :message="errorMessages" />
+      <ErrorMessage v-if="errorMessages" class="mt-2" :message="errorMessages" />
+
       <div class="bg-white flex gap-2 items-center">
         <Button
           icon="trash"

--- a/dashboard/src/components/event/schedule/RenderScheduleItems.vue
+++ b/dashboard/src/components/event/schedule/RenderScheduleItems.vue
@@ -1,12 +1,179 @@
 <script setup>
+import { computed, ref } from 'vue'
+import { FormControl, Switch } from 'frappe-ui'
 import ScheduleItem from './ScheduleItem.vue'
+import dayjs from 'dayjs'
+
 const emit = defineEmits(['modify-item'])
 const schedule_items = defineModel('schedule', { type: Array, default: [] })
+
+// Filter and sort options
+const groupBy = ref('hall') // 'hall', 'time', 'none'
+const sortBy = ref('time') // 'time', 'title'
+const showOnlyNewItems = ref(false)
+
+const SORT_OPTIONS = [
+  { label: 'Start Time', value: 'time' },
+  { label: 'Title', value: 'title' },
+]
+
+const GROUP_OPTIONS = [
+  { label: 'Hall', value: 'hall' },
+  { label: 'Time', value: 'time' },
+  { label: 'None', value: 'none' },
+]
+
+// Filter items based on showOnlyNewItems toggle
+const filteredItems = computed(() => {
+  if (showOnlyNewItems.value) {
+    // When ON, show ONLY new items
+    return schedule_items.value.filter((item) => item.is_new)
+  }
+  // When OFF, show all items
+  return schedule_items.value
+})
+
+// Sort items
+const sortedItems = computed(() => {
+  const items = [...filteredItems.value]
+
+  if (sortBy.value === 'time') {
+    return items.sort((a, b) => {
+      if (!a.start_time && !b.start_time) return 0
+      if (!a.start_time) return 1
+      if (!b.start_time) return -1
+      return a.start_time.localeCompare(b.start_time)
+    })
+  }
+
+  if (sortBy.value === 'title') {
+    return items.sort((a, b) => {
+      const titleA = a.title?.toLowerCase() || ''
+      const titleB = b.title?.toLowerCase() || ''
+      return titleA.localeCompare(titleB)
+    })
+  }
+
+  return items
+})
+
+// Group items
+const groupedItems = computed(() => {
+  if (groupBy.value === 'none') {
+    return [{ key: 'all', label: null, items: sortedItems.value }]
+  }
+
+  const groups = {}
+
+  sortedItems.value.forEach((item) => {
+    let key, label
+
+    if (groupBy.value === 'hall') {
+      key = item.hall || 'No Hall'
+      label = item.hall || 'No Hall Assigned'
+    } else if (groupBy.value === 'time') {
+      if (!item.start_time) {
+        key = 'no-time'
+        label = 'No Time Set'
+      } else {
+        const hour = parseInt(item.start_time.split(':')[0])
+        if (hour < 12) {
+          key = 'morning'
+          label = 'Morning (Before 12 PM)'
+        } else if (hour < 17) {
+          key = 'afternoon'
+          label = 'Afternoon (12 PM - 5 PM)'
+        } else {
+          key = 'evening'
+          label = 'Evening (After 5 PM)'
+        }
+      }
+    }
+
+    if (!groups[key]) {
+      groups[key] = { key, label, items: [] }
+    }
+
+    groups[key].items.push(item)
+  })
+
+  // Sort groups for time-based grouping
+  if (groupBy.value === 'time') {
+    const order = ['morning', 'afternoon', 'evening', 'no-time']
+    return order.map((key) => groups[key]).filter(Boolean)
+  }
+
+  return Object.values(groups)
+})
+
+const newItemsCount = computed(() => schedule_items.value.filter((item) => item.is_new).length)
 </script>
+
 <template>
-  <div class="flex flex-col gap-2">
-    <div v-for="(item, index) in schedule_items" :key="item.idx" class="flex flex-col gap-2">
-      <ScheduleItem v-model="schedule_items[index]" @click="emit('modify-item', item)" />
+  <div class="flex flex-col gap-4">
+    <!-- Filters and Controls -->
+    <div class="bg-gray-50 p-4 rounded-lg border">
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+        <FormControl
+          v-model="groupBy"
+          label="Group By"
+          type="select"
+          :options="GROUP_OPTIONS"
+          variant="outline"
+        />
+
+        <FormControl
+          v-model="sortBy"
+          label="Sort By"
+          type="select"
+          :options="SORT_OPTIONS"
+          variant="outline"
+        />
+
+        <Switch
+          v-model="showOnlyNewItems"
+          label="Show Only New Items"
+          :description="`${newItemsCount} new item(s)`"
+        />
+      </div>
+
+      <!-- Summary -->
+      <div class="mt-3 pt-3 border-t text-sm text-gray-600">
+        Showing {{ filteredItems.length }} of {{ schedule_items.length }} items
+      </div>
+    </div>
+
+    <!-- Grouped Schedule Items -->
+    <div v-if="filteredItems.length === 0" class="text-center py-8 text-gray-500">
+      <p v-if="showOnlyNewItems">No new schedule items</p>
+      <p v-else>No schedule items to display</p>
+      <p v-if="showOnlyNewItems && newItemsCount === 0" class="text-sm mt-2">
+        All items are complete
+      </p>
+    </div>
+
+    <div v-else class="flex flex-col gap-6">
+      <div v-for="group in groupedItems" :key="group.key" class="flex flex-col gap-3">
+        <!-- Group Header -->
+        <div v-if="group.label" class="flex items-center gap-2 pb-2 border-b">
+          <h4 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+            {{ group.label }}
+          </h4>
+          <span class="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded-full">
+            {{ group.items.length }}
+          </span>
+        </div>
+
+        <!-- Items in Group -->
+        <div class="flex flex-col gap-2">
+          <ScheduleItem
+            v-for="item in group.items"
+            :key="item.idx"
+            v-model="schedule_items[schedule_items.findIndex((i) => i.idx === item.idx)]"
+            @click="emit('modify-item', item)"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </template>

--- a/dashboard/src/components/event/schedule/ScheduleItem.vue
+++ b/dashboard/src/components/event/schedule/ScheduleItem.vue
@@ -1,27 +1,131 @@
 <script setup>
-import { IconHomeFilled } from '@tabler/icons-vue'
+import { computed } from 'vue'
 import dayjs from 'dayjs'
 import { Badge } from 'frappe-ui'
+import {
+  IconClock,
+  IconInfoCircleFilled,
+  IconBuilding,
+  IconAlertTriangleFilled,
+} from '@tabler/icons-vue'
+
 const schedule_item = defineModel({ required: true, type: Object })
 
 const formatTime = (time) => {
-  return dayjs(`1970-01-01T${time}`).format('hh:mm a')
+  if (!time) return '--:--'
+  return dayjs(`1970-01-01T${time}`).format('hh:mm A')
 }
+
+const getTypeColor = (type) => {
+  const colors = {
+    Talk: 'blue',
+    'Lightning Talk': 'purple',
+    Workshop: 'green',
+    'Panel Discussion': 'orange',
+    'Opening Note': 'yellow',
+    Break: 'gray',
+    Other: 'gray',
+  }
+  return colors[type] || 'gray'
+}
+
+const duration = computed(() => {
+  if (!schedule_item.value.start_time || !schedule_item.value.end_time) {
+    return null
+  }
+
+  const [startHour, startMin] = schedule_item.value.start_time.split(':').map(Number)
+  const [endHour, endMin] = schedule_item.value.end_time.split(':').map(Number)
+
+  const totalMinutes = endHour * 60 + endMin - (startHour * 60 + startMin)
+
+  if (totalMinutes < 60) {
+    return `${totalMinutes}m`
+  }
+
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+  return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`
+})
+
+const isIncomplete = computed(() => {
+  return (
+    !schedule_item.value.title ||
+    !schedule_item.value.category ||
+    !schedule_item.value.start_time ||
+    !schedule_item.value.end_time ||
+    !schedule_item.value.hall
+  )
+})
 </script>
+
 <template>
   <div
-    class="p-3 rounded border bg-white flex gap-2 hover:border-gray-400 transition-colors cursor-pointer"
-    :class="schedule_item.is_new ? 'stripes' : ''"
+    class="p-4 rounded-lg border bg-white hover:border-gray-400 hover:shadow-sm transition-all cursor-pointer relative overflow-hidden"
+    :class="{
+      stripes: schedule_item.is_new,
+      'border-amber-300 bg-amber-50/30': isIncomplete && !schedule_item.is_new,
+    }"
   >
-    <div class="w-[3px] bg-gray-900 rounded"></div>
-    <div class="flex flex-col gap-1">
-      <h5 class="text-base font-semibold">{{ schedule_item.title }}</h5>
-      <div class="flex gap-2">
-        <div class="flex items-center gap-1 text-sm">
+    <!-- Status Indicator -->
+    <div
+      class="absolute left-0 top-0 bottom-0 w-1 rounded-l-lg"
+      :class="{
+        'bg-gray-400': schedule_item.is_new,
+        'bg-amber-500': isIncomplete && !schedule_item.is_new,
+        'bg-green-500': !isIncomplete && !schedule_item.is_new,
+      }"
+    />
+
+    <div class="pl-3 flex flex-col gap-2">
+      <!-- Title and Category -->
+      <div class="flex items-start justify-between gap-2">
+        <h5 class="text-base font-semibold flex-1 leading-snug">
+          {{ schedule_item.title || 'Untitled Schedule Item' }}
+        </h5>
+        <Badge
+          v-if="schedule_item.category"
+          :label="schedule_item.category"
+          :theme="getTypeColor(schedule_item.category)"
+          variant="subtle"
+        />
+      </div>
+
+      <!-- Time, Duration, and Hall -->
+      <div class="flex flex-wrap items-center gap-2 text-sm text-gray-600">
+        <div class="flex items-center gap-1.5">
+          <IconClock class="h-4 w-4" />
           <span>{{ formatTime(schedule_item.start_time) }}</span>
-          <span>- {{ formatTime(schedule_item.end_time) }}</span>
+          <span>-</span>
+          <span>{{ formatTime(schedule_item.end_time) }}</span>
         </div>
-        <Badge :label="schedule_item.hall" class="w-fit" variant="subtle" />
+
+        <span v-if="duration" class="text-xs bg-gray-100 px-2 py-0.5 rounded-full">
+          {{ duration }}
+        </span>
+
+        <div v-if="schedule_item.hall" class="flex items-center gap-1.5">
+          <IconBuilding class="h-4 w-4" />
+          <span class="font-medium">{{ schedule_item.hall }}</span>
+        </div>
+      </div>
+
+      <!-- Warnings for incomplete items -->
+      <div
+        v-if="isIncomplete"
+        class="flex items-center gap-1.5 text-xs text-amber-700 bg-amber-50 px-2 py-1 rounded"
+      >
+        <IconAlertTriangleFilled class="h-6 w-6" />
+        <span>Incomplete information</span>
+      </div>
+
+      <!-- New item indicator -->
+      <div
+        v-if="schedule_item.is_new"
+        class="flex items-center gap-1.5 text-xs text-gray-600 bg-gray-50 px-2 py-1 rounded"
+      >
+        <IconInfoCircleFilled class="h-4 w-4" />
+        <span>New item - click to complete</span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
- mainly was working on adding talk_video link to map it for schedule items

- Went ahead to enhance schedule filtering for dashboard (event organizers) to help group and modify each items.
- helps visually to group and sort for indiafoss as well

- Although simply more LOC, its battle of UX convenience and usability!


https://github.com/user-attachments/assets/4b51df45-3c26-4068-95d1-a0ca849bd2f0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added advanced filtering, sorting (by time/title), and grouping (by hall/time) controls for managing schedule items.
  * Enabled keyboard shortcut support for saving schedule changes.
  * Enhanced schedule item display with color-coded status indicators, duration formatting, and warnings for incomplete entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->