### PR TITLE
Web accessibility

### DIFF
--- a/dashboard/src/components/form/RenderField.vue
+++ b/dashboard/src/components/form/RenderField.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div role="group" :aria-labelledby="`${field.fieldname}-label`">
     <component
       :is="getComponent"
       v-model="fields[getFieldIndex(field.fieldname)]['value']"
@@ -10,7 +10,23 @@
       :options="field.options || []"
       :description="field.description"
       size="md"
+      :aria-required="field.required"
+      :aria-describedby="field.description ? `${field.fieldname}-description` : undefined"
+      :aria-invalid="hasError ? 'true' : 'false'"
+      :aria-errormessage="hasError ? `${field.fieldname}-error` : undefined"
     ></component>
+    <!-- hidden label for screen readers -->
+    <label v-if="!field.label" :id="`${field.fieldname}-label`" class="sr-only">
+      {{ field.fieldname }}
+    </label>
+    <!-- description for screen readers -->
+    <span v-if="field.description" :id="`${field.fieldname}-description`" class="sr-only">
+      {{ field.description }}
+    </span>
+    <!-- error message -->
+    <span v-if="hasError" :id="`${field.fieldname}-error`" class="sr-only" role="alert">
+      {{ errorMessage }}
+    </span>
   </div>
 </template>
 <script setup>

--- a/dashboard/src/components/form/RenderField.vue
+++ b/dashboard/src/components/form/RenderField.vue
@@ -12,21 +12,11 @@
       size="md"
       :aria-required="field.required"
       :aria-describedby="field.description ? `${field.fieldname}-description` : undefined"
-      :aria-invalid="hasError ? 'true' : 'false'"
-      :aria-errormessage="hasError ? `${field.fieldname}-error` : undefined"
     ></component>
     <!-- hidden label for screen readers -->
     <label v-if="!field.label" :id="`${field.fieldname}-label`" class="sr-only">
       {{ field.fieldname }}
     </label>
-    <!-- description for screen readers -->
-    <span v-if="field.description" :id="`${field.fieldname}-description`" class="sr-only">
-      {{ field.description }}
-    </span>
-    <!-- error message -->
-    <span v-if="hasError" :id="`${field.fieldname}-error`" class="sr-only" role="alert">
-      {{ errorMessage }}
-    </span>
   </div>
 </template>
 <script setup>

--- a/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
+++ b/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
@@ -62,7 +62,6 @@
       src="{{ doc.banner_image or '/assets/fossunited/images/defaults/event_logo.png' }}"
       alt="{{ doc.event_name }} event banner"
       class="v3-banner"
-      role="img"
     />
 
     {% if event_stats and (event_stats.attending > 0 or event_stats.proposals > 0) %}
@@ -349,7 +348,6 @@
                   <img
                     src="/assets/fossunited/images/chapter/fossclub_logo.svg"
                     alt="FOSS Club Logo"
-                    role="img"
                   />
                   <span>{{ chapter.chapter_name | truncate(22, True, '...', 0) }}</span>
                   {% else %}

--- a/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
+++ b/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
@@ -376,7 +376,7 @@
             <!-- Date/Time/Location -->
             <div style="margin-top: 3px;">
               <div class="ev-detail-row">
-                <button
+                <div
                   class="ev-icon"
                   onclick="downloadEventIcs()"
                   type="button"
@@ -384,7 +384,7 @@
                   title="Download to calendar"
                 >
                   <i class="ti ti-calendar-plus" aria-hidden="true"></i>
-                </button>
+                </div>
                 <div class="ev-detail-text">
                   <div class="ev-detail-primary">
                     {% if doc.event_start_date.strftime("%Y-%m-%d") != doc.event_end_date.strftime("%Y-%m-%d") %}

--- a/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
+++ b/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
@@ -22,10 +22,14 @@
   <div
     class="v3-clickable cfp-card-v3"
     onclick="window.location.href='/{{ cfp_status_block.form_route | e }}'"
+    role="button"
+    tabindex="0"
+    aria-label="Call for Proposals - {{ badge_text }}"
+    onkeypress="if(event.key==='Enter'||event.key===' ')window.location.href='/{{ cfp_status_block.form_route | e }}'"
   >
     <div class="ev-cfp-header">
       <div class="ev-cfp-title">Call for Proposals</div>
-      <div class="ev-live {{ badge_class }}">
+      <div class="ev-live {{ badge_class }}" role="status" aria-live="polite">
         {{ badge_icon | safe }}
         <span class="ev-live-text">{{ badge_text }}</span>
       </div>
@@ -46,7 +50,7 @@
           <strong>{{ cfp_status_block.deadline }}</strong>
       {% endif %}
         </div>
-      <i class="ti ti-arrow-right"></i>
+      <i class="ti ti-arrow-right" aria-hidden="true"></i>
     </div>
   </div>
 {% endmacro %}
@@ -56,17 +60,18 @@
   <div class="v3-banner-wrap">
     <img
       src="{{ doc.banner_image or '/assets/fossunited/images/defaults/event_logo.png' }}"
-      alt="{{ doc.event_name }}"
+      alt="{{ doc.event_name }} event banner"
       class="v3-banner"
+      role="img"
     />
 
     {% if event_stats and (event_stats.attending > 0 or event_stats.proposals > 0) %}
-      <div class="ev-stats">
+      <div class="ev-stats" role="region" aria-label="Event statistics">
         {% if event_stats.attending > 0 %}
           <span>{{ event_stats.attending }} Attend{{ "ing" if status_live else "ed" }}</span>
         {% endif %}
         {% if event_stats.attending > 0 and event_stats.proposals > 0 %}
-          <span>•</span>
+          <span aria-hidden="true">•</span>
         {% endif %}
         {% if event_stats.proposals > 0 %}
           <span>{{ event_stats.proposals }} Proposals</span>
@@ -75,8 +80,8 @@
     {% endif %}
 
     {% if user_has_registered %}
-      <div class="ev-registered">
-        <i class="ti ti-discount-check-filled"></i>
+      <div class="ev-registered" role="status" aria-live="polite">
+        <i class="ti ti-discount-check-filled" aria-hidden="true"></i>
         You've Registered for this Event
       </div>
     {% endif %}
