### PR TITLE
frontend: allow self-checkin of rsvp for an event

### DIFF
--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -90,7 +90,8 @@ def check_if_chapter_or_event_core_member(event: str) -> bool:
     event_doc = frappe.get_doc(EVENT, event, ["name"])
     chapter_id = event_doc.chapter
     is_team = bool(
-        check_if_event_lead(event) or check_if_chapter_member(chapter_id, frappe.session.user)
+        check_if_event_lead(event)
+        or check_if_chapter_member(chapter_id, frappe.session.user)
     )
     return is_team
 
@@ -124,13 +125,23 @@ def generate_ics(event_ids):
         ],
     )
     for event in events:
-        tz_name = frappe.db.get_single_value("System Settings", "time_zone") or "Asia/Kolkata"
+        tz_name = (
+            frappe.db.get_single_value("System Settings", "time_zone") or "Asia/Kolkata"
+        )
         tz = ZoneInfo(tz_name)
         start_dt = frappe.utils.get_datetime(event.event_start_date)
         end_dt = frappe.utils.get_datetime(event.event_end_date)
         # If naive, treat as local time in site TZ; if aware, convert
-        start = start_dt.replace(tzinfo=tz) if start_dt.tzinfo is None else start_dt.astimezone(tz)
-        end = end_dt.replace(tzinfo=tz) if end_dt.tzinfo is None else end_dt.astimezone(tz)
+        start = (
+            start_dt.replace(tzinfo=tz)
+            if start_dt.tzinfo is None
+            else start_dt.astimezone(tz)
+        )
+        end = (
+            end_dt.replace(tzinfo=tz)
+            if end_dt.tzinfo is None
+            else end_dt.astimezone(tz)
+        )
 
         # Skip if end is before start
         if end < start:
@@ -348,7 +359,9 @@ def download_attendee_list_csv(event_id: str) -> str:
     csv_data = "\ufeff" + output.getvalue()  # BOM for Excel
 
     # Create safe filename
-    event_name = frappe.db.get_value(EVENT, event_id, "event_name", cache=True) or "event"
+    event_name = (
+        frappe.db.get_value(EVENT, event_id, "event_name", cache=True) or "event"
+    )
     safe_event_name = re.sub(r"[^A-Za-z0-9._-]+", "_", event_name)
     filename = f"Attendee_List_-_{safe_event_name}.csv"
 

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
@@ -72,7 +72,9 @@ class FOSSEventRSVPSubmission(Document):
                     document_type_event=EVENT,
                 )
         except frappe.ValidationError as e:
-            frappe.log_error(frappe.get_traceback(), f"on_trash unsubscribe failed: {e}")
+            frappe.log_error(
+                frappe.get_traceback(), f"on_trash unsubscribe failed: {e}"
+            )
 
     def validate_linked_rsvp_exists(self):
         if not frappe.db.exists(EVENT_RSVP, self.linked_rsvp):
@@ -80,14 +82,18 @@ class FOSSEventRSVPSubmission(Document):
 
     def validate_rsvp_is_published(self):
         is_system_user = frappe.get_roles(frappe.session.user).count("System Manager")
-        is_chapter_member = check_if_chapter_member(chapter=self.chapter, user=frappe.session.user)
+        is_chapter_member = check_if_chapter_member(
+            chapter=self.chapter, user=frappe.session.user
+        )
 
         # If the user is system user or team member,
         # don't check for validation before rsvp submission creation
         if is_system_user or is_chapter_member:
             return
 
-        rsvp_published = frappe.db.get_value(EVENT_RSVP, self.linked_rsvp, "is_published")
+        rsvp_published = frappe.db.get_value(
+            EVENT_RSVP, self.linked_rsvp, "is_published"
+        )
         if not rsvp_published:
             frappe.throw("RSVP is not published")
 
@@ -143,7 +149,9 @@ class FOSSEventRSVPSubmission(Document):
         )
 
         if requires_host_approval and self.status == "Accepted":
