### PR TITLE
refactor: getting rsvp submission for insights

### DIFF
--- a/dashboard/src/components/event/CheckinAttendeeList.vue
+++ b/dashboard/src/components/event/CheckinAttendeeList.vue
@@ -14,11 +14,11 @@
   <div v-if="attendees.data">
     <ListView
       :columns="[
+        { label: 'Ticket ID', key: 'name', width: '100px' },
         { label: 'Name', key: 'full_name' },
-        { label: 'Ticket ID', key: 'name' },
-        { label: 'Bought Tshirt?', key: 'wants_tshirt', width: '150px' },
-        { label: 'Tshirt Delivered?', key: 'tshirt_delivered', width: '150px' },
-        { label: 'Check-in Status', key: 'checkin_status', width: 1.5 },
+        { label: 'Bought Tshirt?', key: 'wants_tshirt', width: '100px' },
+        { label: 'Tshirt Delivered?', key: 'tshirt_delivered', width: '100px' },
+        { label: 'Check-in Status', key: 'checkin_status', width: 1 },
         { label: 'Actions', key: 'action' },
       ]"
       :rows="attendees.data"

--- a/dashboard/src/pages/EventRsvpInsights.vue
+++ b/dashboard/src/pages/EventRsvpInsights.vue
@@ -116,7 +116,7 @@
           </div>
 
           <div v-else>
-            <span class="text-base">{{ item }}</span>
+            <span class="text-base" :title="item">{{ truncate(item, 30) }}</span>
           </div>
         </template>
       </ListView>
@@ -163,7 +163,6 @@ const submissions = createResource({
   url: 'fossunited.api.chapter.get_submissions_with_answers',
   params: {
     event_id: route.params.id,
-    full_answers: false,
   },
   auto: true,
 })
@@ -185,6 +184,12 @@ const checkinColumns = [
 ]
 
 const checkedInGroups = ref([])
