### PR TITLE
init: Grants funding directory doctype+page

### DIFF
--- a/fossunited/doctype_ids.py
+++ b/fossunited/doctype_ids.py
@@ -64,3 +64,6 @@ EMAIL_MEMBER = "Email Group Member"
 # Free code
 FREE_TICKET_CODE = "Event Free Ticket Code"
 FREE_TICKET_APPLY = "Event Free Ticket Applications"
+
+# Grants
+GRANTS_DIR = "Grants Funding Directory"

--- a/fossunited/fossunited/doctype/grants_funding_directory/grants_funding_directory.js
+++ b/fossunited/fossunited/doctype/grants_funding_directory/grants_funding_directory.js
@@ -1,8 +1,31 @@
 // Copyright (c) 2025, Frappe x FOSSUnited and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Grants Funding Directory", {
-// 	refresh(frm) {
+frappe.ui.form.on('Grants Funding Directory', {
+  refresh(frm) {
+    // show button only for saved docs
+    if (frm.is_new()) return
 
-// 	},
-// });
+    frm.add_custom_button('Re-fetch Manifest Data', () => {
+      frappe.call({
+        method:
+          'fossunited.fossunited.doctype.grants_funding_directory.grants_funding_directory.refresh_funding_data',
+        args: { docname: frm.doc.name },
+        freeze: true,
+        freeze_message: 'Refreshing funding data…',
+        callback(r) {
+          if (r && r.message && r.message.success) {
+            frappe.msgprint(r.message.message || 'Funding data refreshed')
+            frm.reload_doc()
+          } else {
+            frappe.msgprint({
+              title: 'Refresh failed',
+              message: (r && r.message && r.message.message) || 'Unknown error',
+              indicator: 'red',
+            })
+          }
+        },
+      })
+    })
+  },
+})