@@ -310,14 +315,19 @@
   <div class="v3-page ev-page">
     <div class="v3-container">
       <div class="d-flex justify-content-between align-items-center">
-        <div class="v3-breadcrumb">
+        <nav class="v3-breadcrumb" aria-label="Breadcrumb navigation">
           <a href="/">Home</a> > <a href="/events/timeline">Events</a> >
-          <a href="">{{ doc.event_name }}</a>
-        </div>
+          <a href="" aria-current="page">{{ doc.event_name }}</a>
+        </nav>
 
         <div>
-          <button class="v3-theme-toggle" id="theme-toggle" title="Toggle theme">
-            <i class="ti ti-moon"></i>
+          <button
+            class="v3-theme-toggle"
+            id="theme-toggle"
+            title="Toggle theme"
+            aria-label="Toggle dark/light theme"
+          >
+            <i class="ti ti-moon" aria-hidden="true"></i>
           </button>
         </div>
       </div>
@@ -333,9 +343,14 @@
                 <a
                   href="/{{ chapter.route }}"
                   class="chapter-brand-block {% if chapter.chapter_type == 'FOSS Club' %}club-brand{% endif %}"
+                  aria-label="{{ chapter.chapter_name }} chapter page"
                 >
                   {% if chapter.chapter_type == 'FOSS Club' %}
-                  <img src="/assets/fossunited/images/chapter/fossclub_logo.svg" alt="FOSS Club Logo" />
+                  <img
+                    src="/assets/fossunited/images/chapter/fossclub_logo.svg"
+                    alt="FOSS Club Logo"
+                    role="img"
+                  />
                   <span>{{ chapter.chapter_name | truncate(22, True, '...', 0) }}</span>
                   {% else %}
                   <span class="no-font-inherit fff-forward">
@@ -346,15 +361,15 @@
 
 
                 <h1 class="ev-title">{{ doc.event_name }}</h1>
-                <div class="ev-tags">
+                <div class="ev-tags" role="list" aria-label="Event tags">
                   {% if doc.must_attend %}
-                    <div class="ev-tag ev-tag-must">
-                      <i class="ti ti-star-filled"></i>
+                    <div class="ev-tag ev-tag-must" role="listitem">
+                      <i class="ti ti-star-filled" aria-hidden="true"></i>
                       Must Attend
                     </div>
                   {% endif %}
                   {% if doc.event_type %}
-                    <div class="ev-tag ev-tag-cat">{{ doc.event_type }}</div>
+                    <div class="ev-tag ev-tag-cat" role="listitem">{{ doc.event_type }}</div>
                   {% endif %}
                 </div>
               </div>
@@ -363,14 +378,14 @@
             <!-- Date/Time/Location -->
             <div style="margin-top: 3px;">
               <div class="ev-detail-row">
-                <div class="ev-icon">
-                  <i
-                    class="ti ti-calendar-plus"
-                    style="cursor: pointer;"
-                    onclick="downloadEventIcs()"
-                    title="Download to calendar"
-                  ></i>
-                </div>
+                <button
+                  class="ev-icon"
+                  onclick="downloadEventIcs()"
+                  aria-label="Add event to calendar"
+                  title="Download to calendar"
+                >
+                  <i class="ti ti-calendar-plus" aria-hidden="true"></i>
+                </button>
                 <div class="ev-detail-text">
                   <div class="ev-detail-primary">
                     {% if doc.event_start_date.strftime("%Y-%m-%d") != doc.event_end_date.strftime("%Y-%m-%d") %}
@@ -380,18 +395,27 @@
                     {% endif %}
                   </div>
                   <div class="ev-detail-secondary">
-                    {{ doc.event_start_date.strftime("%-I:%M %p") }} -
-                    {{ doc.event_end_date.strftime("%-I:%M %p") }}
+                    <time datetime="{{ doc.event_start_date.isoformat() }}">
+                      {{ doc.event_start_date.strftime("%-I:%M %p") }}
+                    </time>
+                     -
+                    <time datetime="{{ doc.event_end_date.isoformat() }}">
+                      {{ doc.event_end_date.strftime("%-I:%M %p") }}
+                    </time>
                   </div>
                 </div>
               </div>
 
               {% if doc.map_link %}
-              <a href="{{ doc.map_link }}" class="ev-detail-row ev-detail-link">
+              <a
+                href="{{ doc.map_link }}"
+                class="ev-detail-row ev-detail-link"
+                aria-label="View {{ doc.event_location or 'event location' }} on map"
+              >
                 {% else %}
                 <div class="ev-detail-row">
                   {% endif %}
-                  <div class="ev-icon"><i class="ti ti-map-pin"></i></div>
+                  <div class="ev-icon" aria-hidden="true"><i class="ti ti-map-pin"></i></div>
                   <div class="ev-detail-secondary">{{ doc.event_location or 'Location TBD' }}</div>
                   {% if doc.map_link %}
               </a>
@@ -404,17 +428,18 @@
             <!-- <div class="ev-detail-row"> -->
             <!--   <div class="ev-detail-secondary">{{ doc.event_bio or '' }}</div> -->
             <!-- </div> -->
-
             <!-- Buttons -->
             <div>
-              <div class="v3-btn-group">
+              <div class="v3-btn-group" role="group" aria-label="Event actions">
                   {% if status_concluded and doc.livestream_embed_link %}
                     <a
                       href="{{ doc.livestream_embed_link }}"
                       target="_blank"
+                      rel="noopener noreferrer"
                       class="v3-btn v3-btn-secondary"
+                      aria-label="Watch event recording on YouTube"
                     >
-                      <i class="ti ti-brand-youtube" style="font-size: 1.1rem;"></i>
+                      <i class="ti ti-brand-youtube" style="font-size: 1.1rem;" aria-hidden="true"></i>
                       <span>Watch</span>
                     </a>
 
@@ -423,16 +448,25 @@
                       <a
                         href="/dashboard/buy-tickets?event={{ doc.name }}"
                         class="v3-btn v3-btn-primary"
