### PR TITLE
desk: add cfp submission to event and cfp connections

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
@@ -517,9 +517,9 @@
  "is_published_field": "is_published",
  "links": [
   {
-   "group": "Participants",
-   "link_doctype": "FOSS Chapter Event Participant",
-   "link_fieldname": "event_name"
+   "group": "Proposals",
+   "link_doctype": "FOSS Event CFP Submission",
+   "link_fieldname": "event"
   },
   {
    "group": "RSVP",
@@ -527,6 +527,7 @@
    "link_fieldname": "chapter"
   },
   {
+   "group": "Tickets",
    "link_doctype": "FOSS Event Ticket",
    "link_fieldname": "event"
   }

--- a/fossunited/fossunited/doctype/foss_event_cfp/foss_event_cfp.json
+++ b/fossunited/fossunited/doctype/foss_event_cfp/foss_event_cfp.json
@@ -1,197 +1,203 @@
 {
-  "actions": [],
-  "allow_rename": 1,
-  "autoname": "hash",
-  "creation": "2023-07-10 01:05:08.149329",
-  "default_view": "List",
-  "doctype": "DocType",
-  "editable_grid": 1,
-  "engine": "InnoDB",
-  "field_order": [
-    "meta_section",
-    "status",
-    "column_break_puww",
-    "allow_cfp_edit",
-    "anonymise_proposals",
-    "only_workshops",
-    "only_talk_proposals",
-    "event_information_section",
-    "event",
-    "event_name",
-    "column_break_je1w",
-    "chapter",
-    "deadline",
-    "cfp_form_description_section",
-    "cfp_form_description",
-    "custom_questions_section",
-    "has_public_custom_responses",
-    "cfp_custom_questions",
-    "cfp_reviewers_tab",
-    "cfp_reviewers"
-  ],
-  "fields": [
-    {
-      "fieldname": "column_break_puww",
-      "fieldtype": "Column Break"
-    },
-    {
-      "default": "0",
-      "fieldname": "allow_cfp_edit",
-      "fieldtype": "Check",
-      "label": "Allow CFP Edit?"
-    },
-    {
-      "fieldname": "event_information_section",
-      "fieldtype": "Section Break",
-      "label": "Event Information"
-    },
-    {
-      "fieldname": "event",
-      "fieldtype": "Link",
-      "in_list_view": 1,
-      "label": "Event",
-      "options": "FOSS Chapter Event",
-      "reqd": 1
-    },
-    {
-      "fetch_from": "event.event_name",
-      "fieldname": "event_name",
-      "fieldtype": "Data",
-      "label": "Event Name"
-    },
-    {
-      "fieldname": "column_break_je1w",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fetch_from": "event.chapter",
-      "fieldname": "chapter",
-      "fieldtype": "Data",
-      "label": "Chapter"
-    },
-    {
-      "fieldname": "cfp_form_description_section",
-      "fieldtype": "Section Break",
-      "label": "CFP Form Description"
-    },
-    {
-      "fieldname": "cfp_form_description",
-      "fieldtype": "Text Editor",
-      "label": "CFP Form Description"
-    },
-    {
-      "fieldname": "custom_questions_section",
-      "fieldtype": "Section Break",
-      "label": "Custom Questions"
-    },
-    {
-      "fieldname": "cfp_custom_questions",
-      "fieldtype": "Table",
-      "label": "CFP Custom Questions",
-      "options": "FOSS Custom Question"
-    },
-    {
-      "fieldname": "cfp_reviewers_tab",
-      "fieldtype": "Tab Break",
-      "label": "CFP Reviewers"
-    },
-    {
-      "fieldname": "cfp_reviewers",
-      "fieldtype": "Table",
-      "label": "CFP Reviewers",
-      "options": "FOSS Event CFP Reviewer"
-    },
-    {
-      "default": "1",
-      "description": "The CFPs will not show the name of the proposer.",
-      "fieldname": "anonymise_proposals",
-      "fieldtype": "Check",
-      "label": "Anonymise Proposals?"
-    },
-    {
-      "default": "0",
-      "description": "Only accept workshop proposals.",
-      "fieldname": "only_workshops",
-      "fieldtype": "Check",
-      "label": "Only Workshop Proposals"
-    },
-    {
-      "default": "0",
-      "description": "Only accept Talk proposals.",
-      "fieldname": "only_talk_proposals",
-      "fieldtype": "Check",
-      "label": "Only Talk Proposals"
-    },
-    {
-      "fieldname": "deadline",
-      "fieldtype": "Datetime",
-      "label": "Deadline"
-    },
-    {
-      "default": "Closed",
-      "fieldname": "status",
-      "fieldtype": "Select",
-      "label": "Status",
-      "options": "Closed\nLive"
-    },
-    {
-      "fieldname": "meta_section",
-      "fieldtype": "Section Break",
-      "label": "Meta"
-    },
-    {
-      "default": "0",
-      "fieldname": "has_public_custom_responses",
-      "fieldtype": "Check",
-      "label": "Has Public Custom Responses"
-    }
-  ],
-  "links": [],
-  "modified": "2025-06-19 20:22:36.333513",
-  "modified_by": "Administrator",
-  "module": "FOSSUnited",
-  "name": "FOSS Event CFP",
-  "naming_rule": "Random",
-  "owner": "Administrator",
-  "permissions": [
-    {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "System Manager",
-      "share": 1,
-      "write": 1
-    },
-    {
-      "create": 1,
-      "delete": 1,
-      "read": 1,
-      "role": "Chapter Team Member",
-      "select": 1,
-      "write": 1
-    },
-    {
-      "read": 1,
-      "role": "All",
-      "select": 1
-    }
-  ],
-  "row_format": "Dynamic",
-  "sort_field": "modified",
-  "sort_order": "DESC",
-  "states": [
-    {
-      "color": "Gray",
-      "title": "Closed"
-    },
-    {
-      "color": "Green",
-      "title": "Live"
-    }
-  ],
-  "track_changes": 1
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "hash",
+ "creation": "2023-07-10 01:05:08.149329",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "meta_section",
+  "status",
+  "column_break_puww",
+  "allow_cfp_edit",
+  "anonymise_proposals",
+  "only_workshops",
+  "only_talk_proposals",
+  "event_information_section",
+  "event",
+  "event_name",
+  "column_break_je1w",
+  "chapter",
+  "deadline",
+  "cfp_form_description_section",
+  "cfp_form_description",
+  "custom_questions_section",
+  "has_public_custom_responses",
+  "cfp_custom_questions",
+  "cfp_reviewers_tab",
+  "cfp_reviewers"
+ ],
+ "fields": [
+  {
+   "fieldname": "column_break_puww",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "allow_cfp_edit",
+   "fieldtype": "Check",
+   "label": "Allow CFP Edit?"
+  },
+  {
+   "fieldname": "event_information_section",
+   "fieldtype": "Section Break",
+   "label": "Event Information"
+  },
+  {
+   "fieldname": "event",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Event",
+   "options": "FOSS Chapter Event",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "event.event_name",
+   "fieldname": "event_name",
+   "fieldtype": "Data",
+   "label": "Event Name"
+  },
+  {
+   "fieldname": "column_break_je1w",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "event.chapter",
+   "fieldname": "chapter",
+   "fieldtype": "Data",
+   "label": "Chapter"
+  },
+  {
+   "fieldname": "cfp_form_description_section",
+   "fieldtype": "Section Break",
+   "label": "CFP Form Description"
+  },
+  {
+   "fieldname": "cfp_form_description",
+   "fieldtype": "Text Editor",
+   "label": "CFP Form Description"
+  },
+  {
+   "fieldname": "custom_questions_section",
+   "fieldtype": "Section Break",
+   "label": "Custom Questions"
+  },
+  {
+   "fieldname": "cfp_custom_questions",
+   "fieldtype": "Table",
+   "label": "CFP Custom Questions",
+   "options": "FOSS Custom Question"
+  },
+  {
+   "fieldname": "cfp_reviewers_tab",
+   "fieldtype": "Tab Break",
+   "label": "CFP Reviewers"
+  },
+  {
+   "fieldname": "cfp_reviewers",
+   "fieldtype": "Table",
+   "label": "CFP Reviewers",
+   "options": "FOSS Event CFP Reviewer"
+  },
+  {
+   "default": "1",
+   "description": "The CFPs will not show the name of the proposer.",
+   "fieldname": "anonymise_proposals",
+   "fieldtype": "Check",
+   "label": "Anonymise Proposals?"
+  },
+  {
+   "default": "0",
+   "description": "Only accept workshop proposals.",
+   "fieldname": "only_workshops",
+   "fieldtype": "Check",
+   "label": "Only Workshop Proposals"
+  },
+  {
+   "default": "0",
+   "description": "Only accept Talk proposals.",
+   "fieldname": "only_talk_proposals",
+   "fieldtype": "Check",
+   "label": "Only Talk Proposals"
+  },
+  {
+   "fieldname": "deadline",
+   "fieldtype": "Datetime",
+   "label": "Deadline"
+  },
+  {
+   "default": "Closed",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "label": "Status",
+   "options": "Closed\nLive"
+  },
+  {
+   "fieldname": "meta_section",
+   "fieldtype": "Section Break",
+   "label": "Meta"
+  },
+  {
+   "default": "0",
+   "fieldname": "has_public_custom_responses",
+   "fieldtype": "Check",
+   "label": "Has Public Custom Responses"
+  }
+ ],
+ "links": [
+  {
+   "group": "Submissions",
+   "link_doctype": "FOSS Event CFP Submission",
+   "link_fieldname": "linked_cfp"
+  }
+ ],
+ "modified": "2025-12-08 17:46:08.489691",
+ "modified_by": "Administrator",
+ "module": "FOSSUnited",
+ "name": "FOSS Event CFP",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "read": 1,
+   "role": "Chapter Team Member",
+   "select": 1,
+   "write": 1
+  },
+  {
+   "read": 1,
+   "role": "All",
+   "select": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [
+  {
+   "color": "Gray",
+   "title": "Closed"
+  },
+  {
+   "color": "Green",
+   "title": "Live"
+  }
+ ],
+ "track_changes": 1
 }