-            frappe.throw("Invalid action. Status cannot be `Accepted`.", frappe.PermissionError)
+            frappe.throw(
+                "Invalid action. Status cannot be `Accepted`.", frappe.PermissionError
+            )
 
         # If the RSVP requires host approval, set the status to Pending
         if requires_host_approval:

--- a/fossunited/fossunited/forms.py
+++ b/fossunited/fossunited/forms.py
@@ -18,39 +18,54 @@ def is_valid_doctype(doctype: str):
 
 @frappe.whitelist()
 def update_submission(doctype, submission, fields, custom):
-    """
-    Used for RSVP and CFPS
-    Update the given submission with the given fields and custom answers
-    """
+    """Update submission fields and upsert custom answers (update existing, append new)."""
     if not is_valid_doctype(doctype):
         frappe.log("Unauthorized usage of update_submission")
-        frappe.throw(
-            "You are not permitted to use this resource",
-            frappe.PermissionError,
-        )
+        frappe.throw("You are not permitted to use this resource", frappe.PermissionError)
 
-    # Add authorization check
     if not check_if_submitter(doctype, submission):
-        frappe.throw(
-            "You are not authorized to update this submission",
-            frappe.PermissionError,
-        )
+        frappe.throw("You are not authorized to update this submission", frappe.PermissionError)
 
-    fields = json.loads(fields)
-    custom = json.loads(custom)
+    fields = json.loads(fields or "{}")
+    custom = json.loads(custom or "[]")
 
     doc = frappe.get_doc(doctype, submission)
 
-    # Update main fields
-    for key, value in fields.items():
-        setattr(doc, key, value)
+    # Update only fields that exist on the doctype (avoid creating unknown fields)
+    meta = frappe.get_meta(doctype)
+    for k, v in fields.items():
+        if meta.get_field(k):
+            doc.set(k, v)
+        else:
+            frappe.logger("rsvp_update").debug(f"Ignored unknown field: {k}")
 
-    # Update custom answers
-    for idx, field in enumerate(doc.custom_answers):
-        field.response = custom[idx]["response"]
+    # Build map of existing custom answers (question -> row)
+    existing = {row.question: row for row in (doc.custom_answers or [])}
 
-    doc.save()  # Triggers frappe controller: before_save()
+    for item in custom:
+        q = item.get("question")
+        resp = item.get("response")
+        ftype = item.get("type")
 
+        if not q:
+            continue
+
+        if q in existing:
+            row = existing[q]
+            row.response = resp
+            if ftype is not None:
+                row.type = ftype
+        else:
+            doc.append(
+                "custom_answers",
+                {
+                    "question": q,
+                    "response": resp,
+                    **({"type": ftype} if ftype is not None else {}),
+                },
+            )
+
+    doc.save()  # runs validations/hooks
     return {"status": "success"}
 
 

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -3181,6 +3181,7 @@ h6 {
 }
 
 .v3-btn-primary:hover {
+  background: var(--v3-primary-button);
   color: var(--v3-main-bg);
   opacity: 0.9;
 }
@@ -3191,16 +3192,7 @@ h6 {
 }
 
 .v3-btn-secondary:hover {
-  color: var(--v3-text-color);
-  opacity: 0.8;
-}
-
-.v3-btn-secondary {
   background: var(--v3-button-border);
-  color: var(--v3-text-color);
-}
-
-.v3-btn-secondary:hover {
   color: var(--v3-text-color);
   opacity: 0.8;
 }

--- a/fossunited/templates/macros/renderfield.html
+++ b/fossunited/templates/macros/renderfield.html
@@ -4,11 +4,11 @@
       {% from "fossunited/templates/macros/custom_question.html" import CustomQuestion %}
       {% if frappe.form_dict.get('cfp') %}
         {% for question in frappe.get_doc("FOSS Event CFP", submission.linked_cfp).custom_questions %}
