### PR TITLE
buy-ticket: Make custom field entry to apply for all or individual attendees

### DIFF
--- a/dashboard/src/pages/BuyTickets.vue
+++ b/dashboard/src/pages/BuyTickets.vue
@@ -142,13 +142,26 @@
             />
           </div>
 
+          <!-- custom fields section -->
           <div v-if="event.data.custom_fields.length > 0">
-            <h2 class="text-base font-semibold text-gray-800 mt-4">Additional Details</h2>
-            <div class="mt-3 sm:grid sm:grid-cols-2 gap-2 space-y-2 sm:space-y-0">
+            <div class="flex-row mb-2">
+              <h2 class="text-base font-semibold text-gray-800 mt-4">Additional Details</h2>
+              <Switch
+                v-model="customFieldsApplyToAll"
+                class="w-fit text-xs"
+                label="Apply Same answers for all tickets/attendees"
+              />
+            </div>
+
+            <!-- global custom fields (when apply to all is enabled) -->
+            <div
+              v-if="customFieldsApplyToAll"
+              class="mt-3 sm:grid sm:grid-cols-2 gap-2 space-y-2 sm:space-y-0"
+            >
               <FormControl
                 v-for="field in event.data.custom_fields"
                 :key="field.name"
-                v-model="customFields[field.field_name]"
+                v-model="globalCustomFields[field.field_name]"
                 :type="FIELD_TYPE_FORM_CONTROL_MAP[field.field_type]"
                 :label="field.label"
                 :options="field.options"
@@ -158,7 +171,7 @@
             </div>
           </div>
 
-          <!-- ATTENDEE DETAILS -->
+          <!-- attendee details -->
           <h2 class="text-lg font-semibold leading-6 text-gray-800 mt-4">Attendees</h2>
           <div>
             <div
@@ -184,18 +197,18 @@
                   label="Email"
                 />
                 <FormControl
-                  v-model="attendee.subscribe_chapter_mailing"
-                  type="checkbox"
-                  size="sm"
-                  variant="subtle"
-                  label="Yes, I'd like to receive email updates about future events."
-                />
-                <FormControl
                   v-model="attendee.organization"
                   type="text"
                   size="sm"
                   variant="subtle"
                   label="Organization / College"
+                />
+                <FormControl
+                  v-model="attendee.subscribe_chapter_mailing"
+                  type="checkbox"
+                  size="sm"
+                  variant="subtle"
+                  :label="`Yes, I'd like to receive email updates about future events from ${event.data.event_name}.`"
                 />
                 <FormControl
                   v-model="attendee.designation"
@@ -205,6 +218,27 @@
                   label="Designation"
                 />
               </div>
+
+              <!-- Per-Attendee custom fields (when apply to all is disabled) -->
+              <div
+                v-if="!customFieldsApplyToAll && event.data.custom_fields.length > 0"
+                class="mt-4 border-t pt-4"
+              >
+                <h3 class="text-sm font-medium text-gray-700 mb-2">Additional Details</h3>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-x-2 gap-y-4">
+                  <FormControl
+                    v-for="field in event.data.custom_fields"
+                    :key="field.name"
+                    v-model="attendee.custom_fields[field.field_name]"
+                    :type="FIELD_TYPE_FORM_CONTROL_MAP[field.field_type]"
+                    :label="field.label"
+                    :options="field.options"
+                    size="sm"
+                    variant="subtle"
+                  />
+                </div>
+              </div>
+
               <div
                 v-if="event.data.paid_tshirts_available"
                 class="grid grid-cols-1 md:grid-cols-2 gap-2 mt-2"