+                        aria-label="Buy ticket for {{ doc.event_name }}"
                       >
                         Buy Ticket
                       </a>
                     {% elif doc.show_rsvp %}
                       {% if user_has_registered %}
-                        <a href="/{{ rsvp_status_block.form_route }}" class="v3-btn v3-btn-primary">
+                        <a
+                          href="/{{ rsvp_status_block.form_route }}"
+                          class="v3-btn v3-btn-primary"
+                          aria-label="Edit your RSVP for this event"
+                        >
                           Edit RSVP
                         </a>
                       {% else %}
-                        <a href="/{{ rsvp_status_block.form_route }}" class="v3-btn v3-btn-primary">
+                        <a
+                          href="/{{ rsvp_status_block.form_route }}"
+                          class="v3-btn v3-btn-primary"
+                          aria-label="Register for {{ doc.event_name }}"
+                        >
                           Register
                         </a>
                       {% endif %}
@@ -440,9 +474,13 @@
                   {% endif %}
 
                   {% if doc.show_cfp and cfp_status_block.has_doc %}
-                    <a href="{{ all_cfp_link }}" class="v3-btn v3-btn-secondary">
+                    <a
+                      href="{{ all_cfp_link }}"
+                      class="v3-btn v3-btn-secondary"
+                      aria-label="View all talk proposals"
+                    >
                       TALK PROPOSALS
-                      <i class="ti ti-arrow-up-right"></i>
+                      <i class="ti ti-arrow-up-right" aria-hidden="true"></i>
                     </a>
                   {% endif %}
                 </div>
@@ -457,22 +495,24 @@
         <!-- Content Grid -->
         <div class="v3-grid">
           <!-- Main Column -->
-          <div class="v3-content-main">
+          <main class="v3-content-main">
             <!-- About -->
             {% if doc.event_description %}
-              <div class="v3-card ev-about-section">
-                <div class="v3-section-title">
-                  <i class="ti ti-info-square"></i>
+              <section class="v3-card ev-about-section" aria-labelledby="about-heading">
+                <h2 class="v3-section-title" id="about-heading">
+                  <i class="ti ti-info-square" aria-hidden="true"></i>
                   <span>About</span>
-                </div>
+                </h2>
 
                 {% if status_live and doc.livestream_link %}
                 <a
                   href="{{ doc.livestream_link }}"
                   target="_blank"
+                  rel="noopener noreferrer"
                   class="v3-btn v3-btn-dark mb-3"
+                  aria-label="Join livestream"
                 >
-                  <i class="ti ti-video" style="font-size: 1.1rem;"></i>
+                  <i class="ti ti-video" style="font-size: 1.1rem;" aria-hidden="true"></i>
                   <span>Livestream Link</span>
                 </a>
                 {% endif %}
@@ -480,7 +520,7 @@
                 <div class="v3-text-primary prose" style="font-size: 1rem; line-height: 1.5rem;">
                   {{ doc.event_description }}
                 </div>
-              </div>
+              </section>
             {% endif %}
 
             <!-- CFP Card (Mobile) -->
@@ -490,19 +530,23 @@
 
             <!-- Schedule -->
             {% if doc.show_schedule and schedule_data %}
-              <div class="ev-agenda-section">{{ agenda_card(schedule_data, doc.route, 10) }}</div>
+              <section class="ev-agenda-section" aria-labelledby="schedule-heading">
+                <h2 id="schedule-heading" class="sr-only">Event Schedule</h2>
+                {{ agenda_card(schedule_data, doc.route, 10) }}
+              </section>
             {% endif %}
 
             <!-- Sponsors -->
             {% if sponsors_dict %}
-              <div class="ev-sponsors-section">
+              <section class="ev-sponsors-section" aria-labelledby="sponsors-heading">
+                <h2 id="sponsors-heading" class="sr-only">Event Sponsors</h2>
                 {{ sponsor_card(sponsors_dict, doc.deck_link) }}
-              </div>
+              </section>
             {% endif %}
-          </div>
+          </main>
 
           <!-- Sidebar -->
-          <div class="v3-content-sidebar">
+          <div class="v3-content-sidebar" aria-label="Event information sidebar">
             <!-- CFP Card (Desktop) -->
             {% if doc.show_cfp and cfp_status_block.has_doc %}
               <div class="show-desktop-only">{{ cfp_block(cfp_status_block, doc) }}</div>
@@ -510,41 +554,64 @@
 
             <!-- Speakers -->
             {% if doc.show_speakers and speakers %}
-              <div class="ev-speakers-section">
+              <section class="ev-speakers-section" aria-labelledby="speakers-heading">
+                <h2 id="speakers-heading" class="sr-only">Event Speakers</h2>
                 {{ people_card(speakers, 'speakers', submissions) }}
-              </div>
+              </section>
             {% endif %}
 
             <!-- Volunteers -->
             {% if volunteers %}
-              <div class="ev-volunteers-section">{{ people_card(volunteers, 'volunteers') }}</div>
+              <section class="ev-volunteers-section" aria-labelledby="volunteers-heading">
+                <h2 id="volunteers-heading" class="sr-only">Event Volunteers</h2>
+                {{ people_card(volunteers, 'volunteers') }}
+              </section>
             {% endif %}
 
             <!-- Contact -->
-            <div class="v3-card ev-contact">
+            <section class="v3-card ev-contact" aria-labelledby="contact-heading">
+              <h2 id="contact-heading" class="sr-only">Contact Information</h2>
               {% if chapter.email %}
               <div class="d-flex align-items-center pb-2">
-                <i class="ti ti-mail"></i>
+                <i class="ti ti-mail" aria-hidden="true"></i>
                 <div class="ev-contact-email">
-                  <a href="mailto:{{ chapter.email }}">{{ chapter.email }}</a>
+                  <a
+                    href="mailto:{{ chapter.email }}"
+                    aria-label="Email {{ chapter.email }}"
+                  >
+                    {{ chapter.email }}
+                  </a>
                 </div>
               </div>
               {% endif %}
 
-              <div class="header-section--socials-event">
+              <nav class="header-section--socials-event" aria-label="Social media links">
                 {% for (k,v) in social_links.items() %}