-          {{ CustomQuestion(question, submission.custom_answers[question.idx - 1]) }}
+          {{ CustomQuestion(question, (submission.custom_answers[question.idx - 1] or {"response": ""})) }}
         {% endfor %}
       {% elif frappe.form_dict.get('rsvp') %}
         {% for question in frappe.get_doc("FOSS Event RSVP", submission.linked_rsvp).custom_questions %}
-          {{ CustomQuestion(question, submission.custom_answers[question.idx - 1]) }}
+          {{ CustomQuestion(question, (submission.custom_answers[question.idx - 1]) or {"response": ""}) }}
         {% endfor %}
       {% endif %}
     {% elif field.fieldtype == 'Data' %}

--- a/fossunited/www/rsvp/submission/edit.html
+++ b/fossunited/www/rsvp/submission/edit.html
@@ -1,35 +1,64 @@
-{% extends "templates/foss_base.html" %} {% block title %}Edit RSVP Submission{% endblock %}
+{% extends "templates/foss_base.html" %}
+{% block title %}Edit RSVP Submission{% endblock %}
+
 {% block page_content %}
-  <div class="container">
-    <div class="backlink mt-5">
-      <a href="/{{ event.route }}">
-        <i class="ti ti-arrow-left"></i>
-        {{ _("Back to Event Page") }}
-      </a>
-    </div>
-    <div class="foss-form-wrapper">
-      <div class="form-container">
+  <div class="v3-page">
+    <div class="v3-container" style="margin-bottom: 3rem;">
+      <!-- Breadcrumb -->
+      <div class="v3-breadcrumb">
+        <a href="/{{ event.route }}">
+          <i class="ti ti-arrow-left"></i>
+          {{ _("Back to Event Page") }}
+        </a>
+      </div>
+
+      <!-- Main Card -->
+      <div class="v3-card" style="margin-top: 1rem;">
         {{ render_form_header() }}
-        <form class="foss-form-body">
+
+        <form class="foss-form-body" style="margin-top: 1.5rem;">
           {% from 'fossunited/templates/macros/renderfield.html' import renderfield %}
-          {%
-            for field
-            in form_fields
-          %}
+          {% for field in form_fields %}
             {{ renderfield(field, submission) }}
           {% endfor %}
         </form>
-        <div class="foss-form-buttons">
+
+        <!-- Action Buttons -->
+        <div class="v3-btn-group" style="margin-top: 2rem;">
+          <!-- Check-in Button - Only show if backend says we can -->
+          {% if show_check_in_button %}
+            <button class="v3-btn v3-btn-primary" id="check-in-btn">
+              <i class="ti ti-circle-check"></i>
+              {{ _("Check-In Now") }}
+            </button>
+          {% endif %}
+
+          <!-- Check-in Status - Only show if already checked in today -->
+          {% if checked_in_today %}
+            <div
+              class="v3-btn"
+              style="display: flex; align-items: center; border-radius: 0.5rem; background: var(--v3-live-button); font-weight: 600; cursor: default;"
+            >
+              <span class="v3-gradient-text">Already checked-in for today!</span>
+            </div>
+          {% endif %}
+
+          <!-- Attendance Toggle -->
           {% if submission.confirm_attendance %}
-            <button class="danger-button" id="toggle-rsvp" data-new-status="0">
+            <button class="v3-btn danger-button" id="toggle-rsvp" data-new-status="0">
+              <i class="ti ti-circle-x"></i>
               {{ _("I can't attend the Event!") }}
             </button>
           {% else %}
-            <button class="secondary-button" id="toggle-rsvp" data-new-status="1">
+            <button class="v3-btn v3-btn-primary" id="toggle-rsvp" data-new-status="1">
+              <i class="ti ti-circle-dashed-check"></i>
               {{ _("I'll attend the Event!") }}
             </button>
           {% endif %}
-          <button class="primary-button" type="submit" id="update-rsvp" disabled="">
+
+          <!-- Update Button -->
+          <button class="v3-btn v3-btn-dark" type="submit" id="update-rsvp" disabled="">
+            <i class="ti ti-device-floppy"></i>
             {{ _("Update RSVP Form") }}
           </button>
         </div>