@@ -480,7 +514,7 @@ watch(
         const randomPlaceholder =
           fullNamePlaceholders[Math.floor(Math.random() * fullNamePlaceholders.length)]
 
-        checkoutInfo.attendees.push({
+        const newAttendee = {
           full_name: '',
           email: '',
           placeholder: randomPlaceholder,
@@ -489,7 +523,17 @@ watch(
           organization: '',
           wants_tshirt: false,
           tshirt_size: 'M',
-        })
+          custom_fields: {},
+        }
+
+        // Initialize custom fields for new attendee if not applying to all
+        if (!customFieldsApplyToAll.value && event.data?.custom_fields) {
+          for (let field of event.data.custom_fields) {
+            newAttendee.custom_fields[field.field_name] = ''
+          }
+        }
+
+        checkoutInfo.attendees.push(newAttendee)
       }
     } else if (checkoutInfo.attendees.length > checkoutInfo.numSeats) {
       checkoutInfo.attendees = checkoutInfo.attendees.slice(0, checkoutInfo.numSeats)
@@ -528,16 +572,52 @@ const redirectToEvent = computed(() => {
   return window.location.origin
 })
 
+const customFieldsApplyToAll = ref(false)
+const globalCustomFields = reactive({})
+
+// Update the customFields initialization
 function resetCustomFields() {
   if (event.data?.custom_fields) {
+    // Reset global custom fields
     for (let field of event.data.custom_fields) {
-      customFields[field.field_name] = ''
+      globalCustomFields[field.field_name] = ''
       if (field.field_type == 'Select') {
         field.options = field.options.split('\n')
       }
     }
+
+    // Initialize custom fields for existing attendees if apply to all is disabled
+    if (!customFieldsApplyToAll.value) {
+      for (let attendee of checkoutInfo.attendees) {
+        if (!attendee.custom_fields) {
+          attendee.custom_fields = {}
+        }
+        for (let field of event.data.custom_fields) {
+          if (!(field.field_name in attendee.custom_fields)) {
+            attendee.custom_fields[field.field_name] = ''
+          }
+        }
+      }
+    }
   }
 }
+
+watch(customFieldsApplyToAll, (newValue) => {
+  if (newValue) {
+    // When switching to "apply to all", clear individual attendee custom fields
+    for (let attendee of checkoutInfo.attendees) {
+      attendee.custom_fields = {}
+    }
+  } else {
+    // When switching to individual, initialize custom fields for each attendee
+    for (let attendee of checkoutInfo.attendees) {
+      attendee.custom_fields = {}
+      for (let field of event.data?.custom_fields || []) {
+        attendee.custom_fields[field.field_name] = globalCustomFields[field.field_name] || ''
+      }
+    }
+  }
+})
 
 function isTierExpired(tier) {
   return tier.valid_till && dayjs().isAfter(tier.valid_till, 'day')
@@ -559,7 +639,8 @@ function createOrder() {
       tier: checkoutInfo.tier,
       attendees: checkoutInfo.attendees,
       num_seats: checkoutInfo.numSeats,
-      custom_fields: customFields,
+      custom_fields_apply_to_all: customFieldsApplyToAll.value,
+      global_custom_fields: customFieldsApplyToAll.value ? globalCustomFields : null,
     },
     event.data.doctype,
     event.data.name,
@@ -572,7 +653,6 @@ function createOrder() {
     },
   )
 }
-
 const showDialog = ref(false)
 const dialogError = ref('')
 
