### PR TITLE
re-use events proposals api to process csv download via frontend

### DIFF
--- a/dashboard/src/components/cfp-public/SubmissionsListView.vue
+++ b/dashboard/src/components/cfp-public/SubmissionsListView.vue
@@ -27,17 +27,29 @@ const submissions = createResource({
   },
   auto: true,
   transform(response) {
-    submissions.proposals = Array.isArray(response.proposals) ? response.proposals : []
-    submissions.originalData = submissions.proposals
-    submissions.customQuestions = Array.isArray(response.custom_questions)
+    // Handle both array and object responses
+    let proposals = []
+
+    if (Array.isArray(response)) {
+      proposals = response
+    } else if (response && Array.isArray(response.proposals)) {
+      proposals = response.proposals
+    }
+
+    // Store metadata
+    submissions.customQuestions = Array.isArray(response?.custom_questions)
       ? response.custom_questions
       : []
-    submissions.eventRoute = response.event_route || ''
-    submissions.eventName = response.event_name || 'submissions'
-    return submissions.proposals
+    submissions.eventRoute = response?.event_route || ''
+    submissions.eventName = response?.event_name || 'submissions'
+
+    // Create a deep copy to avoid reference issues
+    submissions.originalData = JSON.parse(JSON.stringify(proposals))
+
+    return proposals
   },
   onSuccess(data) {
-    if (filters.value) {
+    if (filters.value && Object.keys(filters.value).length > 0) {
       submissions.data = filterSubmissions(data, filters.value)
     }
   },
@@ -74,23 +86,37 @@ const statusOptions = computed(() => {
 const filteredSubmissions = computed(() => {
   const search = searchTitle.value.trim().toLowerCase()
   const status = filteredStatus.value
-  let result = Array.isArray(submissions.originalData) ? [...submissions.originalData] : []
 
-  if (filters.value) {
+  // Ensure we have valid data
+  let result = []
+  if (Array.isArray(submissions.originalData)) {
+    result = [...submissions.originalData]
+  } else {
+    return []
+  }
+
+  // Apply custom filters
+  if (filters.value && Object.keys(filters.value).length > 0) {
     result = filterSubmissions(result, filters.value)
   }
 
+  // Apply status filter
   if (status) {
     result = result.filter((item) => item.status === status)
   }
 
+  // Apply search filter
   if (search) {
-    result = result.filter(({ talk_title, speaker_name, speakers, _speaker }) => {
+    result = result.filter((item) => {
+      const { talk_title, speaker_name, speakers, _speaker } = item
+
       const titleMatch = talk_title?.toLowerCase().includes(search)
+
       const allNames = [
         ...(speaker_name ? [speaker_name.toLowerCase()] : []),
         ...((speakers ?? _speaker)?.map((s) => s?.full_name?.toLowerCase() ?? '') ?? []),
       ]
+
       return titleMatch || allNames.some((n) => n.includes(search))
     })
   }
@@ -108,7 +134,6 @@ function escapeCsv(value) {
 }
 
 function downloadCSV() {
-  const rows = []
   const customQuestions = submissions.customQuestions || []
   const eventRoute = submissions.eventRoute || ''
   const eventName = submissions.eventName || 'submissions'
@@ -128,27 +153,32 @@ function downloadCSV() {
 
   const list = submissions.data || []
 
-  list.forEach((p, i) => {
+  list.forEach((p) => {
     const row = [
-      p.creation,
-      p.session_type,
-      p.talk_title,
+      p.creation || '',
+      p.session_type || '',
+      p.talk_title || '',
       p._speaker?.[0]?.full_name || '',
-      p.status,
+      p.status || '',
       `${baseUrl}/${eventRoute}/cfp/${p.name}`,
-      ...customQuestions.map((q) => p[`custom_question_${q.idx}`] || ''),
+      ...customQuestions.map((q) => {
+        const value = p[`custom_question_${q.idx}`]
+        return value !== undefined && value !== null ? value : ''
+      }),
     ]
 
     csv += row.map(escapeCsv).join(',') + '\n'
   })
 
   const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
   const link = document.createElement('a')
-  link.href = URL.createObjectURL(blob)
+  link.href = url
   link.setAttribute('download', `${eventName}-submissions.csv`)
   document.body.appendChild(link)
   link.click()
   document.body.removeChild(link)
+  URL.revokeObjectURL(url)
 }
 
 watch(
@@ -162,6 +192,7 @@ watch(filteredSubmissions, (val) => {
   submissions.data = val
 })
 </script>
+
 <template>
   <Suspense>
     <div class="flex flex-col gap-4 w-full mb-12">
@@ -184,9 +215,12 @@ watch(filteredSubmissions, (val) => {
           </button>
         </div>
       </div>
-      <SubmissionsList v-model="submissions.data" />
+      <SubmissionsList
+        v-if="submissions.data && submissions.data.length > 0"
+        v-model="submissions.data"
+      />
       <div
-        v-if="submissions.data?.length == 0"
+        v-if="submissions.data?.length === 0"
         class="w-full flex justify-center items-center text-base text-gray-600"
       >
         No proposals found

--- a/dashboard/src/components/cfp-public/SubmissionsListView.vue
+++ b/dashboard/src/components/cfp-public/SubmissionsListView.vue
@@ -19,19 +19,25 @@ const props = defineProps({
 })
 
 const filteredStatus = ref(props.statusFilter)
+
 const submissions = createResource({
   url: 'fossunited.api.proposal.get_event_proposals',
   params: {
     event: props.eventId,
   },
   auto: true,
+  transform(response) {
+    submissions.proposals = response.proposals
+    submissions.originalData = response.proposals
+    submissions.customQuestions = response.custom_questions
+    submissions.eventRoute = response.event_route
+    submissions.eventName = response.event_name
+    return response.proposals
+  },
   onSuccess(data) {
     if (filters.value) {
       submissions.data = filterSubmissions(data, filters.value)
     }
-  },
-  transform(data) {
-    submissions.originalData = data
   },
 })
 
@@ -91,11 +97,46 @@ const filteredSubmissions = computed(() => {
 })
 
 function downloadCSV() {
-  const params = new URLSearchParams()
-  params.append('event', props.eventId)
+  const rows = []
+  const customQuestions = submissions.customQuestions || []
+  const eventRoute = submissions.eventRoute || ''
+  const eventName = submissions.eventName || 'submissions'
+  const baseUrl = window.location.origin
 
-  const url = `/api/method/fossunited.api.proposal.download_proposals_csv?${params.toString()}`
-  window.open(url, '_blank')
+  const headers = [
+    'timestamp',
+    'track',
+    'session_title',
+    'name',
+    'review_status',
+    'link',
+    ...customQuestions.map((q) => q.question),
+  ]
+
+  let csv = headers.join(',') + '\n'
+
+  const list = submissions.data || []
+
+  list.forEach((p) => {
+    const row = [
+      p.creation,
+      p.session_type,
+      p.talk_title,
+      p._speaker?.[0]?.full_name || '',
+      p.status,
+      `${baseUrl}/${eventRoute}/cfp/${p.name}`,
+      ...customQuestions.map((q) => p[`custom_question_${q.idx}`] || ''),
+    ]
+    csv += row.join(',') + '\n'
+  })
+
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+  const link = document.createElement('a')
+  link.href = URL.createObjectURL(blob)
+  link.setAttribute('download', `${eventName}-submissions.csv`)
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
 }
 
 watch(

--- a/dashboard/src/components/cfp-public/SubmissionsListView.vue
+++ b/dashboard/src/components/cfp-public/SubmissionsListView.vue
@@ -27,12 +27,14 @@ const submissions = createResource({
   },
   auto: true,
   transform(response) {
-    submissions.proposals = response.proposals
-    submissions.originalData = response.proposals
-    submissions.customQuestions = response.custom_questions
-    submissions.eventRoute = response.event_route
-    submissions.eventName = response.event_name
-    return response.proposals
+    submissions.proposals = Array.isArray(response.proposals) ? response.proposals : []
+    submissions.originalData = submissions.proposals
+    submissions.customQuestions = Array.isArray(response.custom_questions)
+      ? response.custom_questions
+      : []
+    submissions.eventRoute = response.event_route || ''
+    submissions.eventName = response.event_name || 'submissions'
+    return submissions.proposals
   },
   onSuccess(data) {
     if (filters.value) {
@@ -96,6 +98,15 @@ const filteredSubmissions = computed(() => {
   return result
 })
 
+function escapeCsv(value) {
+  if (value == null) return ''
+  const str = String(value)
+  if (/["\n,]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`
+  }
+  return str
+}
+
 function downloadCSV() {
   const rows = []
   const customQuestions = submissions.customQuestions || []
@@ -107,17 +118,17 @@ function downloadCSV() {
     'timestamp',
     'track',
     'session_title',
-    'name',
+    'speaker',
     'review_status',
     'link',
     ...customQuestions.map((q) => q.question),
   ]
 
-  let csv = headers.join(',') + '\n'
+  let csv = headers.map(escapeCsv).join(',') + '\n'
 
   const list = submissions.data || []
 
-  list.forEach((p) => {
+  list.forEach((p, i) => {
     const row = [
       p.creation,
       p.session_type,
@@ -127,7 +138,8 @@ function downloadCSV() {
       `${baseUrl}/${eventRoute}/cfp/${p.name}`,
       ...customQuestions.map((q) => p[`custom_question_${q.idx}`] || ''),
     ]
-    csv += row.join(',') + '\n'
+
+    csv += row.map(escapeCsv).join(',') + '\n'
   })
 
   const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })

--- a/fossunited/api/proposal.py
+++ b/fossunited/api/proposal.py
@@ -5,9 +5,7 @@ from fossunited.doctype_ids import EVENT, EVENT_CFP, PROPOSAL, SPEAKER
 
 
 @frappe.whitelist(allow_guest=True)
-def get_event_proposals(
-    event: str,
-) -> list:
+def get_event_proposals(event: str) -> dict:
     """
     Get all the proposal submissions for the given event.
 
@@ -17,7 +15,12 @@ def get_event_proposals(
         event (str): The id of the event
 
     Returns:
-        list: proposals of an event
+        dict: {
+            "proposals": list[dict],
+            "custom_questions": list[dict],
+            "event_route": str,
+            "event_name": str,
+        }
     """
     # Get CFP settings in a single query
     cfp = frappe.db.get_value(

--- a/fossunited/api/proposal.py
+++ b/fossunited/api/proposal.py
@@ -1,11 +1,5 @@
-import csv
-import io
-import re
-
 import frappe
 from frappe import qb
-from frappe.utils import get_url
-from frappe.utils.response import as_csv
 
 from fossunited.doctype_ids import EVENT, EVENT_CFP, PROPOSAL, SPEAKER
 
@@ -29,9 +23,11 @@ def get_event_proposals(
     cfp = frappe.db.get_value(
         EVENT_CFP,
         {"event": event},
-        ["anonymise_proposals", "has_public_custom_responses"],
+        ["name", "anonymise_proposals", "has_public_custom_responses"],
         as_dict=True,
     )
+
+    event_route, event_name = frappe.db.get_value(EVENT, event, ["route", "event_name"])
 
     # Use frappe.qb for the main proposals query for better performance
     Proposal = qb.DocType(PROPOSAL)
@@ -94,7 +90,21 @@ def get_event_proposals(
         if cfp.has_public_custom_responses:
             proposal.update(custom_answers_data.get(proposal_name, {}))
 
-    return proposals
+    custom_questions = []
+    if cfp.has_public_custom_responses:
+        custom_questions = frappe.get_all(
+            "FOSS Custom Question",
+            filters={"parenttype": EVENT_CFP, "parent": cfp.name},
+            fields=["idx", "question"],
+            order_by="idx asc",
+        )
+
+    return {
+        "proposals": proposals,
+        "custom_questions": custom_questions,
+        "event_route": event_route,
+        "event_name": event_name,
+    }
 
 
 def _get_bulk_likes_data(proposal_names: list, current_user: str) -> dict:
@@ -274,108 +284,3 @@ def get_public_proposal_filters(
             )
 
     return filter_fields
-
-
-@frappe.whitelist(allow_guest=True)
-def download_proposals_csv(event: str):
-    """
-    CSV export for all proposals from an event.
-    Columns: timestamp, track, session_title, name, review_status, link + dynamic custom questions
-    """
-    if not event:
-        frappe.throw("Event is required")
-
-    event_route, event_name = frappe.db.get_value(EVENT, event, ["route", "event_name"])
-
-    proposals = (
-        frappe.get_all(
-            PROPOSAL,
-            filters={"event": event},
-            fields=["name", "talk_title", "session_type", "status", "creation"],
-            order_by="creation asc",
-        )
-        or []
-    )
-
-    if not proposals:
-        frappe.throw("No proposals found for this event")
-
-    proposal_names = [p["name"] for p in proposals]
-
-    cfp = (
-        frappe.db.get_value(
-            EVENT_CFP,
-            {"event": event},
-            ["name", "anonymise_proposals", "has_public_custom_responses"],
-            as_dict=True,
-        )
-        or {}
-    )
-
-    anonymise = bool(cfp.get("anonymise_proposals"))
-    has_custom = bool(cfp.get("has_public_custom_responses"))
-
-    speakers_map = {}
-    if not anonymise:
-        speakers_map = _get_bulk_speakers_data(proposal_names) or {}
-
-    custom_answers_data = {}
-    if has_custom:
-        custom_answers_data = _get_bulk_custom_answers_data(proposal_names)
-
-        # Fetch actual question labels to use as headers (ordered by idx)
-        custom_questions = frappe.get_all(
-            "FOSS Custom Question",
-            filters={"parenttype": EVENT_CFP, "parent": cfp.name},
-            fields=["idx", "question"],
-            order_by="idx asc",
-        )
-    else:
-        custom_questions = []
-
-    output = io.StringIO()
-    writer = csv.writer(output, quoting=csv.QUOTE_MINIMAL, lineterminator="\r\n")
-
-    header = [
-        "timestamp",
-        "track",
-        "session_title",
-        "name",
-        "review_status",
-        "link",
-    ]
-
-    header.extend([q["question"] for q in custom_questions])
-    writer.writerow(header)
-
-    for p in proposals:
-        name = p.get("name")
-        creation = p.get("creation") or ""
-        track = p.get("session_type") or ""
-        title = p.get("talk_title") or ""
-        status = p.get("status") or ""
-
-        speaker_name = ""
-        if not anonymise and speakers_map.get(name):
-            first_sp = speakers_map[name][0]
-            speaker_name = first_sp.get("full_name") or ""
-
-        link = get_url(f"{event_route}/cfp/{p.name}")
-
-        row = [creation, track, title, speaker_name, status, link]
-
-        if has_custom and custom_questions:
-            answers = custom_answers_data.get(name, {})
-            for q in custom_questions:
-                key = f"custom_question_{q['idx']}"
-                row.append(answers.get(key, ""))
-
-        writer.writerow(row)
-
-    safe_event = re.sub(r"[^A-Za-z0-9_-]+", "_", str(event_name))
-    filename = f"{safe_event}-submissions"
-
-    frappe.response["doctype"] = filename
-    frappe.response["filename"] = f"{filename}.csv"
-    frappe.response["result"] = "\ufeff" + output.getvalue()
-    return as_csv()


### PR DESCRIPTION
- better method for #1270 

We can re-use the prev function to build csv via frontend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSV export rebuilt on the client: includes dynamic custom questions and uses event-based filenames.

* **Improvements**
  * Robust CSV escaping for quotes, newlines and commas to preserve field integrity.
  * Submissions list now renders only when data exists; filtering is re-applied only when active for more reliable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->