### PR TITLE
fix: new page css wherever applicable

### DIFF
--- a/dashboard/src/pages/EventDetails.vue
+++ b/dashboard/src/pages/EventDetails.vue
@@ -25,7 +25,7 @@
         <img
           :src="getBannerImage()"
           alt="Banner Image"
-          class="object-cover w-full border rounded-lg aspect-[4.96/1]"
+          class="object-cover w-[280px] border rounded-lg aspect-[1/1]"
         />
         <div class="flex gap-2 my-2">
           <FileUploader
@@ -58,7 +58,7 @@
           />
         </div>
         <div class="text-sm text-gray-600">
-          The ideal dimensions for a banner image are: 1240 x 300 (WxH)
+          The ideal dimensions for a banner image are: 280px x 280px (WxH) (1:1)
         </div>
       </div>
     </div>

--- a/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
+++ b/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
@@ -326,7 +326,7 @@
       <div class="v3-card ev-main-card">
         <div class="v3-header">
           <div class="show-mobile-only">{{ event_cover() }}</div>
-          <div style="flex: 1; display: flex; flex-direction: column; gap: 1.5rem;">
+          <div style="flex: 1; display: flex; flex-direction: column; gap: 1.2rem;">
             <!-- Header Info -->
             <div style="display: flex; flex-direction: column;">
               <div style="display: flex; flex-direction: column;">
@@ -361,7 +361,7 @@
             </div>
 
             <!-- Date/Time/Location -->
-            <div>
+            <div style="margin-top: 3px;">
               <div class="ev-detail-row">
                 <div class="ev-icon">
                   <i
@@ -399,6 +399,10 @@
             </div>
             {% endif %}
 
+            </div>
+
+            <div class="ev-detail-row">
+              <div class="ev-detail-secondary">{{ doc.event_bio or '' }}</div>
             </div>
 
             <!-- Buttons -->

--- a/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
+++ b/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
@@ -60,7 +60,7 @@
       class="v3-banner"
     />
 
-    {% if event_stats %}
+    {% if event_stats and (event_stats.attending > 0 or event_stats.proposals > 0) %}
       <div class="ev-stats">
         {% if event_stats.attending > 0 %}
           <span>{{ event_stats.attending }} Attend{{ "ing" if status_live else "ed" }}</span>

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -3205,20 +3205,37 @@ h6 {
 }
 
 /* V3 Typography - Inherit font from parent */
-.v3-text-primary,
-.v3-text-primary * {
+.v3-text-primary {
   color: var(--v3-text-color) !important;
 }
 
-.v3-text-secondary,
-.v3-text-secondary * {
+.v3-text-secondary {
   color: var(--v3-text-color2) !important;
 }
 
-.v3-text-tertiary,
-.v3-text-tertiary * {
+.v3-text-tertiary {
   color: var(--v3-text-color3) !important;
 }
+
+.v3-text-primary h1,
+.v3-text-secondary h1,
+.v3-text-tertiary h1 { font-size: 2rem; }
+
+.v3-text-primary h2,
+.v3-text-secondary h2,
+.v3-text-tertiary h2 { font-size: 1.8rem; }
+
+.v3-text-primary h3,
+.v3-text-secondary h3,
+.v3-text-tertiary h3 { font-size: 1.5rem; }
+
+.v3-text-primary h4,
+.v3-text-secondary h4,
+.v3-text-tertiary h4 { font-size: 1.3rem; }
+
+.v3-text-primary :is(h5, h6),
+.v3-text-secondary :is(h5, h6),
+.v3-text-tertiary :is(h5, h6) { font-size: 1.1rem; }
 
 /* V3 Section Title */
 .v3-section-title {

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -3205,15 +3205,18 @@ h6 {
 }
 
 /* V3 Typography - Inherit font from parent */
-.v3-text-primary {
+.v3-text-primary,
+.v3-text-primary * {
   color: var(--v3-text-color) !important;
 }
 
-.v3-text-secondary {
+.v3-text-secondary,
+.v3-text-secondary * {
   color: var(--v3-text-color2) !important;
 }
 
-.v3-text-tertiary {
+.v3-text-tertiary,
+.v3-text-tertiary * {
   color: var(--v3-text-color3) !important;
 }
 
@@ -3754,6 +3757,11 @@ h6 {
   background: var(--v3-text-color);
   color: var(--v3-main-bg);
   opacity: 0.8;
+}
+
+.navbar-toggler {
+  /* not able to get hamburger icon cause they use svg */
+  background: #fafafa !important;
 }
 
 .navbar,

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -3121,6 +3121,7 @@ h6 {
   display: flex;
   flex-direction: column;
   gap: 2rem; /* 32px */
+  margin-bottom: 2rem;
 }
 
 @media (min-width: 52.5rem) {
@@ -3146,6 +3147,7 @@ h6 {
   justify-content: center;
   gap: 0.5rem;
   text-decoration: none;
+  z-index: 9999;
 }
 
 .v3-btn-group {
@@ -3261,7 +3263,7 @@ h6 {
   display: block;
   transition: opacity 0.2s;
   color: var(--v3-card-bg) !important;
-  margin-bottom: 0.5rem;
+  margin-bottom: 1rem;
 }
 
 [data-theme='dark'] .cfp-card-v3 {
@@ -3701,6 +3703,19 @@ h6 {
   transition: color 0.2s;
 }
 
+.v3-card.has-view-all .v3-people-container::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 60px;
+  background: linear-gradient(to bottom, transparent, var(--v3-card-bg));
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 0.3s ease;
+}
+
 .v3-view-all-link:hover {
   color: var(--v3-text-color);
 }
@@ -3733,6 +3748,11 @@ h6 {
   background: var(--v3-card-bg);
   color: var(--v3-text-color) !important;
   border-bottom: 0;
+}
+
+.v3-content-main .v3-card,
+.v3-content-sidebar .v3-card {
+  margin-bottom: 1rem;
 }
 
 /* Responsive */

--- a/fossunited/templates/macros/volunteers_card.html
+++ b/fossunited/templates/macros/volunteers_card.html
@@ -3,7 +3,7 @@
 {% set show_view_all = items|length >= 4 %}
 {% set unique_id = type + '_' + range(1000, 9999) | random | string %}
 
-<div class="v3-card">
+<div class="v3-card {% if show_view_all %}has-view-all{% endif %}">
   <div class="v3-section-title">
     <i class="ti ti-{{ 'empathize' if type == 'volunteers' else 'microphone' }}"></i>
     <span>{{ 'Volunteers' if type == 'volunteers' else 'Speakers' }}</span>


### PR DESCRIPTION
misc css

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved spacing and vertical rhythm across V3 grids, cards, and CFP cards; adjusted stacking for heading blocks
  * Refined V3 text styles with explicit heading sizes per text category
  * Added decorative gradient overlay for volunteer cards in "view all" state
  * Tweak to navbar toggler background for V3

* **UI**
  * Banner image now uses a 1:1 aspect ratio; guidance updated to 280×280 for ideal banner dimensions
  * Reduced gaps and tightened header layout for event cards; added an event bio row

* **Behavior**
  * Volunteer card toggles a "view all" presentation when enough items are present
  * Event stats block now shows only when counts are greater than zero
<!-- end of auto-generated comment: release notes by coderabbit.ai -->