### PR TITLE
api(tickets): set flag to ignore print permission to download tickets

### DIFF
--- a/fossunited/api/tickets.py
+++ b/fossunited/api/tickets.py
@@ -485,6 +485,7 @@ def get_paid_events():
     )
 
 
+@frappe.whitelist()
 def search_tickets(search_term, event=None):
     """Search tickets by ticket_id, email, or coupon_id"""
     if not search_term:
@@ -536,14 +537,19 @@ def download_ticket(ticket_id):
     if not frappe.db.exists(EVENT_TICKET, ticket_id):
         frappe.throw("Ticket not found")
 
-    from frappe.utils.print_format import download_pdf
+    frappe.local.flags.ignore_print_permissions = True
 
-    return download_pdf(
-        doctype=EVENT_TICKET,
-        name=ticket_id,
-        format="[Designer] Event Ticket",
+    pdf_file = frappe.get_print(
+        EVENT_TICKET,
+        ticket_id,
+        "[Designer] Event Ticket",
         no_letterhead=1,
+        as_pdf=True,
     )
+
+    frappe.local.response.filename = "event-ticket.pdf"
+    frappe.local.response.filecontent = pdf_file
+    frappe.local.response.type = "download"
 
 
 @frappe.whitelist()
@@ -564,10 +570,12 @@ def download_all_tickets(ticket_ids):
 
     from frappe.utils.print_format import download_multi_pdf
 
-    # download_multi_pdf returns the PDF content directly
+    frappe.local.flags.ignore_print_permissions = True
+
     download_multi_pdf(
         doctype=EVENT_TICKET,
         name=json.dumps(ticket_ids),
         format="[Designer] Event Ticket",
         no_letterhead=True,
     )
+    frappe.local.response.type = "download"

--- a/fossunited/api/tickets.py
+++ b/fossunited/api/tickets.py
@@ -492,7 +492,7 @@ def search_tickets(search_term, event=None):
     """
     Search tickets by ticket_id or coupon_id.
 
-    Rate limit: 10 requests per 3 hours seconds per IP
+    Rate limit: 10 requests per 3 hours per IP
 
     Args:
         search_term (str): Ticket ID or coupon code to search
@@ -544,7 +544,7 @@ def download_ticket(ticket_id):
     """
     Download single ticket PDF.
 
-    Rate limit: 5 requests per 5 hour per IP
+    Rate limit: 5 requests per 5 hours per IP
 
     Args:
         ticket_id (str): ID of the ticket to download

--- a/fossunited/api/tickets.py
+++ b/fossunited/api/tickets.py
@@ -3,6 +3,7 @@ APIs for Tickets and Transfer Tickets
 """
 
 import frappe
+from frappe.rate_limiter import rate_limit
 from frappe.utils import add_days, now_datetime
 
 from fossunited.api.chapter import check_if_chapter_member
@@ -485,34 +486,40 @@ def get_paid_events():
     )
 
 
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
+@rate_limit(limit=10, seconds=60 * 60 * 3)
 def search_tickets(search_term, event=None):
-    """Search tickets by ticket_id, email, or coupon_id"""
+    """
+    Search tickets by ticket_id or coupon_id.
+
+    Rate limit: 10 requests per 3 hours seconds per IP
+
+    Args:
+        search_term (str): Ticket ID or coupon code to search
+        event (str, optional): Event filter (currently not used)
+
+    Returns:
+        list: List of ticket dictionaries
+
+    Raises:
+        ValidationError: If search_term is empty
+        RateLimitExceededError: If rate limit is exceeded
+    """
     if not search_term:
         frappe.throw("Search term is required")
 
     search_term = search_term.strip()
 
-    # Email search - requires event
-    if "@" in search_term:
-        if not event:
-            frappe.throw("Please select an event to search by email")
-
-        return frappe.get_all(
-            EVENT_TICKET,
-            filters={"event": event, "email": search_term},
-            fields=["name", "full_name", "email", "tier", "organization"],
-            order_by="full_name",
-        )
-
-    # Ticket ID - direct lookup, no event needed
+    # Direct ticket ID lookup
     if frappe.db.exists(EVENT_TICKET, search_term):
         return [get_ticket_details(search_term)]
 
+    # Coupon-based search
     coupon_event = frappe.db.get_value(FREE_TICKET_CODE, search_term, "event")
     if not coupon_event:
         return []
 
+    # Get all emails that applied with this coupon
     coupon_apps = frappe.get_all(
         FREE_TICKET_APPLY,
         filters={"coupon_id": search_term, "event": coupon_event},
@@ -531,9 +538,21 @@ def search_tickets(search_term, event=None):
     return []
 
 
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
+@rate_limit(limit=5, seconds=60 * 60 * 5)
 def download_ticket(ticket_id):
-    """Download single ticket PDF"""
+    """
+    Download single ticket PDF.
+
+    Rate limit: 5 requests per 5 hour per IP
+
+    Args:
+        ticket_id (str): ID of the ticket to download
+
+    Raises:
+        ValidationError: If ticket doesn't exist
+        RateLimitExceededError: If rate limit is exceeded
+    """
     if not frappe.db.exists(EVENT_TICKET, ticket_id):
         frappe.throw("Ticket not found")
 
@@ -552,21 +571,32 @@ def download_ticket(ticket_id):
     frappe.local.response.type = "download"
 
 
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
+@rate_limit(limit=3, seconds=60 * 60 * 12)
 def download_all_tickets(ticket_ids):
-    """Download multiple tickets as single PDF"""
+    """
+    Download multiple tickets as single PDF.
+
+    Rate limit: 3 requests per 12 hours per IP
+    (Lower limit due to higher resource usage)
+
+    Args:
+        ticket_ids (str|list): JSON string or list of ticket IDs
+
+    Raises:
+        ValidationError: If no tickets provided or invalid format
+        RateLimitExceededError: If rate limit is exceeded
+    """
     import json
 
     if isinstance(ticket_ids, str):
-        ticket_ids = json.loads(ticket_ids)
+        try:
+            ticket_ids = json.loads(ticket_ids)
+        except json.JSONDecodeError:
+            frappe.throw("Invalid ticket IDs format")
 
     if not ticket_ids or not isinstance(ticket_ids, list):
         frappe.throw("No tickets provided")
-
-    # Verify all tickets exist
-    for ticket_id in ticket_ids:
-        if not frappe.db.exists(EVENT_TICKET, ticket_id):
-            frappe.throw(f"Ticket {ticket_id} not found")
 
     from frappe.utils.print_format import download_multi_pdf
 

--- a/fossunited/fossunited/web_template/get_event_tickets/get_event_tickets.html
+++ b/fossunited/fossunited/web_template/get_event_tickets/get_event_tickets.html
@@ -221,7 +221,7 @@
 
     function downloadTicket(ticketName) {
       const url = `/api/method/fossunited.api.tickets.download_ticket?ticket_id=${ticketName}`
-      window.open(url, '_blank')
+      window.location.href = url
     }
 
     function downloadAll() {
@@ -233,7 +233,7 @@
 
       const ticketIds = foundTickets.map((t) => t.name)
       const url = `/api/method/fossunited.api.tickets.download_all_tickets?ticket_ids=${encodeURIComponent(JSON.stringify(ticketIds))}`
-      window.open(url, '_blank')
+      window.location.href = url
     }
 
     function showLoading(show) {

--- a/fossunited/tests/test_ticket_download.py
+++ b/fossunited/tests/test_ticket_download.py
@@ -1,0 +1,154 @@
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from fossunited.api.tickets import (
+    download_all_tickets,
+    search_tickets,
+)
+from fossunited.doctype_ids import CHAPTER, EVENT, EVENT_TICKET, FREE_TICKET_CODE
+from fossunited.tests.utils import (
+    insert_test_chapter,
+    insert_test_coupon,
+    insert_test_coupon_application,
+    insert_test_event,
+    insert_test_ticket,
+)
+
+
+class TestTicketAPI(FrappeTestCase):
+    def setUp(self):
+        """Set up test data before each test"""
+        self.chapter = insert_test_chapter()
+        self.event = insert_test_event(self.chapter, is_paid_event=1, tickets_status="Live")
+        self.ticket = insert_test_ticket(self.event.name)
+        self.coupon = insert_test_coupon(self.event.name)
+
+    def tearDown(self):
+        """Clean up test data after each test"""
+        frappe.set_user("Administrator")
+        frappe.db.rollback()
+        frappe.delete_doc(EVENT, self.event.name, force=True)
+        frappe.delete_doc(CHAPTER, self.chapter.name, force=True)
+        frappe.delete_doc(EVENT_TICKET, self.ticket.name, force=True)
+        frappe.delete_doc(FREE_TICKET_CODE, self.coupon.name, force=True)
+
+    def test_search_tickets_with_empty_term(self):
+        """Should throw error for empty search term"""
+        with self.assertRaises(frappe.exceptions.ValidationError):
+            search_tickets("")
+
+    def test_search_tickets_with_none_term(self):
+        """Should throw error for None search term"""
+        with self.assertRaises(frappe.exceptions.ValidationError):
+            search_tickets(None)
+
+    def test_search_tickets_by_ticket_id(self):
+        """Should return ticket when searching by valid ticket_id"""
+        result = search_tickets(self.ticket.name)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["name"], self.ticket.name)
+
+    def test_search_tickets_by_invalid_ticket_id(self):
+        """Should return empty list for non-existent ticket_id"""
+        result = search_tickets("INVALID_TICKET_ID_123")
+
+        self.assertEqual(result, [])
+
+    def test_search_tickets_by_coupon_without_applications(self):
+        """Should return empty list when coupon has no applications"""
+        result = search_tickets(self.coupon.name)
+
+        self.assertEqual(result, [])
+
+    def test_search_tickets_by_coupon_with_applications(self):
+        """Should return tickets for users who applied with coupon"""
+        # Create tickets and coupon applications
+        insert_test_coupon_application(self.coupon.name, self.event.name)
+        insert_test_coupon_application(self.coupon.name, self.event.name)
+
+        result = search_tickets(self.coupon.name)
+        self.assertEqual(len(result), 2)
+
+    def test_search_tickets_coupon_only_returns_matching_event(self):
+        """Should only return tickets for the coupon's event"""
+        # Create another event and tickets
+        other_event = insert_test_event(self.chapter, is_paid_event=1, tickets_status="Live")
+        ticket_same_event = insert_test_ticket(self.event.name)
+        ticket_other_event = insert_test_ticket(other_event.name, email=ticket_same_event.email)
+
+        # Apply coupon only for the first event
+        insert_test_coupon_application(
+            self.coupon.name, self.event.name, email=ticket_same_event.email
+        )
+
+        result = search_tickets(self.coupon.name)
+
+        ticket_ids = [t["name"] for t in result]
+        self.assertIn(ticket_same_event.name, ticket_ids)
+        self.assertNotIn(ticket_other_event.name, ticket_ids)
+
+    def test_search_returns_only_allowed_fields(self):
+        """Should only return specified fields in search results"""
+        insert_test_ticket(self.event.name)
+        insert_test_coupon_application(self.coupon.name, self.event.name)
+
+        result = search_tickets(self.coupon.name)
+
+        allowed_fields = {"name", "full_name", "email", "tier", "organization"}
+        for ticket_data in result:
+            self.assertTrue(set(ticket_data.keys()).issubset(allowed_fields))
+
+
+class TestTicketAPIIntegration(FrappeTestCase):
+    """Integration tests for full workflows"""
+
+    def test_coupon_to_ticket_download_workflow(self):
+        """Test complete workflow: search by coupon -> download tickets"""
+        # Setup
+        chapter = insert_test_chapter()
+        event = insert_test_event(chapter, is_paid_event=1, tickets_status="Live")
+        coupon = insert_test_coupon(event.name)
+
+        # Create multiple tickets with coupon applications
+        tickets = []
+        for _ in range(3):
+            ticket = insert_test_ticket(event.name)
+            insert_test_coupon_application(coupon.name, event.name)
+            tickets.append(ticket)
+
+        # Search by coupon
+        results = search_tickets(coupon.name)
+        self.assertEqual(len(results), 3)
+
+        # Download all tickets
+        ticket_ids = [r["name"] for r in results]
+        download_all_tickets(ticket_ids)
+
+        self.assertEqual(frappe.local.response.type, "download")
+
+        frappe.db.rollback()
+
+    def test_multiple_coupons_same_user(self):
+        """Test user with tickets from multiple coupons"""
+        chapter = insert_test_chapter()
+        event = insert_test_event(chapter, is_paid_event=1, tickets_status="Live")
+
+        # Create two coupons
+        coupon1 = insert_test_coupon(event.name)
+        coupon2 = insert_test_coupon(event.name)
+
+        # Create ticket and apply both coupons
+        insert_test_ticket(event.name)
+        insert_test_coupon_application(coupon1.name, event.name, email="random@example.com")
+        insert_test_coupon_application(coupon2.name, event.name, email="random@example.com")
+
+        # Search with both coupons should return the same ticket
+        results1 = search_tickets(coupon1.name)
+        results2 = search_tickets(coupon2.name)
+
+        self.assertEqual(len(results1), 2)
+        self.assertEqual(len(results2), 2)
+        self.assertEqual(results1[0]["email"], results2[0]["email"])
+
+        frappe.db.rollback()

--- a/fossunited/tests/test_ticket_download.py
+++ b/fossunited/tests/test_ticket_download.py
@@ -26,11 +26,11 @@ class TestTicketAPI(FrappeTestCase):
     def tearDown(self):
         """Clean up test data after each test"""
         frappe.set_user("Administrator")
-        frappe.db.rollback()
         frappe.delete_doc(EVENT, self.event.name, force=True)
         frappe.delete_doc(CHAPTER, self.chapter.name, force=True)
         frappe.delete_doc(EVENT_TICKET, self.ticket.name, force=True)
         frappe.delete_doc(FREE_TICKET_CODE, self.coupon.name, force=True)
+        frappe.db.rollback()
 
     def test_search_tickets_with_empty_term(self):
         """Should throw error for empty search term"""
@@ -143,7 +143,8 @@ class TestTicketAPIIntegration(FrappeTestCase):
         insert_test_coupon_application(coupon1.name, event.name, email="random@example.com")
         insert_test_coupon_application(coupon2.name, event.name, email="random@example.com")
 
-        # Search with both coupons should return the same ticket
+        # the catch is we can only match by their email as common field
+        # so we get two same tickets from each coupon actually.
         results1 = search_tickets(coupon1.name)
         results2 = search_tickets(coupon2.name)
 

--- a/fossunited/tests/utils.py
+++ b/fossunited/tests/utils.py
@@ -10,6 +10,8 @@ from fossunited.doctype_ids import (
     EVENT_CFP,
     EVENT_RSVP,
     EVENT_TICKET,
+    FREE_TICKET_APPLY,
+    FREE_TICKET_CODE,
     HACKATHON,
     HACKATHON_LOCALHOST,
     HACKATHON_PARTICIPANT,
@@ -678,3 +680,61 @@ def insert_test_hackathon_localhost(parent_hackathon: str, **kwargs):
     localhost.insert()
     localhost.reload()
     return localhost
+
+
+def insert_test_coupon(event: str, **kwargs):
+    """
+    Generate a test free ticket coupon/code.
+
+    Args:
+        event (str): ID of linked event
+        **kwargs: Additional fields to set on the coupon
+
+    Returns:
+        coupon doc: Created coupon document
+    """
+    coupon_data = {
+        "doctype": FREE_TICKET_CODE,
+        "event": event,
+        "name": kwargs.get("name", fake.uuid4()[:8].upper()),
+        "mapped_email": kwargs.get("mapped_email", fake.email()),
+        "full_name": kwargs.get("full_name", fake.name()),
+        "max_count": kwargs.get("max_count", 10),
+        "tier": kwargs.get("tier", "Volunteer"),
+    }
+
+    coupon = frappe.get_doc(coupon_data)
+    coupon.flags.ignore_permissions = True
+    coupon.insert()
+    coupon.reload()
+
+    return coupon
+
+
+def insert_test_coupon_application(coupon_id: str, event: str, **kwargs):
+    """
+    Generate a test coupon application linking a user to a coupon.
+
+    Args:
+        coupon_id (str): ID of the coupon being applied
+        event (str): ID of the event
+        email (str): Email of the person applying the coupon
+        **kwargs: Additional fields to set on the application
+
+    Returns:
+        application doc: Created coupon application document
+    """
+    application_data = {
+        "doctype": FREE_TICKET_APPLY,
+        "coupon_id": coupon_id,
+        "email": kwargs.get("email", fake.email()),
+        "full_name": kwargs.get("full_name", fake.name()),
+        "event": event,
+    }
+
+    application = frappe.get_doc(application_data)
+    application.flags.ignore_permissions = True
+    application.insert()
+    application.reload()
+
+    return application

--- a/fossunited/tests/utils.py
+++ b/fossunited/tests/utils.py
@@ -696,7 +696,6 @@ def insert_test_coupon(event: str, **kwargs):
     coupon_data = {
         "doctype": FREE_TICKET_CODE,
         "event": event,
-        "name": kwargs.get("name", fake.uuid4()[:8].upper()),
         "mapped_email": kwargs.get("mapped_email", fake.email()),
         "full_name": kwargs.get("full_name", fake.name()),
         "max_count": kwargs.get("max_count", 10),

--- a/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.json
+++ b/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.json
@@ -165,7 +165,7 @@
   }
  ],
  "links": [],
- "modified": "2025-12-08 21:17:03.458231",
+ "modified": "2025-12-11 13:23:11.242154",
  "modified_by": "Administrator",
  "module": "Ticketing",
  "name": "FOSS Event Ticket",
@@ -188,5 +188,6 @@
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],
- "title_field": "full_name"
+ "title_field": "full_name",
+ "track_changes": 1
 }


### PR DESCRIPTION
- proper fix on #1307 

- No need any document permission (I thought we needed for print permission) but we can set a flag to get print downlaod for ticket

- So search is based on 3 criteria:

1. By ticket ID (obviously if they know)
2. By coupon ID (given for organization or group)
3. By email (exact match) for given event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Guest-access ticket search and single/batch download endpoints now available with rate limits.

* **Improvements**
  * Search prefers direct ticket or coupon lookup, returns consolidated filtered results.
  * Single and batch PDF downloads provide proper filenames and more reliable handling.
  * Batch download input parsing and error handling improved.
  * Download actions navigate the current window instead of opening new tabs.

* **Tests**
  * Comprehensive tests and helpers added for search and download workflows.

* **Chores**
  * Added a ticket record field to track changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->