### PR TITLE
support downloading all proposals in CSV format

### DIFF
--- a/dashboard/src/components/cfp-public/SubmissionsListView.vue
+++ b/dashboard/src/components/cfp-public/SubmissionsListView.vue
@@ -91,10 +91,6 @@ const filteredSubmissions = computed(() => {
 })
 
 function downloadCSV() {
-  const visible = Array.isArray(filteredSubmissions.value)
-    ? filteredSubmissions.value.map((s) => s.name)
-    : []
-
   const params = new URLSearchParams()
   params.append('event', props.eventId)
 

--- a/dashboard/src/components/cfp-public/SubmissionsListView.vue
+++ b/dashboard/src/components/cfp-public/SubmissionsListView.vue
@@ -1,7 +1,7 @@
 <script setup>
 import SubmissionsList from './SubmissionsList.vue'
 import Filter from '@/components/ui/Filter.vue'
-import { IconSearch } from '@tabler/icons-vue'
+import { IconSearch, IconDownload } from '@tabler/icons-vue'
 import { createResource, FormControl, LoadingText, Select } from 'frappe-ui'
 import { filterSubmissions } from '@/helpers/cfp'
 import { watch, ref, computed } from 'vue'
@@ -90,6 +90,18 @@ const filteredSubmissions = computed(() => {
   return result
 })
 
+function downloadCSV() {
+  const visible = Array.isArray(filteredSubmissions.value)
+    ? filteredSubmissions.value.map((s) => s.name)
+    : []
+
+  const params = new URLSearchParams()
+  params.append('event', props.eventId)
+
+  const url = `/api/method/fossunited.api.proposal.download_proposals_csv?${params.toString()}`
+  window.open(url, '_blank')
+}
+
 watch(
   () => props.statusFilter,
   (newVal) => {
@@ -113,6 +125,14 @@ watch(filteredSubmissions, (val) => {
         <div class="flex items-end gap-2">
           <Select v-model="filteredStatus" :options="statusOptions" />
           <Filter v-if="filterFields.data" v-model="filters" :docfields="filterFields.data" />
+
+          <button
+            class="flex bg-black text-white px-3 py-2 rounded text-sm hover:bg-gray-800"
+            @click="downloadCSV"
+          >
+            <IconDownload class="w-4 h-4 mr-1" />
+            <span>CSV</span>
+          </button>
         </div>
       </div>
       <SubmissionsList v-model="submissions.data" />

--- a/fossunited/api/proposal.py
+++ b/fossunited/api/proposal.py
@@ -1,5 +1,6 @@
 import csv
 import io
+import re
 
 import frappe
 from frappe import qb
@@ -278,7 +279,7 @@ def get_public_proposal_filters(
 @frappe.whitelist(allow_guest=True)
 def download_proposals_csv(event: str):
     """
-    CSV export (simple).
+    CSV export for all proposals from an event.
     Columns: timestamp, track, session_title, name, review_status, link
     Uses _get_bulk_speakers_data to fetch speaker full_name (first speaker) unless anonymised.
     """
@@ -306,6 +307,7 @@ def download_proposals_csv(event: str):
 
     cfp = frappe.db.get_value(EVENT_CFP, {"event": event}, ["anonymise_proposals"], as_dict=True)
     anonymise = bool(cfp.get("anonymise_proposals")) if cfp else False
+    proposal_names = [p.get("name") for p in proposals] if proposals else []
 
     speakers_map = {}
     if not anonymise and proposal_names:
@@ -331,7 +333,8 @@ def download_proposals_csv(event: str):
 
         writer.writerow([creation, track, title, speaker_name, status, link])
 
-    filename = f"{event_name}-submissions"
+    safe_event = re.sub(r"[^A-Za-z0-9_-]+", "_", str(event_name))
+    filename = f"{safe_event}-submissions"
 
     frappe.response["doctype"] = filename
     frappe.response["filename"] = f"{filename}.csv"

--- a/fossunited/api/proposal.py
+++ b/fossunited/api/proposal.py
@@ -1,7 +1,12 @@
+import csv
+import io
+
 import frappe
 from frappe import qb
+from frappe.utils import get_url
+from frappe.utils.response import as_csv
 
-from fossunited.doctype_ids import EVENT_CFP, PROPOSAL, SPEAKER
+from fossunited.doctype_ids import EVENT, EVENT_CFP, PROPOSAL, SPEAKER
 
 
 @frappe.whitelist(allow_guest=True)
@@ -237,7 +242,10 @@ def get_public_proposal_filters(
     ]
 
     cfp = frappe.db.get_value(
-        EVENT_CFP, {"event": event}, ["name", "has_public_custom_responses"], as_dict=True
+        EVENT_CFP,
+        {"event": event},
+        ["name", "has_public_custom_responses"],
+        as_dict=True,
     )
 
     if cfp.has_public_custom_responses:
@@ -265,3 +273,76 @@ def get_public_proposal_filters(
             )
 
     return filter_fields
+
+
+@frappe.whitelist(allow_guest=True)
+def download_proposals_csv(event: str):
+    """
+    CSV export (simple).
+    Columns: timestamp, track, session_title, name, review_status, link
+    Uses _get_bulk_speakers_data to fetch speaker full_name (first speaker) unless anonymised.
+    """
+    if not event:
+        frappe.throw("Event is required")
+
+    event_route = frappe.db.get_value(EVENT, event, "route")
+    event_name = frappe.db.get_value(EVENT, event, "event_name")
+
+    proposals = (
+        frappe.get_all(
+            PROPOSAL,
+            filters={"event": event},
+            fields=[
+                "name",
+                "talk_title",
+                "session_type",
+                "status",
+                "creation",
+            ],
+            order_by="creation asc",
+        )
+        or []
+    )
+
+    proposal_names = [p.get("name") for p in proposals] if proposals else []
+
+    anonymise = False
+    try:
+        cfp = (
+            frappe.db.get_value(EVENT_CFP, {"event": event}, ["anonymise_proposals"], as_dict=True)
+            or {}
+        )
+        anonymise = bool(cfp.get("anonymise_proposals"))
+    except Exception:
+        anonymise = False
+
+    speakers_map = {}
+    if not anonymise and proposal_names:
+        speakers_map = _get_bulk_speakers_data(proposal_names) or {}
+
+    output = io.StringIO()
+    writer = csv.writer(output, quoting=csv.QUOTE_MINIMAL, lineterminator="\r\n")
+    writer.writerow(["timestamp", "track", "session_title", "name", "review_status", "link"])
+
+    for p in proposals:
+        name = p.get("name", "")
+        creation = p.get("creation", "")
+        track = p.get("session_type", "") or ""
+        title = p.get("talk_title", "") or ""
+        status = p.get("status", "") or ""
+
+        speaker_name = ""
+        if not anonymise and speakers_map.get(name):
+            first_sp = speakers_map[name][0]
+            speaker_name = first_sp.get("full_name") or ""
+
+        link = get_url(f"{event_route}/cfp/{p.name}")
+
+        writer.writerow([creation, track, title, speaker_name, status, link])
+
+    filename = f"{event_name}-submissions"
+
+    frappe.response["doctype"] = filename
+    frappe.response["filename"] = f"{filename}.csv"
+    frappe.response["result"] = "\ufeff" + output.getvalue()
+    return as_csv()

--- a/fossunited/api/proposal.py
+++ b/fossunited/api/proposal.py
@@ -304,17 +304,8 @@ def download_proposals_csv(event: str):
         or []
     )
 
-    proposal_names = [p.get("name") for p in proposals] if proposals else []
-
-    anonymise = False
-    try:
-        cfp = (
-            frappe.db.get_value(EVENT_CFP, {"event": event}, ["anonymise_proposals"], as_dict=True)
-            or {}
-        )
-        anonymise = bool(cfp.get("anonymise_proposals"))
-    except Exception:
-        anonymise = False
+    cfp = frappe.db.get_value(EVENT_CFP, {"event": event}, ["anonymise_proposals"], as_dict=True)
+    anonymise = bool(cfp.get("anonymise_proposals")) if cfp else False
 
     speakers_map = {}
     if not anonymise and proposal_names:

--- a/fossunited/api/proposal.py
+++ b/fossunited/api/proposal.py
@@ -280,49 +280,80 @@ def get_public_proposal_filters(
 def download_proposals_csv(event: str):
     """
     CSV export for all proposals from an event.
-    Columns: timestamp, track, session_title, name, review_status, link
-    Uses _get_bulk_speakers_data to fetch speaker full_name (first speaker) unless anonymised.
+    Columns: timestamp, track, session_title, name, review_status, link + dynamic custom questions
     """
     if not event:
         frappe.throw("Event is required")
 
-    event_route = frappe.db.get_value(EVENT, event, "route")
-    event_name = frappe.db.get_value(EVENT, event, "event_name")
+    event_route, event_name = frappe.db.get_value(EVENT, event, ["route", "event_name"])
 
     proposals = (
         frappe.get_all(
             PROPOSAL,
             filters={"event": event},
-            fields=[
-                "name",
-                "talk_title",
-                "session_type",
-                "status",
-                "creation",
-            ],
+            fields=["name", "talk_title", "session_type", "status", "creation"],
             order_by="creation asc",
         )
         or []
     )
 
-    cfp = frappe.db.get_value(EVENT_CFP, {"event": event}, ["anonymise_proposals"], as_dict=True)
-    anonymise = bool(cfp.get("anonymise_proposals")) if cfp else False
-    proposal_names = [p.get("name") for p in proposals] if proposals else []
+    if not proposals:
+        frappe.throw("No proposals found for this event")
+
+    proposal_names = [p["name"] for p in proposals]
+
+    cfp = (
+        frappe.db.get_value(
+            EVENT_CFP,
+            {"event": event},
+            ["name", "anonymise_proposals", "has_public_custom_responses"],
+            as_dict=True,
+        )
+        or {}
+    )
+
+    anonymise = bool(cfp.get("anonymise_proposals"))
+    has_custom = bool(cfp.get("has_public_custom_responses"))
 
     speakers_map = {}
-    if not anonymise and proposal_names:
+    if not anonymise:
         speakers_map = _get_bulk_speakers_data(proposal_names) or {}
+
+    custom_answers_data = {}
+    if has_custom:
+        custom_answers_data = _get_bulk_custom_answers_data(proposal_names)
+
+        # Fetch actual question labels to use as headers (ordered by idx)
+        custom_questions = frappe.get_all(
+            "FOSS Custom Question",
+            filters={"parenttype": EVENT_CFP, "parent": cfp.name},
+            fields=["idx", "question"],
+            order_by="idx asc",
+        )
+    else:
+        custom_questions = []
 
     output = io.StringIO()
     writer = csv.writer(output, quoting=csv.QUOTE_MINIMAL, lineterminator="\r\n")
-    writer.writerow(["timestamp", "track", "session_title", "name", "review_status", "link"])
+
+    header = [
+        "timestamp",
+        "track",
+        "session_title",
+        "name",
+        "review_status",
+        "link",
+    ]
+
+    header.extend([q["question"] for q in custom_questions])
+    writer.writerow(header)
 
     for p in proposals:
-        name = p.get("name", "")
-        creation = p.get("creation", "")
-        track = p.get("session_type", "") or ""
-        title = p.get("talk_title", "") or ""
-        status = p.get("status", "") or ""
+        name = p.get("name")
+        creation = p.get("creation") or ""
+        track = p.get("session_type") or ""
+        title = p.get("talk_title") or ""
+        status = p.get("status") or ""
 
         speaker_name = ""
         if not anonymise and speakers_map.get(name):
@@ -331,10 +362,18 @@ def download_proposals_csv(event: str):
 
         link = get_url(f"{event_route}/cfp/{p.name}")
 
-        writer.writerow([creation, track, title, speaker_name, status, link])
+        row = [creation, track, title, speaker_name, status, link]
+
+        if has_custom and custom_questions:
+            answers = custom_answers_data.get(name, {})
+            for q in custom_questions:
+                key = f"custom_question_{q['idx']}"
+                row.append(answers.get(key, ""))
+
+        writer.writerow(row)
 
     safe_event = re.sub(r"[^A-Za-z0-9_-]+", "_", str(event_name))
-    filename = f"{safe_event}-submissions"
+    filename = f"{safe_event}-submissions.csv"
 
     frappe.response["doctype"] = filename
     frappe.response["filename"] = f"{filename}.csv"


### PR DESCRIPTION
- for #1249 

Just like schedule, we can have a button to download all proposals for an event in CSV format.

As discussed there even I dont see a point for any other format.

For now we have 6 fields as requested by shree in the issue thread.

- For more info, they have link to view the individual cfp itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSV export for proposal submissions: users can download submissions (timestamp, track, session title, speaker name, review status, link) as a CSV; respects anonymisation settings.
  * Submissions list UI includes a CSV button that opens the export in a new tab.
  * CSV can include custom question columns when present in the call-for-proposals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->