### PR TITLE
unittest: add insert_user_profile function to create user

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -131,7 +131,7 @@ class FOSSChapterEvent(WebsiteGenerator):
 
         if self.has_value_changed("map_link") or (self.map_link and not self.map_coordinate):
             lat, lng = extract_map_coordinates(self.map_link)
-            self.map_coordinate = f"{lat},{lng}"
+            self.map_coordinate = f"{lat},{lng}" if (lat and lng) else None
 
     def on_trash(self):
         self.delete_campaigns()

--- a/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
@@ -10,37 +10,19 @@ from fossunited.doctype_ids import USER_PROFILE
 from fossunited.foss_profiles.doctype.foss_user_profile.foss_user_profile import (
     PrivateProfileError,
 )
+from fossunited.tests.utils import insert_user_profile
 
 fake = Faker()
 
 
 class TestFOSSUserProfile(FrappeTestCase):
     def test_add_profile(self):
-        # Given a user that does not have a FOSSUnitedProfile
-        inserted_username = fake.user_name()
-        inserted_name = fake.name()
-        inserted_email = fake.email()
-        profile_exists = frappe.db.exists(USER_PROFILE, {"username": inserted_username})
-        self.assertFalse(profile_exists)
-
         # When a FOSSUnitedProfile is created for the user
-        # Note that a Frappe User needs to exist before a Profile can be created
-        # Verify that only required values are provided below
-        frappe_user = frappe.get_doc(
-            {
-                "doctype": "User",
-                # Create a unique email address as it is used as a database key
-                "email": inserted_email,
-                "first_name": inserted_name.split(" ")[0],
-                "full_name": inserted_name,
-            },
-        ).insert()
-        frappe_user.reload()
+        inserted_email = fake.email()
+        insert_user_profile(inserted_email)
 
         # Then verify that the Profile has been stored as expected
-        profile_exists = frappe.db.exists(USER_PROFILE, {"user": frappe_user.name})
-
-        self.assertTrue(profile_exists)
+        self.assertTrue(frappe.db.exists(USER_PROFILE, {"user": inserted_email}))
 
     def test_private_profile_access(self):
         test_name = fake.name()

--- a/fossunited/tests/utils.py
+++ b/fossunited/tests/utils.py
@@ -59,9 +59,10 @@ def insert_user_profile(email=None):
         ).insert(ignore_permissions=True)
         frappe_user.reload()
 
-    # User Profile gets created automatically via hooks/validation
-    # Just retrieve it after user creation
+    # User Profile gets created automatically via hooks "create_profile_on_user_create"
     profile = frappe.db.get_value(USER_PROFILE, {"user": email}, "name")
+    if not profile:
+        raise ValueError(f"User Profile was not auto-created for {email}")
 
     return profile
 
@@ -135,11 +136,11 @@ def insert_test_chapter(**kwargs):
                 )
 
             except Exception as member_error:
-                frappe.log_error(f"Error processing member {member_email}: {str(member_error)}")
+                frappe.log_error(f"Error processing member {member_email}: {member_error}")
                 raise
 
         chapter.insert(ignore_permissions=True)
-        frappe.db.commit()
+        chapter.save()
         chapter.reload()
 
         return chapter
@@ -397,8 +398,7 @@ def insert_rsvp_form(event: str, **kwargs):
 
         return rsvp
 
-    except Exception as e:
-        frappe.log_error(f"Error generating RSVP: {str(e)}")
+    except Exception:
         raise
 
 