-                <a href="{{ v }}" aria-label="{{ k|title }} for {{ doc.chapter_name }} chapter.">
-                  <img src="https://svgl.app/library/{{ k }}.svg" alt="{{ k|title }}" />
+                <a
+                  href="{{ v }}"
+                  aria-label="{{ k|title }} page for {{ doc.chapter_name }} chapter"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <img
+                    src="https://svgl.app/library/{{ k }}.svg"
+                    alt=""
+                    aria-hidden="true"
+                  />
                 </a>
                 {% endfor %}
-              </div>
-            </div>
+              </nav>
+            </section>
 
-            <!-- TODO -->
+            <!-- Map -->
             {% if doc.map_link %}
               <div
                 class="v3-clickable ev-map-section"
                 onclick="window.open('{{ doc.map_link | e }}', '_blank')"
+                role="button"
+                tabindex="0"
+                aria-label="Open location in map"
+                onkeypress="if(event.key==='Enter'||event.key===' ')window.open('{{ doc.map_link | e }}', '_blank')"
               >
                 <!-- <img -->
                 <!--   src="https://via.placeholder.com/396x81" -->

--- a/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
+++ b/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
@@ -381,6 +381,7 @@
                 <button
                   class="ev-icon"
                   onclick="downloadEventIcs()"
+                  type="button"
                   aria-label="Add event to calendar"
                   title="Download to calendar"
                 >

--- a/fossunited/fossunited/doctype/grants_funding_directory/templates/grants_funding_directory.html
+++ b/fossunited/fossunited/doctype/grants_funding_directory/templates/grants_funding_directory.html
@@ -26,10 +26,10 @@
     <div class="v3-container">
       <!-- Breadcrumb -->
       <div class="d-flex justify-content-between align-items-center">
-        <div class="v3-breadcrumb">
+        <nav class="v3-breadcrumb">
           <a href="/">Home</a> > <a href="/grants/">Grants</a> >
           <a href="/grants/directory">Directory</a> > <a href="">{{ entity.name }}</a>
-        </div>
+        </nav>
         <div>
           <button class="v3-theme-toggle" id="theme-toggle" title="Toggle theme">
             <i class="ti ti-moon"></i>

--- a/fossunited/fossunited/web_template/first_commit/first_commit.html
+++ b/fossunited/fossunited/web_template/first_commit/first_commit.html
@@ -194,7 +194,7 @@
   <div class="v3-page">
     <div class="v3-container">
       <div class="d-flex justify-content-between align-items-center">
-        <div class="v3-breadcrumb"><a href="/">Home</a> > First-commit</div>
+        <nav class="v3-breadcrumb"><a href="/">Home</a> > First-commit</nav>
           <button class="v3-theme-toggle" id="theme-toggle" title="Toggle theme">
             <i class="ti ti-moon"></i>
           </button>

--- a/fossunited/fossunited/web_template/volunteers_page/volunteers_page.html
+++ b/fossunited/fossunited/web_template/volunteers_page/volunteers_page.html
@@ -261,7 +261,7 @@
     <div class="v3-container">
       <div class="d-flex justify-content-between align-items-center">
 
-        <div class="v3-breadcrumb"><a href="/">Home</a> > <a href="">Volunteers</a></div>
+        <nav class="v3-breadcrumb"><a href="/">Home</a> > <a href="">Volunteers</a></nav>
         <button class="v3-theme-toggle" id="theme-toggle" title="Toggle theme">
           <i class="ti ti-moon"></i>
         </button>

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -3033,6 +3033,18 @@ h6 {
   }
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
 /* ============================================
    V3 Design Language Styles
    ============================================ */

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -3369,6 +3369,10 @@ h6 {
   margin: 1rem 0;
 }
 
