### PR TITLE
template(likes): avoid multiple likes on same document

### DIFF
--- a/fossunited/templates/includes/like/like.html
+++ b/fossunited/templates/includes/like/like.html
@@ -44,8 +44,8 @@
           in_queue = false
 
           // If server indicates it didn't create/delete (duplicate or error), reconcile
-          const data = r && r.message ? r.message : null
-          if (!data) {
+          const data = r && r.message !== undefined ? r.message : null
+          if (data === null) {
             // server didn't respond properly; revert UI
             toggle_like_icon(like)
             $('.like-count').text(like_count)
@@ -57,11 +57,11 @@
           if (data.liked) {
             if (data.created === false) {
               like = true
-              like_count = Math.max(like_count, new_count)
               $('.like-count').text(like_count)
             } else {
               like = true
               like_count = new_count
+              $('.like-count').text(like_count)
             }
           } else {
             if (data.deleted === false) {

--- a/fossunited/templates/includes/like/like.html
+++ b/fossunited/templates/includes/like/like.html
@@ -5,8 +5,9 @@
 
 <script type="text/javascript">
   frappe.ready(() => {
-    let like = parseInt('{{ like or 0 }}')
+    let like = Boolean(parseInt('{{ like or 0 }}'))
     let like_count = parseInt('{{ like_count or 0 }}')
+    let in_queue = false
 
     let toggle_like_icon = function (active) {
       active ? $('.like-icon').addClass('liked') : $('.like-icon').removeClass('liked')
@@ -14,27 +15,71 @@
 
     $('.like-icon').append(`<svg class="icon icon-sm"><use href="#icon-heart"></use></svg>`)
     toggle_like_icon(like)
-
     $('.like-count').text(like_count)
 
     $('.like-icon').click(() => {
+      if (in_queue) return
       update_like()
     })
 
     let update_like = function () {
-      like = !like
-      like ? like_count++ : like_count--
-      toggle_like_icon(like)
-      $('.like-count').text(like_count)
+      in_queue = true
 
-      return frappe.call({
-        method: 'fossunited.templates.includes.like.like.like',
-        args: {
-          reference_doctype: '{{ reference_doctype or doctype }}',
-          reference_name: '{{ reference_name or name }}',
-          like,
-        },
-      })
+      // update likes on UI
+      const new_like = !like
+      const new_count = new_like ? like_count + 1 : like_count - 1
+      toggle_like_icon(new_like)
+      $('.like-count').text(new_count)
+
+      return frappe
+        .call({
+          method: 'fossunited.templates.includes.like.like.like',
+          args: {
+            reference_doctype: '{{ reference_doctype or doctype }}',
+            reference_name: '{{ reference_name or name }}',
+            like: new_like,
+          },
+        })
+        .then((r) => {
+          in_queue = false
+
+          // If server indicates it didn't create/delete (duplicate or error), reconcile
+          const data = r && r.message ? r.message : null
+          if (!data) {
+            // server didn't respond properly; revert UI
+            toggle_like_icon(like)
+            $('.like-count').text(like_count)
+            frappe.msgprint('Could not update like. Please try again.')
+            return
+          }
+
+          // server returns { liked: bool, created/deleted: bool }
+          if (data.liked) {
+            if (data.created === false) {
+              like = true
+              like_count = Math.max(like_count, new_count)
+              $('.like-count').text(like_count)
+            } else {
+              like = true
+              like_count = new_count
+            }
+          } else {
+            if (data.deleted === false) {
+              like = false
+              like_count = Math.max(0, like_count)
+              $('.like-count').text(like_count)
+            } else {
+              like = false
+              like_count = new_count
+            }
+          }
+        })
+        .catch((err) => {
+          in_queue = false
+          // revert UI on error
+          toggle_like_icon(like)
+          $('.like-count').text(like_count)
+        })
     }
   })
 </script>

--- a/fossunited/templates/includes/like/like.py
+++ b/fossunited/templates/includes/like/like.py
@@ -32,7 +32,6 @@ def like_filters(reference_doctype, reference_name):
     return filters
 
 
-@rate_limit(limit=10, seconds=60 * 60 * 12)
 def add_like(reference_doctype, reference_name):
     """
     Return True if a like was created, False if it already existed.
@@ -62,7 +61,6 @@ def add_like(reference_doctype, reference_name):
     return True
 
 
-@rate_limit(limit=10, seconds=60 * 60 * 12)
 def delete_like(reference_doctype, reference_name):
     """
     Return True if a like was deleted, False if none found.

--- a/fossunited/templates/includes/like/like.py
+++ b/fossunited/templates/includes/like/like.py
@@ -1,7 +1,9 @@
 import frappe
+from frappe.rate_limiter import rate_limit
 
 
 @frappe.whitelist(allow_guest=True)
+@rate_limit(limit=10, seconds=60 * 60 * 12)
 def like(reference_doctype, reference_name, like):
     like = frappe.parse_json(like)
 
@@ -13,9 +15,38 @@ def like(reference_doctype, reference_name, like):
     return liked
 
 
-def add_like(reference_doctype, reference_name):
+def like_filters(reference_doctype, reference_name):
     user = frappe.session.user
+    filters = {
+        "comment_type": "Like",
+        "reference_doctype": reference_doctype,
+        "reference_name": reference_name,
+    }
 
+    if user == "Guest":
+        # Use ip_address to identify guest
+        filters["ip_address"] = frappe.local.request_ip
+    else:
+        filters["comment_email"] = user
+
+    return filters
+
+
+@rate_limit(limit=10, seconds=60 * 60 * 12)
+def add_like(reference_doctype, reference_name):
+    """
+    Return True if a like was created, False if it already existed.
+    """
+    filters = like_filters(reference_doctype, reference_name)
+
+    # Check first to avoid duplicates
+    exists = frappe.db.exists("Comment", filters)
+    if exists:
+        # Already liked by this identity
+        return False
+
+    # Create the like
+    user = frappe.session.user
     like = frappe.new_doc("Comment")
     like.comment_type = "Like"
     like.comment_email = user
@@ -24,22 +55,24 @@ def add_like(reference_doctype, reference_name):
     like.content = "Liked by: " + user
     if user == "Guest":
         like.ip_address = frappe.local.request_ip
+
+    # save and return True
     like.save(ignore_permissions=True)
+    # optionally re-check or log created id
     return True
 
 
+@rate_limit(limit=10, seconds=60 * 60 * 12)
 def delete_like(reference_doctype, reference_name):
-    user = frappe.session.user
+    """
+    Return True if a like was deleted, False if none found.
+    """
+    filters = like_filters(reference_doctype, reference_name)
 
-    filters = {
-        "comment_type": "Like",
-        "comment_email": user,
-        "reference_doctype": reference_doctype,
-        "reference_name": reference_name,
-    }
-
-    if user == "Guest":
-        filters["ip_address"] = frappe.local.request_ip
+    # Use delete and return whether anything was removed
+    exists = frappe.db.exists("Comment", filters)
+    if not exists:
+        return False
 
     frappe.db.delete("Comment", filters)
-    return False
+    return True

--- a/fossunited/tests/test_likes.py
+++ b/fossunited/tests/test_likes.py
@@ -1,0 +1,172 @@
+import frappe
+from faker import Faker
+from frappe.tests.utils import FrappeTestCase
+
+from fossunited.doctype_ids import PROPOSAL
+
+# Import the like functions from your module (adjust path if your module path differs)
+from fossunited.templates.includes.like.like import add_like, delete_like, like
+from fossunited.tests.utils import (
+    insert_cfp_form,
+    insert_cfp_submission,
+    insert_test_chapter,
+    insert_test_event,
+)
+
+fake = Faker()
+CoreTeam = "test1@example.com"
+
+
+class TestLikeOnProposal(FrappeTestCase):
+    def setUp(self):
+        # create the environment similar to your CFP tests
+        self.chapter = insert_test_chapter(members=[CoreTeam])
+        self.event = insert_test_event(chapter=self.chapter)
+        self.cfp = insert_cfp_form(event=self.event.name, status="Live")
+
+        speakers = [
+            {
+                "full_name": fake.name(),
+                "email": fake.email(),
+                "designation": fake.job(),
+                "organization": fake.company(),
+                "bio": "Test Submission",
+            }
+        ]
+        self.submission = insert_cfp_submission(
+            linked_cfp=self.cfp.name,
+            event=self.event.name,
+            speakers=speakers,
+            submitted_by=CoreTeam,
+        )
+
+        frappe.set_user(CoreTeam)
+
+    def tearDown(self):
+        # cleanup comments created by tests
+        frappe.set_user("Administrator")
+        frappe.db.delete(
+            "Comment",
+            {
+                "reference_doctype": PROPOSAL,
+                "reference_name": self.submission.name,
+                "comment_type": "Like",
+            },
+        )
+
+        # remove created docs
+        submissions = frappe.get_all(PROPOSAL, {"event": self.event.name}, pluck="name")
+        for submission in submissions:
+            frappe.delete_doc(PROPOSAL, submission, force=True)
+
+        self.cfp.delete(force=True)
+        self.event.delete(force=True)
+        self.chapter.delete(force=True)
+
+        frappe.set_user("Administrator")
+
+    def _get_like_comments(self):
+        return frappe.get_all(
+            "Comment",
+            filters={
+                "reference_doctype": PROPOSAL,
+                "reference_name": self.submission.name,
+                "comment_type": "Like",
+            },
+            fields=["name", "comment_email", "ip_address", "content"],
+        )
+
+    def test_add_like_creates_comment_once(self):
+        """
+        Add a like once and assert exactly one Comment is created.
+        """
+        # ensure no likes initially
+        before = self._get_like_comments()
+        assert len(before) == 0
+
+        # call the backend helper directly (simulates internal call)
+        like(PROPOSAL, self.submission.name, True)
+
+        likes = self._get_like_comments()
+        self.assertEqual(len(likes), 1)
+        # the comment_email should match the current user
+        self.assertEqual(likes[0]["comment_email"], frappe.session.user)
+
+    def test_repeated_add_like_does_not_create_duplicates(self):
+        """
+        Repeated calls to add_like should not create multiple Comment rows for same identity.
+        """
+        # first add
+        add_like(PROPOSAL, self.submission.name)
+        # repeated add attempts
+        like(PROPOSAL, self.submission.name, True)
+        add_like(PROPOSAL, self.submission.name)
+
+        likes = self._get_like_comments()
+        # still only one comment for this user
+        self.assertEqual(len(likes), 1)
+
+    def test_delete_like_removes_comment(self):
+        """
+        add then delete a like, ensure comment is removed.
+        """
+        add_like(PROPOSAL, self.submission.name)
+        add_like(PROPOSAL, self.submission.name)
+        likes = self._get_like_comments()
+        self.assertEqual(len(likes), 1)
+
+        delete_like(PROPOSAL, self.submission.name)
+        delete_like(PROPOSAL, self.submission.name)
+        likes_after = self._get_like_comments()
+        self.assertEqual(len(likes_after), 0)
+
+    def test_different_users_create_multiple_likes(self):
+        """
+        Likes from different logged-in users should create multiple Comment rows.
+        """
+        frappe.set_user("user1@example.com")
+        add_like(PROPOSAL, self.submission.name)
+
+        frappe.set_user("user2@example.com")
+        add_like(PROPOSAL, self.submission.name)
+
+        likes = self._get_like_comments()
+        # expect 2 likes (distinct comment_email)
+        self.assertEqual(len(likes), 2)
+        emails = {c["comment_email"] for c in likes}
+        self.assertEqual(emails, {"user1@example.com", "user2@example.com"})
+
+        # restore user for tearDown
+        frappe.set_user(CoreTeam)
+
+    def test_guest_like_uses_ip_address(self):
+        """
+        When user is Guest, the comment should store ip_address and delete_like must match ip.
+        """
+        frappe.set_user("Guest")
+        frappe.local.request_ip = "203.0.113.45"
+
+        # even if tried multiple
+        like(PROPOSAL, self.submission.name, True)
+        add_like(PROPOSAL, self.submission.name)
+        like(PROPOSAL, self.submission.name, True)
+
+        likes = frappe.get_all(
+            "Comment",
+            filters={
+                "reference_doctype": PROPOSAL,
+                "reference_name": self.submission.name,
+                "comment_type": "Like",
+                "ip_address": "203.0.113.45",
+            },
+            fields=["name"],
+        )
+        self.assertEqual(len(likes), 1)
+
+        delete_like(PROPOSAL, self.submission.name)
+        likes_after = self._get_like_comments()
+        self.assertEqual(len(likes_after), 0)
+
+        # cleanup guest state
+        frappe.local.request_ip = None
+        frappe.set_user(CoreTeam)


### PR DESCRIPTION
- We did not have rate limit or protecting of multiple likes from same IP (guest) or user (email)

- This adds a rate limit to allow only 10 likes per 12 hours in total action over any CFP
- Check for IP or email and ignore if already exists for given doctype item (name)
- Let web page updated based on this return values.

Issue is in mangalorefoss proposals we can see high number of likes.

<img width="240" height="372" alt="image" src="https://github.com/user-attachments/assets/3fbb8340-5596-4220-a1fd-6fbcae3d1b89" />


ref: https://fossunited.org/dashboard/cfp/all/mangalore/mangalorefoss

and in our database (desk) we see many likes "Comment" doctype items created.

This is a vulnerability , just running loop over curl on this API can get anyone zillion likes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optimistic like/unlike UI with request queuing to avoid duplicate clicks and smoother feedback.
  * Guest likes tracked consistently (IP-based) and deduplicated across requests.

* **Bug Fixes**
  * Prevents concurrent/re-entrant like requests, reconciles UI with server results, and reverts on errors or mismatches.
  * Rate limiting applied to like actions to reduce abuse.

* **Tests**
  * Added tests covering like/unlike flows for authenticated users and guests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->