### PR TITLE
feat: proposal review notification

### DIFF
--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -105,6 +105,7 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         self.validate_session_type_permissions()
         if self.has_value_changed("subscribe_chapter_mailing"):
             self.handle_email_group("CFP Proposers")
+        self.notify_proposer_on_review()
 
     def after_insert(self):
         # Always handle initial subscription on insert
@@ -417,3 +418,76 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         except Exception as exc:
             frappe.log_error(title="email_core_team:send_failed", message=frappe.get_traceback())
             frappe.throw(f"Failed to send email: {exc}")
+
+    def notify_proposer_on_review(self):
+        """Notify proposer on new or updated review."""
+        if self.is_new() or not self._doc_before_save:
+            return
+
+        old_reviews = {r.name: r for r in self._doc_before_save.reviews if r.name}
+
+        for review in self.reviews:
+            old_review = old_reviews.get(review.name)
+
+            # New review
+            if not old_review:
+                self._send_review_email("New review on your proposal for", review, "new")
+            # Updated review
+            elif old_review.to_approve != review.to_approve:
+                self._send_review_email(
+                    "A Review status changed on your proposal for",
+                    review,
+                    "approval_changed",
+                    old_review,
+                )
+            elif review.remarks != old_review.remarks:
+                self._send_review_email(
+                    "A Review remarks changed on your proposal for",
+                    review,
+                    "remarks_changed",
+                    old_review,
+                )
+
+    def _send_review_email(self, subject_prefix, review, change_type, old_review=None):
+        """Helper to send review notification emails."""
+        frappe.sendmail(
+            recipients=self.email,
+            subject=f"{subject_prefix} {self.event_name}",
+            message=build_review_message(self, review, change_type, old_review),
+        )
+
+
+def build_review_message(submission, review, change_type, old_review=None):
+    """Build review notification message."""
+    base_intro = (
+        f"Dear {submission.full_name},<br><br>"
+        f"Your proposal for <b>{submission.event_name}</b>, "
+        f"titled <b>{submission.talk_title}</b>, has an update.<br><br>"
+    )
+
+    messages = {
+        "new": (
+            f"<b>A new review has been submitted.</b><br>"
+            f"Review Conclusion: {review}<br>"
+            f"Remarks: <pre><code> {review.remarks} </code></pre><br>"
+        ),
+        "approval_changed": lambda: (
+            f"<b>A reviewer decision has changed.</b><br>"
+            f"Previous decision: {old_review.to_approve}<br>"
+            f"New decision: <b>{review.to_approve}</b><br>"
+            f"Remarks: <pre><code> {review.remarks} </code></pre><br>"
+        ),
+        "remarks_changed": lambda: (
+            f"<b>A reviewer has updated their remarks.</b><br>"
+            f"Old Remarks: <pre><code> {old_review.remarks} </code></pre><br>"
+            f"New Remarks: <pre><code> {review.remarks} </code></pre><br>"
+            f"Review Conclusion: {review.to_approve}<br>"
+        ),
+    }
+
+    closing = (
+        f"You can access your proposal here: https://fossunited.org/{submission.route}<br><br>"
+        "Regards,<br>FOSS United Team"
+    )
+
+    return base_intro + messages[change_type] + closing

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -440,6 +440,7 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
                     "approval_changed",
                     old_review,
                 )
+
             elif review.remarks != old_review.remarks:
                 self._send_review_email(
                     "A Review remarks changed on your proposal for",
@@ -477,29 +478,32 @@ def build_review_message(submission, review, change_type, old_review=None):
         f"titled <b>{submission.talk_title}</b>, has an update.<br><br>"
     )
 
-    messages = {
-        "new": (
+    if change_type == "new":
+        body = (
             f"<b>A new review has been submitted.</b><br>"
             f"Review Conclusion: {review.to_approve}<br>"
             f"Remarks: <pre><code> {review.remarks} </code></pre><br>"
-        ),
-        "approval_changed": lambda: (
+        )
+
+    elif change_type == "approval_changed":
+        body = (
             f"<b>A reviewer decision has changed.</b><br>"
             f"Previous decision: {old_review.to_approve}<br>"
             f"New decision: <b>{review.to_approve}</b><br>"
             f"Remarks: <pre><code> {review.remarks} </code></pre><br>"
-        ),
-        "remarks_changed": lambda: (
+        )
+
+    elif change_type == "remarks_changed":
+        body = (
             f"<b>A reviewer has updated their remarks.</b><br>"
             f"Old Remarks: <pre><code> {old_review.remarks} </code></pre><br>"
             f"New Remarks: <pre><code> {review.remarks} </code></pre><br>"
             f"Review Conclusion: {review.to_approve}<br>"
-        ),
-    }
+        )
 
     closing = (
         f"You can access your proposal here: https://fossunited.org/{submission.route}<br><br>"
         "Regards,<br>FOSS United Team"
     )
 
