### PR TITLE
backend(cfp): notify chapter member if approved proposal has been withdrawn

### DIFF
--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -10,6 +10,7 @@ from ics import Calendar, Event
 from fossunited.doctype_ids import (
     CHAPTER,
     CHAPTER_MEMBER,
+    CORE_TEAM,
     EVENT,
     EVENT_CHECKIN,
     EVENT_VOLUNTEER,
@@ -307,3 +308,15 @@ def get_checked_in_attendees(event_id):
         "event_start": str(getdate(event_start)),
         "event_end": str(getdate(event_end)),
     }
+
+
+@frappe.whitelist()
+def get_chapter_members_email(chapter):
+    return frappe.db.get_all(
+        CHAPTER_MEMBER,
+        {
+            "parent": chapter,
+            "role": ["in", [CORE_TEAM, "Volunteer"]],
+        },
+        pluck="email",
+    )

--- a/fossunited/doctype_ids.py
+++ b/fossunited/doctype_ids.py
@@ -22,6 +22,7 @@ STUDENT_CLUB = "FOSS Club"
 CONFERENCE = "Conference"
 VIRTUAL = "Virtual"
 CHAPTER_MEMBER = "FOSS Chapter Lead Team Member"
+CORE_TEAM = "Core Team Member"
 
 # Event-related identifiers
 EVENT_VOLUNTEER = "FOSS Chapter Event Member"

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -6,13 +6,12 @@ import textwrap
 import frappe
 from frappe.website.website_generator import WebsiteGenerator
 
+from fossunited.api.chapter import get_chapter_members_email
 from fossunited.api.emailing import (
     handle_email_group_subscription,
 )
 from fossunited.doctype_ids import (
     CHAPTER,
-    CHAPTER_MEMBER,
-    CORE_TEAM,
     EVENT,
     EVENT_CFP,
     EVENT_SCHEDULE,
@@ -95,7 +94,7 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         if self.has_value_changed("is_withdrawn"):
             if self.is_withdrawn and self.status == "Approved":
                 self.status = "Withdrawn"
-                self.proposal_withdrawn_inform_chapter_member()
+                self.notify_team_approved_proposal_withdrawn()
             elif self.is_withdrawn:
                 self.status = "Withdrawn"
             else:
@@ -384,17 +383,9 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
 
         return talk_scheduled
 
-    def proposal_withdrawn_inform_chapter_member(self):
-        members_email = frappe.db.get_all(
-            CHAPTER_MEMBER,
-            {
-                "parent": self.chapter,
-                "role": CORE_TEAM,
-            },
-            ["email"],
-        )
-
-        emails = [m["email"] for m in members_email if m.get("email")]
+    def notify_team_approved_proposal_withdrawn(self):
+        """Notify chapter members that an approved proposal has been withdrawn by proposer."""
+        team_emails = get_chapter_members_email(self.chapter)
         to = frappe.db.get_value(CHAPTER, self.chapter, "email")
         message = f"""
         <p>Dear {self.chapter} team,</p>
@@ -402,6 +393,7 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         <p><b>{self.full_name}</b> has withdrawn their proposal from <b>{self.event_name}</b>,
         which was <b>approved</b> before for the event.</p>
 
+        Proposal title: {self.talk_title}
         <p>You can find the proposal link below:</p>
 
         <p><a href="{frappe.utils.get_url(self.route)}" target="_blank">
@@ -415,7 +407,7 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         try:
             frappe.sendmail(
                 recipients=to,
-                cc=emails,
+                cc=team_emails,
                 subject=f"{self.full_name} has Withdrawn their proposal from {self.event_name}",
                 message=message,
                 reference_doctype=PROPOSAL,

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -9,7 +9,15 @@ from frappe.website.website_generator import WebsiteGenerator
 from fossunited.api.emailing import (
     handle_email_group_subscription,
 )
-from fossunited.doctype_ids import CHAPTER, EVENT, EVENT_CFP, EVENT_SCHEDULE
+from fossunited.doctype_ids import (
+    CHAPTER,
+    CHAPTER_MEMBER,
+    CORE_TEAM,
+    EVENT,
+    EVENT_CFP,
+    EVENT_SCHEDULE,
+    PROPOSAL,
+)
 
 
 class FOSSEventCFPSubmission(WebsiteGenerator):
@@ -85,7 +93,10 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
 
     def before_save(self):
         if self.has_value_changed("is_withdrawn"):
-            if self.is_withdrawn:
+            if self.is_withdrawn and self.status == "Approved":
+                self.status = "Withdrawn"
+                self.proposal_withdrawn_inform_chapter_member()
+            elif self.is_withdrawn:
                 self.status = "Withdrawn"
             else:
                 self.status = "Review Pending"
@@ -372,3 +383,45 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         )
 
         return talk_scheduled
+
+    def proposal_withdrawn_inform_chapter_member(self):
+        members_email = frappe.db.get_all(
+            CHAPTER_MEMBER,
+            {
+                "parent": self.chapter,
+                "role": CORE_TEAM,
+            },
+            ["email"],
+        )
+
+        emails = [m["email"] for m in members_email if m.get("email")]
+        to = frappe.db.get_value(CHAPTER, self.chapter, "email")
+        message = f"""
+        <p>Dear {self.chapter} team,</p>
+
+        <p><b>{self.full_name}</b> has withdrawn their proposal from <b>{self.event_name}</b>,
+        which was <b>approved</b> before for the event.</p>
+
+        <p>You can find the proposal link below:</p>
+
+        <p><a href="{frappe.utils.get_url(self.route)}" target="_blank">
+            View CFP
+        </a></p>
+
+        <p>Regards,<br>
+        FOSS United Team</p>
+        """
+
+        try:
+            frappe.sendmail(
+                recipients=to,
+                cc=emails,
+                subject=f"{self.full_name} has Withdrawn their proposal from {self.event_name}",
+                message=message,
+                reference_doctype=PROPOSAL,
+                reference_name=self.name,
+            )
+
+        except Exception as exc:
+            frappe.log_error(title="email_core_team:send_failed", message=frappe.get_traceback())
+            frappe.throw(f"Failed to send email: {exc}")

--- a/fossunited/hooks.py
+++ b/fossunited/hooks.py
@@ -53,6 +53,7 @@ jinja = {
         "fossunited.stack.utils.get_stack_dict",
         "fossunited.fossunited.utils.get_main_foss_events",
         "fossunited.fossunited.utils.get_all_city_names",
+        "fossunited.api.chapter.get_chapter_members_email",
     ],
     "filters": [
         "fossunited.fossunited.utils.make_badge",


### PR DESCRIPTION
- Event members would like to get notification if approved proposer has withdrawn their proposal This helps them to keep track and get notified formally.

- We already allow them to download CSV for all proposals, but still not every time they would visit and screen.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notify chapter core team members by email when an approved proposal is withdrawn.
  * New API to fetch chapter member emails and exposed to templating/Jinja.

* **Improvements**
  * Refined withdrawal handling to set appropriate submission statuses and trigger the new notification flow.
  * Added a distinct "Core Team" role identifier for chapter membership.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->