+.v3-breadcrumb a:hover {
+  text-decoration: underline;
+}
+
 .v3-main-card {
   width: 100%;
   max-width: 840px;
@@ -3806,11 +3810,7 @@ h6 {
 }
 
 .v3-gradient-text {
-  background: linear-gradient(
-    135deg,
-    var(--v3-primary-button),
-    var(--v3-dark-green)
-  );
+  background: linear-gradient(135deg, var(--v3-primary-button), var(--v3-dark-green));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;

--- a/fossunited/templates/macros/renderfield.html
+++ b/fossunited/templates/macros/renderfield.html
@@ -1,5 +1,5 @@
 {% macro renderfield(field, submission = None) %}
-  <div class="my-4 py-1" role="group" aria-labelledby="{{ field.fieldname }}-label">
+<div class="my-4 py-1" role="group" {% if field.fieldtype != 'Table' %}aria-labelledby="{{ field.fieldname }}-label"{% endif %}>
     {% if field.fieldtype == 'Table' %}
       {% from "fossunited/templates/macros/custom_question.html" import CustomQuestion %}
       {% if frappe.form_dict.get('cfp') %}
@@ -18,7 +18,6 @@
         class="foss-form-question text-sm"
       >
         {{ field.label }}
-        {% if field.reqd %}<span aria-label="required">*</span>{% endif %}
       </label>
       <input
         name="{{ field.fieldname }}"
@@ -29,9 +28,7 @@
         id="{{ field.fieldname }}"
         value="{{ submission[field.fieldname] or field.value or '' }}"
         {% if field.read_only %}readonly aria-readonly="true"{% endif %}
-        {% if field.reqd %}required aria-required="true"{% endif %}
         {% if field.description %}aria-describedby="{{ field.fieldname }}-description"{% endif %}
-        aria-invalid="false"
       />
     {% elif field.fieldtype == 'Select' %}
       <div class="d-flex flex-column">
@@ -41,7 +38,6 @@
           class="foss-form-question text-sm"
         >
           {{ field.label }}
-          {% if field.reqd %}<span aria-label="required">*</span>{% endif %}
         </label>
         <select
           data-label="{{ field.label }}"
@@ -49,9 +45,7 @@
           name="{{ field.fieldname }}"
           id="{{ field.fieldname }}"
           class="form-select form-control custom-select text-sm rounded-input w-100 px-3 py-1"
-          {% if field.reqd %}required aria-required="true"{% endif %}
           {% if field.description %}aria-describedby="{{ field.fieldname }}-description"{% endif %}
-          aria-invalid="false"
         >
           {% set field_value = field.get('value') if field else '' %}
           {% set submission_value = submission.get(field.fieldname) if submission else '' %}
@@ -76,10 +70,8 @@
           type="checkbox"
           class="form-control form-check-input text-sm"
           id="{{ field.fieldname }}"
-          {% if field.reqd %}required aria-required="true"{% endif %}
           {% if field.value == '1' or submission[field.fieldname] == 1 %}checked{% endif %}
           {% if field.description %}aria-describedby="{{ field.fieldname }}-description"{% endif %}
-          aria-invalid="false"
         />
         <label
           class="form-check-label foss-form-question text-sm m-2"
@@ -87,7 +79,6 @@
           id="{{ field.fieldname }}-label"
         >
           {{ field.label }}
-          {% if field.reqd %}<span aria-label="required">*</span>{% endif %}
         </label>
       </div>
     {% elif field.fieldtype == 'Text Editor' %}
@@ -97,7 +88,6 @@
         class="foss-form-question text-sm mb-2"
       >
         {{ field.label }}
-        {% if field.reqd %}<span aria-label="required">*</span>{% endif %}
       </label>
       <div
         data-label="{{ field.label }}"
@@ -108,9 +98,7 @@
         type="text-editor"
         role="textbox"
         aria-multiline="true"
-        {% if field.reqd %}required aria-required="true"{% endif %}
         {% if field.description %}aria-describedby="{{ field.fieldname }}-description"{% endif %}
-        aria-invalid="false"
         aria-labelledby="{{ field.fieldname }}-label"
       >
         {{ submission[field.fieldname] or field.value or '' }}
@@ -122,7 +110,6 @@
         class="foss-form-question text-sm"
       >
         {{ field.label }}
-        {% if field.reqd %}<span aria-label="required">*</span>{% endif %}
       </label>
       <input
         data-label="{{ field.label }}"
@@ -132,9 +119,7 @@
         class="form-control text-sm rounded-input"
         id="{{ field.fieldname }}"
         value="{{ submission[field.fieldname] or field.value or '' }}"
-        {% if field.reqd %}required aria-required="true"{% endif %}
         {% if field.description %}aria-describedby="{{ field.fieldname }}-description"{% endif %}
-        aria-invalid="false"
       />
     {% elif field.fieldtype == 'Small Text' %}
       <label
@@ -143,7 +128,6 @@
         class="foss-form-question text-sm"
       >
         {{ field.label }}
-        {% if field.reqd %}<span aria-label="required">*</span>{% endif %}
       </label>
       <textarea
         data-label="{{ field.label }}"
@@ -152,9 +136,7 @@
         class="form-control text-sm rounded-input"
         id="{{ field.fieldname }}"
         rows="3"
-        {% if field.reqd %}required aria-required="true"{% endif %}
         {% if field.description %}aria-describedby="{{ field.fieldname }}-description"{% endif %}
-        aria-invalid="false"
       >{{ submission[field.fieldname] or field.value or '' }}</textarea>
     {% elif field.fieldtype == 'Long Text' %}
       <label
@@ -163,7 +145,6 @@
         class="foss-form-question text-sm"
       >
         {{ field.label }}
-        {% if field.reqd %}<span aria-label="required">*</span>{% endif %}
       </label>
       <textarea
         data-label="{{ field.label }}"
@@ -172,9 +153,7 @@
         class="form-control text-sm rounded-input"
         id="{{ field.fieldname }}"
         rows="6"
-        {% if field.reqd %}required aria-required="true"{% endif %}
         {% if field.description %}aria-describedby="{{ field.fieldname }}-description"{% endif %}
-        aria-invalid="false"
       >{{ submission[field.fieldname] or field.value or '' }}</textarea>
     {% elif field.fieldtype == 'Date' %}
       <label
@@ -183,7 +162,6 @@
         class="foss-form-question text-sm"
       >
         {{ field.label }}
-        {% if field.reqd %}<span aria-label="required">*</span>{% endif %}
       </label>
       <input
         data-label="{{ field.label }}"
@@ -192,9 +170,7 @@
         class="form-control text-sm rounded-input"
         id="{{ field.fieldname }}"
         value="{{ submission[field.fieldname] }}"
-        {% if field.reqd %}required aria-required="true"{% endif %}
         {% if field.description %}aria-describedby="{{ field.fieldname }}-description"{% endif %}
-        aria-invalid="false"
       />
     {% elif field.fieldtype == 'Time' %}
       <label
@@ -203,7 +179,6 @@
         class="foss-form-question text-sm"
       >
         {{ field.label }}
-        {% if field.reqd %}<span aria-label="required">*</span>{% endif %}
       </label>
       <input
         data-label="{{ field.label }}"
@@ -212,9 +187,7 @@
         class="form-control text-sm rounded-input"
         id="{{ field.fieldname }}"
         value="{{ submission[field.fieldname] }}"
-        {% if field.reqd %}required aria-required="true"{% endif %}
         {% if field.description %}aria-describedby="{{ field.fieldname }}-description"{% endif %}
-        aria-invalid="false"
       />
     {% elif field.fieldtype == 'Datetime' %}
       <label
@@ -223,7 +196,6 @@
         class="foss-form-question text-sm"
       >
         {{ field.label }}
-        {% if field.reqd %}<span aria-label="required">*</span>{% endif %}
       </label>
       <input
         data-label="{{ field.label }}"
@@ -232,9 +204,7 @@
         class="form-control text-sm rounded-input"
         id="{{ field.fieldname }}"
         value="{{ submission[field.fieldname] }}"
-        {% if field.reqd %}required aria-required="true"{% endif %}
         {% if field.description %}aria-describedby="{{ field.fieldname }}-description"{% endif %}
-        aria-invalid="false"
       />
     {% elif field.fieldtype == 'Link' %}
       <label
@@ -243,7 +213,6 @@
         class="foss-form-question text-sm"
       >
         {{ field.label }}
-        {% if field.reqd %}<span aria-label="required">*</span>{% endif %}
       </label>
       <input
         data-label="{{ field.label }}"
@@ -252,9 +221,7 @@
         class="form-control text-sm rounded-input"
         id="{{ field.fieldname }}"
         value="{{ submission[field.fieldname] }}"
-        {% if field.reqd %}required aria-required="true"{% endif %}
         {% if field.description %}aria-describedby="{{ field.fieldname }}-description"{% endif %}
-        aria-invalid="false"
         inputmode="url"
       />
     {% elif field.fieldtype == 'Currency' %}
@@ -264,7 +231,6 @@
         class="foss-form-question text-sm"
       >
         {{ field.label }}
-        {% if field.reqd %}<span aria-label="required">*</span>{% endif %}
       </label>
       <input
         data-label="{{ field.label }}"
@@ -273,9 +239,7 @@
         class="form-control text-sm rounded-input"
         id="{{ field.fieldname }}"
         value="{{ submission[field.fieldname] }}"
-        {% if field.reqd %}required aria-required="true"{% endif %}
         {% if field.description %}aria-describedby="{{ field.fieldname }}-description"{% endif %}
-        aria-invalid="false"
         inputmode="numeric"
       />
     {% endif %}
@@ -325,7 +289,8 @@
       }
 
       // Add accessible labels to toolbar buttons
-      var toolbar = document.querySelector('#{{ field.fieldname }}').previousSibling;
+      var editorContainer = document.querySelector('#{{ field.fieldname }}').parentElement;
+      var toolbar = editorContainer ? editorContainer.querySelector('.ql-toolbar') : null;
       if (toolbar && toolbar.classList.contains('ql-toolbar')) {
         // Add aria-label to toolbar
         toolbar.setAttribute('role', 'toolbar');

--- a/fossunited/templates/macros/renderfield.html
+++ b/fossunited/templates/macros/renderfield.html
@@ -1,5 +1,5 @@
 {% macro renderfield(field, submission = None) %}
-  <div class="my-4 py-1">
+  <div class="my-4 py-1" role="group" aria-labelledby="{{ field.fieldname }}-label">
     {% if field.fieldtype == 'Table' %}
       {% from "fossunited/templates/macros/custom_question.html" import CustomQuestion %}
       {% if frappe.form_dict.get('cfp') %}
@@ -12,9 +12,14 @@
         {% endfor %}
       {% endif %}
     {% elif field.fieldtype == 'Data' %}
-      <label for="{{ field.fieldname }}" class="foss-form-question text-sm"
-        >{{ field.label }}</label
+      <label
+        for="{{ field.fieldname }}"
+        id="{{ field.fieldname }}-label"
+        class="foss-form-question text-sm"
       >
+        {{ field.label }}
+        {% if field.reqd %}<span aria-label="required">*</span>{% endif %}
+      </label>
       <input
         name="{{ field.fieldname }}"
         data-label="{{ field.label }}"
@@ -23,21 +28,30 @@
         class="form-control text-sm rounded-input"
         id="{{ field.fieldname }}"
         value="{{ submission[field.fieldname] or field.value or '' }}"
-        {% if field.read_only %}readonly{% endif %}
-        {% if field.reqd %}required{% endif %}
+        {% if field.read_only %}readonly aria-readonly="true"{% endif %}
+        {% if field.reqd %}required aria-required="true"{% endif %}
+        {% if field.description %}aria-describedby="{{ field.fieldname }}-description"{% endif %}
+        aria-invalid="false"
       />
     {% elif field.fieldtype == 'Select' %}
       <div class="d-flex flex-column">
-        <label for="{{ field.fieldname }}" class="foss-form-question text-sm"
-          >{{ field.label }}</label
+        <label
+          for="{{ field.fieldname }}"
+          id="{{ field.fieldname }}-label"
+          class="foss-form-question text-sm"
         >
+          {{ field.label }}
+          {% if field.reqd %}<span aria-label="required">*</span>{% endif %}
+        </label>
         <select
           data-label="{{ field.label }}"
           data-type="Select"
           name="{{ field.fieldname }}"
           id="{{ field.fieldname }}"
           class="form-select form-control custom-select text-sm rounded-input w-100 px-3 py-1"
-          {% if field.reqd %}required{% endif %}
+          {% if field.reqd %}required aria-required="true"{% endif %}
+          {% if field.description %}aria-describedby="{{ field.fieldname }}-description"{% endif %}
+          aria-invalid="false"
         >
           {% set field_value = field.get('value') if field else '' %}
           {% set submission_value = submission.get(field.fieldname) if submission else '' %}
@@ -62,15 +76,29 @@
           type="checkbox"
           class="form-control form-check-input text-sm"
           id="{{ field.fieldname }}"
-          {% if field.reqd %}required{% endif %}
+          {% if field.reqd %}required aria-required="true"{% endif %}
           {% if field.value == '1' or submission[field.fieldname] == 1 %}checked{% endif %}
+          {% if field.description %}aria-describedby="{{ field.fieldname }}-description"{% endif %}
+          aria-invalid="false"
         />
-        <label class="form-check-label foss-form-question text-sm m-2" for="{{ field.fieldname }}"
-          >{{ field.label }}</label
+        <label
+          class="form-check-label foss-form-question text-sm m-2"
+          for="{{ field.fieldname }}"
+          id="{{ field.fieldname }}-label"
         >
+          {{ field.label }}
+          {% if field.reqd %}<span aria-label="required">*</span>{% endif %}
+        </label>
       </div>
     {% elif field.fieldtype == 'Text Editor' %}
-      <div class="foss-form-question text-sm mb-2">{{ field.label }}</div>
+      <label
+        for="{{ field.fieldname }}"
+        id="{{ field.fieldname }}-label"
+        class="foss-form-question text-sm mb-2"
+      >
+        {{ field.label }}
+        {% if field.reqd %}<span aria-label="required">*</span>{% endif %}
+      </label>
       <div
         data-label="{{ field.label }}"
         data-type="Text Editor"
@@ -78,14 +106,24 @@
         id="{{ field.fieldname }}"
         class="ql-editor-custom"
         type="text-editor"
-        {% if field.reqd %}required{% endif %}
+        role="textbox"
+        aria-multiline="true"
+        {% if field.reqd %}required aria-required="true"{% endif %}
+        {% if field.description %}aria-describedby="{{ field.fieldname }}-description"{% endif %}
+        aria-invalid="false"
+        aria-labelledby="{{ field.fieldname }}-label"
       >
         {{ submission[field.fieldname] or field.value or '' }}
       </div>
     {% elif field.fieldtype == 'Text' %}
-      <label for="{{ field.fieldname }}" class="foss-form-question text-sm"
-        >{{ field.label }}</label
+      <label
+        for="{{ field.fieldname }}"
+        id="{{ field.fieldname }}-label"
+        class="foss-form-question text-sm"
       >
+        {{ field.label }}
+        {% if field.reqd %}<span aria-label="required">*</span>{% endif %}
+      </label>
       <input
         data-label="{{ field.label }}"
         data-type="Text"
@@ -94,11 +132,19 @@
         class="form-control text-sm rounded-input"
         id="{{ field.fieldname }}"
         value="{{ submission[field.fieldname] or field.value or '' }}"
+        {% if field.reqd %}required aria-required="true"{% endif %}
+        {% if field.description %}aria-describedby="{{ field.fieldname }}-description"{% endif %}
+        aria-invalid="false"
       />
     {% elif field.fieldtype == 'Small Text' %}
-      <label for="{{ field.fieldname }}" class="foss-form-question text-sm"
-        >{{ field.label }}</label
+      <label
+        for="{{ field.fieldname }}"
+        id="{{ field.fieldname }}-label"
+        class="foss-form-question text-sm"
       >
+        {{ field.label }}
+        {% if field.reqd %}<span aria-label="required">*</span>{% endif %}
+      </label>
       <textarea
         data-label="{{ field.label }}"
         data-type="Small Text"
@@ -106,14 +152,19 @@
         class="form-control text-sm rounded-input"
         id="{{ field.fieldname }}"
         rows="3"
-        {% if field.reqd %}required{% endif %}
-      >
-{{ submission[field.fieldname] or field.value or '' }}</textarea
-      >
+        {% if field.reqd %}required aria-required="true"{% endif %}
+        {% if field.description %}aria-describedby="{{ field.fieldname }}-description"{% endif %}
+        aria-invalid="false"
+      >{{ submission[field.fieldname] or field.value or '' }}</textarea>
     {% elif field.fieldtype == 'Long Text' %}
-      <label for="{{ field.fieldname }}" class="foss-form-question text-sm"
-        >{{ field.label }}</label
+      <label
+        for="{{ field.fieldname }}"
+        id="{{ field.fieldname }}-label"
+        class="foss-form-question text-sm"
       >
+        {{ field.label }}
+        {% if field.reqd %}<span aria-label="required">*</span>{% endif %}
+      </label>
       <textarea
         data-label="{{ field.label }}"
         data-type="Long Text"
@@ -121,14 +172,19 @@
         class="form-control text-sm rounded-input"
         id="{{ field.fieldname }}"
         rows="6"
-        {% if field.reqd %}required{% endif %}
-      >
-{{ submission[field.fieldname] or field.value or '' }}</textarea
-      >
+        {% if field.reqd %}required aria-required="true"{% endif %}
+        {% if field.description %}aria-describedby="{{ field.fieldname }}-description"{% endif %}
+        aria-invalid="false"
+      >{{ submission[field.fieldname] or field.value or '' }}</textarea>
     {% elif field.fieldtype == 'Date' %}
-      <label for="{{ field.fieldname }}" class="foss-form-question text-sm"
-        >{{ field.label }}</label
+      <label
+        for="{{ field.fieldname }}"
+        id="{{ field.fieldname }}-label"
+        class="foss-form-question text-sm"
       >
+        {{ field.label }}
+        {% if field.reqd %}<span aria-label="required">*</span>{% endif %}
+      </label>
       <input
         data-label="{{ field.label }}"
         name="{{ field.fieldname }}"
@@ -136,11 +192,19 @@
         class="form-control text-sm rounded-input"
         id="{{ field.fieldname }}"
         value="{{ submission[field.fieldname] }}"
+        {% if field.reqd %}required aria-required="true"{% endif %}
+        {% if field.description %}aria-describedby="{{ field.fieldname }}-description"{% endif %}
+        aria-invalid="false"
       />
     {% elif field.fieldtype == 'Time' %}
-      <label for="{{ field.fieldname }}" class="foss-form-question text-sm"
-        >{{ field.label }}</label
+      <label
+        for="{{ field.fieldname }}"
+        id="{{ field.fieldname }}-label"
+        class="foss-form-question text-sm"
       >
+        {{ field.label }}
+        {% if field.reqd %}<span aria-label="required">*</span>{% endif %}
+      </label>
       <input
         data-label="{{ field.label }}"
         name="{{ field.fieldname }}"
@@ -148,11 +212,19 @@
         class="form-control text-sm rounded-input"
         id="{{ field.fieldname }}"
         value="{{ submission[field.fieldname] }}"
+        {% if field.reqd %}required aria-required="true"{% endif %}
+        {% if field.description %}aria-describedby="{{ field.fieldname }}-description"{% endif %}
+        aria-invalid="false"
       />
     {% elif field.fieldtype == 'Datetime' %}
-      <label for="{{ field.fieldname }}" class="foss-form-question text-sm"
-        >{{ field.label }}</label
+      <label
+        for="{{ field.fieldname }}"
+        id="{{ field.fieldname }}-label"
+        class="foss-form-question text-sm"
       >
+        {{ field.label }}
+        {% if field.reqd %}<span aria-label="required">*</span>{% endif %}
+      </label>
       <input
         data-label="{{ field.label }}"
         name="{{ field.fieldname }}"
@@ -160,11 +232,19 @@
         class="form-control text-sm rounded-input"
         id="{{ field.fieldname }}"
         value="{{ submission[field.fieldname] }}"
+        {% if field.reqd %}required aria-required="true"{% endif %}
+        {% if field.description %}aria-describedby="{{ field.fieldname }}-description"{% endif %}
+        aria-invalid="false"
       />
     {% elif field.fieldtype == 'Link' %}
-      <label for="{{ field.fieldname }}" class="foss-form-question text-sm"
-        >{{ field.label }}</label
+      <label
+        for="{{ field.fieldname }}"
+        id="{{ field.fieldname }}-label"
+        class="foss-form-question text-sm"
       >
+        {{ field.label }}
+        {% if field.reqd %}<span aria-label="required">*</span>{% endif %}
+      </label>
       <input
         data-label="{{ field.label }}"
         name="{{ field.fieldname }}"
@@ -172,11 +252,20 @@
         class="form-control text-sm rounded-input"
         id="{{ field.fieldname }}"
         value="{{ submission[field.fieldname] }}"
+        {% if field.reqd %}required aria-required="true"{% endif %}
+        {% if field.description %}aria-describedby="{{ field.fieldname }}-description"{% endif %}
+        aria-invalid="false"
+        inputmode="url"
       />
     {% elif field.fieldtype == 'Currency' %}
-      <label for="{{ field.fieldname }}" class="foss-form-question text-sm"
-        >{{ field.label }}</label
+      <label
+        for="{{ field.fieldname }}"
+        id="{{ field.fieldname }}-label"
+        class="foss-form-question text-sm"
       >
+        {{ field.label }}
+        {% if field.reqd %}<span aria-label="required">*</span>{% endif %}
+      </label>
       <input
         data-label="{{ field.label }}"
         name="{{ field.fieldname }}"
@@ -184,12 +273,18 @@
         class="form-control text-sm rounded-input"
         id="{{ field.fieldname }}"
         value="{{ submission[field.fieldname] }}"
+        {% if field.reqd %}required aria-required="true"{% endif %}
+        {% if field.description %}aria-describedby="{{ field.fieldname }}-description"{% endif %}
+        aria-invalid="false"
+        inputmode="numeric"
       />
     {% endif %}
 
     {% if field.description %}
       <div class="mt-1"></div>
-      <small>{{ field.description }}</small>
+      <small id="{{ field.fieldname }}-description" class="form-text">
+        {{ field.description }}
+      </small>
     {% endif %}
   </div>
 
@@ -214,6 +309,57 @@
         },
         theme: 'snow',
       })