@@ -674,9 +754,22 @@ const checkoutFormErrors = computed(() => {
     errors.push('\nPlease fill in all attendee details')
   }
 
-  for (let field of event.data?.custom_fields || []) {
-    if (field.mandatory && !customFields[field.field_name]) {
-      errors.push(`Please fill in ${field.label}`)
+  // Validate global custom fields if apply to all is enabled
+  if (customFieldsApplyToAll.value) {
+    for (let field of event.data?.custom_fields || []) {
+      if (field.mandatory && !globalCustomFields[field.field_name]) {
+        errors.push(`\nPlease fill in ${field.label}`)
+      }
+    }
+  } else {
+    // Validate individual attendee custom fields
+    for (let attendee of checkoutInfo.attendees) {
+      for (let field of event.data?.custom_fields || []) {
+        if (field.mandatory && !attendee.custom_fields?.[field.field_name]) {
+          errors.push(`\nPlease fill in ${field.label} for all attendees`)
+          break // Only show error once per missing field
+        }
+      }
     }
   }
 

--- a/dashboard/src/pages/BuyTickets.vue
+++ b/dashboard/src/pages/BuyTickets.vue
@@ -181,42 +181,49 @@
             >
               <p class="text-base text-gray-600 font-medium mb-1">#{{ index + 1 }}</p>
               <div class="grid grid-cols-1 md:grid-cols-2 gap-x-2 gap-y-4">
-                <FormControl
-                  v-model="attendee.full_name"
-                  type="text"
-                  size="sm"
-                  variant="subtle"
-                  :placeholder="attendee.placeholder"
-                  label="Full Name"
-                />
-                <FormControl
-                  v-model="attendee.email"
-                  type="email"
-                  size="sm"
-                  variant="subtle"
-                  label="Email"
-                />
-                <FormControl
-                  v-model="attendee.organization"
-                  type="text"
-                  size="sm"
-                  variant="subtle"
-                  label="Organization / College"
-                />
-                <FormControl
-                  v-model="attendee.subscribe_chapter_mailing"
-                  type="checkbox"
-                  size="sm"
-                  variant="subtle"
-                  :label="`Yes, I'd like to receive email updates about future events from ${event.data.event_name}.`"
-                />
-                <FormControl
-                  v-model="attendee.designation"
-                  type="text"
-                  size="sm"
-                  variant="subtle"
-                  label="Designation"
-                />
+                <div class="flex flex-col gap-7">
+                  <FormControl
+                    v-model="attendee.full_name"
+                    type="text"
+                    size="sm"
+                    variant="subtle"
+                    :placeholder="attendee.placeholder"
+                    label="Full Name"
+                  />
+                  <FormControl
+                    v-model="attendee.organization"
+                    type="text"
+                    size="sm"
+                    variant="subtle"
+                    label="Organization / College"
+                  />
+                </div>
+                <div class="flex flex-col gap-1">
+                  <FormControl
+                    v-model="attendee.email"
+                    type="email"
+                    size="sm"
+                    variant="subtle"
+                    label="Email"
+                  />
+                  <div class="pl-1">
+                    <FormControl
+                      v-model="attendee.subscribe_chapter_mailing"
+                      class="text-sm"
+                      type="checkbox"
+                      size="sm"
+                      variant="subtle"
+                      :label="`Yes, I'd like to receive email updates about future events from ${event.data.event_name}.`"
+                    />
+                  </div>
+                  <FormControl
+                    v-model="attendee.designation"
+                    type="text"
+                    size="sm"
+                    variant="subtle"
+                    label="Designation"
+                  />
+                </div>
               </div>
 
               <!-- Per-Attendee custom fields (when apply to all is disabled) -->
@@ -496,6 +503,9 @@ const checkoutInfo = reactive({
 const customFields = reactive({})
 const errorMessage = ref(null)
 
+const customFieldsApplyToAll = ref(false)
+const globalCustomFields = reactive({})
+
 const fullNamePlaceholders = ['Jenny Smith', 'Jacob Doe', 'Jim Brown']
 
 const stateOptions = createResource({
@@ -504,6 +514,36 @@ const stateOptions = createResource({
     return data.map((state) => ({ label: state.name, value: state.name }))
   },
   auto: true,
+})
+
+const rzpCheckout = ref(null)
+
+const event = createResource({
+  url: 'fossunited.api.dashboard.get_event',
+  makeParams() {
+    return {
+      name: eventName.value,
+    }
+  },
+  onSuccess(data) {
+    const activeTiersList = data.tiers.filter((tier) => {
+      const isEnabled = Boolean(tier.enabled)
+      const deadlinePassed = tier.valid_till && dayjs().isAfter(tier.valid_till, 'day')
+      return isEnabled && !deadlinePassed
+    })
+
+    if (activeTiersList.length > 0) {
+      checkoutInfo.tier = activeTiersList[0]
+    }
+    resetCustomFields()
+  },
+})
+
+const redirectToEvent = computed(() => {
+  if (event.data) {
+    return `${window.location.origin}/${event.data.route}`
+  }
+  return window.location.origin
 })
 
 watch(
@@ -542,39 +582,6 @@ watch(
   { immediate: true },
 )
 
-const rzpCheckout = ref(null)
-
-const event = createResource({
-  url: 'fossunited.api.dashboard.get_event',
-  makeParams() {
-    return {
-      name: eventName.value,
-    }
-  },
-  onSuccess(data) {
-    const activeTiersList = data.tiers.filter((tier) => {
-      const isEnabled = Boolean(tier.enabled)
-      const deadlinePassed = tier.valid_till && dayjs().isAfter(tier.valid_till, 'day')
-      return isEnabled && !deadlinePassed
-    })
-
-    if (activeTiersList.length > 0) {
-      checkoutInfo.tier = activeTiersList[0]
-    }
-    resetCustomFields()
-  },
-})
-
-const redirectToEvent = computed(() => {
-  if (event.data) {
-    return `${window.location.origin}/${event.data.route}`
-  }
-  return window.location.origin
-})
-
-const customFieldsApplyToAll = ref(false)
-const globalCustomFields = reactive({})
-
 // Update the customFields initialization
 function resetCustomFields() {
   if (event.data?.custom_fields) {
@@ -603,6 +610,8 @@ function resetCustomFields() {
 }
 
 watch(customFieldsApplyToAll, (newValue) => {
+  if (!event.data?.custom_fields) return
+
   if (newValue) {
     // When switching to "apply to all", clear individual attendee custom fields
     for (let attendee of checkoutInfo.attendees) {
@@ -611,8 +620,10 @@ watch(customFieldsApplyToAll, (newValue) => {
   } else {
     // When switching to individual, initialize custom fields for each attendee
     for (let attendee of checkoutInfo.attendees) {
-      attendee.custom_fields = {}
-      for (let field of event.data?.custom_fields || []) {
+      if (!attendee.custom_fields) {
+        attendee.custom_fields = {}
+      }
+      for (let field of event.data.custom_fields) {
         attendee.custom_fields[field.field_name] = globalCustomFields[field.field_name] || ''
       }
     }

--- a/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
@@ -51,8 +51,17 @@ class FOSSEventTicket(Document):
 
     @staticmethod
     def create_tickets_for_payment(payment: "RazorpayPayment"):
+        """
+        Create tickets for a successful payment.
+        Handles both global custom fields (applied to all attendees)
+        and individual custom fields (per attendee).
+        """
         payment_meta_data: dict = frappe.parse_json(payment.meta_data)
         attendees = payment_meta_data.get("attendees", [])
+
+        # Check if custom fields should be applied to all attendees
+        custom_fields_apply_to_all = payment_meta_data.get("custom_fields_apply_to_all", False)
+        global_custom_fields = payment_meta_data.get("global_custom_fields", {})
 
         for attendee in attendees:
             ticket_doc = frappe.get_doc(
@@ -71,14 +80,22 @@ class FOSSEventTicket(Document):
                 }
             )
 
-            # add custom fields
-            custom_fields = payment_meta_data.get("custom_fields", {})
+            # Determine which custom fields to use
+            if custom_fields_apply_to_all:
+                # Use global custom fields for all attendees
+                custom_fields = global_custom_fields
+            else:
+                # Use individual attendee's custom fields
+                custom_fields = attendee.get("custom_fields", {})
+
+            # Add custom fields to ticket
             for k, v in custom_fields.items():
                 if k and v:
                     ticket_doc.append(
                         "custom_fields",
                         {"field_name": k, "data": str(v)},
                     )
+
             ticket_doc.save(ignore_permissions=True)
 
     def before_insert(self):

--- a/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
@@ -71,6 +71,7 @@ class FOSSEventTicket(Document):
                     "event": payment.document_name,
                     "full_name": attendee.get("full_name"),
                     "email": attendee.get("email"),
+                    "subscribe_chapter_mailing": attendee.get("subscribe_chapter_mailing"),
                     "organization": attendee.get("organization"),
                     "designation": attendee.get("designation"),
                     "wants_tshirt": attendee.get("wants_tshirt", 0),


### PR DESCRIPTION
- closes #1296 

- We give a switch toggle (default: false) to make the process easy, so for multiple tickets they can either apply same answer to all or give individual responses.

- This helps to cover some survey kinda response from each ticket holders, without repeating for all

<img width="2655" height="619" alt="image" src="https://github.com/user-attachments/assets/13378ead-f728-4e41-ab7d-2de2a4e3aeda" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom fields can be applied globally to all attendees or set per-attendee via a new checkout toggle and combined header UI.
  * Global custom field values are displayed and can be propagated to all attendees.

* **Bug Fixes / Improvements**
  * Validation now enforces required custom fields correctly for global or per-attendee modes.
  * Custom field choices are included with your order submission.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->