### PR TITLE
dashboard: adjust mobile adaptiveness of some components

### DIFF
--- a/dashboard/src/components/event/schedule/ManageDates.vue
+++ b/dashboard/src/components/event/schedule/ManageDates.vue
@@ -76,7 +76,7 @@ const handleRemoveScheduleDate = () => {
       ],
     }"
   ></Dialog>
-  <div class="flex gap-2 items-center my-4">
+  <div class="flex flex-wrap gap-2 items-center my-4">
     <Button
       v-for="(date, index) in dates"
       :key="index"

--- a/dashboard/src/components/ui/CommentBox.vue
+++ b/dashboard/src/components/ui/CommentBox.vue
@@ -2,14 +2,14 @@
   <div class="border rounded p-4 bg-white w-full">
     <EditorContent :editor="editor" />
     <div class="flex justify-between items-center pt-2 mt-4">
-      <div class="flex gap-2">
+      <div class="flex gap-1">
         <button
           class="p-1 rounded-sm"
           :disabled="!editor.can().chain().focus().toggleBold().run()"
           :class="{ 'bg-gray-200': editor.isActive('bold') }"
           @click="editor.chain().focus().toggleBold().run()"
         >
-          <IconBold class="w-5 h-5" />
+          <IconBold class="w-4 h-4 sm:w-5 sm:h-5" />
         </button>
         <button
           class="p-1 rounded-sm"
@@ -17,7 +17,7 @@
           :class="{ 'bg-gray-200': editor.isActive('italic') }"
           @click="editor.chain().focus().toggleItalic().run()"
         >
-          <IconItalic class="w-5 h-5" />
+          <IconItalic class="w-4 h-4 sm:w-5 sm:h-5" />
         </button>
         <button
           class="p-1 rounded-sm"
@@ -25,7 +25,7 @@
           :class="{ 'bg-gray-200': editor.isActive('underline') }"
           @click="editor.chain().focus().toggleUnderline().run()"
         >
-          <IconUnderline class="w-5 h-5" />
+          <IconUnderline class="w-4 h-4 sm:w-5 sm:h-5" />
         </button>
         <button
           class="p-1 rounded-sm"
@@ -33,28 +33,28 @@
           :class="{ 'bg-gray-200': editor.isActive('strike') }"
           @click="editor.chain().focus().toggleStrike().run()"
         >
-          <IconStrikethrough class="w-5 h-5" />
+          <IconStrikethrough class="w-4 h-4 sm:w-5 sm:h-5" />
         </button>
         <button
           class="p-1 rounded-sm"
           :class="{ 'bg-gray-200': editor.isActive('bulletList') }"
           @click="editor.chain().focus().toggleBulletList().run()"
         >
-          <IconList class="w-5 h-5" />
+          <IconList class="w-4 h-4 sm:w-5 sm:h-5" />
         </button>
         <button
           class="p-1 rounded-sm"
           :class="{ 'bg-gray-200': editor.isActive('orderedList') }"
           @click="editor.chain().focus().toggleOrderedList().run()"
         >
-          <IconListNumbers class="w-5 h-5" />
+          <IconListNumbers class="w-4 h-4 sm:w-5 sm:h-5" />
         </button>
         <button
           class="p-1 rounded-sm"
           :class="{ 'bg-gray-200': editor.isActive('blockquote') }"
           @click="editor.chain().focus().toggleBlockquote().run()"
         >
-          <IconBlockquote class="w-5 h-5" />
+          <IconBlockquote class="w-4 h-4 sm:w-5 sm:h-5" />
         </button>
       </div>
       <Button :label="buttonLabel" variant="solid" @click="submit" />

--- a/dashboard/src/components/ui/Drawer.vue
+++ b/dashboard/src/components/ui/Drawer.vue
@@ -15,7 +15,7 @@
 
       <div class="fixed inset-0 overflow-hidden">
         <div class="absolute inset-0 overflow-hidden">
-          <div class="pointer-events-none fixed inset-y-0 right-0 flex max-w-full pl-10">
+          <div class="pointer-events-none fixed inset-y-0 right-0 flex max-w-full pl-0 sm:pl-10">
             <TransitionChild
               as="template"
               enter="transform transition ease-in-out duration-500 sm:duration-700"
@@ -35,7 +35,7 @@
                   leave-from="opacity-100"
                   leave-to="opacity-0"
                 >