-    return base_intro + messages[change_type] + closing
+    return base_intro + body + closing

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -429,37 +429,29 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         for review in self.reviews:
             old_review = old_reviews.get(review.name)
 
-            # New review
             if not old_review:
-                self._send_review_email("New review on your proposal for", review, "new")
-            # Updated review
-            elif old_review.to_approve != review.to_approve:
-                self._send_review_email(
-                    "A Review status changed on your proposal for",
-                    review,
-                    "approval_changed",
-                    old_review,
-                )
-
+                change_type = "new"
             elif review.remarks != old_review.remarks:
-                self._send_review_email(
-                    "A Review remarks changed on your proposal for",
-                    review,
-                    "remarks_changed",
-                    old_review,
-                )
+                change_type = "remarks_changed"
+            else:
+                continue
 
-    def _send_review_email(self, subject_prefix, review, change_type, old_review=None):
+            self._send_review_email(review, change_type, old_review)
+
+    def _send_review_email(self, review, change_type, old_review=None):
         """Helper to send review notification emails."""
         if not self.email:
             return
+
         speaker_emails = [s.email for s in self.speakers if s.email]
+        sub_prefix = "New review" if change_type == "new" else "Review remarks updated"
+
         try:
             frappe.sendmail(
                 recipients=self.email,
                 cc=speaker_emails,
-                subject=f"{subject_prefix} {self.event_name}",
-                message=build_review_message(self, review, change_type, old_review),
+                subject=f"{sub_prefix} on your proposal for {self.event_name}",
+                message=self._build_review_message(review, change_type, old_review),
                 reference_doctype=PROPOSAL,
                 reference_name=self.name,
             )
@@ -469,44 +461,29 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
                 message=frappe.get_traceback(),
             )
 
-
-def build_review_message(submission, review, change_type, old_review=None):
-    """Build review notification message."""
-    base_intro = (
-        f"Dear {submission.full_name},<br><br>"
-        f"Your proposal for <b>{submission.event_name}</b>, "
-        f"titled <b>{submission.talk_title}</b>, has an update.<br><br>"
-    )
-
-    if change_type == "new":
-        remarks_section = (
-            f"Remarks: <pre><code> {review.remarks} </code></pre><br>" if review.remarks else ""
-        )
-        body = (
-            f"<b>A new review has been submitted.</b><br>"
-            f"Review Conclusion: {review.to_approve}<br>"
-            f"{remarks_section}"
+    def _build_review_message(self, review, change_type, old_review=None):
+        """Build review notification message."""
+        base_intro = (
+            f"Dear {self.full_name},<br><br>"
+            f"Your proposal for <b>{self.event_name}</b>, "
+            f"titled <b>{self.talk_title}</b>, has an update.<br><br>"
         )
 
-    elif change_type == "approval_changed":
-        body = (
-            f"<b>A reviewer decision has changed.</b><br>"
-            f"Previous decision: {old_review.to_approve}<br>"
-            f"New decision: <b>{review.to_approve}</b><br>"
-            f"Remarks: <pre><code> {review.remarks} </code></pre><br>"
+        if change_type == "new":
+            remarks_section = (
+                f"Remarks: <pre><code>{review.remarks}</code></pre><br>" if review.remarks else ""
+            )
+            body = f"<b>A new review has been submitted.</b><br>{remarks_section}"
+        else:  # remarks_changed
+            body = (
+                f"<b>A reviewer has updated their remarks.</b><br>"
+                f"Old Remarks: <pre><code>{old_review.remarks}</code></pre><br>"
+                f"New Remarks: <pre><code>{review.remarks}</code></pre><br>"
+            )
+
+        closing = (
+            f"You can access your proposal here: {frappe.utils.get_url(self.route)}<br><br>"
+            "Regards,<br>FOSS United Team"
         )
 
-    elif change_type == "remarks_changed":
-        body = (
-            f"<b>A reviewer has updated their remarks.</b><br>"
-            f"Old Remarks: <pre><code> {old_review.remarks} </code></pre><br>"
-            f"New Remarks: <pre><code> {review.remarks} </code></pre><br>"
-            f"Review Conclusion: {review.to_approve}<br>"
-        )
-
-    closing = (
-        f"You can access your proposal here: {frappe.utils.get_url(submission.route)}<br><br>"
-        "Regards,<br>FOSS United Team"
-    )
-
-    return base_intro + body + closing
+        return base_intro + body + closing

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -453,14 +453,20 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         if not self.email:
             return
         speaker_emails = [s.email for s in self.speakers if s.email]
-        frappe.sendmail(
-            recipients=self.email,
-            cc=speaker_emails,
-            subject=f"{subject_prefix} {self.event_name}",
-            message=build_review_message(self, review, change_type, old_review),
-            reference_doctype=PROPOSAL,
-            reference_name=self.name,
-        )
+        try:
+            frappe.sendmail(
+                recipients=self.email,
+                cc=speaker_emails,
+                subject=f"{subject_prefix} {self.event_name}",
+                message=build_review_message(self, review, change_type, old_review),
+                reference_doctype=PROPOSAL,
+                reference_name=self.name,
+            )
+        except Exception:
+            frappe.log_error(
+                title="review_notification:send_failed",
+                message=frappe.get_traceback(),
+            )
 
 
 def build_review_message(submission, review, change_type, old_review=None):

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -479,10 +479,13 @@ def build_review_message(submission, review, change_type, old_review=None):
     )
 
     if change_type == "new":
+        remarks_section = (
+            f"Remarks: <pre><code> {review.remarks} </code></pre><br>" if review.remarks else ""
+        )
         body = (
             f"<b>A new review has been submitted.</b><br>"
             f"Review Conclusion: {review.to_approve}<br>"
-            f"Remarks: <pre><code> {review.remarks} </code></pre><br>"
+            f"{remarks_section}"
         )
 
     elif change_type == "approval_changed":
@@ -502,7 +505,7 @@ def build_review_message(submission, review, change_type, old_review=None):
         )
 
     closing = (
-        f"You can access your proposal here: https://fossunited.org/{submission.route}<br><br>"
+        f"You can access your proposal here: {frappe.utils.get_url(submission.route)}<br><br>"
         "Regards,<br>FOSS United Team"
     )
 

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -421,11 +421,11 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
 
     def notify_proposer_on_review(self):
         """Notify proposer on new or updated review."""
