### PR TITLE
template: download event tickets via web page

### DIFF
--- a/fossunited/api/tickets.py
+++ b/fossunited/api/tickets.py
@@ -475,24 +475,21 @@ def search_tickets(search_term, event=None):
         )
         return [ticket_data]
 
+    coupon_event = frappe.db.get_value(FREE_TICKET_CODE, search_term, "event")
+    if not coupon_event:
+        return []
+
     coupon_apps = frappe.get_all(
         FREE_TICKET_APPLY,
-        filters={"coupon_id": search_term},
-        fields=["email", "event"],
+        filters={"coupon_id": search_term, "event": coupon_event},
+        fields=["email"],
+        pluck="email",
     )
 
     if coupon_apps:
-        # Get event from coupon to scope ticket search
-        coupon_event = coupon_apps[0].get("event") if coupon_apps else None
-        emails = [app.email for app in coupon_apps]
-
-        filters = {"email": ["in", emails]}
-        if coupon_event:
-            filters["event"] = coupon_event
-
         return frappe.get_all(
             EVENT_TICKET,
-            filters=filters,
+            filters={"email": ["in", coupon_apps], "event": coupon_event},
             fields=["name", "full_name", "email", "tier", "organization"],
             order_by="full_name",
         )

--- a/fossunited/api/tickets.py
+++ b/fossunited/api/tickets.py
@@ -478,19 +478,26 @@ def search_tickets(search_term, event=None):
     coupon_apps = frappe.get_all(
         FREE_TICKET_APPLY,
         filters={"coupon_id": search_term},
-        fields=["email"],
-        pluck="email",
+        fields=["email", "event"],
     )
 
     if coupon_apps:
+        # Get event from coupon to scope ticket search
+        coupon_event = coupon_apps[0].get("event") if coupon_apps else None
+        emails = [app.email for app in coupon_apps]
+
+        filters = {"email": ["in", emails]}
+        if coupon_event:
+            filters["event"] = coupon_event
+
         return frappe.get_all(
             EVENT_TICKET,
-            filters={"email": ["in", coupon_apps]},
+            filters=filters,
             fields=["name", "full_name", "email", "tier", "organization"],
             order_by="full_name",
         )
 
-    frappe.throw("No tickets found")
+    return []
 
 
 @frappe.whitelist(allow_guest=True)
@@ -501,7 +508,12 @@ def download_ticket(ticket_id):
 
     from frappe.utils.print_format import download_pdf
 
-    return download_pdf(doctype=EVENT_TICKET, name=ticket_id, format="Standard", no_letterhead=1)
+    return download_pdf(
+        doctype=EVENT_TICKET,
+        name=ticket_id,
+        format="[Designer] Event Ticket",
+        no_letterhead=1,
+    )
 
 
 @frappe.whitelist(allow_guest=True)
@@ -526,6 +538,6 @@ def download_all_tickets(ticket_ids):
     download_multi_pdf(
         doctype=EVENT_TICKET,
         name=json.dumps(ticket_ids),
-        format="Standard",
+        format="[Designer] Event Ticket",
         no_letterhead=True,
     )