--- a/fossunited/fossunited/doctype/foss_event_cfp/foss_event_cfp.json
+++ b/fossunited/fossunited/doctype/foss_event_cfp/foss_event_cfp.json
@@ -1,203 +1,203 @@
 {
- "actions": [],
- "allow_rename": 1,
- "autoname": "hash",
- "creation": "2023-07-10 01:05:08.149329",
- "default_view": "List",
- "doctype": "DocType",
- "editable_grid": 1,
- "engine": "InnoDB",
- "field_order": [
-  "meta_section",
-  "status",
-  "column_break_puww",
-  "allow_cfp_edit",
-  "anonymise_proposals",
-  "only_workshops",
-  "only_talk_proposals",
-  "event_information_section",
-  "event",
-  "event_name",
-  "column_break_je1w",
-  "chapter",
-  "deadline",
-  "cfp_form_description_section",
-  "cfp_form_description",
-  "custom_questions_section",
-  "has_public_custom_responses",
-  "cfp_custom_questions",
-  "cfp_reviewers_tab",
-  "cfp_reviewers"
- ],
- "fields": [
-  {
-   "fieldname": "column_break_puww",
-   "fieldtype": "Column Break"
-  },
-  {
-   "default": "0",
-   "fieldname": "allow_cfp_edit",
-   "fieldtype": "Check",
-   "label": "Allow CFP Edit?"
-  },
-  {
-   "fieldname": "event_information_section",
-   "fieldtype": "Section Break",
-   "label": "Event Information"
-  },
-  {
-   "fieldname": "event",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Event",
-   "options": "FOSS Chapter Event",
-   "reqd": 1
-  },
-  {
-   "fetch_from": "event.event_name",
-   "fieldname": "event_name",
-   "fieldtype": "Data",
-   "label": "Event Name"
-  },
-  {
-   "fieldname": "column_break_je1w",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fetch_from": "event.chapter",
-   "fieldname": "chapter",
-   "fieldtype": "Data",
-   "label": "Chapter"
-  },
-  {
-   "fieldname": "cfp_form_description_section",
-   "fieldtype": "Section Break",
-   "label": "CFP Form Description"
-  },
-  {
-   "fieldname": "cfp_form_description",
-   "fieldtype": "Text Editor",
-   "label": "CFP Form Description"
-  },
-  {
-   "fieldname": "custom_questions_section",
-   "fieldtype": "Section Break",
-   "label": "Custom Questions"
-  },
-  {
-   "fieldname": "cfp_custom_questions",
-   "fieldtype": "Table",
-   "label": "CFP Custom Questions",
-   "options": "FOSS Custom Question"
-  },
-  {
-   "fieldname": "cfp_reviewers_tab",
-   "fieldtype": "Tab Break",
-   "label": "CFP Reviewers"
-  },
-  {
-   "fieldname": "cfp_reviewers",
-   "fieldtype": "Table",
-   "label": "CFP Reviewers",
-   "options": "FOSS Event CFP Reviewer"
-  },
-  {
-   "default": "1",
-   "description": "The CFPs will not show the name of the proposer.",
-   "fieldname": "anonymise_proposals",
-   "fieldtype": "Check",
-   "label": "Anonymise Proposals?"
-  },
-  {
-   "default": "0",
-   "description": "Only accept workshop proposals.",
-   "fieldname": "only_workshops",
-   "fieldtype": "Check",
-   "label": "Only Workshop Proposals"
-  },
-  {
-   "default": "0",
-   "description": "Only accept Talk proposals.",
-   "fieldname": "only_talk_proposals",
-   "fieldtype": "Check",
-   "label": "Only Talk Proposals"
-  },
-  {
-   "fieldname": "deadline",
-   "fieldtype": "Datetime",
-   "label": "Deadline"
-  },
-  {
-   "default": "Closed",
-   "fieldname": "status",
-   "fieldtype": "Select",
-   "label": "Status",
-   "options": "Closed\nLive"
-  },
-  {
-   "fieldname": "meta_section",
-   "fieldtype": "Section Break",
-   "label": "Meta"
-  },
-  {
-   "default": "0",
-   "fieldname": "has_public_custom_responses",
-   "fieldtype": "Check",
-   "label": "Has Public Custom Responses"
-  }
- ],
- "links": [
-  {
-   "group": "Submissions",
-   "link_doctype": "FOSS Event CFP Submission",
-   "link_fieldname": "linked_cfp"
-  }
- ],
- "modified": "2025-12-08 17:46:08.489691",
- "modified_by": "Administrator",
- "module": "FOSSUnited",
- "name": "FOSS Event CFP",
- "naming_rule": "Random",
- "owner": "Administrator",
- "permissions": [
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "System Manager",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "create": 1,
-   "delete": 1,
-   "read": 1,
-   "role": "Chapter Team Member",
-   "select": 1,
-   "write": 1
-  },
-  {
-   "read": 1,
-   "role": "All",
-   "select": 1
-  }
- ],
- "row_format": "Dynamic",
- "sort_field": "modified",
- "sort_order": "DESC",
- "states": [
-  {
-   "color": "Gray",
-   "title": "Closed"
-  },
-  {
-   "color": "Green",
-   "title": "Live"
-  }
- ],
- "track_changes": 1
+  "actions": [],
+  "allow_rename": 1,
+  "autoname": "hash",
+  "creation": "2023-07-10 01:05:08.149329",
+  "default_view": "List",
+  "doctype": "DocType",
+  "editable_grid": 1,
+  "engine": "InnoDB",
+  "field_order": [
+    "meta_section",
+    "status",
+    "column_break_puww",
+    "allow_cfp_edit",
+    "anonymise_proposals",
+    "only_workshops",
+    "only_talk_proposals",
+    "event_information_section",
+    "event",
+    "event_name",
+    "column_break_je1w",
+    "chapter",
+    "deadline",
+    "cfp_form_description_section",
+    "cfp_form_description",
+    "custom_questions_section",
+    "has_public_custom_responses",
+    "cfp_custom_questions",
+    "cfp_reviewers_tab",
+    "cfp_reviewers"
+  ],
+  "fields": [
+    {
+      "fieldname": "column_break_puww",
+      "fieldtype": "Column Break"
+    },
+    {
+      "default": "0",
+      "fieldname": "allow_cfp_edit",
+      "fieldtype": "Check",
+      "label": "Allow CFP Edit?"
+    },
+    {
+      "fieldname": "event_information_section",
+      "fieldtype": "Section Break",
+      "label": "Event Information"
+    },
+    {
+      "fieldname": "event",
+      "fieldtype": "Link",
+      "in_list_view": 1,
+      "label": "Event",
+      "options": "FOSS Chapter Event",
+      "reqd": 1
+    },
+    {
+      "fetch_from": "event.event_name",
+      "fieldname": "event_name",
+      "fieldtype": "Data",
+      "label": "Event Name"
+    },
+    {
+      "fieldname": "column_break_je1w",
+      "fieldtype": "Column Break"
+    },
+    {
+      "fetch_from": "event.chapter",
+      "fieldname": "chapter",
+      "fieldtype": "Data",
+      "label": "Chapter"
+    },
+    {
+      "fieldname": "cfp_form_description_section",
+      "fieldtype": "Section Break",
+      "label": "CFP Form Description"
+    },
+    {
+      "fieldname": "cfp_form_description",
+      "fieldtype": "Text Editor",
+      "label": "CFP Form Description"
+    },
+    {
+      "fieldname": "custom_questions_section",
+      "fieldtype": "Section Break",
+      "label": "Custom Questions"
+    },
+    {
+      "fieldname": "cfp_custom_questions",
+      "fieldtype": "Table",
+      "label": "CFP Custom Questions",
+      "options": "FOSS Custom Question"
+    },
+    {
+      "fieldname": "cfp_reviewers_tab",
+      "fieldtype": "Tab Break",
+      "label": "CFP Reviewers"
+    },
+    {
+      "fieldname": "cfp_reviewers",
+      "fieldtype": "Table",
+      "label": "CFP Reviewers",
+      "options": "FOSS Event CFP Reviewer"
+    },
+    {
+      "default": "1",
+      "description": "The CFPs will not show the name of the proposer.",
+      "fieldname": "anonymise_proposals",
+      "fieldtype": "Check",
+      "label": "Anonymise Proposals?"
+    },
+    {
+      "default": "0",
+      "description": "Only accept workshop proposals.",
+      "fieldname": "only_workshops",
+      "fieldtype": "Check",
+      "label": "Only Workshop Proposals"
+    },
+    {
+      "default": "0",
+      "description": "Only accept Talk proposals.",
+      "fieldname": "only_talk_proposals",
+      "fieldtype": "Check",
+      "label": "Only Talk Proposals"
+    },
+    {
+      "fieldname": "deadline",
+      "fieldtype": "Datetime",
+      "label": "Deadline"
+    },
+    {
+      "default": "Closed",
+      "fieldname": "status",
+      "fieldtype": "Select",
+      "label": "Status",
+      "options": "Closed\nLive"
+    },
+    {
+      "fieldname": "meta_section",
+      "fieldtype": "Section Break",
+      "label": "Meta"
+    },
+    {
+      "default": "0",
+      "fieldname": "has_public_custom_responses",
+      "fieldtype": "Check",
+      "label": "Has Public Custom Responses"
+    }
+  ],
+  "links": [
+    {
+      "group": "Submissions",
+      "link_doctype": "FOSS Event CFP Submission",
+      "link_fieldname": "linked_cfp"
+    }
+  ],
+  "modified": "2025-12-08 17:46:08.489691",
+  "modified_by": "Administrator",
+  "module": "FOSSUnited",
+  "name": "FOSS Event CFP",
+  "naming_rule": "Random",
+  "owner": "Administrator",
+  "permissions": [
+    {
+      "create": 1,
+      "delete": 1,
+      "email": 1,
+      "export": 1,
+      "print": 1,
+      "read": 1,
+      "report": 1,
+      "role": "System Manager",
+      "share": 1,
+      "write": 1
+    },
+    {
+      "create": 1,
+      "delete": 1,
+      "read": 1,
+      "role": "Chapter Team Member",
+      "select": 1,
+      "write": 1
+    },
+    {
+      "read": 1,
+      "role": "All",
+      "select": 1
+    }
+  ],
+  "row_format": "Dynamic",
+  "sort_field": "modified",
+  "sort_order": "DESC",
+  "states": [
+    {
+      "color": "Gray",
+      "title": "Closed"
+    },
+    {
+      "color": "Green",
+      "title": "Live"
+    }
+  ],
+  "track_changes": 1
 }


### PR DESCRIPTION
helps to click and see list of items

Helps for one-to-many connections

<img width="1309" height="317" alt="image" src="https://github.com/user-attachments/assets/71e41f51-6c4d-48f1-87ae-60029b49867b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chapter Events now display related Proposals and Tickets for improved visibility and relationship management.
  * Call for Papers entries now show linked Submissions, making it easier to track and review proposal submissions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->