### PR TITLE
doctype(cfp-submission): increase link char limit to 250

### DIFF
--- a/dashboard/src/components/cfp-public/ActionsForm.vue
+++ b/dashboard/src/components/cfp-public/ActionsForm.vue
@@ -79,7 +79,9 @@ const toggleWithdrawCFP = () => {
       toast.success('Proposal Withdrawal Status Changed!')
     })
     .catch((err) => {
-      toast.error(err)
+      toast.error('Failed to withdraw your proposal', {
+        description: err.message,
+      })
     })
   showConfirmDialog.value = false
 }

--- a/dashboard/src/helpers/cfp.js
+++ b/dashboard/src/helpers/cfp.js
@@ -319,9 +319,15 @@ export const validateReferences = (references) => {
       errors.push(`Reference #${index + 1} is missing a link`)
     }
 
+    const short_url = truncateStr(item.link, 20)
     if (!isValidUrl(item.link)) {
       errors.push(
-        `Reference #${index + 1} (${truncateStr(item.link, 20)}) link is invalid. Only https links are allowed.`,
+        `Reference #${index + 1} (${short_url}) link is invalid. Only https links are allowed.`,
+      )
+    }
+    if (item.link.length > 250) {
+      errors.push(
+        `Reference #${index + 1} (${short_url}) link is longer than 250 characters. Please use URL shortner or add clean links.`,
       )
     }
   })

--- a/dashboard/src/helpers/cfp.js
+++ b/dashboard/src/helpers/cfp.js
@@ -1,5 +1,5 @@
 import { ref } from 'vue'
-import { isValidUrl } from './utils'
+import { isValidUrl, truncateStr } from './utils'
 import { createResource } from 'frappe-ui'
 
 export const getProposalFormFields = (cfpData) => {
@@ -320,7 +320,9 @@ export const validateReferences = (references) => {
     }
 
     if (!isValidUrl(item.link)) {
-      errors.push(`Reference #${index + 1} link is invalid`)
+      errors.push(
+        `Reference #${index + 1} (${truncateStr(item.link, 20)}) link is invalid. Only https links are allowed.`,
+      )
     }
   })
 

--- a/dashboard/src/helpers/utils.js
+++ b/dashboard/src/helpers/utils.js
@@ -36,9 +36,9 @@ export const cleanedHTML = (htmlData) => {
 
 export const isValidUrl = (link) => {
   try {
-    new URL(link)
-    return true
-  } catch (e) {
+    const url = new URL(link)
+    return url.protocol === 'https:'
+  } catch {
     return false
   }
 }

--- a/dashboard/src/pages/cfp/ProposalEdit.vue
+++ b/dashboard/src/pages/cfp/ProposalEdit.vue
@@ -151,7 +151,7 @@ const saveProposal = () => {
 
   if (errors.length) {
     errorMessages.value = errors.join('\n')
-    toast.error(errorMessages)
+    toast.error(errorMessages.value)
     return
   }
 

--- a/dashboard/src/pages/cfp/ProposalEdit.vue
+++ b/dashboard/src/pages/cfp/ProposalEdit.vue
@@ -151,6 +151,7 @@ const saveProposal = () => {
 
   if (errors.length) {
     errorMessages.value = errors.join('\n')
+    toast.error(errorMessages)
     return
   }
 
@@ -167,7 +168,9 @@ const saveProposal = () => {
       toast.success('Proposal Updated Successfully!')
     })
     .catch((err) => {
-      toast.error(err)
+      toast.error('Failed to update your proposal', {
+        description: err.message,
+      })
     })
 }
 </script>

--- a/fossunited/fossunited/doctype/cfp_submission_reference/cfp_submission_reference.json
+++ b/fossunited/fossunited/doctype/cfp_submission_reference/cfp_submission_reference.json
@@ -5,14 +5,15 @@
   "doctype": "DocType",
   "editable_grid": 1,
   "engine": "InnoDB",
-  "field_order": ["link"],
+  "field_order": [
+    "link"
+  ],
   "fields": [
     {
       "fieldname": "link",
-      "fieldtype": "Data",
+      "fieldtype": "Small Text",
       "in_list_view": 1,
       "label": "Link",
-      "options": "URL",
       "reqd": 1
     }
   ],
@@ -20,7 +21,7 @@
   "index_web_pages_for_search": 1,
   "istable": 1,
   "links": [],
-  "modified": "2025-03-09 01:09:55.317425",
+  "modified": "2025-12-17 12:27:33.314482",
   "modified_by": "Administrator",
   "module": "FOSSUnited",
   "name": "CFP Submission Reference",

--- a/fossunited/fossunited/doctype/cfp_submission_reference/cfp_submission_reference.json
+++ b/fossunited/fossunited/doctype/cfp_submission_reference/cfp_submission_reference.json
@@ -11,9 +11,11 @@
   "fields": [
     {
       "fieldname": "link",
-      "fieldtype": "Small Text",
+      "fieldtype": "Data",
       "in_list_view": 1,
       "label": "Link",
+      "length": 250,
+      "options": "URL",
       "reqd": 1
     }
   ],
@@ -21,7 +23,7 @@
   "index_web_pages_for_search": 1,
   "istable": 1,
   "links": [],
-  "modified": "2025-12-17 12:27:33.314482",
+  "modified": "2025-12-17 14:20:47.355244",
   "modified_by": "Administrator",
   "module": "FOSSUnited",
   "name": "CFP Submission Reference",

--- a/fossunited/fossunited/doctype/cfp_submission_reference/cfp_submission_reference.py
+++ b/fossunited/fossunited/doctype/cfp_submission_reference/cfp_submission_reference.py
@@ -14,7 +14,7 @@ class CFPSubmissionReference(Document):
     if TYPE_CHECKING:
         from frappe.types import DF
 
-        link: DF.SmallText
+        link: DF.Data
         parent: DF.Data
         parentfield: DF.Data
         parenttype: DF.Data

--- a/fossunited/fossunited/doctype/cfp_submission_reference/cfp_submission_reference.py
+++ b/fossunited/fossunited/doctype/cfp_submission_reference/cfp_submission_reference.py
@@ -14,7 +14,7 @@ class CFPSubmissionReference(Document):
     if TYPE_CHECKING:
         from frappe.types import DF
 
-        link: DF.Data
+        link: DF.SmallText
         parent: DF.Data
         parentfield: DF.Data
         parenttype: DF.Data


### PR DESCRIPTION
- Initially thought to warn users client side to use shortened URLs 
- But feel like making it text will solve it better
  Since normal users might not want to go somewhere to shorten, most of the gdocs, presentation, drive and even blog links can be long.

- still to keep it clean we can warn users client side
- we've helper function which only allows https protocol links strictly

- Closes #1338 

- Either it can be

<img width="1556" height="359" alt="image" src="https://github.com/user-attachments/assets/e1df7933-8f6c-4343-b2d7-8543f59aa459" />


or 
- 
<img width="1202" height="315" alt="image" src="https://github.com/user-attachments/assets/722fde0d-e732-4ebf-8594-493cccc06b4c" />


^ Applies to CFP submission form as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error messaging when withdrawing proposals and updating proposal submissions with clearer, more descriptive feedback.

* **New Features**
  * Added URL validation requiring HTTPS protocol for all reference links.
  * Implemented 250-character limit for proposal reference links.
  * Enhanced error messages for invalid or oversized URLs with helpful suggestions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->