### PR TITLE
locally retain comment review text to have it accessible

### DIFF
--- a/dashboard/src/components/reviewers/ReviewCommentBox.vue
+++ b/dashboard/src/components/reviewers/ReviewCommentBox.vue
@@ -25,6 +25,7 @@ import { ref, inject } from 'vue'
 import CommentBox from '@/components/ui/CommentBox.vue'
 import { toast } from 'vue-sonner'
 import { filter } from 'lodash'
+import { useStorage } from '@vueuse/core'
 
 const emits = defineEmits(['add:review', 'update:review'])
 
@@ -48,8 +49,8 @@ const props = defineProps({
   },
 })
 
-const review = ref(props.review.to_approve)
-const remarks = ref(props.review.remarks)
+const review = useStorage(`review-${props.submissionId}`, props.review.to_approve)
+const remarks = useStorage(`remarks-${props.submissionId}`, props.review.remarks)
 
 const reviewOptions = [
   { label: 'Approve', value: 'Yes' },


### PR DESCRIPTION
- closes #968
- retains the text value even after reload or Shift+R refresh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Review comments and remarks now persist when navigating away from submissions, ensuring your input is retained across sessions without requiring manual saves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->