--- a/fossunited/api/tickets.py
+++ b/fossunited/api/tickets.py
@@ -3,9 +3,16 @@ APIs for Tickets and Transfer Tickets
 """
 
 import frappe
+from frappe.utils import add_days, now_datetime
 
 from fossunited.api.chapter import check_if_chapter_member
-from fossunited.doctype_ids import EVENT, EVENT_TICKET, TICKET_TRANSFER
+from fossunited.doctype_ids import (
+    EVENT,
+    EVENT_TICKET,
+    FREE_TICKET_APPLY,
+    FREE_TICKET_CODE,
+    TICKET_TRANSFER,
+)
 
 
 @frappe.whitelist(allow_guest=True)
@@ -284,7 +291,7 @@ def has_valid_permission(event_id: str) -> bool:
 
     # Allow if user has "Chapter Team Member" role AND is a member of the chapter
     if frappe.db.exists("Has Role", {"role": "Chapter Team Member", "parent": session_user}):
-        chapter_id = frappe.db.get_value("FOSS Chapter Event", event_id, "chapter")
+        chapter_id = frappe.db.get_value(EVENT, event_id, "chapter")
         if chapter_id and check_if_chapter_member(chapter_id, session_user):
             return True
 
@@ -293,7 +300,7 @@ def has_valid_permission(event_id: str) -> bool:
         "FOSS Chapter Event Member",
         {
             "parent": event_id,
-            "parenttype": "FOSS Chapter Event",
+            "parenttype": EVENT,
             "email": session_user,
         },
     ):
@@ -402,7 +409,7 @@ def get_event_free_codes(event):
         frappe.throw("You are not authorized to view the tickets for this event")
 
     codes = frappe.get_all(
-        "Event Free Ticket Code",
+        FREE_TICKET_CODE,
         filters={"event": event},
         fields=[
             "name",
@@ -419,3 +426,106 @@ def get_event_free_codes(event):
     )
 
     return codes
+
+
+@frappe.whitelist()
+def get_paid_events():
+    """Get list of paid events for ticket search - Live or recently concluded (within 30 days)"""
+    thirty_days_ago = add_days(now_datetime(), -30)
+
+    return frappe.get_all(
+        EVENT,
+        filters={
+            "is_paid_event": 1,
+            "status": ["in", ["Live", "Concluded"]],
+            "event_end_date": [">=", thirty_days_ago],
+        },
+        fields=["name", "event_name"],
+        order_by="event_end_date desc",
+    )
+
+
+@frappe.whitelist()
+def search_tickets(search_term, event=None):
+    """Search tickets by ticket_id, email, or coupon_id"""
+    if not search_term:
+        frappe.throw("Search term is required")
+
+    search_term = search_term.strip()
+
+    # Email search - requires event
+    if "@" in search_term:
+        if not event:
+            frappe.throw("Please select an event to search by email")
+
+        return frappe.get_all(
+            EVENT_TICKET,
+            filters={"event": event, "email": search_term},
+            fields=["name", "full_name", "email", "tier", "organization"],
+            order_by="full_name",
+        )
+
+    # Ticket ID - direct lookup, no event needed
+    if frappe.db.exists(EVENT_TICKET, search_term):
+        ticket_data = frappe.db.get_value(
+            EVENT_TICKET,
+            search_term,
+            ["name", "full_name", "email", "tier", "organization"],
+            as_dict=True,
+        )
+        return [ticket_data]
+
+    coupon_apps = frappe.get_all(
+        FREE_TICKET_APPLY,
+        filters={"coupon_id": search_term},
+        fields=["email"],
+        pluck="email",
+    )
+
+    if coupon_apps:
+        return frappe.get_all(
+            EVENT_TICKET,
+            filters={"email": ["in", coupon_apps]},
+            fields=["name", "full_name", "email", "tier", "organization"],
+            order_by="full_name",
+        )
+
+    frappe.throw("No tickets found")
+
+
+@frappe.whitelist(allow_guest=True)
+def download_ticket(ticket_id):
+    """Download single ticket PDF"""
+    if not frappe.db.exists(EVENT_TICKET, ticket_id):
+        frappe.throw("Ticket not found")
+
+    from frappe.utils.print_format import download_pdf
+
+    return download_pdf(doctype=EVENT_TICKET, name=ticket_id, format="Standard", no_letterhead=1)
+
+
+@frappe.whitelist(allow_guest=True)
+def download_all_tickets(ticket_ids):
+    """Download multiple tickets as single PDF"""
+    import json
+
+    if isinstance(ticket_ids, str):
+        ticket_ids = json.loads(ticket_ids)
+
+    if not ticket_ids or not isinstance(ticket_ids, list):
+        frappe.throw("No tickets provided")
+
+    # Verify all tickets exist
+    for ticket_id in ticket_ids:
+        if not frappe.db.exists(EVENT_TICKET, ticket_id):
+            frappe.throw(f"Ticket {ticket_id} not found")
+
+    from frappe.utils.print_format import download_multi_pdf
+
+    # download_multi_pdf returns the PDF content directly
+    download_multi_pdf(
+        doctype=EVENT_TICKET,
+        name=json.dumps(ticket_ids),
+        format="Standard",
+        no_letterhead=True,
+    )

--- a/fossunited/fossunited/web_template/get_event_tickets/get_event_tickets.html
+++ b/fossunited/fossunited/web_template/get_event_tickets/get_event_tickets.html
@@ -37,9 +37,9 @@
       <div class="v3-card v3-main-card">
         <div class="mb-5">
           <h1 class="v3-gradient-text mb-1" style="font-size:2.4rem;">{{ page_title }}</h1>
-          <p class="v3-text-secondary mt-2 mb-0">
+          <div class="v3-text-secondary mt-2 mb-0">
             {{ frappe.utils.md_to_html(intro_text) }}
-          </p>
+          </div>
         </div>
 
         <div id="search-section">
@@ -79,7 +79,7 @@
         </div>
 
         <div id="loading" style="display:none; text-align:center; padding:2rem;">
-          <p class="v3-text-secondary">Loading...</p>
+          <span class="v3-text-secondary">Loading...</span>
         </div>
 
         <div
@@ -96,7 +96,9 @@
               Download All Tickets
             </button>
           </div>
-          <p class="text-sm mb-2">{{ ticket_info_text }}</p>
+          {% if ticket_info_text %}
+          <div class="v3-text-secondary text-sm mb-4">{{ ticket_info_text }}</div>
+          {% endif %}
 
           <div id="tickets-list" style="display:flex; flex-direction:column; gap:1rem;"></div>
         </div>
@@ -113,7 +115,7 @@
       loadEvents()
 
       const urlParams = new URLSearchParams(window.location.search)
-      const ticketId = urlParams.get('ticket-id')
+      const ticketId = urlParams.get('id')
 
       if (ticketId) {
         document.getElementById('search-input').value = ticketId
@@ -176,6 +178,10 @@
           } else {
             showError('No tickets found matching your search')
           }
+        },
+        error: function (r) {
+          showLoading(false)
+          showError(r.message || 'An error occurred while searching')
         },
       })
     }

--- a/fossunited/fossunited/web_template/get_event_tickets/get_event_tickets.html
+++ b/fossunited/fossunited/web_template/get_event_tickets/get_event_tickets.html
@@ -1,0 +1,255 @@
+{% block foss_base %}
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/tabler-icons.min.css"
+/>
+<style>
+  {% include "public/css/custom.css" %}
+    .v3-container {
+      font-family: 'Inter', sans-serif;
+      min-height: 100vh;
+    }
+</style>
+<script>
+  {% include "public/js/common_functions.js" %}
+</script>
+{% endblock %}
+
+{% block title %}Get Your Event Tickets{% endblock %}
+
+{% block page_content %}
+  {% set page_title = page_title | default("Grab Your Event Tickets") %}
+  {% set intro_text = intro_text | default("Download your event tickets by searching with your ticket ID, email, or name.") %}
+  {% set ticket_info_text = ticket_info_text | default("") %}
+
+
+  <div class="v3-page">
+    <div class="v3-container mb-5">
+      <div
+        style="display:flex; justify-content:space-between; align-items:center; margin-bottom:1rem;"
+      >
+        <nav class="v3-breadcrumb"><a href="/">Home</a> > <a href="">{{ page_title }}</a></nav>
+        <button class="v3-theme-toggle" id="theme-toggle" title="Toggle theme">
+          <i class="ti ti-moon"></i>
+        </button>
+      </div>
+
+      <div class="v3-card v3-main-card">
+        <div class="mb-5">
+          <h1 class="v3-gradient-text mb-1" style="font-size:2.4rem;">{{ page_title }}</h1>
+          <p class="v3-text-secondary mt-2 mb-0">
+            {{ frappe.utils.md_to_html(intro_text) }}
+          </p>
+        </div>
+
+        <div id="search-section">
+          <div class="mb-8">
+            <label class="v3-text-primary mb-2" style="display:block; font-weight:500;">
+              Select Event
+              <span class="v3-text-tertiary" style="font-size:0.85rem; font-weight:400;"
+                >(only needed for email search)</span
+              >
+            </label>
+            <select
+              id="event-select"
+              class="v3-text-primary"
+              style="width:100%; padding:0.65rem; border-radius:6px; border:1px solid var(--v3-button-border); background:var(--v3-main-bg);"
+            >
+              <option value="">-- Select Event --</option>
+            </select>
+          </div>
+
+          <div class="mb-8">
+            <label class="v3-text-primary mb-2" style="display:block; font-weight:500;"
+              >Search by Ticket ID, Email or Coupon Code</label
+            >
+            <input
+              type="text"
+              id="search-input"
+              class="v3-text-primary"
+              placeholder="Enter ticket ID, email or coupon code"
+              style="width:100%; padding:0.65rem; border-radius:6px; border:1px solid var(--v3-button-border); background:var(--v3-main-bg);"
+            />
+          </div>
+
+          <button class="v3-btn v3-btn-primary" id="search-btn">
+            <i class="ti ti-search"></i>
+            Search Tickets
+          </button>
+        </div>
+
+        <div id="loading" style="display:none; text-align:center; padding:2rem;">
+          <p class="v3-text-secondary">Loading...</p>
+        </div>
+
+        <div
+          id="error-message"
+          class="v3-text-secondary"
+          style="display:none; margin-top:1.5rem; padding:1rem; background:var(--v3-main-bg); border-radius:6px; border:1px solid var(--v3-button-border);"
+        ></div>
+
+        <div id="results-section" style="display:none; margin-top:2rem;">
+          <div class="flex flex-wrap align-items-center justify-content-between mb-4">
+            <h3 class="v3-gradient-text" style="font-size:2rem;">Your Tickets are here!</h3>
+            <button class="v3-btn v3-btn-dark" id="download-all-btn" style="display:none;">
+              <i class="ti ti-download"></i>
+              Download All Tickets
+            </button>
+          </div>
+          <p class="text-sm mb-2">{{ ticket_info_text }}</p>
+
+          <div id="tickets-list" style="display:flex; flex-direction:column; gap:1rem;"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    let foundTickets = []
+
+    document.addEventListener('DOMContentLoaded', function () {
+      if (typeof initThemeToggle === 'function') initThemeToggle('theme-toggle')
+
+      loadEvents()
+
+      const urlParams = new URLSearchParams(window.location.search)
+      const ticketId = urlParams.get('ticket-id')
+
+      if (ticketId) {
+        document.getElementById('search-input').value = ticketId
+        searchTickets()
+      }
+
+      document.getElementById('search-btn').addEventListener('click', searchTickets)
+      document.getElementById('download-all-btn').addEventListener('click', downloadAll)
+      document.getElementById('search-input').addEventListener('keypress', function (e) {
+        if (e.key === 'Enter') searchTickets()
+      })
+    })
+
+    function loadEvents() {
+      frappe.call({
+        method: 'fossunited.api.tickets.get_paid_events',
+        callback: function (r) {
+          if (r.message) {
+            const select = document.getElementById('event-select')
+            r.message.forEach((event) => {
+              const option = document.createElement('option')
+              option.value = event.name
+              option.textContent = event.event_name || event.name
+              select.appendChild(option)
+            })
+          }
+        },
+      })
+    }
+
+    function searchTickets() {
+      const event = document.getElementById('event-select').value
+      const searchTerm = document.getElementById('search-input').value.trim()
+
+      if (!searchTerm) {
+        showError('Please enter ticket ID, email or coupon code')
+        return
+      }
+
+      if (searchTerm.includes('@') && !event) {
+        showError('Please select an event to search by email')
+        return
+      }
+
+      showLoading(true)
+      hideError()
+      document.getElementById('results-section').style.display = 'none'
+
+      frappe.call({
+        method: 'fossunited.api.tickets.search_tickets',
+        args: {
+          search_term: searchTerm,
+          event: event || null,
+        },
+        callback: function (r) {
+          showLoading(false)
+          if (r.message && r.message.length > 0) {
+            foundTickets = r.message
+            displayTickets(r.message)
+          } else {
+            showError('No tickets found matching your search')
+          }
+        },
+      })
+    }
+
+    function displayTickets(tickets) {
+      const list = document.getElementById('tickets-list')
+      list.innerHTML = ''
+
+      tickets.forEach((ticket) => {
+        const div = document.createElement('div')
+        div.className = 'v3-card'
+        div.style.padding = '1rem'
+        div.innerHTML = `
+        <div style="margin-bottom:0.5rem;">
+          <strong class="v3-text-primary" style="font-size:1.1rem;">${ticket.full_name}</strong>
+        </div>
+        <div class="v3-text-secondary" style="font-size:0.9rem; margin-bottom:0.5rem;">
+          ${ticket.email}
+        </div>
+        <div class="v3-text-tertiary" style="font-size:0.85rem; margin-bottom:0.75rem;">
+    Ticket ID: ${ticket.name}${[
+      ticket.tier && ` | Tier: ${ticket.tier}`,
+      ticket.organization && ` | Organization: ${ticket.organization}`,
+    ]
+      .filter(Boolean)
+      .join('')}
+
+        </div>
+        <button class="v3-btn v3-btn-secondary v3-btn-sm" onclick="downloadTicket('${ticket.name}')" style="padding:0.5rem 1rem; font-size:0.8rem;">
+          <i class="ti ti-download"></i>
+          Download Ticket
+        </button>
+      `
+        list.appendChild(div)
+      })
+
+      document.getElementById('results-section').style.display = 'block'
+
+      if (tickets.length > 1) {
+        document.getElementById('download-all-btn').style.display = 'inline-flex'
+      }
+    }
+
+    function downloadTicket(ticketName) {
+      const url = `/api/method/fossunited.api.tickets.download_ticket?ticket_id=${ticketName}`
+      window.open(url, '_blank')
+    }
+
+    function downloadAll() {
+      if (foundTickets.length > 1) {
+        if (!confirm(`Download ${foundTickets.length} tickets as single PDF?`)) {
+          return
+        }
+      }
+
+      const ticketIds = foundTickets.map((t) => t.name)
+      const url = `/api/method/fossunited.api.tickets.download_all_tickets?ticket_ids=${encodeURIComponent(JSON.stringify(ticketIds))}`
+      window.open(url, '_blank')
+    }
+
+    function showLoading(show) {
+      document.getElementById('loading').style.display = show ? 'block' : 'none'
+      document.getElementById('search-section').style.opacity = show ? '0.5' : '1'
+      document.getElementById('search-btn').disabled = show
+    }
+
+    function showError(message) {
+      const errorDiv = document.getElementById('error-message')
+      errorDiv.innerHTML = `<i class="ti ti-alert-circle" style="margin-right:0.5rem;"></i>${message}`
+      errorDiv.style.display = 'block'
+    }
+
+    function hideError() {
+      document.getElementById('error-message').style.display = 'none'
+    }
+  </script>
+{% endblock %}

--- a/fossunited/fossunited/web_template/get_event_tickets/get_event_tickets.json
+++ b/fossunited/fossunited/web_template/get_event_tickets/get_event_tickets.json
@@ -1,0 +1,41 @@
+{
+ "__unsaved": 1,
+ "creation": "2025-12-04 13:19:26.165629",
+ "docstatus": 0,
+ "doctype": "Web Template",
+ "fields": [
+  {
+   "__islocal": 1,
+   "__unsaved": 1,
+   "fieldname": "page_title",
+   "fieldtype": "Data",
+   "label": "Page title",
+   "reqd": 0
+  },
+  {
+   "__islocal": 1,
+   "__unsaved": 1,
+   "fieldname": "intro_text",
+   "fieldtype": "Markdown Editor",
+   "label": "Intro Text",
+   "reqd": 0
+  },
+  {
+   "__islocal": 1,
+   "__unsaved": 1,
+   "fieldname": "ticket_info_text",
+   "fieldtype": "Markdown Editor",
+   "label": "Ticket info text",
+   "reqd": 0
+  }
+ ],
+ "idx": 0,
+ "modified": "2025-12-04 14:04:04.626082",
+ "modified_by": "Administrator",
+ "module": "FOSSUnited",
+ "name": "Get Event Tickets",
+ "owner": "Administrator",
+ "standard": 1,
+ "template": "",
+ "type": "Section"
+}

--- a/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.json
+++ b/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.json
@@ -165,7 +165,7 @@
   }
  ],
  "links": [],
- "modified": "2025-10-15 12:51:09.109565",
+ "modified": "2025-12-04 12:15:15.917296",
  "modified_by": "Administrator",
  "module": "Ticketing",
  "name": "FOSS Event Ticket",
@@ -182,6 +182,11 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "print": 1,
+   "read": 1,
+   "role": "All"
   }
  ],
  "row_format": "Dynamic",


### PR DESCRIPTION
- Added api to downlaod tickets

- Add web template page to download tickets.

- This page also serves to pass URL in mails for direct download.
- <baseurl.org>/get-tickets?id=ABCDEDF

- Allows to download multiple in single pdf for given coupon as well.

<img width="1240" height="1309" alt="image" src="https://github.com/user-attachments/assets/42850a04-1fd7-4f27-b846-66738747e058" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a ticket lookup page to search by email (requires selecting an event), ticket ID, or coupon code; loads recent paid events and auto-fills from ticket-id URL param.
  * Per-ticket PDF download and bulk download of multiple tickets as a single PDF; UI shows loading, errors, and validations.

* **Permissions**
  * Ticket visibility updated so all users can view and print tickets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->