### PR TITLE
Host rsvp

### DIFF
--- a/dashboard/src/pages/EventRsvpCreate.vue
+++ b/dashboard/src/pages/EventRsvpCreate.vue
@@ -17,6 +17,18 @@
           <span class="text-sm text-gray-600"
             >Allow users to edit their RSVP after submission.</span
           >
+          <div class="flex items-center justify-between mt-2">
+            <div class="flex items-center pr-2">
+              <Switch v-model="rsvp_doc.requires_host_approval" />
+            </div>
+            <div class="flex flex-col">
+              <span class="font-medium text-gray-800">Requires organizer approval</span>
+              <span class="text-sm text-gray-600">
+                When enabled, Attendees must be accepted or denied via insights tab to confirm them
+                via mail.
+              </span>
+            </div>
+          </div>
         </div>
         <FormControl
           v-model="rsvp_doc.max_rsvp_count"
@@ -146,7 +158,14 @@
   </div>
 </template>
 <script setup>
-import { createDocumentResource, FormControl, ListView, Dialog, createResource } from 'frappe-ui'
+import {
+  createDocumentResource,
+  FormControl,
+  ListView,
+  Dialog,
+  createResource,
+  Switch,
+} from 'frappe-ui'
 import { reactive, ref, defineEmits } from 'vue'
 import { useRoute } from 'vue-router'
 import { toast } from 'vue-sonner'