-        if self.is_new() or not self._doc_before_save:
+        old_doc = self.get_doc_before_save()
+        if self.is_new() or not old_doc:
             return
 
-        old_reviews = {r.name: r for r in self._doc_before_save.reviews if r.name}
-
+        old_reviews = {r.name: r for r in old_doc.reviews if r.name}
         for review in self.reviews:
             old_review = old_reviews.get(review.name)
 
@@ -450,10 +450,16 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
 
     def _send_review_email(self, subject_prefix, review, change_type, old_review=None):
         """Helper to send review notification emails."""
+        if not self.email:
+            return
+        speaker_emails = [s.email for s in self.speakers if s.email]
         frappe.sendmail(
             recipients=self.email,
+            cc=speaker_emails,
             subject=f"{subject_prefix} {self.event_name}",
             message=build_review_message(self, review, change_type, old_review),
+            reference_doctype=PROPOSAL,
+            reference_name=self.name,
         )
 
 
@@ -468,7 +474,7 @@ def build_review_message(submission, review, change_type, old_review=None):
     messages = {
         "new": (
             f"<b>A new review has been submitted.</b><br>"
-            f"Review Conclusion: {review}<br>"
+            f"Review Conclusion: {review.to_approve}<br>"
             f"Remarks: <pre><code> {review.remarks} </code></pre><br>"
         ),
         "approval_changed": lambda: (

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/test_foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/test_foss_event_cfp_submission.py
@@ -343,6 +343,51 @@ class TestFOSSEventCFPSubmission(FrappeTestCase):
             expected_recipients=[self.submission.email],
         )
 
+    def test_notify_proposer_on_approval_change(self):
+        frappe.set_user(CoreTeam)
+
+        self.submission.append(
+            "reviews",
+            {
+                "reviewer": CoreTeam,
+                "to_approve": "Maybe",
+                "remarks": "Might be good?",
+            },
+        )
+        self.submission.save()
+
+        frappe.db.delete("Email Queue")
+        self.submission.reviews[0].to_approve = "No"
+        self.submission.save()
+
+        self._assert_email_sent(
+            subject_contains="A Review status changed on your proposal for",
+            expected_recipients=[self.submission.email],
+        )
+
+    def test_notify_proposer_on_remarks_changed(self):
+        frappe.set_user(CoreTeam)
+
+        # When a review is added
+        self.submission.append(
+            "reviews",
+            {
+                "reviewer": CoreTeam,
+                "to_approve": "Maybe",
+                "remarks": "This needs more explanation.",
+            },
+        )
+        self.submission.save()
+
+        frappe.db.delete("Email Queue")
+        self.submission.reviews[0].remarks = "This is promising now!"
+        self.submission.save()
+
+        self._assert_email_sent(
+            subject_contains="A Review remarks changed on your proposal for",
+            expected_recipients=[self.submission.email],
+        )
+
     def test_get_review_scores_calculation(self):
         # Given a submission with multiple reviews
         frappe.set_user(CoreTeam)

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/test_foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/test_foss_event_cfp_submission.py
@@ -343,28 +343,6 @@ class TestFOSSEventCFPSubmission(FrappeTestCase):
             expected_recipients=[self.submission.email],
         )
 
