### PR TITLE
fix: word wrap text content + show livestream link in about section

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
+++ b/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
@@ -326,7 +326,7 @@
       <div class="v3-card ev-main-card">
         <div class="v3-header">
           <div class="show-mobile-only">{{ event_cover() }}</div>
-          <div style="flex: 1; display: flex; flex-direction: column; gap: 1.2rem;">
+          <div style="flex: 1; display: flex; flex-direction: column; gap: 1.2rem; justify-content: space-between;">
             <!-- Header Info -->
             <div style="display: flex; flex-direction: column;">
               <div style="display: flex; flex-direction: column;">
@@ -398,12 +398,12 @@
               {% else %}
             </div>
             {% endif %}
-
             </div>
 
-            <div class="ev-detail-row">
-              <div class="ev-detail-secondary">{{ doc.event_bio or '' }}</div>
-            </div>
+            <!-- Do we need to make them repeat same content? -->
+            <!-- <div class="ev-detail-row"> -->
+            <!--   <div class="ev-detail-secondary">{{ doc.event_bio or '' }}</div> -->
+            <!-- </div> -->
 
             <!-- Buttons -->
             <div>
@@ -414,8 +414,8 @@
                       target="_blank"
                       class="v3-btn v3-btn-secondary"
                     >
-                      <i class="ti ti-brand-youtube"></i>
-                      <span>Livestream</span>
+                      <i class="ti ti-brand-youtube" style="font-size: 1.1rem;"></i>
+                      <span>Watch</span>
                     </a>
 
                   {% elif status_live %}
@@ -465,6 +465,18 @@
                   <i class="ti ti-info-square"></i>
                   <span>About</span>
                 </div>
+
+                {% if status_live and doc.livestream_link %}
+                <a
+                  href="{{ doc.livestream_link }}"
+                  target="_blank"
+                  class="v3-btn v3-btn-dark mb-3"
+                >
+                  <i class="ti ti-video" style="font-size: 1.1rem;"></i>
+                  <span>Livestream Link</span>
+                </a>
+                {% endif %}
+
                 <div class="v3-text-primary prose" style="font-size: 1rem; line-height: 1.5rem;">
                   {{ doc.event_description }}
                 </div>

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -3127,7 +3127,7 @@ h6 {
 @media (min-width: 52.5rem) {
   .v3-grid {
     display: grid;
-    grid-template-columns: 1fr 20rem;
+    grid-template-columns: 1fr 1fr;
     gap: 2rem; /* 32px */
   }
 }
@@ -3208,37 +3208,50 @@ h6 {
 .v3-text-primary,
 .v3-text-primary * {
   color: var(--v3-text-color) !important;
+  word-break: break-all;
 }
 
 .v3-text-secondary,
 .v3-text-secondary * {
   color: var(--v3-text-color2) !important;
+  word-break: break-all;
 }
 
 .v3-text-tertiary,
 .v3-text-tertiary * {
   color: var(--v3-text-color3) !important;
+  word-break: break-all;
 }
 
 .v3-text-primary h1,
 .v3-text-secondary h1,
-.v3-text-tertiary h1 { font-size: 2rem; }
+.v3-text-tertiary h1 {
+  font-size: 2rem;
+}
 
 .v3-text-primary h2,
 .v3-text-secondary h2,
-.v3-text-tertiary h2 { font-size: 1.8rem; }
+.v3-text-tertiary h2 {
+  font-size: 1.8rem;
+}
 
 .v3-text-primary h3,
 .v3-text-secondary h3,
-.v3-text-tertiary h3 { font-size: 1.5rem; }
+.v3-text-tertiary h3 {
+  font-size: 1.5rem;
+}
 
 .v3-text-primary h4,
 .v3-text-secondary h4,
-.v3-text-tertiary h4 { font-size: 1.3rem; }
+.v3-text-tertiary h4 {
+  font-size: 1.3rem;
+}
 
 .v3-text-primary :is(h5, h6),
 .v3-text-secondary :is(h5, h6),
-.v3-text-tertiary :is(h5, h6) { font-size: 1.1rem; }
+.v3-text-tertiary :is(h5, h6) {
+  font-size: 1.1rem;
+}
 
 /* V3 Section Title */
 .v3-section-title {
@@ -3724,7 +3737,7 @@ h6 {
 }
 
 .v3-card.has-view-all .v3-people-container::after {
-  content: "";
+  content: '';
   position: absolute;
   bottom: 0;
   left: 0;


### PR DESCRIPTION
- we had long line issue with a link which expands the div card
- adjust to word wrap it
- also show live stream link in about section if it exists



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conditional "Livestream Link" button that appears when an event is live

* **Style**
  * Updated header layout spacing and alignment
  * Changed "Livestream" button label to "Watch"
  * Improved text wrapping for long content
  * Adjusted grid layout for better content distribution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->