### PR TITLE
doctype: support check_ins for RSVP events as well

### DIFF
--- a/dashboard/src/pages/EventRsvpInsights.vue
+++ b/dashboard/src/pages/EventRsvpInsights.vue
@@ -120,24 +120,26 @@ const submissions = createResource({
 const listColumns = computed(() => {
   const columns = new Map()
 
+  const excludedFields = ['confirm_attendance', 'status', 'name']
+
   // Collect keys from all submissions
   if (Array.isArray(submissions.data)) {
     submissions.data.forEach((submission) => {
       Object.keys(submission).forEach((key) => {
-        if (key !== 'confirm_attendance' && key !== 'status' && !columns.has(key)) {
-          columns.set(key, { key, label: key }) // Use key as label directly
+        if (!excludedFields.includes(key) && !columns.has(key)) {
+          columns.set(key, { key, label: key })
         }
       })
     })
   }
 
-  // include confirm_attendance and status
+  // include confirm_attendance only (status stays hidden)
   const result = [
     { key: 'confirm_attendance', label: 'Attending', icon: 'check-circle' },
     ...Array.from(columns.values()),
   ]
 
-  // for host approval, add an actions column
+  // host approval column
   if (rsvp_form.data?.requires_host_approval) {
     result.push({ key: 'actions', label: 'Actions' })
   }

--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -393,13 +393,18 @@ def get_checked_in_attendees(event_id):
         .run(as_dict=True)
     )
 
+    total_accepted = frappe.db.count(
+        RSVP_RESPONSE,
+        filters={"event": event_id, "status": "Accepted"},
+    )
+
     if not rows:
         return {
             "show_checkins": True,
             "attendees": [],
             "by_date": {},
             "total_checked_in": 0,
-            "total_accepted": 0,
+            "total_accepted": total_accepted,
             "event_start": str(getdate(event_start)),
             "event_end": str(getdate(event_end)),
         }
@@ -447,7 +452,7 @@ def get_checked_in_attendees(event_id):
         "attendees": attendees,
         "by_date": by_date_sorted,
         "total_checked_in": len(attendees),
-        "total_accepted": len({r["submission"] for r in rows}),
+        "total_accepted": total_accepted,
         "event_start": str(getdate(event_start)),
         "event_end": str(getdate(event_end)),
     }

--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -1,7 +1,10 @@
 import ast
+from collections import defaultdict
 from zoneinfo import ZoneInfo
 
 import frappe
+from frappe.query_builder import DocType, Order
+from frappe.utils import get_datetime, getdate
 from ics import Calendar, Event
 
 from fossunited.doctype_ids import (
@@ -356,3 +359,95 @@ def download_attendee_list_csv(event_id: str) -> str:
     frappe.response["type"] = "download"
 
     return csv_data
+
+
+@frappe.whitelist()
+def get_checked_in_attendees(event_id):
+    # event date check (same guard as before)
+    event_start, event_end = frappe.db.get_value(
+        EVENT, event_id, ["event_start_date", "event_end_date"]
+    )
+    if not event_start or not event_end:
+        return {"show_checkins": False, "attendees": [], "by_date": {}}
+    now = get_datetime()
+    if not (get_datetime(event_start) <= now <= get_datetime(event_end)):
+        return {"show_checkins": False, "attendees": [], "by_date": {}}
+
+    Submission = DocType("FOSS Event RSVP Submission")
+    CheckIn = DocType("Event Check In")
+
+    rows = (
+        frappe.qb.from_(CheckIn)
+        .join(Submission)
+        .on(CheckIn.parent == Submission.name)
+        .select(
+            Submission.name.as_("submission"),
+            Submission.name1,
+            Submission.email,
+            Submission.im_a,
+            CheckIn.check_in_time,
+        )
+        .where(Submission.event == event_id)
+        .where(Submission.status == "Accepted")
+        .orderby(CheckIn.check_in_time, Order.desc)
+        .run(as_dict=True)
+    )
+
+    if not rows:
+        return {
+            "show_checkins": True,
+            "attendees": [],
+            "by_date": {},
+            "total_checked_in": 0,
+            "total_accepted": 0,
+            "event_start": str(getdate(event_start)),
+            "event_end": str(getdate(event_end)),
+        }
+
+    checkins_by_parent = defaultdict(list)
+    by_date = defaultdict(lambda: {"date": None, "attendees": [], "unique_count": 0})
+    seen = set()
+
+    for r in rows:
+        p, t = r["submission"], r["check_in_time"]
+        checkins_by_parent[p].append(r)
+        date_key = str(getdate(t))
+        if by_date[date_key]["date"] is None:
+            by_date[date_key]["date"] = date_key
+        by_date[date_key]["attendees"].append(
+            {
+                "name": p,
+                "name1": r.get("name1"),
+                "email": r.get("email"),
+                "im_a": r.get("im_a"),
+                "check_in_time": t,
+            }
+        )
+        key = f"{date_key}:{p}"
+        if key not in seen:
+            seen.add(key)
+            by_date[date_key]["unique_count"] += 1
+
+    attendees = [
+        {
+            "name": p,
+            "name1": lst[0].get("name1"),
+            "email": lst[0].get("email"),
+            "im_a": lst[0].get("im_a"),
+            "check_in_time": lst[0].get("check_in_time"),
+            "total_check_ins": len(lst),
+        }
+        for p, lst in checkins_by_parent.items()
+    ]
+
+    by_date_sorted = {d: by_date[d] for d in sorted(by_date)}
+
+    return {
+        "show_checkins": True,
+        "attendees": attendees,
+        "by_date": by_date_sorted,
+        "total_checked_in": len(attendees),
+        "total_accepted": len({r["submission"] for r in rows}),
+        "event_start": str(getdate(event_start)),
+        "event_end": str(getdate(event_end)),
+    }

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.json
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.json
@@ -23,7 +23,9 @@
   "confirm_attendance",
   "subscribe_chapter_mailing",
   "section_break_vzwa",
-  "custom_answers"
+  "custom_answers",
+  "checkin_section",
+  "check_ins"
  ],
  "fields": [
   {
@@ -138,10 +140,21 @@
    "fieldname": "subscribe_chapter_mailing",
    "fieldtype": "Check",
    "label": "Subscribe to Chapter Mailing?"
+  },
+  {
+   "fieldname": "checkin_section",
+   "fieldtype": "Section Break",
+   "label": "Checkin"
+  },
+  {
+   "fieldname": "check_ins",
+   "fieldtype": "Table",
+   "label": "Checkin Table",
+   "options": "Event Check In"
   }
  ],
  "links": [],
- "modified": "2025-10-31 16:53:04.612511",
+ "modified": "2025-11-21 12:03:36.919346",
  "modified_by": "Administrator",
  "module": "Chapters",
  "name": "FOSS Event RSVP Submission",

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
@@ -185,7 +185,7 @@ class FOSSEventRSVPSubmission(Document):
 
         # Add check-in record
         self.append("check_ins", {"check_in_time": now_datetime()})
-        self.save(ignore_permissions=True)
+        self.save()
 
         return {"success": True, "message": "Checked in successfully"}
 

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
@@ -18,20 +18,22 @@ class FOSSEventRSVPSubmission(Document):
     if TYPE_CHECKING:
         from frappe.types import DF
 
+        from fossunited.fossunited.doctype.event_check_in.event_check_in import EventCheckIn
         from fossunited.fossunited.doctype.foss_custom_answer.foss_custom_answer import (
             FOSSCustomAnswer,
         )
 
         chapter: DF.Data | None
+        check_ins: DF.Table[EventCheckIn]
         confirm_attendance: DF.Check
         custom_answers: DF.Table[FOSSCustomAnswer]
         email: DF.Data
         event: DF.Data
         event_name: DF.Data | None
-        im_a: DF.Literal["", "Student", "Professional", "FOSS Enthusiast", "Other"]  # noqa: F722, F821
+        im_a: DF.Literal["", "Student", "Professional", "FOSS Enthusiast", "Other"]
         linked_rsvp: DF.Link
         name1: DF.Data
-        status: DF.Literal["Pending", "Accepted", "Rejected"]  # noqa: F722, F821
+        status: DF.Literal["Pending", "Accepted", "Rejected"]
         submitted_by: DF.Link | None
         subscribe_chapter_mailing: DF.Check
     # end: auto-generated types

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
@@ -1,6 +1,6 @@
 import frappe
 from frappe.model.document import Document
-from frappe.utils import cint
+from frappe.utils import cint, get_datetime, getdate, now_datetime
 
 from fossunited.api.chapter import check_if_chapter_member
 from fossunited.api.emailing import handle_email_group_subscription
@@ -18,7 +18,9 @@ class FOSSEventRSVPSubmission(Document):
     if TYPE_CHECKING:
         from frappe.types import DF
 
-        from fossunited.fossunited.doctype.event_check_in.event_check_in import EventCheckIn
+        from fossunited.fossunited.doctype.event_check_in.event_check_in import (
+            EventCheckIn,
+        )
         from fossunited.fossunited.doctype.foss_custom_answer.foss_custom_answer import (
             FOSSCustomAnswer,
         )
@@ -166,3 +168,50 @@ class FOSSEventRSVPSubmission(Document):
             subscribe_to_event=is_accepted and is_attending,
             document_type_event=EVENT,
         )
+
+    @frappe.whitelist()
+    def add_check_in(self):
+        """Add a check-in record for this submission"""
+        # Check if event allows check-in (between start and end date)
+        event_start, event_end = frappe.db.get_value(
+            EVENT, self.event, ["event_start_date", "event_end_date"]
+        )
+        if not self.can_check_in(event_start, event_end):
+            frappe.throw("Check-in is only available during the event dates")
+
+        # Check if already checked in today
+        if self.has_checked_in_today():
+            frappe.throw("You have already checked in today")
+
+        # Add check-in record
+        self.append("check_ins", {"check_in_time": now_datetime()})
+        self.save(ignore_permissions=True)
+
+        return {"success": True, "message": "Checked in successfully"}
+
+    def can_check_in(self, event_start_date, event_end_date):
+        """Check if check-in is allowed (between event start and end dates)"""
+        if not event_start_date or not event_end_date:
+            return False
+
+        now = get_datetime()
+        start = get_datetime(event_start_date)
+        end = get_datetime(event_end_date)
+
+        return start <= now <= end
+
+    def has_checked_in_today(self):
+        """Check if user has already checked in today"""
+
+        today = getdate()
+        for check_in in self.check_ins:
+            if getdate(check_in.check_in_time) == today:
+                return True
+        return False
+
+
+@frappe.whitelist()
+def self_check_in(submission_name):
+    """API endpoint for self check-in"""
+    doc = frappe.get_doc(RSVP_RESPONSE, submission_name)
+    return doc.add_check_in()


### PR DESCRIPTION
- For #634 

- We have check in for ticketing (paid)

RSVP can also use check in for providing insights and obviously for data

We utilize same event check in table to record datetime of it

- This won't allow for QR code based check-ins or single perosn doing check-in via dashboard (as register desk does)
- This is intended for self-checkin via "[Edit rsvp](https://docs.fossunited.org/attend-event/?h=edit%20rsvp#updating-your-rsvp)" form
 - Soon there be PR on that with visualization.

- Further we will let RSVP insights have another list view to show how many has checked in (able to download as well)


TLDR;

#### Allow self-checkin of attendees for rsvp events

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added check-in capability for event RSVP submissions with validation to prevent duplicate same-day check-ins and enforce event time windows.
  * Added an API to retrieve attendee check-in statistics and details.
  * RSVP submission form now shows check-in records and history.

* **Bug Fixes / UI**
  * Adjusted attendee table columns: "name" is excluded from dynamic columns and "status" is hidden while confirmation/attendance is shown.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->