+
+      // Enhance accessibility for Quill editor
+      var editor = document.querySelector('#{{ field.fieldname }} .ql-editor');
+      if (editor) {
+        editor.setAttribute('role', 'textbox');
+        editor.setAttribute('aria-multiline', 'true');
+        editor.setAttribute('aria-labelledby', '{{ field.fieldname }}-label');
+        {% if field.description %}
+        editor.setAttribute('aria-describedby', '{{ field.fieldname }}-description');
+        {% endif %}
+        {% if field.reqd %}
+        editor.setAttribute('aria-required', 'true');
+        {% endif %}
+      }
+
+      // Add accessible labels to toolbar buttons
+      var toolbar = document.querySelector('#{{ field.fieldname }}').previousSibling;
+      if (toolbar && toolbar.classList.contains('ql-toolbar')) {
+        // Add aria-label to toolbar
+        toolbar.setAttribute('role', 'toolbar');
+        toolbar.setAttribute('aria-label', 'Text formatting options');
+        toolbar.setAttribute('aria-controls', '{{ field.fieldname }}');
+
+        // Label common buttons
+        var boldBtn = toolbar.querySelector('.ql-bold');
+        if (boldBtn) boldBtn.setAttribute('aria-label', 'Bold');
+
+        var italicBtn = toolbar.querySelector('.ql-italic');
+        if (italicBtn) italicBtn.setAttribute('aria-label', 'Italic');
+
+        var underlineBtn = toolbar.querySelector('.ql-underline');
+        if (underlineBtn) underlineBtn.setAttribute('aria-label', 'Underline');
+
+        var strikeBtn = toolbar.querySelector('.ql-strike');
+        if (strikeBtn) strikeBtn.setAttribute('aria-label', 'Strikethrough');
+
+        var blockquoteBtn = toolbar.querySelector('.ql-blockquote');
+        if (blockquoteBtn) blockquoteBtn.setAttribute('aria-label', 'Blockquote');
+
+        var codeBlockBtn = toolbar.querySelector('.ql-code-block');
+        if (codeBlockBtn) codeBlockBtn.setAttribute('aria-label', 'Code block');
+
+        var orderedListBtn = toolbar.querySelector('.ql-list[value="ordered"]');
+        if (orderedListBtn) orderedListBtn.setAttribute('aria-label', 'Numbered list');
+
+        var bulletListBtn = toolbar.querySelector('.ql-list[value="bullet"]');
+        if (bulletListBtn) bulletListBtn.setAttribute('aria-label', 'Bullet list');
+
+        var cleanBtn = toolbar.querySelector('.ql-clean');
+        if (cleanBtn) cleanBtn.setAttribute('aria-label', 'Remove formatting');
+      }
     </script>
   {% endif %}
 {% endmacro %}

--- a/fossunited/www/grants/directory/index.html
+++ b/fossunited/www/grants/directory/index.html
@@ -15,10 +15,10 @@
       <div
         style="display:flex; justify-content:space-between; align-items:center; margin-bottom:1rem;"
       >
-        <div class="v3-breadcrumb">
+        <nav class="v3-breadcrumb">
           <a href="/">Home</a> > <a href="/grants/">Grants</a> >
           <a href="">Directory</a>
-        </div>
+        </nav>
         <button class="v3-theme-toggle" id="theme-toggle" title="Toggle theme">
           <i class="ti ti-moon"></i>
         </button>


### PR DESCRIPTION
- Partially on #788 

Thought that events page and render field would take prior for accessibility.

- Added aria labels wherever applicable.

Still unsure on most parts, will keep on hold for a while and read up more

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved accessibility and semantics across forms, macros, event and site pages: ARIA roles, aria-labels/descriptions, aria-live regions, screen‑reader headings, keyboard support for interactive items, accessible rich‑text toolbar labels, required indicators, and semantic breadcrumb/nav updates.
* **Style**
  * Added screen‑reader helper (.sr-only) and a hover underline rule for breadcrumb links; minor gradient formatting cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->