@@ -37,42 +66,128 @@
     </div>
   </div>
 {% endblock %}
+
 {% macro render_form_header() %}
-  <div class="foss-form-header">
-    <h3 class="foss-form-heading-3xl">{{ _("Edit RSVP Form") }}</h3>
-    <div class="event-details my-2">
+  <div style="margin-bottom: 1.5rem;">
+    <h3 class="v3-text-primary" style="font-size: 1.5rem; font-weight: 600; margin-bottom: 1rem;">
+      {{ _("Edit RSVP Form") }}
+    </h3>
+
+    <div style="display: flex; flex-direction: column; gap: 0.5rem;">
       {% from 'fossunited/templates/macros/chapter_branding_block.html' import chapter_branding_block %}
-      <div class="py-2">{{ chapter_branding_block(event.chapter) }}</div>
-      <div class="event-title my-1">
-        <span><strong>Event:</strong></span>
-        {{ event.event_name }}
-      </div>
-      <div class="event-date my-1">
-        <span><strong>Date:</strong></span>
-        {{ event.event_start_date.strftime("%B %d, %Y") }}
+      <div>{{ chapter_branding_block(event.chapter) }}</div>
+
+      <div class="v3-text-secondary"><strong>Event:</strong> {{ event.event_name }}</div>
+
+      <div class="v3-text-secondary">
+        <strong>Date:</strong> {{ event.event_start_date.strftime("%B %d, %Y") }}
       </div>
     </div>
-    <div class="foss-form-description my-4">Edit your RSVP form for the event.</div>
+
+    <p class="v3-text-tertiary" style="margin-top: 1rem;">Edit your RSVP form for the event.</p>
   </div>
 {% endmacro %}
+
 {% block page_script %}
   <script>
     $(document).ready(function () {
       check_if_submitter()
       enable_update_button()
       set_mandatory_asterisk()
+      check_if_can_check_in()
 
       $('#update-rsvp').on('click', (e) => {
+        e.preventDefault()
         update_rsvp()
       })
+
       $('#toggle-rsvp').on('click', function (e) {
         e.preventDefault()
-
         const newStatus = $(this).data('new-status')
-
         update_rsvp({ confirm_attendance: newStatus })
       })
+
+      $('#check-in-btn').on('click', function (e) {
+        e.preventDefault()
+        do_check_in()
+      })
     })
+
+    function check_if_can_check_in() {
+      frappe.call({
+        method:
+          'fossunited.www.rsvp.submission.edit.can_check_in_now',
+        args: {
+          event_id: '{{ event.name }}',
+        },
+        callback: (r) => {
+          if (r.message && r.message.allowed) {
+            check_if_checked_in_today()
+          }
+        },
+      })
+    }
+
+    function check_if_checked_in_today() {
+      frappe.call({
+        method: 'frappe.client.get',
+        args: {
+          doctype: 'FOSS Event RSVP Submission',
+          name: '{{ frappe.form_dict.submission }}',
+        },
+        callback: (r) => {
+          if (r.message && r.message.check_ins) {
+            const today = new Date().toDateString()
+            const hasCheckedInToday = r.message.check_ins.some((check_in) => {
+              return new Date(check_in.check_in_time).toDateString() === today
+            })
+
+            if (hasCheckedInToday) {
+              $('#check-in-status').css('display', 'flex')
+            } else {
+              $('#check-in-btn').show()
+            }
+          } else {
+            $('#check-in-btn').show()
+          }
+        },
+      })
+    }
+
+    function do_check_in() {
+      const btn = $('#check-in-btn')
+      const originalText = btn.html()
+
+      btn.prop('disabled', true).html('<i class="ti ti-loader"></i> Checking in...')
+
+      frappe.call({
+        method:
+          'fossunited.chapters.doctype.foss_event_rsvp_submission.foss_event_rsvp_submission.self_check_in',
+        args: {
+          submission_name: '{{ frappe.form_dict.submission }}',
+        },
+        callback: (r) => {
+          if (r.message && r.message.success) {
+            frappe.show_alert(
+              {
+                message: __('Checked in successfully!'),
+                indicator: 'green',
+              },
+              3,
+            )
+            btn.hide()
+            $('#check-in-status').css('display', 'flex')
+          }
+        },
+        error: (e) => {
+          btn.prop('disabled', false).html(originalText)
+          frappe.msgprint({
+            message: e.message || __('Failed to check in. Please try again.'),
+            indicator: 'red',
+          })
+        },
+      })
+    }
 
     function enable_update_button() {
       let formFields = document.querySelectorAll(
@@ -134,7 +249,6 @@
       })
 
       let custom_answers = []
