### PR TITLE
redirect: use /tickets to direct for buy-ticket page

### DIFF
--- a/fossunited/api/pages.py
+++ b/fossunited/api/pages.py
@@ -1,6 +1,6 @@
 import frappe
 
-from fossunited.doctype_ids import CHAPTER, STUDENT_CLUB
+from fossunited.doctype_ids import CHAPTER, EVENT, STUDENT_CLUB
 
 
 @frappe.whitelist(allow_guest=True)
@@ -43,3 +43,29 @@ def get_more_grants(start=0, limit=30):
     )
 
     return {"grants": grants}
+
+
+@frappe.whitelist(allow_guest=True)
+def buy_tickets_page(route):
+    event = frappe.db.get_value(
+        EVENT,
+        {"route": route},
+        ["name", "is_paid_event"],
+        as_dict=True,
+    )
+
+    if not event:
+        # return a 404 page or fallback
+        frappe.local.response["type"] = "redirect"
+        frappe.local.response["location"] = "/404"
+        return
+
+    frappe.local.response["type"] = "redirect"
+
+    # redirect based on whether the event is paid
+    if event.is_paid_event:
+        frappe.local.response["location"] = f"/dashboard/buy-tickets?event={event.name}"
+        return
+
+    frappe.local.response["location"] = f"/{route}/rsvp"
+    return

--- a/fossunited/hooks.py
+++ b/fossunited/hooks.py
@@ -88,6 +88,10 @@ website_redirects = [
     {"source": r"c/(.+)/cfp", "target": r"/dashboard/cfp/apply/\1"},
     {"source": r"c/(.+)/cfp/all", "target": r"/dashboard/cfp/all/\1"},
     {"source": r"c/(.+)/schedule", "target": r"/dashboard/schedule/\1"},
+    {
+        "source": r"c/(.+)/tickets",
+        "target": r"/api/method/fossunited.api.pages.buy_tickets_page?route=c/\1",
+    },
 ]
 
 # Installation


### PR DESCRIPTION
- convenient redirection to make /c/chapter/event/tickets to go to buy-ticket?event=ID page

- if event is not paid it will take to rsvp page if so

helps use URL that are easy to navigate and share

- Closes #1298 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launched event ticket purchasing routing: visiting c/{event}/tickets now redirects users to the appropriate flow.
  * Paid events redirect to the checkout dashboard for payment; free events redirect to the RSVP registration page.
  * Streamlined ticket URL pattern for simpler access to event registration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->