+
+function truncate(text, maxLength = 30) {
+  if (!text) return ''
+  const str = String(text).trim()
+  return str.length > maxLength ? str.substring(0, maxLength) + '…' : str
+}
 
 watchEffect(() => {
   const byDate = checkedInData.data?.by_date || {}
@@ -224,33 +229,33 @@ const formatTime = (datetime) => {
 }
 
 const listColumns = computed(() => {
-  const columns = new Map()
+  if (!submissions.data?.length) return []
 
-  const excludedFields = ['confirm_attendance', 'status', 'name']
-
-  // Collect keys from all submissions
-  if (Array.isArray(submissions.data)) {
-    submissions.data.forEach((submission) => {
-      Object.keys(submission).forEach((key) => {
-        if (!excludedFields.includes(key) && !columns.has(key)) {
-          columns.set(key, { key, label: key })
-        }
-      })
-    })
-  }
-
-  // include confirm_attendance only (status stays hidden)
-  const result = [
-    { key: 'confirm_attendance', label: 'Attending', icon: 'check-circle', width: '40px' },
-    ...Array.from(columns.values()),
+  const baseColumns = [
+    { label: 'Name', key: 'name1', width: '200px' },
+    { label: 'Email', key: 'email', width: '250px' },
+    { label: 'Im a', key: 'im_a', width: '150px' },
+    { label: 'Confirmed', key: 'confirm_attendance', width: '120px' },
   ]
 
-  // host approval column
+  const firstSubmission = submissions.data[0]
+  const customFields = Object.keys(firstSubmission).filter(
+    (key) => !['name', 'name1', 'email', 'im_a', 'confirm_attendance', 'status'].includes(key),
+  )
+
+  const customColumns = customFields.map((field) => ({
+    label: truncate(field, 20),
+    key: field,
+    width: '300px',
+  }))
+
+  const columns = [...baseColumns, ...customColumns]
+
   if (rsvp_form.data?.requires_host_approval) {
-    result.push({ key: 'actions', label: 'Actions' })
+    columns.push({ label: 'Actions', key: 'actions', width: '200px' })
   }
 
-  return result
+  return columns
 })
 
 const groupedRows = ref([])
@@ -338,49 +343,37 @@ watchEffect(() => {
   }
 })
 
+const downloadCSV = (data, filename, excludeKeys = ['name']) => {
+  if (!data?.length) return
+
+  const keys = Object.keys(data[0]).filter((k) => !excludeKeys.includes(k))
+
+  const rows = [
+    keys.join(','), // Header
+    ...data.map((row) =>
+      keys.map((k) => `"${String(row[k] || '').replace(/"/g, '""')}"`).join(','),
+    ),
+  ]
+
+  const blob = new Blob([rows.join('\n')], { type: 'text/csv;charset=utf-8;' })
+  const link = document.createElement('a')
+  link.href = URL.createObjectURL(blob)
+  link.download = filename
+  link.click()
+  URL.revokeObjectURL(link.href)
+}
+
 const downloadAttendeeList = () => {
-  const eventId = route.params.id
-  window.open(
-    `/api/method/fossunited.api.chapter.download_attendee_list_csv?event_id=${eventId}`,
-    '_self',
-  )
+  downloadCSV(submissions.data, `rsvp_submissions_${route.params.id}.csv`)
 }
 
 const downloadCheckinCSV = () => {
   if (!checkedInData.data?.by_date) return
 
-  const rows = []
+  const flatData = Object.entries(checkedInData.data.by_date).flatMap(([date, data]) =>
+    data.attendees.map((a) => ({ date, ...a })),
+  )
 
-  // add header
-  rows.push(['date', 'name', 'email', 'im_a', 'checkin_time'])
-
-  // Add data grouped by date
-  for (const [date, data] of Object.entries(checkedInData.data.by_date)) {
-    for (const attendee of data.attendees) {
-      rows.push([
-        date,
-        attendee.name1 || '',
-        attendee.email || '',
-        attendee.im_a || '',
-        attendee.check_in_time || '',
-      ])
-    }
-  }
-
-  // convert to CSV
-  const csvContent = rows
-    .map((row) => row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(','))
-    .join('\n')
-
-  // Download
-  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' })
-  const link = document.createElement('a')
-  const url = URL.createObjectURL(blob)
-  link.setAttribute('href', url)
-  link.setAttribute('download', `event-checkins-${route.params.id}.csv`)
-  link.style.visibility = 'hidden'
-  document.body.appendChild(link)
-  link.click()
-  document.body.removeChild(link)
+  downloadCSV(flatData, `event-checkins-${route.params.id}.csv`)
 }
 </script>

--- a/dashboard/src/pages/EventRsvpInsights.vue
+++ b/dashboard/src/pages/EventRsvpInsights.vue
@@ -186,7 +186,7 @@ const checkinColumns = [
 const checkedInGroups = ref([])
 
 function truncate(text, maxLength = 30) {
-  if (!text) return ''
+  if (text === null || text === undefined) return ''
   const str = String(text).trim()
   return str.length > maxLength ? str.substring(0, maxLength) + '…' : str
 }
@@ -351,7 +351,7 @@ const downloadCSV = (data, filename, excludeKeys = ['name']) => {
   const rows = [
     keys.join(','), // Header
     ...data.map((row) =>
-      keys.map((k) => `"${String(row[k] || '').replace(/"/g, '""')}"`).join(','),
+      keys.map((k) => `"${String(row[k] ?? '').replace(/"/g, '""')}"`).join(','),
     ),
   ]
 

--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -153,217 +153,62 @@ def generate_ics(event_ids):
 
 
 @frappe.whitelist()
-def get_submissions_with_answers(
-    event_id: str,
-    full_answers: bool = False,
-    remove_id: bool = False,
-) -> list[dict]:
+def get_submissions_with_answers(event_id: str) -> list[dict]:
     """
-    Provide RSVP submission with answers for EventInsights.
+    Get all RSVP submissions with their custom field answers.
 
     Args:
         event_id (str): Event ID
-        full_answers (bool): If True, return full question labels and responses;
-                     otherwise truncate for UI display. Applicable for csv export/download.
+
     Returns:
-        List of submission dicts with custom field answers for core team members.
+        list[dict]: List of submissions with custom answers as dynamic fields
     """
-    if not frappe.session.user or frappe.session.user == "Guest":
+    if not check_if_chapter_or_event_core_member(event_id):
         frappe.throw("Not permitted", frappe.PermissionError)
 
-    # Get basic submission fields
+    # Get all submissions
     submissions = frappe.get_all(
         RSVP_RESPONSE,
         filters={"event": event_id},
         fields=["name", "confirm_attendance", "status", "name1", "email", "im_a"],
         order_by="creation asc",
-        limit_page_length=9999,
     )
 
-    if not check_if_chapter_or_event_core_member(event_id):
-        for s in submissions:
-            s["email"] = mask_email(s.get("email"))
-            s.pop("name", None)
-        return submissions
+    if not submissions:
+        return []
 
-    # Event lead: fetch full answers
+    # Get all custom field answers for these submissions
     submission_ids = [s["name"] for s in submissions]
-    if not submission_ids:
-        return submissions
 
-    answers_rows = frappe.get_all(
+    answers = frappe.get_all(
         RSVP_CUSTOM_FIELD,
         filters={
             "parent": ["in", submission_ids],
             "parenttype": RSVP_RESPONSE,
             "parentfield": "custom_answers",
         },
-        fields=["parent", "question", "response", "idx"],
+        fields=["parent", "question", "response"],
         order_by="parent asc, idx asc",
-        limit_page_length=0,
     )
 
-    answers_by_parent = {}
-    for a in answers_rows:
-        answers_by_parent.setdefault(a["parent"], []).append(a)
+    # Group answers by parent (submission)
+    answers_map = {}
+    for answer in answers:
+        parent = answer["parent"]
+        if parent not in answers_map:
+            answers_map[parent] = {}
 
-    for s in submissions:
-        for a in answers_by_parent.get(s["name"], []):
-            key = _safe_column_key(a["question"])  # always max 50 chars
+        # Use question as key, response as value
+        question = answer["question"] or "custom_field"
+        answers_map[parent][question] = answer["response"] or ""
 
-            # Truncate the answer if not full
-            response = a.get("response")
-            if response is None:
-                response = ""
-            if not full_answers:
-                response = _truncate_label(str(response), 30)
-
-            s[f"{key}"] = response
-
-            # Truncate label if not full
-            raw_label = a.get("question")
-            label = "" if raw_label is None else str(raw_label)
-            if not full_answers:
-                label = _truncate_label(label, 30)
-
-            if remove_id:
-                s.pop("name", None)
+    # merge answers into submissions
+    for submission in submissions:
+        submission_id = submission["name"]
+        if submission_id in answers_map:
+            submission.update(answers_map[submission_id])
 
     return submissions
-
-
-def _safe_column_key(label: str) -> str:
-    """
-    Sanitize and shorten a label to create a safe dictionary/column key.
-    This function:
-    - Ensures the label is a string; otherwise returns 'custom_field'.
-    - Normalizes whitespace and strips leading/trailing spaces.
-    - Removes all characters except alphanumerics, underscores, spaces, and hyphens.
-    - Replaces spaces with underscores.
-    - Converts the label to lowercase.
-    - Prefixes the key with an underscore if it starts with a dangerous character
-      (i.e., '=', '+', '-', '@') to prevent CSV injection.
-    - Truncates the key to a maximum of 50 characters.
-
-    Args:
-        label (str): The original label to sanitize.
-
-    Returns:
-        str: A sanitized, safe key string suitable for use in CSV headers or dict keys.
-
-    """
-    import re
-
-    if not isinstance(label, str):
-        return "custom_field"
-
-    key = re.sub(r"\s+", " ", label).strip()  # Normalize spaces
-    key = re.sub(r"[^\w\s-]", "", key)  # Remove special chars
-    key = re.sub(r"\s+", "_", key).lower()  # Convert to snake_case
-
-    if not key or key[0] in "=+-@":
-        key = f"_{key}"
-
-    return key[:50]  # Limit to 50 characters
-
-
-def _truncate_label(label: str, max_length: int = 50) -> str:
-    s = "" if label is None else str(label)
-    s = " ".join(s.split())  # collapse whitespace/newlines
-    return s if len(s) <= max_length else s[:max_length].rstrip() + "…"
-
-
-def mask_email(email: str) -> str:
-    """
-    Mask email to reduce PII exposure:
-    - Keep first 2 characters of local-part (or fewer if not available).
-    - For local-part length <= 2: keep first char, mask rest
-    - For 3 <= length <= 8: show first 3, mask the middle, show last
-    - For length > 8: show first 2, one middle char, show last
-    - Keep domain intact.
-    """
-    if not email or "@" not in email:
-        return "***"
-
-    local, domain = email.split("@", 1)
-    local_len = len(local)
-
-    if local_len <= 2:
-        visible = local[0] + "*" * (local_len - 1)
-    elif local_len <= 8:
-        visible = local[:3] + "*" * (local_len - 3)
-    else:
-        mid_index = local_len // 2
-        visible = (
-            local[:2]
-            + "*" * (mid_index - 2)
-            + local[mid_index]
-            + "*" * (local_len - mid_index - 2)
-            + local[-1]
-        )
-
-    return f"{visible}@{domain}"
-
-
-@frappe.whitelist()
-def download_attendee_list_csv(event_id: str) -> str:
-    """
-    Generates and returns a CSV string of RSVP submissions with custom field answers.
-    Accessible only by core team / event leads.
-    """
-    import csv
-    import io
-    import re
-
-    # Get full submission data (each is a dict)
-    submissions = get_submissions_with_answers(event_id, full_answers=True, remove_id=True)
-
-    if not submissions:
-        return ""
-
-    # Start with keys from the first row to preserve order
-    columns = list(submissions[0].keys())
-    seen = set(columns)
-
-    # Add any new keys from other rows (if any), in the order they appear
-    for row in submissions[1:]:
-        for key in row.keys():
-            if key not in seen:
-                columns.append(key)
-                seen.add(key)
-
-    headers = columns
-
-    # Escape helper (like toCSVCell)
-    def cleanse_csv_cell(value):
-        s = "" if value is None else str(value)
-        if s.startswith(("=", "+", "-", "@")):
-            s = "'" + s
-        return s
-
-    # Prepare CSV content
-    output = io.StringIO()
-    writer = csv.writer(output, quoting=csv.QUOTE_ALL, lineterminator="\r\n")
-
-    writer.writerow([cleanse_csv_cell(h) for h in headers])
-
-    for row in submissions:
-        writer.writerow([cleanse_csv_cell(row.get(col, "")) for col in columns])
-
-    csv_data = "\ufeff" + output.getvalue()  # BOM for Excel
-
-    # Create safe filename
-    event_name = frappe.db.get_value(EVENT, event_id, "event_name", cache=True) or "event"
-    safe_event_name = re.sub(r"[^A-Za-z0-9._-]+", "_", event_name)
-    filename = f"Attendee_List_-_{safe_event_name}.csv"
-
-    # Set file response
-    frappe.response["filename"] = filename
-    frappe.response["filecontent"] = csv_data
-    frappe.response["content_type"] = "text/csv; charset=utf-8"
-    frappe.response["type"] = "download"
-
-    return csv_data
 
 
 @frappe.whitelist()

--- a/fossunited/tests/test_rsvp_insights_field.py
+++ b/fossunited/tests/test_rsvp_insights_field.py
@@ -7,7 +7,6 @@ from fossunited.doctype_ids import (
     EVENT,
     EVENT_RSVP,
     RSVP_RESPONSE,
-    USER_PROFILE,
 )
 
 from .utils import (
@@ -22,7 +21,7 @@ class TestGetSubmissionsWithAnswersAPI(FrappeTestCase):
     def setUp(self):
         # Create a chapter → event → RSVP form
         self.core_team_email = "test1@example.com"
-        self.volunteer_user = "volunteer@example.com"
+        self.volunteer_user = "volunteer1@example.com"
         self.chapter = insert_test_chapter(
             members=[self.core_team_email, self.volunteer_user],
         )
@@ -43,15 +42,6 @@ class TestGetSubmissionsWithAnswersAPI(FrappeTestCase):
         )
         self._extra_responses = []
 
-        # After insert_test_chapter is called
-        self.event.reload()
-        for member in self.event.event_members:
-            if frappe.db.get_value(USER_PROFILE, member.member, "user") == self.volunteer_user:
-                member.role = "Volunteer"
-
-        self.event.save(ignore_permissions=True)
-        self.event.reload()
-
     def tearDown(self):
         frappe.set_user("Administrator")
         # Delete children first, then parents
@@ -67,91 +57,29 @@ class TestGetSubmissionsWithAnswersAPI(FrappeTestCase):
         with self.assertRaises(frappe.PermissionError):
             get_submissions_with_answers(self.event.name)
 
-    def test_non_event_core_team_masks_email(self):
-        frappe.set_user(self.volunteer_user)
-        result = get_submissions_with_answers(self.event.name, full_answers=False)
-        self.assertTrue(result)
-        # Check email is masked: basic pattern check
-        self.assertIn("@", result[0]["email"])
-        self.assertNotEqual(result[0]["email"], "alicewonderland@example.com")
-
     def test_event_core_team_full_email(self):
         frappe.set_user(self.core_team_email)
-        result = get_submissions_with_answers(self.event.name, full_answers=False)
+        result = get_submissions_with_answers(self.event.name)
         self.assertTrue(result)
         self.assertIn("@", result[0]["email"])
         self.assertEqual(result[0]["email"], "alicewonderland@example.com")
 
     def test_event_core_team_gets_full_answers(self):
         frappe.set_user(self.core_team_email)
-        result = get_submissions_with_answers(self.event.name, full_answers=True)
-        self.assertIn("whats_your_goal", result[0])
+        result = get_submissions_with_answers(self.event.name)
+        self.assertIn("What’s your goal?", result[0])
         self.assertEqual(
-            result[0]["whats_your_goal"],
+            result[0]["What’s your goal?"],
             "To become the king of the pirates and greatest swordsmen.",
         )
 
-    def test_truncation_when_full_false(self):
+    def test_custom_field(self):
+        # Simulate a user who is part of the chapter (member)
         frappe.set_user(self.core_team_email)
-        # Use long question/response to test truncation
-        long_q = "Q" * 100
-        long_r = "R" * 100
-        # Create another submission
-        _bob = insert_rsvp_submission(
-            linked_rsvp=self.rsvp.name,
-            name="Bob",
-            email="bob@example.com",
-            custom_answers=[{"question": long_q, "response": long_r}],
-        )
-        result = get_submissions_with_answers(self.event.name, full_answers=False)
-        for s in result:
-            for key, val in s.items():
-                if key not in ["name1", "email", "im_a", "confirm_attendance"]:
-                    self.assertLessEqual(len(val), 52)
-
-    def test_no_truncation_when_full_true(self):
-        frappe.set_user(self.core_team_email)
-        question = "What do you bring?"
-        response = "Experience and energy."
-        _charlie = insert_rsvp_submission(
-            linked_rsvp=self.rsvp.name,
-            name="Charlie",
-            email="charlie@example.com",
-            custom_answers=[{"question": question, "response": response}],
-        )
-        self._extra_responses.append(_charlie.name)
-
-        result = get_submissions_with_answers(self.event.name, full_answers=True)
-        found = False
-        for s in result:
-            if s.get("email") == "charlie@example.com":
-                found = True
-                self.assertEqual(s["what_do_you_bring"], response)
-        self.assertTrue(found, "Charlie submission not found in results")
-
-    def test_non_core_basic_fields(self):
-        # Simulate a user who is part of the chapter (member) but not the core member
-        frappe.set_user(self.volunteer_user)
-
-        # Add another submission with custom fields
-        _bob2 = insert_rsvp_submission(
-            linked_rsvp=self.rsvp.name,
-            name="Bob",
-            email="bob@example.com",
-            im_a="Student",
-            custom_answers=[{"question": "Why are you attending?", "response": "To network"}],
-        )
-        self._extra_responses.append(_bob2.name)
 
         result = get_submissions_with_answers(self.event.name)
         for submission in result:
             self.assertIn("name1", submission)
             self.assertIn("email", submission)
             self.assertIn("im_a", submission)
-
-            # Ensure no custom fields (starting with '') are present
-            for key in submission.keys():
-                self.assertFalse(
-                    key.startswith("why"),
-                    f"Non-core_team should not see custom field: {key}",
-                )
+            self.assertIn("What’s your goal?", submission)


### PR DESCRIPTION
- Always thought that previous method was very bad, so decided to simplify the method to just grab the data, and let frontend take care of processing.

- Refactors getting rsvp responses with answers for rsvp insights dashboard.

Work same, just removed redundant code mass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attendee fields now show truncated values with hover tooltips for full text.

* **Refactor**
  * Reorganized attendee/check-in columns and adjusted column widths for a cleaner layout.
  * CSV export/download flow consolidated in the UI and data shape simplified for export.
  * Server-side submission response normalized to include custom-field answers directly.

* **Tests**
  * Tests updated to match revised submission visibility and field-label behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->