-      // for each value in submission, if the key has custom_question in it, then add it to custom answers as {question: field.data('label'), response: value}
       for (const key in submission) {
         if (key.includes('custom_question')) {
           const label = $(`[name="${key}"]`).data('label')
@@ -144,14 +258,8 @@
         }
       }
 
-      // removing empty string keys
       submission = Object.fromEntries(Object.entries(submission).filter(([k, v]) => k !== ''))
-
-      // Merge overrides (like confirm_attendance: 0)
-      submission = {
-        ...submission,
-        ...override_fields,
-      }
+      submission = { ...submission, ...override_fields }
 
       frappe.call({
         method: 'fossunited.fossunited.forms.update_submission',

--- a/fossunited/www/rsvp/submission/edit.html
+++ b/fossunited/www/rsvp/submission/edit.html
@@ -29,7 +29,7 @@
           {% if show_check_in_button %}
             <button class="v3-btn v3-btn-primary" id="check-in-btn">
               <i class="ti ti-circle-check"></i>
-              {{ _("Check-In Now") }}
+              {{ _("Check-In Today") }}
             </button>
           {% endif %}
 
@@ -94,7 +94,6 @@
       check_if_submitter()
       enable_update_button()
       set_mandatory_asterisk()
-      check_if_can_check_in()
 
       $('#update-rsvp').on('click', (e) => {
         e.preventDefault()
@@ -112,47 +111,6 @@
         do_check_in()
       })
     })