--- a/fossunited/tests/utils.py
+++ b/fossunited/tests/utils.py
@@ -28,6 +28,44 @@ from fossunited.ticketing.doctype.foss_ticket_tier.foss_ticket_tier import (
 fake = Faker()
 
 
+def insert_user_profile(email=None):
+    """
+    Create a test user and their profile.
+
+    Args:
+        email (str, optional): Email for the user. If not provided, generates a fake email.
+
+    Returns:
+        str: Name of the created User Profile
+    """
+    if not email:
+        email = fake.email()
+
+    # Check if profile already exists
+    profile = frappe.db.get_value(USER_PROFILE, {"user": email}, "name")
+    if profile:
+        return profile
+
+    # Create Frappe User if it doesn't exist
+    if not frappe.db.exists("User", email):
+        name_parts = email.split("@")[0].title()
+        frappe_user = frappe.get_doc(
+            {
+                "doctype": "User",
+                "email": email,
+                "first_name": name_parts,
+                "full_name": name_parts,
+            }
+        ).insert(ignore_permissions=True)
+        frappe_user.reload()
+
+    # User Profile gets created automatically via hooks/validation
+    # Just retrieve it after user creation
+    profile = frappe.db.get_value(USER_PROFILE, {"user": email}, "name")
+
+    return profile
+
+
 def insert_test_chapter(**kwargs):
     """
     Generate a test chapter with flexible configuration options.
@@ -57,7 +95,12 @@ def insert_test_chapter(**kwargs):
     ```
     """
     try:
-        # Validate and set default values
+        # Create Role if it doesn't exist
+        if not frappe.db.exists("Role", "Chapter Team Member"):
+            frappe.get_doc({"doctype": "Role", "role_name": "Chapter Team Member"}).insert(
+                ignore_permissions=True
+            )
+
         chapter_data = {
             "doctype": CHAPTER,
             "chapter_name": kwargs.get("chapter_name", fake.text(max_nb_chars=40).strip()),
@@ -75,30 +118,13 @@ def insert_test_chapter(**kwargs):
             "x": kwargs.get("x", fake.url()),
         }
 
-        # Create chapter document
         chapter = frappe.get_doc(chapter_data)
-        chapter.insert()
 
-        if not frappe.db.exists("Role", "Chapter Team Member"):
-            frappe.get_doc({"doctype": "Role", "role_name": "Chapter Team Member"}).insert(
-                ignore_permissions=True
-            )
-        # Add additional members
+        # Add members using the helper function
         members = kwargs.get("members", [])
-        for member in members:
+        for member_email in members:
             try:
-                profile = frappe.db.get_value(USER_PROFILE, {"user": member}, "name")
-                if not profile:
-                    # Create User and User Profile
-                    user_profile = frappe.get_doc(
-                        {
-                            "doctype": USER_PROFILE,
-                            "user": member,
-                            "full_name": member.split("@")[0].title(),
-                        }
-                    ).insert(ignore_permissions=True)
-
-                    profile = user_profile.name
+                profile = insert_user_profile(member_email)
 
                 chapter.append(
                     "chapter_members",
@@ -107,17 +133,19 @@ def insert_test_chapter(**kwargs):
                         "role": "Core Team Member",
                     },
                 )
-            except Exception as member_error:
-                frappe.log_error(f"Error processing member {member}: {str(member_error)}")
 
-        # Save and reload chapter
-        chapter.save()
+            except Exception as member_error:
+                frappe.log_error(f"Error processing member {member_email}: {str(member_error)}")
+                raise
+
+        chapter.insert(ignore_permissions=True)
+        frappe.db.commit()
         chapter.reload()
 
         return chapter
 
     except Exception:
-        # Re-raise the exception to maintain original error handling
+        frappe.db.rollback()
         raise
 
 


### PR DESCRIPTION
- until now `insert_test_chapter` did not add members to chapter_members (or maybe I did something bad)

- hence we might miss many permission check unittests
- this solves it further to have thorough tests on whats allowed for logged users, guest and chapter members from our API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Map coordinate handling for chapter events now validates latitude and longitude and clears the coordinate when values are missing, preventing incomplete location data.

* **Chores**
  * Test infrastructure improved with a reusable helper for creating user profiles, more robust member setup, and safer test commit/rollback behavior to improve reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->