@@ -179,6 +198,7 @@ let rsvp_doc = reactive({
   doctype: 'FOSS Event RSVP',
   event: route.params.id,
   allow_edit: 0,
+  requires_host_approval: 0,
   max_rsvp_count: 100,
   rsvp_description: '',
   custom_questions: [],

--- a/dashboard/src/pages/EventRsvpEdit.vue
+++ b/dashboard/src/pages/EventRsvpEdit.vue
@@ -225,7 +225,6 @@ import CopyToClipboardComponent from '../components/CopyToClipboardComponent.vue
 import TextEditor from '@/components/ui/TextEditor.vue'
 
 const route = useRoute()
-const hostApproval = ref(false)
 
 const rsvp_form = createResource({
   url: 'frappe.client.get',

--- a/dashboard/src/pages/EventRsvpEdit.vue
+++ b/dashboard/src/pages/EventRsvpEdit.vue
@@ -22,19 +22,38 @@
             <span v-else class="text-red-500">Unpublished</span>
           </div>
 
-          <span v-if="rsvp.doc.is_published" class="text-sm text-gray-600"
-            >Unpublishing the form will make it unaccessible to users.</span
-          >
-          <span v-else class="text-sm text-gray-600"
-            >Publish this form to make it accessible to public.</span
-          >
+          <span v-if="rsvp.doc.is_published" class="text-sm text-gray-600">
+            Unpublishing the form will make it unaccessible to users.
+          </span>
+          <span v-else class="text-sm text-gray-600">
+            Publish this form to make it accessible to public.
+          </span>
+
+          <div class="flex items-center justify-between mt-2 p-3 border rounded-md">
+            <div class="flex flex-col">
+              <span class="font-medium text-gray-800">Requires organizer approval</span>
+              <span class="text-sm text-gray-600">
+                When enabled, Attendees must be accepted or denied via
+                <RouterLink :to="`/event/${route.params.id}/rsvp/insights`" class="underline">
+                  insights
+                </RouterLink>
+                tab to confirm them via mail.
+              </span>
+            </div>
+
+            <div class="flex items-center gap-2">
+              <Switch v-model="rsvp.doc.requires_host_approval" />
+            </div>
+          </div>
         </div>
+
         <div class="flex flex-col gap-2 text-base">
           <span>Route of the RSVP form</span>
           <CopyToClipboardComponent :route="whole_route" />
         </div>
       </div>
     </div>
+
     <div class="flex flex-col my-4 gap-6">
       <div class="font-semibold text-gray-800 border-b-2 pb-2">Edit Details</div>
       <div class="grid sm:grid-cols-1 md:grid-cols-2 gap-4">
@@ -191,7 +210,14 @@
   </div>
 </template>
 <script setup>
-import { createDocumentResource, createResource, FormControl, ListView, Dialog } from 'frappe-ui'
+import {
+  createDocumentResource,
+  createResource,
+  FormControl,
+  ListView,
+  Dialog,
+  Switch,
+} from 'frappe-ui'
 import { reactive, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { toast } from 'vue-sonner'
@@ -199,6 +225,7 @@ import CopyToClipboardComponent from '../components/CopyToClipboardComponent.vue
 import TextEditor from '@/components/ui/TextEditor.vue'
 
 const route = useRoute()
+const hostApproval = ref(false)
 
 const rsvp_form = createResource({
   url: 'frappe.client.get',

--- a/dashboard/src/pages/EventRsvpInsights.vue
+++ b/dashboard/src/pages/EventRsvpInsights.vue
@@ -3,7 +3,7 @@
     <div class="flex flex-col gap-4 mt-5">
       <div class="flex items-center justify-between">
         <div class="font-semibold text-gray-800">Attendees</div>
-        <Button size="md" icon-left="download" @click="downloadAttendeeList2">Download</Button>
+        <Button size="md" icon-left="download" @click="downloadAttendeeList">Download</Button>
       </div>
 
       <ListView
@@ -24,6 +24,45 @@
             {{ group.group }} ({{ group.rows.length }})
           </span>
         </template>
+
+        <template #cell="{ item, row, column }">
+          <div v-if="column.key === 'confirm_attendance'">
+            <span
+              class="px-2 py-1 rounded text-sm font-medium"
+              :class="
+                Number(row.confirm_attendance || 0) === 1
+                  ? 'bg-green-100 text-green-700'
+                  : 'bg-red-100 text-red-700'
+              "
+            >
+              {{ Number(row.confirm_attendance || 0) === 1 ? 'Yes' : 'No' }}
+            </span>
+          </div>
+
+          <div v-else-if="column.key === 'actions'">
+            <!-- show actions when host approval is required -->
+            <div class="flex gap-2">
+              <Button
+                size="sm"
+                label="Accept"
+                variant="solid"
+                :disabled="row.status === 'Accepted'"
+                @click="() => updateRsvpStatus(row, 'Accepted')"
+              />
+              <Button
+                size="sm"
+                label="Reject"
+                theme="red"
+                :disabled="row.status === 'Rejected'"
+                @click="() => updateRsvpStatus(row, 'Rejected')"
+              />
+            </div>
+          </div>
+
+          <div v-else>
+            <span class="text-base">{{ item }}</span>
+          </div>
+        </template>
       </ListView>
     </div>
   </div>
@@ -33,6 +72,7 @@
 import { useRoute } from 'vue-router'
 import { inject, ref, computed, watchEffect } from 'vue'
 import { createListResource, createResource, ListView, Button } from 'frappe-ui'
+import { toast } from 'vue-sonner'
 
 const route = useRoute()
 const session = inject('$session')
@@ -79,47 +119,107 @@ const listColumns = computed(() => {
   if (Array.isArray(submissions.data)) {
     submissions.data.forEach((submission) => {
       Object.keys(submission).forEach((key) => {
-        if (key !== 'confirm_attendance' && !columns.has(key)) {
+        if (key !== 'confirm_attendance' && key !== 'status' && !columns.has(key)) {
           columns.set(key, { key, label: key }) // Use key as label directly
         }
       })
     })
   }
 
-  return Array.from(columns.values())
+  // include confirm_attendance and status
+  const result = [
+    { key: 'confirm_attendance', label: 'Attending', icon: 'check-circle' },
+    ...Array.from(columns.values()),
+  ]
+
+  // for host approval, add an actions column
+  if (rsvp_form.data?.requires_host_approval) {
+    result.push({ key: 'actions', label: 'Actions' })
+  }
+
+  return result
 })
 
 const groupedRows = ref([])
 
+const updateRsvpStatus = (row, status) => {
+  if (!row?.name) {
+    toast.error('Invalid row')
+    return
+  }
+
+  createResource({
+    url: 'frappe.client.set_value',
+    params: {
+      doctype: 'FOSS Event RSVP Submission',
+      name: row.name,
+      fieldname: {
+        status,
+        confirm_attendance: status === 'Accepted' ? 1 : 0,
+      },
+    },
+    onSuccess() {
+      toast.success(`RSVP ${status}`)
+      submissions.fetch()
+    },
+    onError(err) {
+      toast.error(err.message || 'Update failed')
+    },
+  }).fetch()
+}
+
 watchEffect(() => {
   const rows = Array.isArray(submissions.data) ? submissions.data : []
-  const attending = []
+
+  const pending = []
+  const accepted = []
+  const rejected = []
   const notAttending = []
 
+  const requiresHostApproval = Boolean(rsvp_form.data?.requires_host_approval)
+
   for (const row of rows) {
-    const isAttending = Boolean(Number(row?.confirm_attendance || 0))
-    if (isAttending) {
-      attending.push(row)
+    const confirm = Number(row?.confirm_attendance || 0) === 1
+    const status = String(row?.status || '').trim()
+
+    if (requiresHostApproval) {
+      if (status === 'Pending') {
+        pending.push(row)
+      } else if (status === 'Accepted' && confirm) {
+        accepted.push(row)
+      } else if (status === 'Rejected') {
+        rejected.push(row)
+      } else {
+        // everything else falls into Not attending (covers accepted but confirm=false,
+        // missing status, or other odd cases)
+        notAttending.push(row)
+      }
     } else {
-      notAttending.push(row)
+      // legacy behaviour: grouping based purely on confirm_attendance
+      if (confirm) {
+        accepted.push(row)
+      } else {
+        notAttending.push(row)
+      }
     }
   }
 
-  groupedRows.value = [
-    {
-      group: 'Attending event',
-      collapsed: false,
-      rows: attending,
-    },
-    {
-      group: 'Not attending',
-      collapsed: true,
-      rows: notAttending,
-    },
-  ]
+  if (requiresHostApproval) {
+    groupedRows.value = [
+      { group: 'Pending requests', collapsed: false, rows: pending },
+      { group: 'Attending event', collapsed: false, rows: accepted },
+      { group: 'Not attending', collapsed: true, rows: notAttending },
+      { group: 'Rejected attendees', collapsed: true, rows: rejected },
+    ]
+  } else {
+    groupedRows.value = [
+      { group: 'Attending event', collapsed: false, rows: accepted },
+      { group: 'Not attending', collapsed: true, rows: notAttending },
+    ]
+  }
 })
 
-const downloadAttendeeList2 = () => {
+const downloadAttendeeList = () => {
   const eventId = route.params.id
   window.open(
     `/api/method/fossunited.api.chapter.download_attendee_list_csv?event_id=${eventId}`,

--- a/dashboard/src/pages/EventRsvpInsights.vue
+++ b/dashboard/src/pages/EventRsvpInsights.vue
@@ -1,6 +1,11 @@
 <template>
   <div v-if="submissions.data && rsvp_form.data" class="px-4 py-8 md:p-8 flex flex-col gap-4">
-    <div class="flex flex-col gap-4 mt-5">
+    <div class="flex flex-col gap-4 mt-1">
+      <div v-if="rsvp_form.data?.requires_host_approval" class="text-sm text-gray-600">
+        Note: Host approval is enabled, attendees will receive an email notification when you
+        accept or reject their RSVP.
+      </div>
+
       <div class="flex items-center justify-between">
         <div class="font-semibold text-gray-800">Attendees</div>
         <Button size="md" icon-left="download" @click="downloadAttendeeList">Download</Button>
@@ -54,7 +59,7 @@
                 label="Reject"
                 theme="red"
                 :disabled="row.status === 'Rejected'"
-                @click="() => updateRsvpStatus(row, 'Rejected')"
+                @click="() => confirmReject(row)"
               />
             </div>
           </div>
@@ -166,6 +171,12 @@ const updateRsvpStatus = (row, status) => {
       toast.error(err.message || 'Update failed')
     },
   }).fetch()
+}
+
+const confirmReject = (row) => {
+  if (confirm(`Are you sure you want to reject ${row.name1 || 'this attendee'}?`)) {
+    updateRsvpStatus(row, 'Rejected')
+  }
 }
 
 watchEffect(() => {

--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -170,7 +170,7 @@ def get_submissions_with_answers(
     submissions = frappe.get_all(
         RSVP_RESPONSE,
         filters={"event": event_id},
-        fields=["name", "confirm_attendance", "name1", "email", "im_a"],
+        fields=["name", "confirm_attendance", "status", "name1", "email", "im_a"],
         order_by="creation asc",
         limit_page_length=9999,
     )
@@ -220,8 +220,6 @@ def get_submissions_with_answers(
             label = "" if raw_label is None else str(raw_label)
             if not full_answers:
                 label = _truncate_label(label, 30)
-
-        s.pop("name", None)
 
     return submissions
 


### PR DESCRIPTION
- closes #842

- Added simply "accept" and "reject" button in insights listview to update status based on click

- rsvp edit and create form will have toggle switch to enable host requires approval field for thier rsvp form

- Normally only 2 group is shown "Attending" and Not attending

- But event has host req approval then 4 group is shown
  1. Pending approval
  2. attending event (accepted)
  3. not attending (if they un-rsvp'd)
  4. rejected attendees


https://github.com/user-attachments/assets/28bbc6a3-dd5b-47d3-b5c2-4b958d77d291



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added host approval setting toggle for RSVP events
  * Added accept and reject actions for individual RSVP submissions
  * Enhanced attendee insights view with approval status grouping (pending, attending, not attending, rejected)
  * Added action buttons for managing RSVP responses
  * Improved RSVP data tracking to include approval status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->