### PR TITLE
api(utils): refactor getting volunteers data

### DIFF
--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -147,7 +147,6 @@ def generate_ics(event_ids):
     return c.serialize()
 
 
-@frappe.whitelist()
 def get_chapter_members_email(chapter):
     return frappe.db.get_all(
         CHAPTER_MEMBER,

--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import frappe
 from frappe import qb
-from frappe.query_builder.functions import Count, Max
+from frappe.query_builder.functions import Max
 from frappe.utils import add_to_date, get_datetime, nowdate
 from frappe.utils.data import now_datetime
 
@@ -524,24 +524,25 @@ def get_volunteers_stats():
     Chapter = qb.DocType(CHAPTER)
     Event = qb.DocType(EVENT)
 
-    active_count = Count(ChapterMember.chapter_member).distinct().as_("active_count")
-    communities_count = Count(Chapter.name).distinct().as_("communities_count")
-
     query = (
         frappe.qb.from_(ChapterMember)
         .inner_join(Chapter)
         .on(ChapterMember.parent == Chapter.name)
         .left_join(Event)
         .on(Event.chapter == Chapter.name)
-        .select(active_count, communities_count)
+        .select(ChapterMember.chapter_member, Chapter.name.as_("chapter_name"))
         .where(ChapterMember.chapter_member.isnotnull())
-        .groupby(Chapter.name)
+        .groupby(ChapterMember.chapter_member, Chapter.name)
         .having(Max(Event.event_start_date) >= one_year_ago)
     )
 
     rows = query.run(as_dict=True)
 
+    # Count unique members and chapters (we can use email also)
+    unique_members = {row["chapter_member"] for row in rows}
+    unique_chapters = {row["chapter_name"] for row in rows}
+
     return {
-        "active_count": sum(r.active_count for r in rows),
-        "communities_count": len(rows),
+        "active_count": len(unique_members),
+        "communities_count": len(unique_chapters),
     }

--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -479,10 +479,10 @@ def get_volunteers_data():
     """
     Get all volunteers data - returns flat list of members
     """
-    Member = qb.DocType("FOSS Chapter Lead Team Member")
-    Profile = qb.DocType("FOSS User Profile")
-    Chapter = qb.DocType("FOSS Chapter")
-    Event = qb.DocType("FOSS Chapter Event")
+    Member = qb.DocType(CHAPTER_MEMBER)
+    Profile = qb.DocType(USER_PROFILE)
+    Chapter = qb.DocType(CHAPTER)
+    Event = qb.DocType(EVENT)
 
     results = (
         qb.from_(Member)

--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -3,11 +3,14 @@ from collections import defaultdict
 from datetime import datetime
 
 import frappe
+from frappe import qb
+from frappe.query_builder.functions import Count, Max
 from frappe.utils import add_to_date, get_datetime, nowdate
 from frappe.utils.data import now_datetime
 
 from fossunited.doctype_ids import (
     CHAPTER,
+    CHAPTER_MEMBER,
     CITY_COMMUNITY,
     CONFERENCE,
     EVENT,
@@ -472,119 +475,73 @@ def get_select_field_options(doctype_name, fieldname):
     return options
 
 
-@frappe.whitelist(allow_guest=True)
 def get_volunteers_data():
     """
     Get all volunteers data - returns flat list of members
-    Frontend handles grouping and sorting via JavaScript
-
-    Returns:
-        dict: Contains members list and stats
     """
+    Member = qb.DocType("FOSS Chapter Lead Team Member")
+    Profile = qb.DocType("FOSS User Profile")
+    Chapter = qb.DocType("FOSS Chapter")
+    Event = qb.DocType("FOSS Chapter Event")
 
-    # Calculate one year ago date
-    one_year_ago = add_to_date(nowdate(), years=-1)
-    one_year_ago_dt = get_datetime(one_year_ago)
+    results = (
+        qb.from_(Member)
+        .inner_join(Profile)
+        .on(Member.chapter_member == Profile.name)
+        .inner_join(Chapter)
+        .on(Member.parent == Chapter.name)
+        .left_join(Event)
+        .on(Event.chapter == Chapter.name)
+        .select(
+            Member.chapter_member,
+            Profile.route,
+            Profile.full_name,
+            Profile.profile_photo,
+            Profile.show_activity,
+            Profile.current_city,
+            Chapter.chapter_name,
+            Chapter.chapter_logo,
+            Chapter.route.as_("chapter_route"),
+            Max(Event.event_start_date).as_("latest_event"),
+        )
+        .where(Member.chapter_member.isnotnull())
+        .groupby(Member.chapter_member, Member.parent)
+    ).run(as_dict=True)
 
-    # Get all chapters with their latest event date in one query
-    chapters_data = frappe.db.sql(
-        """
-        SELECT
-            c.name as chapter_id,
-            c.chapter_name,
-            c.chapter_logo,
-            MAX(e.event_start_date) as latest_event_date
-        FROM `tabFOSS Chapter` c
-        LEFT JOIN `tabFOSS Chapter Event` e ON e.chapter = c.name
-        GROUP BY c.name, c.chapter_name, c.chapter_logo
-    """,
-        as_dict=True,
+    # Convert datetime to string for JSON serialization
+    for row in results:
+        if row.get("latest_event"):
+            row["latest_event"] = row["latest_event"].isoformat()
+
+    return results
+
+
+def get_volunteers_stats():
+    """Just get the stats for active volunteers. For page initial load."""
+    one_year_ago = get_datetime(add_to_date(nowdate(), years=-1))
+
+    ChapterMember = qb.DocType(CHAPTER_MEMBER)
+    Chapter = qb.DocType(CHAPTER)
+    Event = qb.DocType(EVENT)
+
+    active_count = Count(ChapterMember.chapter_member).distinct().as_("active_count")
+    communities_count = Count(Chapter.name).distinct().as_("communities_count")
+
+    query = (
+        frappe.qb.from_(ChapterMember)
+        .inner_join(Chapter)
+        .on(ChapterMember.parent == Chapter.name)
+        .left_join(Event)
+        .on(Event.chapter == Chapter.name)
+        .select(active_count, communities_count)
+        .where(ChapterMember.chapter_member.isnotnull())
+        .groupby(Chapter.name)
+        .having(Max(Event.event_start_date) >= one_year_ago)
     )
 
-    # Build chapter lookup maps
-    active_chapters = set()
-    chapter_info = {}
-
-    for chapter in chapters_data:
-        chapter_info[chapter.chapter_id] = {
-            "name": chapter.chapter_name,
-            "logo": chapter.chapter_logo
-            or "/assets/fossunited/images/chapter/foss_club_profile.svg",
-        }
-
-        if chapter.latest_event_date and chapter.latest_event_date >= one_year_ago_dt:
-            active_chapters.add(chapter.chapter_id)
-
-    # Get all chapter members with profile data in single query
-    members_raw = frappe.db.sql(
-        """
-        SELECT DISTINCT
-            cm.chapter_member,
-            cm.parent as chapter_id,
-            p.route as username,
-            p.full_name,
-            p.profile_photo,
-            p.show_activity,
-            p.current_city
-        FROM `tabFOSS Chapter Lead Team Member` cm
-        LEFT JOIN `tabFOSS User Profile` p ON cm.chapter_member = p.name
-        WHERE cm.chapter_member IS NOT NULL
-        AND cm.chapter_member != ''
-        AND p.name IS NOT NULL
-    """,
-        as_dict=True,
-    )
-
-    # Build member data structure
-    members_map = {}
-    active_member_ids = set()
-
-    for row in members_raw:
-        member_id = row.chapter_member
-        chapter_id = row.chapter_id
-        is_active_chapter = chapter_id in active_chapters
-
-        # Initialize member if not exists
-        if member_id not in members_map:
-            members_map[member_id] = {
-                "id": member_id,
-                "username": row.username,
-                "name": row.full_name,
-                "photo": row.profile_photo
-                or "/assets/fossunited/images/defaults/user_profile_image.png",
-                "activity": 1 if row.show_activity else 0,
-                "city": row.current_city or "Unknown",
-                "chapters": [],
-                "is_active": 0,
-            }
-
-        # Add chapter info
-        if chapter_id in chapter_info:
-            members_map[member_id]["chapters"].append(
-                {
-                    "id": chapter_id,
-                    "name": chapter_info[chapter_id]["name"],
-                    "logo": chapter_info[chapter_id]["logo"],
-                    "active": 1 if is_active_chapter else 0,
-                }
-            )
-
-            # Mark member as active if in any active chapter
-            if is_active_chapter:
-                members_map[member_id]["is_active"] = 1
-                active_member_ids.add(member_id)
-
-    # Convert to list and separate active/past
-    all_members = list(members_map.values())
-    active_members = [m for m in all_members if m["is_active"]]
-    past_members = [m for m in all_members if not m["is_active"]]
+    rows = query.run(as_dict=True)
 
     return {
-        "active": active_members,
-        "past": past_members,
-        "stats": {
-            "active_count": len(active_members),
-            "past_count": len(past_members),
-            "communities_count": len(active_chapters),
-        },
+        "active_count": sum(r.active_count for r in rows),
+        "communities_count": len(rows),
     }

--- a/fossunited/hooks.py
+++ b/fossunited/hooks.py
@@ -54,7 +54,6 @@ jinja = {
         "fossunited.stack.utils.get_stack_dict",
         "fossunited.fossunited.utils.get_main_foss_events",
         "fossunited.fossunited.utils.get_all_city_names",
-        "fossunited.api.chapter.get_chapter_members_email",
     ],
     "filters": [
         "fossunited.fossunited.utils.make_badge",

--- a/fossunited/hooks.py
+++ b/fossunited/hooks.py
@@ -49,6 +49,7 @@ jinja = {
         "fossunited.fossunited.utils.get_signup_optin_checks",
         "fossunited.fossunited.utils.get_grouped_events_by_chapter_type",
         "fossunited.fossunited.utils.get_volunteers_data",
+        "fossunited.fossunited.utils.get_volunteers_stats",
         "fossunited.fossunited.utils.get_chapter_details",
         "fossunited.stack.utils.get_stack_dict",
         "fossunited.fossunited.utils.get_main_foss_events",

--- a/fossunited/tests/test_likes.py
+++ b/fossunited/tests/test_likes.py
@@ -2,7 +2,7 @@ import frappe
 from faker import Faker
 from frappe.tests.utils import FrappeTestCase
 
-from fossunited.doctype_ids import PROPOSAL
+from fossunited.doctype_ids import PROPOSAL, USER_PROFILE
 
 # Import the like functions from your module (adjust path if your module path differs)
 from fossunited.templates.includes.like.like import add_like, delete_like, like
@@ -58,7 +58,7 @@ class TestLikeOnProposal(FrappeTestCase):
         submissions = frappe.get_all(PROPOSAL, {"event": self.event.name}, pluck="name")
         for submission in submissions:
             frappe.delete_doc(PROPOSAL, submission, force=True)
-
+        frappe.db.delete(USER_PROFILE, {"email": CoreTeam})
         self.cfp.delete(force=True)
         self.event.delete(force=True)
         self.chapter.delete(force=True)

--- a/fossunited/tests/test_rsvp_insights.py
+++ b/fossunited/tests/test_rsvp_insights.py
@@ -10,9 +10,11 @@ from fossunited.api.rsvp import (
 )
 from fossunited.doctype_ids import (
     CHAPTER,
+    CHAPTER_MEMBER,
     EVENT,
     EVENT_RSVP,
     RSVP_RESPONSE,
+    USER_PROFILE,
 )
 from fossunited.tests.utils import (
     insert_rsvp_form,
@@ -51,6 +53,8 @@ class TestRSVPInsightsAPI(FrappeTestCase):
         frappe.delete_doc(EVENT, self.event.name, force=True)
         frappe.delete_doc(CHAPTER, self.chapter.name, force=True)
         frappe.delete_doc(CHAPTER, self.other_chapter.name, force=True)
+        frappe.db.delete(USER_PROFILE, {"email": self.core_team_email})
+        frappe.db.delete(CHAPTER_MEMBER, {"email": self.core_team_email})
 
     def test_get_submissions_guest_denied(self):
         """Guest users should not access RSVP submissions."""

--- a/fossunited/tests/test_volunteers.py
+++ b/fossunited/tests/test_volunteers.py
@@ -1,0 +1,232 @@
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_to_date, nowdate
+
+from fossunited.doctype_ids import CHAPTER, EVENT, USER_PROFILE
+from fossunited.fossunited.utils import (
+    get_volunteers_data,
+    get_volunteers_stats,
+)
+from fossunited.tests.utils import (
+    insert_test_chapter,
+    insert_test_event,
+    insert_user_profile,
+)
+
+
+class TestVolunteersPage(FrappeTestCase):
+    """Test cases for volunteers page data functions."""
+
+    def setUp(self):
+        self.member1_email = "luffy@example.com"
+        self.member2_email = "zoro@example.com"
+        self.member3_email = "xebec@example.com"
+
+        # Create test user profiles using existing helper
+        self.profile1_name = insert_user_profile(
+            self.member1_email, first_name="Monkey", last_name="Luffy"
+        )
+        self.profile2_name = insert_user_profile(self.member2_email, full_name="Zoro")
+        self.profile3_name = insert_user_profile(self.member3_email, full_name="Xebec")
+
+        self.profile1 = frappe.get_doc(USER_PROFILE, self.profile1_name)
+        self.profile1.current_city = "Bangalore"
+        self.profile1.show_activity = 1
+        self.profile1.save()
+
+        self.profile2 = frappe.get_doc(USER_PROFILE, self.profile2_name)
+        self.profile2.route = "u/zoro"
+        self.profile2.current_city = "Mumbai"
+        self.profile2.show_activity = 0
+        self.profile2.save()
+
+        self.profile3 = frappe.get_doc(USER_PROFILE, self.profile3_name)
+        self.profile3.route = "u/xebec"
+        self.profile3.current_city = "Delhi"
+        self.profile3.show_activity = 1
+        self.profile3.save()
+
+        self.chapter1 = insert_test_chapter(
+            city="Bangalore",
+            state="Karnataka",
+            members=[self.member1_email, self.member2_email],
+        )
+        self.chapter2 = insert_test_chapter(
+            city="Mumbai",
+            state="Maharashtra",
+            members=[self.member1_email, self.member3_email],  # luffy in both chapters
+        )
+
+        self._events = []
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+        for event in self._events:
+            frappe.delete_doc(EVENT, event.name, force=True)
+        frappe.delete_doc(CHAPTER, self.chapter1.name, force=True)
+        frappe.delete_doc(CHAPTER, self.chapter2.name, force=True)
+        frappe.delete_doc(USER_PROFILE, self.profile1.name, force=True)
+        frappe.delete_doc(USER_PROFILE, self.profile2.name, force=True)
+        frappe.delete_doc(USER_PROFILE, self.profile3.name, force=True)
+        # Delete associated Frappe Users
+        for email in [self.member1_email, self.member2_email, self.member3_email]:
+            if frappe.db.exists("User", email):
+                frappe.delete_doc("User", email, force=True)
+
+    def test_get_volunteers_data_returns_correct_structure(self):
+        """Test that volunteers data returns expected fields and structure."""
+        # Create a recent event
+        event = insert_test_event(chapter=self.chapter1)
+        self._events.append(event)
+
+        result = get_volunteers_data()
+
+        # Should have volunteers from both chapters
+        self.assertEqual(len(result), 4)
+
+        # Check structure of first result
+        first = result[0]
+        expected_fields = {
+            "chapter_member",
+            "route",
+            "full_name",
+            "profile_photo",
+            "show_activity",
+            "current_city",
+            "chapter_name",
+            "chapter_logo",
+            "chapter_route",
+            "latest_event",
+        }
+        self.assertEqual(set(first.keys()), expected_fields)
+
+        # Verify data types
+        self.assertIsInstance(first["route"], str)
+        self.assertIsInstance(first["full_name"], str)
+        self.assertIsInstance(first["show_activity"], int)
+        self.assertIsInstance(first["chapter_name"], str)
+        self.assertIsInstance(first["chapter_route"], str)
+
+        # latest_event should be ISO string or None
+        if first["latest_event"]:
+            self.assertIsInstance(first["latest_event"], str)
+            self.assertIn("T", first["latest_event"])  # ISO format check
+
+    def test_get_volunteers_data_includes_all_members(self):
+        """Test that all chapter members are included in results."""
+        # Create events for both chapters
+        event1 = insert_test_event(chapter=self.chapter1)
+        event2 = insert_test_event(chapter=self.chapter2)
+        self._events.extend([event1, event2])
+
+        result = get_volunteers_data()
+
+        # Get all unique member profile names from results
+        member_profiles = {row["chapter_member"] for row in result}
+
+        # Should include all three members (by their profile names)
+        self.assertIn(self.profile1.name, member_profiles)
+        self.assertIn(self.profile2.name, member_profiles)
+        self.assertIn(self.profile3.name, member_profiles)
+
+    def test_get_volunteers_data_member_in_multiple_chapters(self):
+        """Test that a member in multiple chapters appears multiple times."""
+        # Create events for both chapters
+        event1 = insert_test_event(chapter=self.chapter1)
+        event2 = insert_test_event(chapter=self.chapter2)
+        self._events.extend([event1, event2])
+
+        result = get_volunteers_data()
+
+        # luffy (profile1) is in both chapters
+        luffy_entries = [r for r in result if r["chapter_member"] == self.profile1.name]
+
+        # Should have 2 entries (one per chapter)
+        self.assertEqual(len(luffy_entries), 2)
+
+        # Should have different chapter names
+        chapter_names = {entry["chapter_name"] for entry in luffy_entries}
+        self.assertEqual(len(chapter_names), 2)
+
+    def test_get_volunteers_data_respects_profile_fields(self):
+        """Test that profile fields are correctly populated."""
+        event = insert_test_event(chapter=self.chapter1)
+        self._events.append(event)
+
+        result = get_volunteers_data()
+
+        # Find luffy's entry
+        luffy_entry = next((r for r in result if r["chapter_member"] == self.profile1.name), None)
+        self.assertIsNotNone(luffy_entry)
+
+        # Verify profile data
+        self.assertEqual(luffy_entry["full_name"], "Monkey Luffy")
+        self.assertEqual(luffy_entry["route"], "u/monkey_luffy")
+        self.assertEqual(luffy_entry["current_city"], "Bangalore")
+        self.assertEqual(luffy_entry["show_activity"], 1)
+
+        # Find Zoro (is he lost again?)
+        zoro_entry = next((r for r in result if r["chapter_member"] == self.profile2.name), None)
+        self.assertIsNotNone(zoro_entry)
+        self.assertEqual(zoro_entry["show_activity"], 0)
+
+    def test_get_volunteers_stats_counts_unique_volunteers(self):
+        """Test that stats count unique volunteers even if in multiple chapters."""
+        # Create recent events (within last year)
+        event1 = insert_test_event(chapter=self.chapter1)
+        event2 = insert_test_event(chapter=self.chapter2)
+        self._events.extend([event1, event2])
+
+        result = get_volunteers_stats()
+        # Should count unique volunteers (Luffy in 2 chapters = 1 unique)
+        # Total unique: Luffy, Zoro, Xebec = 3
+        self.assertEqual(result["active_count"], 3)
+
+        # Should count both chapters
+        self.assertEqual(result["communities_count"], 2)
+
+    def test_get_volunteers_stats_excludes_inactive_chapters(self):
+        """Test that stats only include chapters with events in last year."""
+        # Create old event (more than 1 year ago) for chapter1
+        old_date = add_to_date(nowdate(), years=-2)
+        old_event = insert_test_event(
+            chapter=self.chapter1,
+            event_start_date=old_date,
+        )
+
+        # Create recent event for chapter2
+        recent_event = insert_test_event(chapter=self.chapter2)
+        self._events.extend([old_event, recent_event])
+
+        result = get_volunteers_stats()
+
+        # Should only count chapter2 (with recent event)
+        self.assertEqual(result["communities_count"], 1)
+
+        # Should only count volunteers from chapter2 (Luffy and Xebec)
+        self.assertEqual(result["active_count"], 2)
+
+    def test_get_volunteers_data_includes_latest_event_timestamp(self):
+        """Test that latest_event shows the most recent event date."""
+        # Create multiple events for chapter1
+        old_event = insert_test_event(
+            chapter=self.chapter1,
+            event_start_date=add_to_date(nowdate(), days=-30),
+        )
+        recent_event = insert_test_event(
+            chapter=self.chapter1,
+            event_start_date=add_to_date(nowdate(), days=-5),
+        )
+        self._events.extend([old_event, recent_event])
+
+        result = get_volunteers_data()
+
+        chapter1_entries = [r for r in result if r["chapter_name"] == self.chapter1.chapter_name]
+
+        # All should have the same latest_event (the most recent one)
+        latest_dates = {entry["latest_event"] for entry in chapter1_entries}
+        self.assertEqual(len(latest_dates), 1)
+
+        # Verify it's the recent event's date (ISO format comparison)
+        latest_date = list(latest_dates)[0]
+        self.assertIn(recent_event.event_start_date.strftime("%Y-%m-%d"), latest_date)

--- a/fossunited/tests/test_volunteers.py
+++ b/fossunited/tests/test_volunteers.py
@@ -18,6 +18,9 @@ class TestVolunteersPage(FrappeTestCase):
     """Test cases for volunteers page data functions."""
 
     def setUp(self):
+        frappe.db.delete("FOSS Chapter Lead Team Member", {"email": "test1@example.com"})
+        frappe.db.delete("FOSS Chapter Lead Team Member", {"email": "core1@example.com"})
+
         self.member1_email = "luffy@example.com"
         self.member2_email = "zoro@example.com"
         self.member3_email = "xebec@example.com"

--- a/fossunited/tests/utils.py
+++ b/fossunited/tests/utils.py
@@ -21,6 +21,7 @@ from fossunited.doctype_ids import (
     TICKET_TIER,
     USER_PROFILE,
 )
+from fossunited.fossunited.user_utils import create_profile_on_user_create
 from fossunited.ticketing.doctype.foss_ticket_tier.foss_ticket_tier import (
     FOSSTicketTier,
 )
@@ -64,8 +65,24 @@ def insert_user_profile(email=None, **kwargs):
 
     # User Profile gets created automatically via hooks "create_profile_on_user_create"
     profile = frappe.db.get_value(USER_PROFILE, {"user": email}, "name")
+    user = None
+    try:
+        user = frappe.get_doc("User", email)
+    except Exception:
+        user = None
+
     if not profile:
-        raise ValueError(f"User Profile was not auto-created for {email}")
+        if user:
+            # attempt to create the profile via hook, then re-query
+            create_profile_on_user_create(user, None)
+            # re-query the DB to fetch the newly created profile
+            profile = frappe.db.get_value(USER_PROFILE, {"user": email}, "name")
+            if not profile:
+                raise ValueError(f"User Profile was not auto-created for {email} after hook call.")
+        else:
+            raise ValueError(
+                f"User Profile was not auto-created for {email} and User doc not found"
+            )
 
     return profile
 

--- a/fossunited/tests/utils.py
+++ b/fossunited/tests/utils.py
@@ -28,7 +28,7 @@ from fossunited.ticketing.doctype.foss_ticket_tier.foss_ticket_tier import (
 fake = Faker()
 
 
-def insert_user_profile(email=None):
+def insert_user_profile(email=None, **kwargs):
     """
     Create a test user and their profile.
 
@@ -49,14 +49,17 @@ def insert_user_profile(email=None):
     # Create Frappe User if it doesn't exist
     if not frappe.db.exists("User", email):
         name_parts = email.split("@")[0].title()
-        frappe_user = frappe.get_doc(
-            {
-                "doctype": "User",
-                "email": email,
-                "first_name": name_parts,
-                "full_name": name_parts,
-            }
-        ).insert(ignore_permissions=True)
+        user_data = {
+            "doctype": "User",
+            "email": email,
+            "first_name": kwargs.get("first_name", name_parts),
+            "last_name": kwargs.get("last_name", name_parts),
+        }
+        for key, value in kwargs.items():
+            if key not in user_data:
+                user_data[key] = value
+
+        frappe_user = frappe.get_doc(user_data).insert(ignore_permissions=True)
         frappe_user.reload()
 
     # User Profile gets created automatically via hooks "create_profile_on_user_create"
@@ -125,7 +128,9 @@ def insert_test_chapter(**kwargs):
         members = kwargs.get("members", [])
         for member_email in members:
             try:
-                profile = insert_user_profile(member_email)
+                profile = frappe.db.get_value(USER_PROFILE, {"user": member_email}, "name")
+                if not profile:
+                    profile = insert_user_profile(member_email)
 
                 chapter.append(
                     "chapter_members",


### PR DESCRIPTION
- Keep the function very simply to pass list of dict with required values
- Let client take care of processing (very easy to maintain)

- Added another function that gets stats for active count on volunteers (chapter members) and active chapter (that has done event within an hour)

- Expected data is in format of:

```python
# data
[{'chapter_member': '3lp5qrnv4r',
  'route': 'u/david',
  'full_name': 'david',
  'profile_photo': None,
  'show_activity': 0,
  'current_city': None,
  'chapter_name': 'TechnoMacs',
  'chapter_logo': None,
  'chapter_route': 'c/technomacs',
  'latest_event': '2025-10-15T16:09:19'},
  .....
  .....
  
  ]


# stats
{'active_count': 4, 'communities_count': 2}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked volunteer data retrieval to use a single, more efficient query; returns latest event timestamps, simplifies volunteer entries, and improves unique volunteer counts.

* **Chores**
  * Made volunteer statistics available to templates.
  * Restricted guest-level access to volunteer data and chapter-members endpoints.

* **Tests**
  * Added comprehensive tests and test helpers to validate volunteers data, stats, and cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->