-
-    function check_if_can_check_in() {
-      frappe.call({
-        method:
-          'fossunited.www.rsvp.submission.edit.can_check_in_now',
-        args: {
-          event_id: '{{ event.name }}',
-        },
-        callback: (r) => {
-          if (r.message && r.message.allowed) {
-            check_if_checked_in_today()
-          }
-        },
-      })
-    }
-
-    function check_if_checked_in_today() {
-      frappe.call({
-        method: 'frappe.client.get',
-        args: {
-          doctype: 'FOSS Event RSVP Submission',
-          name: '{{ frappe.form_dict.submission }}',
-        },
-        callback: (r) => {
-          if (r.message && r.message.check_ins) {
-            const today = new Date().toDateString()
-            const hasCheckedInToday = r.message.check_ins.some((check_in) => {
-              return new Date(check_in.check_in_time).toDateString() === today
-            })
-
-            if (hasCheckedInToday) {
-              $('#check-in-status').css('display', 'flex')
-            } else {
-              $('#check-in-btn').show()
-            }
-          } else {
-            $('#check-in-btn').show()
-          }
-        },
-      })
-    }
 
     function do_check_in() {
       const btn = $('#check-in-btn')
@@ -260,6 +218,7 @@
 
       submission = Object.fromEntries(Object.entries(submission).filter(([k, v]) => k !== ''))
       submission = { ...submission, ...override_fields }
+      console.log("ans", custom_answers)
 
       frappe.call({
         method: 'fossunited.fossunited.forms.update_submission',

--- a/fossunited/www/rsvp/submission/edit.html
+++ b/fossunited/www/rsvp/submission/edit.html
@@ -134,7 +134,6 @@
               3,
             )
             btn.hide()
-            $('#check-in-status').css('display', 'flex')
           }
         },
         error: (e) => {

--- a/fossunited/www/rsvp/submission/edit.py
+++ b/fossunited/www/rsvp/submission/edit.py
@@ -1,6 +1,8 @@
 import frappe
-from frappe.utils import get_datetime, getdate
 
+from fossunited.chapters.doctype.foss_event_rsvp_submission.foss_event_rsvp_submission import (
+    FOSSEventRSVPSubmission,
+)
 from fossunited.doctype_ids import EVENT, EVENT_RSVP, RSVP_RESPONSE
 from fossunited.fossunited.utils import filter_field_values
 
@@ -28,37 +30,13 @@ def get_context(context):
     context.form_fields = get_form_fields(context.submission.doctype, context.submission)
 
     # Check-in logic
-    context.can_check_in = can_check_in_now(context.event)
-    context.checked_in_today = has_checked_in_today(context.submission)
+    context.can_check_in = FOSSEventRSVPSubmission.can_check_in(
+        context.event, context.event.event_start_date, context.event.event_end_date
+    )
+    context.checked_in_today = FOSSEventRSVPSubmission.has_checked_in_today(context.submission)
     context.show_check_in_button = context.can_check_in and not context.checked_in_today
 
     context.no_cache = 1
-
-
-@frappe.whitelist()
-def can_check_in_now(event):
-    """Check if check-in is currently allowed for this event"""
-    if not event.event_start_date or not event.event_end_date:
-        return False
-
-    now = get_datetime()
-    start = get_datetime(event.event_start_date)
-    end = get_datetime(event.event_end_date)
-
-    return start <= now <= end
-
-
-def has_checked_in_today(submission):
-    """Check if user has already checked in today"""
-    if not submission.check_ins:
-        return False
-
-    today = getdate()
-    for check_in in submission.check_ins:
-        if getdate(check_in.check_in_time) == today:
-            return True
-
-    return False
 
 
 def get_form_fields(doctype, submission):

--- a/fossunited/www/rsvp/submission/edit.py
+++ b/fossunited/www/rsvp/submission/edit.py
@@ -1,7 +1,23 @@
 import frappe
+from frappe.utils import get_datetime, getdate
 
 from fossunited.doctype_ids import EVENT, EVENT_RSVP, RSVP_RESPONSE
 from fossunited.fossunited.utils import filter_field_values
+
+IGNORE_FIELDNAMES = {
+    "confirm_attendance",
+    "check_ins",
+    "subscribe_chapter_mailing",
+}
+
+IGNORE_FIELD_LABEL_SECTIONS = {
+    "Meta Info",
+    "Custom Answers",
+}
+
+IGNORE_FIELDTYPES = {
+    "Column Break",
+}
 
 
 def get_context(context):
@@ -11,40 +27,91 @@ def get_context(context):
     frappe.form_dict["doctype"] = RSVP_RESPONSE
     context.confirm_attendance = context.submission.confirm_attendance
     context.form_fields = get_form_fields(context.submission.doctype, context.submission)
+
+    # Check-in logic
+    context.can_check_in = can_check_in_now(context.event)
+    context.checked_in_today = has_checked_in_today(context.submission)
+    context.show_check_in_button = context.can_check_in and not context.checked_in_today
+
     context.no_cache = 1
+
+
+@frappe.whitelist()
+def can_check_in_now(event):
+    """Check if check-in is currently allowed for this event"""
+    if not event.event_start_date or not event.event_end_date:
+        return False
+
+    now = get_datetime()
+    start = get_datetime(event.event_start_date)
+    end = get_datetime(event.event_end_date)
+
+    return start <= now <= end
+
+
+def has_checked_in_today(submission):
+    """Check if user has already checked in today"""
+    if not submission.check_ins:
+        return False
+
+    today = getdate()
+    for check_in in submission.check_ins:
+        if getdate(check_in.check_in_time) == today:
+            return True
+
+    return False
 
 
 def get_form_fields(doctype, submission):
     meta = frappe.get_meta(doctype).as_dict()
     form_fields = []
     current_section = None
+
     for field in meta["fields"]:
-        if field["fieldtype"] == "Column Break":
+        # Skip unwanted fieldtypes
+        if field["fieldtype"] in IGNORE_FIELDTYPES:
             continue
+
+        # Section logic
         if field["fieldtype"] == "Section Break":
-            current_section = field["label"]
+            current_section = field.get("label")
             continue
+
+        # Skip entire sections
+        if current_section in IGNORE_FIELD_LABEL_SECTIONS:
+            continue
+
+        # Skip specific fieldnames
+        if field["fieldname"] in IGNORE_FIELDNAMES:
+            continue
+
+        # Special case — dynamic label
         if field["fieldname"] == "subscribe_chapter_mailing":
             field["label"] = (
                 f"Yes, I'd like to receive updates about future events from {submission.chapter}."
             )
-        if field["fieldname"] == "confirm_attendance":
-            continue
-        if current_section in ["Meta Info", "Custom Answers"]:
-            continue
+
         form_fields.append({k: v for k, v in field.items() if filter_field_values(k)})
 
+    if not submission.custom_answers:
+        return form_fields
+
     rsvp_doc = frappe.get_doc(EVENT_RSVP, submission.linked_rsvp)
-    for question in submission.custom_answers:
+
+    # Create a mapping of question -> response for quick lookup
+    answer_map = {ans.question: ans.response for ans in submission.custom_answers}
+
+    # Iterate through RSVP questions (not submission answers) to avoid duplicates
+    for idx, question in enumerate(rsvp_doc.custom_questions, start=1):
         form_fields.append(
             {
-                "fieldname": f"custom_question_{question.idx}",
+                "fieldname": f"custom_question_{idx}",
                 "fieldtype": question.type,
                 "label": question.question,
-                "value": question.response,
-                "options": rsvp_doc.custom_questions[question.idx - 1].options,
-                "reqd": rsvp_doc.custom_questions[question.idx - 1].is_mandatory or 0,
-                "description": rsvp_doc.custom_questions[question.idx - 1].description,
+                "value": answer_map.get(question.question, ""),
+                "options": question.options,
+                "reqd": question.is_mandatory or 0,
+                "description": question.description,
             }
         )
 

--- a/fossunited/www/rsvp/submission/edit.py
+++ b/fossunited/www/rsvp/submission/edit.py
@@ -7,7 +7,6 @@ from fossunited.fossunited.utils import filter_field_values
 IGNORE_FIELDNAMES = {
     "confirm_attendance",
     "check_ins",
-    "subscribe_chapter_mailing",
 }
 
 IGNORE_FIELD_LABEL_SECTIONS = {
@@ -92,9 +91,6 @@ def get_form_fields(doctype, submission):
             )
 
         form_fields.append({k: v for k, v in field.items() if filter_field_values(k)})
-
-    if not submission.custom_answers:
-        return form_fields
 
     rsvp_doc = frappe.get_doc(EVENT_RSVP, submission.linked_rsvp)
 


### PR DESCRIPTION
- goes after #1286 

- During event timeline attendee can go to "Edit rsvp" and it will show "Check-in for today" to do self-checkin for the event.

- Also themed edit page be in in-line with v3 theme and colors (since event page is so..)

- Check in button will only be showed during event timeline.

Visualization:

<img width="1333" height="1312" alt="image" src="https://github.com/user-attachments/assets/2c73c579-acbd-4472-b183-f0efc5757df0" />


- When check-in for the day

<img width="1333" height="1312" alt="image" src="https://github.com/user-attachments/assets/04e7b9e0-7414-46f5-ba57-36e92432cbf0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added check-in functionality to RSVP submissions with real-time status indicators.

* **Bug Fixes**
  * Fixed handling of missing custom answer responses in submission forms.

* **Style**
  * Redesigned RSVP submission form with improved layout, navigation, and button styling.
  * Enhanced button hover states for better visual feedback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->