-    def test_notify_proposer_on_approval_change(self):
-        frappe.set_user(CoreTeam)
-
-        self.submission.append(
-            "reviews",
-            {
-                "reviewer": CoreTeam,
-                "to_approve": "Maybe",
-                "remarks": "Might be good?",
-            },
-        )
-        self.submission.save()
-
-        frappe.db.delete("Email Queue")
-        self.submission.reviews[0].to_approve = "No"
-        self.submission.save()
-
-        self._assert_email_sent(
-            subject_contains="A Review status changed on your proposal for",
-            expected_recipients=[self.submission.email],
-        )
-
     def test_notify_proposer_on_remarks_changed(self):
         frappe.set_user(CoreTeam)
 
@@ -384,7 +362,7 @@ class TestFOSSEventCFPSubmission(FrappeTestCase):
         self.submission.save()
 
         self._assert_email_sent(
-            subject_contains="A Review remarks changed on your proposal for",
+            subject_contains="Review remarks updated on your proposal for",
             expected_recipients=[self.submission.email],
         )
 
@@ -426,13 +404,3 @@ class TestFOSSEventCFPSubmission(FrappeTestCase):
         self.assertIsNotNone(self.submission.positive_reviews)
         self.assertIsNotNone(self.submission.negative_reviews)
         self.assertIsNotNone(self.submission.approvability)
-
-    def test_illegal_status_change_on_insert(self):
-        # When trying to insert with non-pending status
-        # Then it should raise ValidationError
-        with self.assertRaises(frappe.ValidationError):
-            submission = frappe.new_doc(PROPOSAL)
-            submission.linked_cfp = self.cfp.name
-            submission.event = self.event.name
-            submission.status = "Approved"
-            submission.insert()

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/test_foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/test_foss_event_cfp_submission.py
@@ -224,3 +224,170 @@ class TestFOSSEventCFPSubmission(FrappeTestCase):
             self.assertTrue(
                 self.is_added_to_email_group(self.event.name, sp.email, "CFP Proposers")
             )