--- a/fossunited/fossunited/doctype/grants_funding_directory/grants_funding_directory.js
+++ b/fossunited/fossunited/doctype/grants_funding_directory/grants_funding_directory.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, Frappe x FOSSUnited and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Grants Funding Directory", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/fossunited/fossunited/doctype/grants_funding_directory/grants_funding_directory.json
+++ b/fossunited/fossunited/doctype/grants_funding_directory/grants_funding_directory.json
@@ -28,8 +28,10 @@
   {
    "fieldname": "funding_json",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "funding json",
-   "options": "URL"
+   "options": "URL",
+   "unique": 1
   },
   {
    "fieldname": "json_data",
@@ -54,7 +56,7 @@
  "has_web_view": 1,
  "is_published_field": "is_published",
  "links": [],
- "modified": "2025-11-19 18:00:57.167249",
+ "modified": "2025-11-19 20:35:45.761953",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "Grants Funding Directory",

--- a/fossunited/fossunited/doctype/grants_funding_directory/grants_funding_directory.json
+++ b/fossunited/fossunited/doctype/grants_funding_directory/grants_funding_directory.json
@@ -10,8 +10,8 @@
   "route",
   "email",
   "funding_json",
-  "json_data",
-  "last_updated"
+  "last_updated",
+  "json_data"
  ],
  "fields": [
   {
@@ -31,6 +31,7 @@
    "in_list_view": 1,
    "label": "funding json",
    "options": "URL",
+   "reqd": 1,
    "unique": 1
   },
   {
@@ -56,7 +57,7 @@
  "has_web_view": 1,
  "is_published_field": "is_published",
  "links": [],
- "modified": "2025-11-19 20:35:45.761953",
+ "modified": "2025-11-19 22:42:31.910608",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "Grants Funding Directory",

--- a/fossunited/fossunited/doctype/grants_funding_directory/grants_funding_directory.json
+++ b/fossunited/fossunited/doctype/grants_funding_directory/grants_funding_directory.json
@@ -1,0 +1,82 @@
+{
+ "actions": [],
+ "allow_guest_to_view": 1,
+ "allow_rename": 1,
+ "creation": "2025-10-27 16:12:04.274953",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "is_published",
+  "route",
+  "email",
+  "funding_json",
+  "json_data",
+  "last_updated"
+ ],
+ "fields": [
+  {
+   "default": "0",
+   "fieldname": "is_published",
+   "fieldtype": "Check",
+   "label": "Published?"
+  },
+  {
+   "fieldname": "route",
+   "fieldtype": "Data",
+   "label": "route"
+  },
+  {
+   "fieldname": "funding_json",
+   "fieldtype": "Data",
+   "label": "funding json",
+   "options": "URL"
+  },
+  {
+   "fieldname": "json_data",
+   "fieldtype": "Code",
+   "label": "json data",
+   "options": "JSON",
+   "read_only": 1
+  },
+  {
+   "fieldname": "last_updated",
+   "fieldtype": "Datetime",
+   "label": "last updated"
+  },
+  {
+   "fieldname": "email",
+   "fieldtype": "Data",
+   "label": "contact email",
+   "options": "Email"
+  }
+ ],
+ "grid_page_length": 50,
+ "has_web_view": 1,
+ "is_published_field": "is_published",
+ "links": [],
+ "modified": "2025-11-19 18:00:57.167249",
+ "modified_by": "Administrator",
+ "module": "FOSSUnited",
+ "name": "Grants Funding Directory",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/fossunited/fossunited/doctype/grants_funding_directory/grants_funding_directory.py
+++ b/fossunited/fossunited/doctype/grants_funding_directory/grants_funding_directory.py
@@ -1,0 +1,259 @@
+# Copyright (c) 2025, Frappe x FOSSUnited and contributors
+# For license information, please see license.txt
+
+import json
+import re
+from typing import Dict, List, Optional, Tuple
+
+import frappe
+import requests
+from frappe.utils import now_datetime
+from frappe.website.website_generator import WebsiteGenerator
+
+EMAIL_REGEX = re.compile(r"[^@]+@[^@]+\.[^@]+")
+
+
+class GrantsFundingDirectory(WebsiteGenerator):
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        email: DF.Data | None
+        funding_json: DF.Data | None
+        is_published: DF.Check
+        json_data: DF.Code | None
+        last_updated: DF.Datetime | None
+        route: DF.Data | None
+    # end: auto-generated types
+
+    def before_save(self):
+        """called before saving the document."""
+        if self.is_new() or self.has_value_changed("funding_json"):
+            self.fetch_and_validate_json()
+
+        # auto-set route based on entity name
+        if not self.route:
+            self.set_route()
+
+        # auto-extract email if not provided
+        if not self.email:
+            self.extract_email_from_json()
+
+    def fetch_and_validate_json(self):
+        """Fetch and validate funding JSON from URL."""
+        if not self.funding_json:
+            frappe.throw("Please enter a Funding JSON Link before saving.")
+
+        try:
+            # Fetch JSON content
+            json_content = self._fetch_json_from_url(self.funding_json)
+
+            # Validate using official API
+            validated_data = self._validate_json_with_api(self.funding_json, json_content)
+
+            # Store validated JSON
+            self.json_data = json.dumps(validated_data, indent=2)
+            self.last_updated = now_datetime()
+
+        except requests.exceptions.RequestException as e:
+            frappe.log_error(
+                f"Error fetching funding JSON for {self.name or 'new'}: {str(e)}",
+                "Grants Funding Directory Error",
+            )
+            frappe.throw(f"Failed to fetch JSON from URL: {str(e)}")
+        except json.JSONDecodeError as e:
+            frappe.throw(f"Invalid JSON format: {str(e)}")
+        except Exception as e:
+            frappe.log_error(
+                f"Unexpected error processing funding JSON: {str(e)}",
+                "Grants Funding Directory Error",
+            )
+            frappe.throw(f"Error processing JSON: {str(e)}")
+
+    def _fetch_json_from_url(self, url: str) -> str:
+        """Fetch JSON content from URL."""
+        response = requests.get(url, timeout=15)
+        response.raise_for_status()
+        return response.text
+
+    def _validate_json_with_api(self, url: str, json_content: str) -> dict:
+        """Validate JSON using dir.floss.fund API."""
+        # First try with just the body (some URLs might fail with url parameter)
+        validation_data = {"body": json_content}
+
+        try:
+            validation_response = requests.post(
+                "https://dir.floss.fund/api/validate",
+                data=validation_data,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                timeout=15,
+            )
+
+            validation_result = validation_response.json()
+
+            # Check if validation failed
+            if validation_response.status_code != 200:
+                error_msg = validation_result.get("message", "Invalid Funding JSON")
+                frappe.throw(f"Validation failed: {error_msg}")
+
+            return validation_result.get("data", json.loads(json_content))
+
+        except Exception as e:
+            # Fallback: if validation API fails, do basic JSON parsing
+            frappe.log_error(
+                f"Validation API failed, falling back to basic parsing: {str(e)}",
+                "Grants Funding Directory Warning",
+            )
+            return json.loads(json_content)
+
+    def set_route(self):
+        """route based on entity name."""
+        try:
+            data = json.loads(self.json_data or "{}")
+            entity_name = data.get("entity", {}).get("name", self.name)
+            slug = frappe.scrub(entity_name)
+            self.route = f"grants/directory/{slug}"
+        except Exception as e:
+            frappe.log_error(f"Error setting route: {str(e)}")
+            # Fallback to default
+            self.route = f"grants/directory/{frappe.scrub(self.name)}"
+
+    def extract_email_from_json(self):
+        """Extract email from JSON data if available."""
+        try:
+            data = json.loads(self.json_data or "{}")
+
+            # Try multiple places for email
+            email = None
+
+            # Check entity email
+            entity = data.get("entity", {})
+            if entity.get("email"):
+                email = entity["email"]
+
+            if email:
+                self.email = email
+
+        except Exception as e:
+            frappe.log_error(f"Error extracting email: {str(e)}")
+
+    def get_context(self, context):
+        """Prepare context for rendering the page."""
+        try:
+            data = json.loads(self.json_data or "{}")
+        except json.JSONDecodeError:
+            frappe.throw("Invalid JSON data stored in document")
+
+        # extract top-level parts
+        context.entity = data.get("entity", {})
+        context.projects = data.get("projects", [])
+        context.funding = data.get("funding", {})
+
+        # normalize funding channels
+        channels, channels_dict = self._normalize_channels(context.funding.get("channels", []))
+        context.funding_channels_list = channels
+        context.funding_channels = channels_dict
+
+        # page metadata
+        entity_name = context.entity.get("name") or self.name
+        context.page_title = f"{entity_name} – Funding Profile"
+        context.doctype_name = self.doctype
+        context.doc_name = self.name
+
+        return context
+
+    def _normalize_channels(self, channels: List[dict]) -> Tuple[List[dict], Dict[str, dict]]:
+        """Normalize funding channel addresses."""
+        site_url = frappe.utils.get_url()
+        normalized_channels = []
+
+        for ch in channels:
+            addr = ch.get("address", "")
+
+            # If address is present and not absolute, prepend base URL
+            if addr:
+                # Detect raw emails
+                if EMAIL_REGEX.match(addr):
+                    ch["address"] = f"mailto:{addr}"
+                # Detect relative paths (neither http nor mailto)
+                elif not addr.startswith("http") and not addr.startswith("mailto:"):
+                    ch["address"] = f"{site_url.rstrip('/')}/{addr.lstrip('/')}"
+
+            normalized_channels.append(ch)
+
+        # Create dictionary for quick lookup
+        channels_dict = {ch["guid"]: ch for ch in normalized_channels if ch.get("guid")}
+
+        return normalized_channels, channels_dict
+
+
+@frappe.whitelist(allow_guest=True)
+def validate_json(url: Optional[str] = None, body: Optional[str] = None) -> dict:
+    """
+    API endpoint to validate funding JSON.
+    Proxies to official dir.floss.fund/api/validate
+    """
+    try:
+        # Prepare data for validation
+        data = {}
+        if body:
+            data["body"] = body
+        if url and not body:  # Only send URL if no body provided
+            data["url"] = url
+
+        if not data:
+            return {
+                "error": True,
+                "message": "Either 'url' or 'body' parameter required",
+            }
+
+        # Call official validation API
+        response = requests.post(
+            "https://dir.floss.fund/api/validate",
+            data=data,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=15,
+        )
+
+        result = response.json()
+
+        # Return result in consistent format
+        if response.status_code == 200:
+            return {
+                "error": False,
+                "message": result.get("message", "Valid funding JSON"),
+                "data": result.get("data"),
+            }
+        else:
+            return {
+                "error": True,
+                "message": result.get("message", "Validation failed"),
+            }
+
+    except requests.exceptions.RequestException as e:
+        return {
+            "error": True,
+            "message": f"Failed to connect to validation service: {str(e)}",
+        }
+    except json.JSONDecodeError as e:
+        return {"error": True, "message": f"Invalid JSON response: {str(e)}"}
+    except Exception as e:
+        frappe.log_error(f"Validation error: {e}")
+        return {"error": True, "message": f"Validation error: {str(e)}"}
+
+
+@frappe.whitelist()
+def refresh_funding_data(docname: str) -> dict:
+    """Refresh funding data by re-fetching and validating JSON."""
+    try:
+        doc = frappe.get_doc("Grants Funding Directory", docname)
+        doc._fetch_and_validate_json()
+        doc.save()
+        return {"success": True, "message": "Funding data refreshed successfully"}
+    except Exception as e:
+        frappe.log_error(f"Error refreshing funding data: {str(e)}")
+        return {"success": False, "message": str(e)}

--- a/fossunited/fossunited/doctype/grants_funding_directory/grants_funding_directory.py
+++ b/fossunited/fossunited/doctype/grants_funding_directory/grants_funding_directory.py
@@ -83,7 +83,7 @@ class GrantsFundingDirectory(WebsiteGenerator):
     def _validate_json_with_api(self, url: str, json_content: str) -> dict:
         """Validate JSON using dir.floss.fund API."""
         # First try with just the body (some URLs might fail with url parameter)
-        validation_data = {"body": json_content}
+        validation_data = {"url": url, "body": json_content}
 
         try:
             validation_response = requests.post(
@@ -251,7 +251,7 @@ def refresh_funding_data(docname: str) -> dict:
     """Refresh funding data by re-fetching and validating JSON."""
     try:
         doc = frappe.get_doc("Grants Funding Directory", docname)
-        doc._fetch_and_validate_json()
+        doc.fetch_and_validate_json()
         doc.save()
         return {"success": True, "message": "Funding data refreshed successfully"}
     except Exception as e:

--- a/fossunited/fossunited/doctype/grants_funding_directory/grants_funding_directory.py
+++ b/fossunited/fossunited/doctype/grants_funding_directory/grants_funding_directory.py
@@ -23,7 +23,7 @@ class GrantsFundingDirectory(WebsiteGenerator):
         from frappe.types import DF
 
         email: DF.Data | None
-        funding_json: DF.Data | None
+        funding_json: DF.Data
         is_published: DF.Check
         json_data: DF.Code | None
         last_updated: DF.Datetime | None

--- a/fossunited/fossunited/doctype/grants_funding_directory/grants_funding_directory.py
+++ b/fossunited/fossunited/doctype/grants_funding_directory/grants_funding_directory.py
@@ -3,7 +3,7 @@
 
 import json
 import re
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 import frappe
 import requests
@@ -82,7 +82,6 @@ class GrantsFundingDirectory(WebsiteGenerator):
 
     def _validate_json_with_api(self, url: str, json_content: str) -> dict:
         """Validate JSON using dir.floss.fund API."""
-        # First try with just the body (some URLs might fail with url parameter)
         validation_data = {"url": url, "body": json_content}
 
         try:
@@ -93,22 +92,25 @@ class GrantsFundingDirectory(WebsiteGenerator):
                 timeout=15,
             )
 
-            validation_result = validation_response.json()
-
-            # Check if validation failed
+            # If API returned non-200, raise immediately
             if validation_response.status_code != 200:
-                error_msg = validation_result.get("message", "Invalid Funding JSON")
+                result = validation_response.json()
+                error_msg = result.get("message", "Invalid Funding JSON")
                 frappe.throw(f"Validation failed: {error_msg}")
 
-            return validation_result.get("data", json.loads(json_content))
+            # API returned 200 → parse JSON
+            result = validation_response.json()
+
+            # Must contain validated data
+            if "data" not in result:
+                frappe.throw("Validation failed: API returned no data")
+
+            return result["data"]
 
         except Exception as e:
-            # Fallback: if validation API fails, do basic JSON parsing
-            frappe.log_error(
-                f"Validation API failed, falling back to basic parsing: {str(e)}",
-                "Grants Funding Directory Warning",
+            frappe.throw(
+                f"Validation error. Please verify with https://dir.floss.fund/validate: {str(e)}"
             )
-            return json.loads(json_content)
 
     def set_route(self):
         """route based on entity name."""
@@ -189,61 +191,6 @@ class GrantsFundingDirectory(WebsiteGenerator):
         channels_dict = {ch["guid"]: ch for ch in normalized_channels if ch.get("guid")}
 
         return normalized_channels, channels_dict
-
-
-@frappe.whitelist(allow_guest=True)
-def validate_json(url: Optional[str] = None, body: Optional[str] = None) -> dict:
-    """
-    API endpoint to validate funding JSON.
-    Proxies to official dir.floss.fund/api/validate
-    """
-    try:
-        # Prepare data for validation
-        data = {}
-        if body:
-            data["body"] = body
-        if url and not body:  # Only send URL if no body provided
-            data["url"] = url
-
-        if not data:
-            return {
-                "error": True,
-                "message": "Either 'url' or 'body' parameter required",
-            }
-
-        # Call official validation API
-        response = requests.post(
-            "https://dir.floss.fund/api/validate",
-            data=data,
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-            timeout=15,
-        )
-
-        result = response.json()
-
-        # Return result in consistent format
-        if response.status_code == 200:
-            return {
-                "error": False,
-                "message": result.get("message", "Valid funding JSON"),
-                "data": result.get("data"),
-            }
-        else:
-            return {
-                "error": True,
-                "message": result.get("message", "Validation failed"),
-            }
-
-    except requests.exceptions.RequestException as e:
-        return {
-            "error": True,
-            "message": f"Failed to connect to validation service: {str(e)}",
-        }
-    except json.JSONDecodeError as e:
-        return {"error": True, "message": f"Invalid JSON response: {str(e)}"}
-    except Exception as e:
-        frappe.log_error(f"Validation error: {e}")
-        return {"error": True, "message": f"Validation error: {str(e)}"}
 
 
 @frappe.whitelist()

--- a/fossunited/fossunited/doctype/grants_funding_directory/templates/grants_funding_directory.html
+++ b/fossunited/fossunited/doctype/grants_funding_directory/templates/grants_funding_directory.html
@@ -38,33 +38,57 @@
       </div>
 
       <!-- Header Card -->
+      {# helper macro to avoid repeating URL checks #}
+      {% macro external_link(url, classes, icon, text) -%}
+        {%- if url and url.startswith(("http://", "https://")) -%}
+          <a href="{{ url }}" target="_blank" rel="noopener noreferrer" class="{{ classes }}">
+            <i class="{{ icon }}"></i> {{ text }}
+          </a>
+        {%- endif -%}
+      {%- endmacro %}
+
+      {# main card #}
       <div class="v3-card v3-main-card">
-        <h1
-          class="v3-text-primary"
-          style="font-size: 2rem; font-weight: 700; margin-bottom: 1rem;"
-        >
+        <h1 class="v3-text-primary" style="font-size:2rem; font-weight:700; margin-bottom:1rem;">
           {{ entity.name }}
         </h1>
 
         {% if entity.description %}
           <p
             class="v3-text-secondary"
-            style="font-size: 1rem; line-height: 1.6; margin-bottom: 1.5rem;"
+            style="font-size:1rem; line-height:1.6; margin-bottom:1.5rem;"
           >
             {{ entity.description }}
           </p>
         {% endif %}
 
         <div class="d-flex justify-content-between align-items-center">
-          <div class="v3-btn-group">
+          <div class="v3-btn-group d-flex" style="gap:1rem;">
             {% set website_url = entity.webpageUrl.url if entity.webpageUrl else None %}
             {{ external_link(website_url, "v3-btn v3-btn-primary", "ti ti-external-link", "Visit Website") }}
+
+            {% if entity.email %}
+              <a href="mailto:{{ entity.email }}" class="v3-btn v3-btn-secondary">
+                <i class="ti ti-mail"></i>email
+              </a>
+            {% endif %}
           </div>
 
-          <a href="mailto:foundation@fossunited.org" class="v3-btn v3-btn-secondary small-btn">
-            <i class="ti ti-flag"></i>
-            Report Issue
-          </a>
+          <div class="v3-btn-group d-flex" style="gap:0.5rem;">
+            {% set funding_url = funding_json if funding_json else None %}
+            {{ external_link(funding_url, "v3-btn v3-btn-dark", "ti ti-braces", "Manifest") }}
+
+            {%
+              set mailto =
+              "mailto:foundation@fossunited.org"
+              ~ "?subject=" ~ ("[Funding Directory] Issue with " ~ entity.name)|urlencode
+              ~ "&body=" ~ ("Link: " ~ funding_url)|urlencode
+            %}
+
+            <a href="{{ mailto }}" class="v3-btn v3-btn-secondary">
+              <i class="ti ti-flag"></i> Report
+            </a>
+          </div>
         </div>
       </div>
 
@@ -125,7 +149,7 @@
       {% if funding.plans %}
         <div class="v3-card">
           <div class="v3-section-title">
-            <i class="ti ti-coin"></i>
+            <i class="ti ti-coin-rupee"></i>
             <span>Funding Plans</span>
           </div>
 

--- a/fossunited/fossunited/doctype/grants_funding_directory/templates/grants_funding_directory.html
+++ b/fossunited/fossunited/doctype/grants_funding_directory/templates/grants_funding_directory.html
@@ -1,0 +1,362 @@
+{% extends "templates/foss_base.html" %}
+
+{% block title %}{{ entity.name }} – Funding Profile{% endblock %}
+
+{% block page_content %}
+  <style>
+    .small-btn {
+      padding: 0.35rem 0.6rem;
+      font-size: 0.75rem;
+    }
+    .v3-card {
+        margin-bottom: 2rem;
+    }
+  </style>
+
+  <div class="v3-page">
+    <div class="v3-container">
+      <!-- Breadcrumb -->
+      <div class="d-flex justify-content-between align-items-center">
+        <div class="v3-breadcrumb">
+          <a href="/">Home</a> > <a href="/grants/">Grants</a> >
+          <a href="/grants/directory">Directory</a> > <a href="">{{ entity.name }}</a>
+        </div>
+        <div>
+          <button class="v3-theme-toggle" id="theme-toggle" title="Toggle theme">
+            <i class="ti ti-moon"></i>
+          </button>
+        </div>
+      </div>
+
+      <!-- Header Card -->
+      <div class="v3-card v3-main-card">
+        <h1
+          class="v3-text-primary"
+          style="font-size: 2rem; font-weight: 700; margin-bottom: 1rem;"
+        >
+          {{ entity.name }}
+        </h1>
+
+        {% if entity.description %}
+          <p
+            class="v3-text-secondary"
+            style="font-size: 1rem; line-height: 1.6; margin-bottom: 1.5rem;"
+          >
+            {{ entity.description }}
+          </p>
+        {% endif %}
+
+        <div class="d-flex justify-content-between align-items-center">
+          <div class="v3-btn-group">
+            {% if entity.webpageUrl and entity.webpageUrl.url %}
+              <a href="{{ entity.webpageUrl.url }}" target="_blank" class="v3-btn v3-btn-primary">
+                <i class="ti ti-external-link"></i>
+                Visit Website
+              </a>
+            {% endif %}
+          </div>
+
+          <a href="mailto:foundation@fossunited.org" class="v3-btn v3-btn-secondary small-btn">
+            <i class="ti ti-flag"></i>
+            Report Issue
+          </a>
+        </div>
+      </div>
+
+      <!-- Projects Card -->
+      {% if projects %}
+        <div class="v3-card">
+          <div class="v3-section-title">
+            <i class="ti ti-code"></i>
+            <span>Projects</span>
+          </div>
+
+          <div
+            style="display: grid; grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr)); gap: 1rem;"
+          >
+            {% for project in projects %}
+              <div
+                style="padding: 1.25rem; background: var(--v3-main-bg); border-radius: 0.5rem; display: flex; flex-direction: column;"
+              >
+                <h3
+                  class="v3-text-primary"
+                  style="font-size: 1.125rem; font-weight: 600; margin-bottom: 0.5rem;"
+                >
+                  {{ project.name }}
+                </h3>
+
+                {% if project.licenses %}
+                  <div
+                    class="v3-text-tertiary"
+                    style="font-size: 0.875rem; margin-bottom: 0.75rem;"
+                  >
+                    {{ project.licenses | join(', ') }}
+                  </div>
+                {% endif %}
+
+                {% if project.description %}
+                  <p
+                    class="v3-text-secondary"
+                    style="font-size: 0.9375rem; line-height: 1.5; margin-bottom: 1rem; flex: 1;"
+                  >
+                    {{ project.description }}
+                  </p>
+                {% endif %}
+
+                <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
+                  {% if project.webpageUrl and project.webpageUrl.url %}
+                    <a
+                      href="{{ project.webpageUrl.url }}"
+                      target="_blank"
+                      class="v3-btn v3-btn-secondary"
+                    >
+                      <i class="ti ti-world"></i>
+                      Website
+                    </a>
+                  {% endif %}
+
+                  {% if project.repositoryUrl and project.repositoryUrl.url %}
+                    <a
+                      href="{{ project.repositoryUrl.url }}"
+                      target="_blank"
+                      class="v3-btn v3-btn-dark"
+                    >
+                      <i class="ti ti-brand-github"></i>
+                      Repository
+                    </a>
+                  {% endif %}
+                </div>
+              </div>
+            {% endfor %}
+          </div>
+        </div>
+      {% endif %}
+
+      <!-- Funding Plans Card -->
+      {% if funding.plans %}
+        <div class="v3-card">
+          <div class="v3-section-title">
+            <i class="ti ti-coin"></i>
+            <span>Funding Plans</span>
+          </div>
+
+          <div
+            style="display: grid; grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr)); gap: 1rem;"
+          >
+            {% for plan in funding.plans %}
+              <div
+                style="padding: 1.5rem; background: var(--v3-main-bg); border-radius: 0.5rem; display: flex; flex-direction: column;"
+              >
+                <h3
+                  class="v3-text-primary"
+                  style="font-size: 1.125rem; font-weight: 600; margin-bottom: 0.5rem;"
+                >
+                  {{ plan.name }}
+                </h3>
+
+                <div class="v3-text-tertiary" style="font-size: 0.875rem; margin-bottom: 0.75rem;">
+                  {{ plan.frequency | capitalize }} · {{ plan.currency }}
+                </div>
+
+                {% if plan.description %}
+                  <p
+                    class="v3-text-secondary"
+                    style="font-size: 0.875rem; line-height: 1.5; margin-bottom: 1rem; flex: 1;"
+                  >
+                    {{ plan.description }}
+                  </p>
+                {% endif %}
+
+                {% if plan.amount %}
+                  <div
+                    class="v3-text-primary"
+                    style="font-size: 1.5rem; font-weight: 700; margin-bottom: 1rem;"
+                  >
+                    {{ plan.amount }} {{ plan.currency }}
+                    {% if plan.frequency != "one-time" %}
+                      <span
+                        class="v3-text-tertiary"
+                        style="font-size: 0.875rem; font-weight: 400;"
+                      >
+                        / {{ plan.frequency }}
+                      </span>
+                    {% endif %}
+                  </div>
+                {% endif %}
+
+                <div style="display: flex; flex-direction: column; gap: 0.5rem;">
+                  {% for ch_guid in plan.channels %}
+                    {% set channel = funding_channels.get(ch_guid) %}
+                    {% if channel and channel.address %}
+                      <a
+                        href="{{ channel.address }}"
+                        target="_blank"
+                        class="v3-btn v3-btn-primary"
+                      >
+                        {{ channel.guid }}
+                      </a>
+                    {% endif %}
+                  {% endfor %}
+                </div>
+              </div>
+            {% endfor %}
+          </div>
+        </div>
+      {% endif %}
+
+      <!-- Funding Channels Card -->
+      {% if funding_channels_list %}
+        <div class="v3-card">
+          <div class="v3-section-title">
+            <i class="ti ti-wallet"></i>
+            <span>Funding Channels</span>
+          </div>
+
+          <div
+            style="display: grid; grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr)); gap: 1rem;"
+          >
+            {% for channel in funding_channels_list %}
+              <div style="padding: 1rem; background: var(--v3-main-bg); border-radius: 0.5rem;">
+                <div
+                  class="v3-text-primary"
+                  style="font-size: 0.9375rem; font-weight: 600; margin-bottom: 0.25rem;"
+                >
+                  {{ channel.guid | replace("_", " ") | title }}
+                </div>
+                <div class="v3-text-tertiary" style="font-size: 0.8125rem; margin-bottom: 0.5rem;">
+                  {{ channel.type | title }}
+                </div>
+                {% if channel.description %}
+                  <div
+                    class="v3-text-secondary"
+                    style="font-size: 0.8125rem; margin-bottom: 0.5rem;"
+                  >
+                    {{ channel.description }}
+                  </div>
+                {% endif %}
+                {% if channel.address %}
+                  {% if channel.address.startswith("http") %}
+                    <a
+                      href="{{ channel.address }}"
+                      target="_blank"
+                      class="v3-text-primary"
+                      style="font-size: 0.8125rem; text-decoration: underline;"
+                    >
+                      Visit Channel
+                    </a>
+                  {% elif channel.address.startswith("mailto:") %}
+                    <a
+                      href="{{ channel.address }}"
+                      class="v3-text-primary"
+                      style="font-size: 0.8125rem; text-decoration: underline;"
+                    >
+                      {{ channel.address[7:] }}
+                    </a>
+                  {% else %}
+                    <div
+                      class="v3-text-tertiary"
+                      style="font-size: 0.8125rem; font-family: monospace; word-break: break-all;"
+                    >
+                      {{ channel.address }}
+                    </div>
+                  {% endif %}
+                {% endif %}
+              </div>
+            {% endfor %}
+          </div>
+        </div>
+      {% endif %}
+
+      <!-- Funding History Card -->
+      {% if funding.history %}
+        <div class="v3-card">
+          <div class="v3-section-title">
+            <i class="ti ti-history"></i>
+            <span>Funding History</span>
+          </div>
+
+          <div style="overflow-x: auto;">
+            <table style="width: 100%; border-collapse: collapse;">
+              <thead>
+                <tr style="border-bottom: 1px solid var(--v3-button-border);">
+                  <th
+                    class="v3-text-secondary"
+                    style="text-align: left; padding: 0.75rem 0.5rem; font-size: 0.875rem; font-weight: 600;"
+                  >
+                    Year
+                  </th>
+                  <th
+                    class="v3-text-secondary"
+                    style="text-align: left; padding: 0.75rem 0.5rem; font-size: 0.875rem; font-weight: 600;"
+                  >
+                    Income
+                  </th>
+                  <th
+                    class="v3-text-secondary"
+                    style="text-align: left; padding: 0.75rem 0.5rem; font-size: 0.875rem; font-weight: 600;"
+                  >
+                    Expenses
+                  </th>
+                  <th
+                    class="v3-text-secondary"
+                    style="text-align: left; padding: 0.75rem 0.5rem; font-size: 0.875rem; font-weight: 600;"
+                  >
+                    Taxes
+                  </th>
+                  <th
+                    class="v3-text-secondary"
+                    style="text-align: left; padding: 0.75rem 0.5rem; font-size: 0.875rem; font-weight: 600;"
+                  >
+                    Description
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for item in funding.history %}
+                  <tr style="border-bottom: 1px solid var(--v3-button-border);">
+                    <td
+                      class="v3-text-primary"
+                      style="padding: 0.75rem 0.5rem; font-size: 0.9375rem;"
+                    >
+                      {{ item.year }}
+                    </td>
+                    <td
+                      class="v3-text-primary"
+                      style="padding: 0.75rem 0.5rem; font-size: 0.9375rem;"
+                    >
+                      {{ item.income }} {{ item.currency }}
+                    </td>
+                    <td
+                      class="v3-text-primary"
+                      style="padding: 0.75rem 0.5rem; font-size: 0.9375rem;"
+                    >
+                      {{ item.expenses }} {{ item.currency }}
+                    </td>
+                    <td
+                      class="v3-text-primary"
+                      style="padding: 0.75rem 0.5rem; font-size: 0.9375rem;"
+                    >
+                      {{ item.taxes }} {{ item.currency }}
+                    </td>
+                    <td
+                      class="v3-text-tertiary"
+                      style="padding: 0.75rem 0.5rem; font-size: 0.875rem;"
+                    >
+                      {{ item.description or "—" }}
+                    </td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      {% endif %}
+    </div>
+  </div>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      initThemeToggle('theme-toggle')
+    })
+  </script>
+{% endblock %}

--- a/fossunited/fossunited/doctype/grants_funding_directory/templates/grants_funding_directory.html
+++ b/fossunited/fossunited/doctype/grants_funding_directory/templates/grants_funding_directory.html
@@ -2,6 +2,15 @@
 
 {% block title %}{{ entity.name }} – Funding Profile{% endblock %}
 
+{% macro external_link(url, classes, icon, text) %}
+  {% if url and url.startswith(("http://", "https://")) %}
+    <a href="{{ url }}" target="_blank" class="{{ classes }}">
+      <i class="{{ icon }}"></i>
+      {{ text }}
+    </a>
+  {% endif %}
+{% endmacro %}
+
 {% block page_content %}
   <style>
     .small-btn {
@@ -9,7 +18,7 @@
       font-size: 0.75rem;
     }
     .v3-card {
-        margin-bottom: 2rem;
+      margin-bottom: 2rem;
     }
   </style>
 
@@ -48,12 +57,8 @@
 
         <div class="d-flex justify-content-between align-items-center">
           <div class="v3-btn-group">
-            {% if entity.webpageUrl and entity.webpageUrl.url %}
-              <a href="{{ entity.webpageUrl.url }}" target="_blank" class="v3-btn v3-btn-primary">
-                <i class="ti ti-external-link"></i>
-                Visit Website
-              </a>
-            {% endif %}
+            {% set website_url = entity.webpageUrl.url if entity.webpageUrl else None %}
+            {{ external_link(website_url, "v3-btn v3-btn-primary", "ti ti-external-link", "Visit Website") }}
           </div>
 
           <a href="mailto:foundation@fossunited.org" class="v3-btn v3-btn-secondary small-btn">
@@ -104,27 +109,11 @@
                 {% endif %}
 
                 <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
-                  {% if project.webpageUrl and project.webpageUrl.url %}
-                    <a
-                      href="{{ project.webpageUrl.url }}"
-                      target="_blank"
-                      class="v3-btn v3-btn-secondary"
-                    >
-                      <i class="ti ti-world"></i>
-                      Website
-                    </a>
-                  {% endif %}
+                  {% set website_url = project.webpageUrl.url if project.webpageUrl else None %}
+                  {{ external_link(website_url, "v3-btn v3-btn-secondary", "ti ti-world", "Website") }}
 
-                  {% if project.repositoryUrl and project.repositoryUrl.url %}
-                    <a
-                      href="{{ project.repositoryUrl.url }}"
-                      target="_blank"
-                      class="v3-btn v3-btn-dark"
-                    >
-                      <i class="ti ti-brand-github"></i>
-                      Repository
-                    </a>
-                  {% endif %}
+                  {% set repo_url = project.repositoryUrl.url if project.repositoryUrl else None %}
+                  {{ external_link(repo_url, "v3-btn v3-btn-dark", "ti ti-brand-github", "Repository") }}
                 </div>
               </div>
             {% endfor %}

--- a/fossunited/fossunited/doctype/grants_funding_directory/templates/grants_funding_directory_row.html
+++ b/fossunited/fossunited/doctype/grants_funding_directory/templates/grants_funding_directory_row.html
@@ -1,0 +1,23 @@
+<div class="v3-clickable mb-5" onclick="window.location.href='/{{ doc.route }}'">
+  <div
+    style="padding: 1.25rem; background: var(--v3-main-bg); border-radius: 0.5rem; border: 1px solid var(--v3-button-border);"
+  >
+    <h3
+      class="v3-text-primary"
+      style="font-size: 1.125rem; font-weight: 600; margin-bottom: 0.5rem;"
+    >
+      {{ json.loads(doc.json_data).get("entity", {}).name }}
+    </h3>
+
+    <p>
+      {{ json.loads(doc.json_data).get("entity", {}).description[:100] + "..." or "" }}
+    </p>
+
+    {% if doc.last_updated %}
+      <div class="v3-text-tertiary" style="font-size: 0.875rem; margin-bottom: 0.5rem;">
+        Last updated: {{ frappe.utils.format_datetime(doc.last_updated, "dd MMM yyyy") }}
+      </div>
+    {% endif %}
+    <div class="v3-text-secondary" style="font-size: 0.9375rem;">View funding profile →</div>
+  </div>
+</div>

--- a/fossunited/fossunited/doctype/grants_funding_directory/test_grants_funding_directory.py
+++ b/fossunited/fossunited/doctype/grants_funding_directory/test_grants_funding_directory.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2025, Frappe x FOSSUnited and contributors
+# For license information, please see license.txt
+
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestGrantsFundingDirectory(FrappeTestCase):
+    pass

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -3066,6 +3066,7 @@ h6 {
 
 /* V3 Base Typography - Inter font for all v3 pages */
 .v3-page {
+  background: var(--v3-main-bg);
   font-family: 'Inter', sans-serif;
 }
 
@@ -3195,7 +3196,6 @@ h6 {
 .v3-btn-dark {
   background: var(--v3-text-color);
   color: var(--v3-main-bg);
-  min-width: 180px;
 }
 
 .v3-btn-dark:hover {
@@ -3791,6 +3791,17 @@ h6 {
 .v3-content-main .v3-card,
 .v3-content-sidebar .v3-card {
   margin-bottom: 1rem;
+}
+
+.v3-gradient-text {
+  background: linear-gradient(
+    135deg,
+    var(--v3-primary-button),
+    var(--v3-dark-green)
+  );
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
 /* Responsive */

--- a/fossunited/www/grants/directory/index.html
+++ b/fossunited/www/grants/directory/index.html
@@ -1,0 +1,159 @@
+{% extends "templates/foss_base.html" %}
+
+{% block title %}{{ page_title or "FOSS Grants & Funding" }}{% endblock %}
+
+{% block page_content %}
+  <style>
+    .v3-container {
+      font-family: 'Inter', sans-serif;
+      min-height: 100vh;
+    }
+  </style>
+
+  <div class="v3-page">
+    <div class="v3-container mb-5">
+      <div
+        style="display:flex; justify-content:space-between; align-items:center; margin-bottom:1rem;"
+      >
+        <div class="v3-breadcrumb">
+          <a href="/">Home</a> > <a href="/grants/">Grants</a> >
+          <a href="">Directory</a>
+        </div>
+        <button class="v3-theme-toggle" id="theme-toggle" title="Toggle theme">
+          <i class="ti ti-moon"></i>
+        </button>
+      </div>
+
+      <div class="v3-card v3-main-card">
+        <div class="d-flex justify-content-between align-items-center mb-4">
+          <div class="d-flex flex-column">
+            <h1 class="v3-gradient-text mb-1" style="font-size:2.4rem;">FOSS Grants & Funding</h1>
+            <p class="v3-text-secondary mb-0">
+              Explore projects from Funding JSON manifests. Inspired by
+              <a style="text-decoration: underline;" href="https://dir.floss.fund">floss.fund</a>
+            </p>
+          </div>
+
+          <div
+            id="count"
+            class="text-end v3-gradient-text ms-auto"
+            style="font-size:1.75rem; font-weight:500;"
+          >
+            {{ items|length }} Projects
+          </div>
+        </div>
+
+        <!-- Search + Sort -->
+        <div style="display:flex; gap:1rem; flex-wrap:wrap; margin-bottom:1.25rem;">
+          <input
+            id="search"
+            placeholder="Search by name..."
+            class="v3-text-primary"
+            style="flex:1; min-width:200px; padding:0.65rem; border-radius:6px; border:1px solid var(--v3-button-border); background:var(--v3-main-bg);"
+          />
+          <select
+            id="sort"
+            class="v3-text-primary"
+            style="padding:0.65rem; border-radius:6px; border:1px solid var(--v3-button-border); background:var(--v3-main-bg);"
+          >
+            <option value="modified-desc">Recently updated</option>
+            <option value="modified-asc">Oldest first</option>
+            <option value="name-asc">Name A–Z</option>
+            <option value="name-desc">Name Z–A</option>
+          </select>
+        </div>
+
+        <!-- List -->
+        <div id="grants-list" style="display:flex; flex-direction:column; gap:0.75rem;">
+          {% for it in items %}
+            <a
+              class="grant-row v3-card v3-clickable align-items-center d-flex"
+              data-datetime="{{ it.last_updated_iso or '' }}"
+              data-title="{{ it.entity_name|lower }}"
+              href="/{{ it.route }}"
+            >
+              <div style="flex:1; margin-right:1rem;">
+                <h3 class="v3-text-primary mb-1" style="font-size:1.1rem;">
+                  {{ it.entity_name }}
+                </h3>
+
+                {% if it.description_short %}
+                  <p class="v3-text-secondary mb-0" style="font-size:0.95rem;">
+                    {{ it.description_short }}
+                  </p>
+                {% endif %}
+              </div>
+
+              <div
+                class="text-end v3-text-tertiary"
+                style="white-space:nowrap; font-size:0.85rem;"
+              >
+                {{ it.last_updated_fmt }}
+              </div>
+            </a>
+          {% endfor %}
+        </div>
+
+        <!-- Empty state -->
+        <div id="empty" style="display:none; text-align:center; padding:2.5rem 1rem;">
+          <i
+            class="ti ti-folder-open v3-text-tertiary"
+            style="font-size:2.5rem; margin-bottom:0.75rem;"
+          ></i>
+          <p class="v3-text-secondary">No funding profiles found.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <style>
+    .grant-row.hidden {
+      display: none !important;
+    }
+  </style>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      if (typeof initThemeToggle === 'function') initThemeToggle('theme-toggle')
+      const search = document.getElementById('search')
+      const sort = document.getElementById('sort')
+      const list = document.getElementById('grants-list')
+      const empty = document.getElementById('empty')
+      const count = document.getElementById('count')
+
+      const dateOf = (r) => (r.dataset.datetime ? new Date(r.dataset.datetime).getTime() : 0)
+      const titleOf = (r) =>
+        (r.dataset.title || r.querySelector('h3')?.textContent || '').toLowerCase()
+
+      function render() {
+        const q = (search.value || '').toLowerCase()
+        const rows = Array.from(list.querySelectorAll('.grant-row'))
+        let visible = 0
+        rows.forEach((r) => {
+          const match = q === '' || titleOf(r).includes(q)
+          r.classList.toggle('hidden', !match)
+          if (match) visible++
+        })
+
+        rows
+          .filter((r) => !r.classList.contains('hidden'))
+          .sort((a, b) => {
+            const mode = sort.value
+            if (mode === 'modified-desc') return dateOf(b) - dateOf(a)
+            if (mode === 'modified-asc') return dateOf(a) - dateOf(b)
+            if (mode === 'name-asc') return titleOf(a).localeCompare(titleOf(b))
+            if (mode === 'name-desc') return titleOf(b).localeCompare(titleOf(a))
+            return 0
+          })
+          .forEach((r) => list.appendChild(r))
+
+        empty.style.display = visible ? 'none' : 'block'
+        count.textContent = visible + ' Projects'
+      }
+
+      search.addEventListener('input', render)
+      sort.addEventListener('change', render)
+      render()
+    })
+  </script>
+{% endblock %}

--- a/fossunited/www/grants/directory/index.py
+++ b/fossunited/www/grants/directory/index.py
@@ -18,7 +18,7 @@ def get_context(context):
     for d in docs:
         try:
             data = json.loads(d.get("json_data") or "{}")
-        except Exception:
+        except json.JSONDecodeError:
             data = {}
 
         entity = data.get("entity") or {}
@@ -39,7 +39,7 @@ def get_context(context):
                     "route": d.route,
                     "entity_name": entity_name,
                     "description_short": short_desc,
-                    "last_updated_iso": dt,
+                    "last_updated_iso": dt.isoformat() if dt else "",
                     "last_updated_fmt": dt_fmt,
                 }
             )

--- a/fossunited/www/grants/directory/index.py
+++ b/fossunited/www/grants/directory/index.py
@@ -1,0 +1,51 @@
+import json
+
+import frappe
+
+from fossunited.doctype_ids import GRANTS_DIR
+
+
+def get_context(context):
+    docs = frappe.get_all(
+        GRANTS_DIR,
+        fields=["name", "route", "json_data", "last_updated", "modified"],
+        filters={"is_published": 1},
+        order_by="last_updated desc, modified desc",
+        limit_page_length=200,
+    )
+
+    items = []
+    for d in docs:
+        try:
+            data = json.loads(d.get("json_data") or "{}")
+        except Exception:
+            data = {}
+
+        entity = data.get("entity") or {}
+        entity_name = entity.get("name") or d.get("name")
+        description = (entity.get("description") or "").strip()
+
+        # inline truncation
+        short_desc = (description[:150] + "…") if len(description) > 150 else description
+
+        # inline date formatting (converted to datetime by frappe)
+        dt = d.get("last_updated") or d.get("modified")
+        dt_fmt = dt.strftime("%d %b %Y") if dt else ""
+
+        items.append(
+            frappe._dict(
+                {
+                    "name": d.name,
+                    "route": d.route,
+                    "entity_name": entity_name,
+                    "description_short": short_desc,
+                    "last_updated_iso": dt,
+                    "last_updated_fmt": dt_fmt,
+                }
+            )
+        )
+
+    context.items = items
+    context.count = len(items)
+    context.page_title = "FOSS Grants & Funding"
+    return context


### PR DESCRIPTION
- Inspired by dir.floss.fund

we can have an doctype which takes json link and get the data to replicate the same as listing pages and to show info.

- tried to use floss fund /api/validate to validate the given json file.

We will have two pages, one to list and another to show all information on project

- Route will be on /grants/directory/

Visualization :

- Listing page
<img width="872" height="940" alt="image" src="https://github.com/user-attachments/assets/81861990-7823-4e79-971b-561c9ff4c6f5" />

- Info page on python manifest
<img width="1843" height="3061" alt="image" src="https://github.com/user-attachments/assets/43aabd77-4a35-4d34-9509-32e3bddd3ee0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Grants Funding Directory doctype and per-profile pages with projects, plans, channels, history, contact, and last-updated info.
  * Public grants directory page showing published profiles with live search, sorting, counts, and clickable rows.

* **User Interaction**
  * “Re-fetch Manifest Data” button on profiles to refresh funding data with progress and success/error feedback.

* **Style**
  * Page styling tweaks including gradient text utility and background refinements.

* **Tests**
  * Test scaffold added for the Grants Funding Directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->