-                  <div class="absolute left-0 top-0 -ml-8 flex pr-2 pt-4 sm:-ml-10 sm:pr-4">
+                  <div class="absolute left-0 top-0 -ml-0 sm:-ml-8 flex pr-2 pt-2 sm:pr-4 pl-2 sm:pl-0">
                     <button
                       type="button"
                       class="relative rounded-md text-gray-300 hover:text-white focus:outline-none focus:ring-2 focus:ring-white"
@@ -47,7 +47,7 @@
                     </button>
                   </div>
                 </TransitionChild>
-                <div class="flex h-full flex-col overflow-y-scroll bg-white py-6 shadow-xl">
+                <div class="flex h-full flex-col overflow-y-scroll bg-white py-10 shadow-xl">
                   <div class="px-4 sm:px-6 flex gap-2">
                     <slot name="pre-title"></slot>
                     <DialogTitle class="text-2xl font-semibold text-gray-900">

--- a/dashboard/src/pages/EventRsvpInsights.vue
+++ b/dashboard/src/pages/EventRsvpInsights.vue
@@ -2,7 +2,7 @@
   <div v-if="submissions.data && rsvp_form.data" class="px-4 py-8 md:p-8 flex flex-col gap-4">
     <!-- Check-In Section - only visible during event dates -->
     <div v-if="checkedInData.data?.show_checkins" class="flex flex-col gap-4 mt-1">
-      <div class="flex items-center justify-between">
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div class="font-semibold text-gray-800">
           Event Check-Ins
           <span class="ml-2 text-sm font-normal text-gray-600">
@@ -10,7 +10,8 @@
             {{ checkedInData.data.total_accepted }} confirmed attendees)
           </span>
         </div>
-        <div class="flex gap-2">
+
+        <div class="flex gap-2 w-full sm:w-auto sm:justify-end">
           <Button size="md" icon-left="download" @click="downloadCheckinCSV"> Download </Button>
           <Button size="md" icon-left="refresh-cw" @click="checkedInData.reload()">
             Refresh
@@ -240,7 +241,7 @@ const listColumns = computed(() => {
 
   // include confirm_attendance only (status stays hidden)
   const result = [
-    { key: 'confirm_attendance', label: 'Attending', icon: 'check-circle' },
+    { key: 'confirm_attendance', label: 'Attending', icon: 'check-circle', width: '40px' },
     ...Array.from(columns.values()),
   ]
 

--- a/fossunited/fossunited/doctype/grants_funding_directory/templates/grants_funding_directory.html
+++ b/fossunited/fossunited/doctype/grants_funding_directory/templates/grants_funding_directory.html
@@ -57,8 +57,8 @@
           {%
             set mailto =
             "mailto:foundation@fossunited.org"
-            ~ "?subject=" ~ ("[Funding Directory] Issue with " ~ entity.name)|urlencode
-            ~ "&body=" ~ ("Link: " ~ funding_url)|urlencode
+            ~ "?subject=" ~ ("[Grants Directory] Issue with " ~ entity.name)|urlencode
+            ~ "&body=" ~ ("Link: " ~ funding_json)|urlencode
           %}
 
           <a href="{{ mailto }}" class="v3-text-tertiary"> <i class="ti ti-flag"></i> Report </a>
@@ -86,8 +86,7 @@
           </div>
 
           <div class="v3-btn-group d-flex" style="gap:1rem;">
-            {% set funding_url = funding_json if funding_json else None %}
-            {{ external_link(funding_url, "v3-btn v3-btn-dark", "ti ti-braces", "Manifest") }}
+            {{ external_link(funding_json, "v3-btn v3-btn-dark", "ti ti-braces", "Manifest") }}
           </div>
         </div>
       </div>


### PR DESCRIPTION
- partially based on #718 

- Adjust rsvp insights info text to wrap as row 
- Adjust drawer to take full-width on mobile and let close button appear on top
  ^ reason being why waste some horizontal space for a close button?
  This problem exists for dev <400px width

Prev style (old):
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/a36c2658-141e-4830-9200-e64112b16a5f" />


New style which takes full width:
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/2ebb60be-3068-4c8f-8f9c-74aa764b6c82" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layouts across interface sections for better adaptation on various screen sizes
  * Optimized toolbar spacing and icon sizing with responsive breakpoints
  * Enhanced date input controls to wrap across multiple lines
  * Refined drawer padding and alignment for improved visual consistency
  * Constrained attendee list column width for better display

* **Updates**
  * Updated email subject and link parameters in grants directory feature

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->