### PR TITLE
a11y: fix keyboard navigation with proper ARIA labels for My Proposals

### DIFF
--- a/dashboard/src/components/profile/SubmissionListItem.vue
+++ b/dashboard/src/components/profile/SubmissionListItem.vue
@@ -1,12 +1,16 @@
 <template>
   <div
     class="p-4 border-b first:border-t border-gray-500 w-full flex flex-col gap-3 focus:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-700 hover:cursor-pointer hover:bg-gray-50"
-    tabindex="0" @click="$router.push({ name: 'Proposal Edit', params: { id: proposal.name } })"
-    @keydown.enter="$router.push({ name: 'Proposal Edit', params: { id: proposal.name } })"
-    @keydown.space="$router.push({ name: 'Proposal Edit', params: { id: proposal.name } })"
-    aria-label="Edit proposal: {{ proposal.talk_title }}" role="link"
-    aria-labelledby="proposal-title-{{ proposal.name }}">
-    <h4 id="proposal-title-{{  proposal.name }}" class="text-base font-medium">{{ proposal.talk_title }}</h4>
+    tabindex="0"
+    @click="navigateToProposal"
+    @keydown.enter="navigateToProposal"
+    @keydown.space.prevent="navigateToProposal"
+    role="link"
+    :aria-labelledby="`proposal-title-${proposal.name}`"
+  >
+    <h4 :id="`proposal-title-${proposal.name}`" class="text-base font-medium">
+      {{ proposal.talk_title }}
+    </h4>
     <div class="flex flex-col md:flex-row md:items-center justify-between gap-2">
       <div class="flex flex-wrap gap-2 items-center divide-x-2 text-gray-800">
         <Badge class="!rounded-sm" :theme="getTheme[proposal.status]">{{ proposal.status }}</Badge>
@@ -21,7 +25,10 @@
 import { Badge } from 'frappe-ui'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
+import { useRouter } from 'vue-router'
 dayjs.extend(relativeTime)
+
+const router = useRouter()
 
 const props = defineProps({
   proposal: {
@@ -29,6 +36,10 @@ const props = defineProps({
     required: true,
   },
 })
+
+const navigateToProposal = () => {
+  router.push({ name: 'Proposal Edit', params: { id: props.proposal.name } })
+}
 
 const getTheme = {
   'Review Pending': 'orange',

--- a/dashboard/src/components/profile/SubmissionListItem.vue
+++ b/dashboard/src/components/profile/SubmissionListItem.vue
@@ -1,9 +1,14 @@
 <template>
   <div
     class="p-4 border-b first:border-t border-gray-500 w-full flex flex-col gap-3 hover:cursor-pointer hover:bg-gray-50"
+    tabindex="0"
     @click="$router.push({ name: 'Proposal Edit', params: { id: proposal.name } })"
-  >
-    <h4 class="text-base font-medium">{{ proposal.talk_title }}</h4>
+    @keydown.enter="$router.push({ name: 'Proposal Edit', params: { id: proposal.name } })"
+    @keydown.space="$router.push({ name: 'Proposal Edit', params: { id: proposal.name } })"
+    aria-label="Edit proposal: {{ proposal.talk_title }}" role="link"
+    aria-labelledby="proposal-title-{{ proposal.name }}"
+    >
+    <h4 id="proposal-title-{{  proposal.name }}" class="text-base font-medium">{{ proposal.talk_title }}</h4>
     <div class="flex flex-col md:flex-row md:items-center justify-between gap-2">
       <div class="flex flex-wrap gap-2 items-center divide-x-2 text-gray-800">
         <Badge class="!rounded-sm" :theme="getTheme[proposal.status]">{{ proposal.status }}</Badge>

--- a/dashboard/src/components/profile/SubmissionListItem.vue
+++ b/dashboard/src/components/profile/SubmissionListItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="p-4 border-b first:border-t border-gray-500 w-full flex flex-col gap-3 hover:cursor-pointer hover:bg-gray-50"
+    class="p-4 border-b first:border-t border-gray-500 w-full flex flex-col gap-3 focus:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-700 hover:cursor-pointer hover:bg-gray-50"
     tabindex="0" @click="$router.push({ name: 'Proposal Edit', params: { id: proposal.name } })"
     @keydown.enter="$router.push({ name: 'Proposal Edit', params: { id: proposal.name } })"
     @keydown.space="$router.push({ name: 'Proposal Edit', params: { id: proposal.name } })"

--- a/dashboard/src/components/profile/SubmissionListItem.vue
+++ b/dashboard/src/components/profile/SubmissionListItem.vue
@@ -1,13 +1,11 @@
 <template>
   <div
     class="p-4 border-b first:border-t border-gray-500 w-full flex flex-col gap-3 hover:cursor-pointer hover:bg-gray-50"
-    tabindex="0"
-    @click="$router.push({ name: 'Proposal Edit', params: { id: proposal.name } })"
+    tabindex="0" @click="$router.push({ name: 'Proposal Edit', params: { id: proposal.name } })"
     @keydown.enter="$router.push({ name: 'Proposal Edit', params: { id: proposal.name } })"
     @keydown.space="$router.push({ name: 'Proposal Edit', params: { id: proposal.name } })"
     aria-label="Edit proposal: {{ proposal.talk_title }}" role="link"
-    aria-labelledby="proposal-title-{{ proposal.name }}"
-    >
+    aria-labelledby="proposal-title-{{ proposal.name }}">
     <h4 id="proposal-title-{{  proposal.name }}" class="text-base font-medium">{{ proposal.talk_title }}</h4>
     <div class="flex flex-col md:flex-row md:items-center justify-between gap-2">
       <div class="flex flex-wrap gap-2 items-center divide-x-2 text-gray-800">


### PR DESCRIPTION
## Status

- [x] Ready for review

---

## Related Issue

Addresses: #786 #787 #788

---

## Problem

<!-- Briefly describe the problem or motivation for this PR -->
1. The proposal listing in dashboard under My Proposal is not accessible via keyboard and the proposal title isn't read properly by screen reader due to missing ARIA attributes and lacks focus indicators.
---

## Solution

1. Add keyboard navigation support with proper ARIA attribute for proper screen reader support in My Proposal while being adherent to design guidelines with focus indicators to support low vision users.
---

## Progress (All must be checked to merge)

- [x] Tested locally
- [x] Tested with Orca
- [ ] Tested with Talkback
- [ ] Tested with VoiceOver
- [ ] Tested with NVDA

---

## Changelog

a11y: add aria attributes, focus indicator and keyboard support for My Proposal

---

## Further Ahead

Working further on CFP field accessibility to make proposal submission accessible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Submission items now support keyboard navigation with Enter and Space for improved usability
  * Added screen reader compatibility via ARIA labeling and title associations
  * Clear visual focus indicators added for keyboard users while preserving hover behavior
  * Navigation from submission items is now consistently operable via keyboard and click actions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->