### PR TITLE
dashboard: normal-case Input field and ticket tier title

### DIFF
--- a/dashboard/src/components/Input.vue
+++ b/dashboard/src/components/Input.vue
@@ -16,7 +16,7 @@
       <input
         v-model="model"
         :placeholder="placeholder"
-        class="focus:border-none focus:ring-0 border-none p-0 uppercase w-full"
+        class="focus:border-none focus:ring-0 border-none p-0 w-full"
         :type="type"
         :class="inputClasses"
       />

--- a/dashboard/src/components/event/ManageTicketTierDialog.vue
+++ b/dashboard/src/components/event/ManageTicketTierDialog.vue
@@ -15,7 +15,7 @@
           <div class="flex flex-col gap-2">
             <div class="text-sm text-gray-600">Status</div>
             <div
-              class="font-medium text-sm uppercase flex items-center gap-2"
+              class="font-medium text-sm flex items-center gap-2"
               :class="tier.enabled ? 'text-green-600' : ''"
             >
               <LivePing v-if="tier.enabled" />

--- a/dashboard/src/components/event/TicketTierCard.vue
+++ b/dashboard/src/components/event/TicketTierCard.vue
@@ -4,7 +4,7 @@
     <div class="flex w-full justify-between items-center">
       <div class="flex flex-wrap items-center">
         <div class="prose">
-          <h3 class="uppercase">{{ tier.title }}</h3>
+          <h3>{{ tier.title }}</h3>
         </div>
         <Badge :theme="tier.enabled ? 'green' : 'gray'" class="ml-2">
           {{ tier.enabled ? 'Active' : 'Inactive' }}

--- a/dashboard/src/components/event/TicketTierInsightCard.vue
+++ b/dashboard/src/components/event/TicketTierInsightCard.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex flex-col w-full border rounded-sm p-4">
-    <div class="text-sm uppercase font-semibold">{{ tier.title }}</div>
+    <div class="text-sm font-semibold">{{ tier.title }}</div>
     <div class="flex gap-2 items-end justify-between mt-6">
       <div>
         <div class="prose">


### PR DESCRIPTION
Remove uppercasing ticket tier title everywhere. Let is appear as it is typed.

- Follow WYSIWYG, its confusing to know what tier title appears and a bad UI problem. Let organizer manage the casing.

- Input field is used only in setting numericals in dialog popup, so no worries in removing this.

- closes #1297



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed uppercase text transformation from input fields, status labels, and ticket tier titles across dashboard components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->