+
+    def test_withdrawal_changes_status_to_withdrawn(self):
+        # Given an approved submission
+        frappe.set_user(CoreTeam)
+        self.submission.status = "Approved"
+        self.submission.save()
+
+        self.submission.is_withdrawn = 1
+        self.submission.save()
+
+        self.assertEqual(self.submission.status, "Withdrawn")
+
+    def _get_single_email(self, reference_doctype=PROPOSAL, reference_name=None):
+        """Return the single Email Queue doc for a given reference."""
+        if reference_name is None:
+            reference_name = self.submission.name
+
+        email_name = frappe.db.get_value(
+            "Email Queue",
+            {
+                "reference_doctype": reference_doctype,
+                "reference_name": reference_name,
+            },
+            "name",
+        )
+
+        self.assertIsNotNone(
+            email_name,
+            f"No Email Queue record found for {reference_doctype} {reference_name}",
+        )
+
+        return frappe.get_doc("Email Queue", email_name)
+
+    def _assert_email_sent(
+        self,
+        subject_contains: str,
+        expected_recipients: list[str],
+        reference_doctype=PROPOSAL,
+        reference_name=None,
+    ):
+        """Assert an email was queued with the given subject fragment and recipients."""
+        email = self._get_single_email(reference_doctype, reference_name)
+
+        self.assertIn(subject_contains, email.message)
+
+        # Recipients is a child table; collect all emails into a set
+        recipients = {r.recipient for r in email.recipients}
+        for addr in expected_recipients:
+            self.assertIn(
+                addr,
+                recipients,
+                f"Expected recipient {addr} not found in {recipients}",
+            )
+
+    def test_un_withdrawal_restores_status(self):
+        # Given a withdrawn submission
+        frappe.set_user(CoreTeam)
+        self.submission.is_withdrawn = 1
+        self.submission.save()
+        self.assertEqual(self.submission.status, "Withdrawn")
+
+        # When withdrawal is reverted
+        self.submission.is_withdrawn = 0
+        self.submission.save()
+
+        # Then status should be Review Pending
+        self.assertEqual(self.submission.status, "Review Pending")
+
+    def test_session_type_invited_talk_blocked_for_website_users(self):
+        # Given a website user
+        frappe.set_user("test_website_user@example.com")
+
+        # When trying to set session_type to Invited Talk
+        # Then it should raise PermissionError
+        with self.assertRaises(frappe.PermissionError):
+            self.submission.session_type = "Invited Talk"
+            self.submission.save()
+
+    def test_withdrawal_notifies_team_when_approved(self):
+        # Given an approved submission
+        frappe.set_user(CoreTeam)
+        self.submission.status = "Approved"
+        self.submission.save()
+
+        # Clear email queue
+        frappe.db.delete("Email Queue")
+
+        # When it is withdrawn
+        self.submission.is_withdrawn = 1
+        self.submission.save()
+
+        # Then team should be notified via email
+        self._assert_email_sent(
+            subject_contains="Withdrawn",
+            expected_recipients=[self.chapter.email],
+        )
+
+    def test_notify_proposer_on_new_review(self):
+        # Given a submission
+        frappe.set_user(CoreTeam)
+        frappe.db.delete("Email Queue")
+
+        # When a review is added
+        self.submission.append(
+            "reviews",
+            {
+                "reviewer": CoreTeam,
+                "to_approve": "Yes",
+                "remarks": "Great proposal!",
+            },
+        )
+        self.submission.save()
+
+        # Then proposer should be notified
+        self._assert_email_sent(
+            subject_contains="New review",
+            expected_recipients=[self.submission.email],
+        )
+
+    def test_get_review_scores_calculation(self):
+        # Given a submission with multiple reviews
+        frappe.set_user(CoreTeam)
+        self.submission.append(
+            "reviews", {"reviewer": CoreTeam, "to_approve": "Yes", "remarks": ""}
+        )
+        self.submission.append(
+            "reviews", {"reviewer": CoreTeam, "to_approve": "Yes", "remarks": ""}
+        )
+        self.submission.append(
+            "reviews", {"reviewer": CoreTeam, "to_approve": "No", "remarks": ""}
+        )
+        self.submission.append(
+            "reviews", {"reviewer": CoreTeam, "to_approve": "Maybe", "remarks": ""}
+        )
+        self.submission.save()
+
+        # When getting review scores
+        scores = self.submission.get_review_scores()
+
+        # Then scores should be calculated correctly
+        self.assertEqual(scores["positive"], 2)
+        self.assertEqual(scores["negative"], 1)
+        self.assertEqual(scores["unsure"], 1)
+        self.assertEqual(scores["approvability"], 66)  # 2/(2+1) * 100
+
+    def test_set_scores_updates_fields(self):
+        # Given a submission with reviews
+        frappe.set_user(CoreTeam)
+        self.submission.append(
+            "reviews", {"reviewer": CoreTeam, "to_approve": "Yes", "remarks": ""}
+        )
+        self.submission.save()
+
+        # Then score fields should be updated
+        self.assertIsNotNone(self.submission.positive_reviews)
+        self.assertIsNotNone(self.submission.negative_reviews)
+        self.assertIsNotNone(self.submission.approvability)
+
+    def test_illegal_status_change_on_insert(self):
+        # When trying to insert with non-pending status
+        # Then it should raise ValidationError
+        with self.assertRaises(frappe.ValidationError):
+            submission = frappe.new_doc(PROPOSAL)
+            submission.linked_cfp = self.cfp.name
+            submission.event = self.event.name
+            submission.status = "Approved"
+            submission.insert()


### PR DESCRIPTION
- #601 (taking prev work based on #982)

Credits: Aryak

Battles with child table to handle controller, after exploring frappe.model.document file we have _doc_before_save method and since reviews are actually less given, we can simply evaluate those by loop.

- Tested, this works by sending email!

To test can replace email with:

frappe.log_error(
    title="A review on the proposal {self.name}",
    message=build_review_message(self, review, "new"),
)


Will add screenshot later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Proposers and listed speakers receive automated emails when a new review is added or reviewer remarks are changed; messages include prior values and clearer subject prefixes and link to the proposal.
* **Bug Fixes**
  * Notifications reliably trigger on save so proposers stay informed of review and approval changes.
* **Tests**
  * Expanded coverage: withdrawals, review notifications (new/remarks-changed), score calculations, permission checks, and email assertion helpers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->