### PR TITLE
Feature/concluded events

### DIFF
--- a/dashboard/src/pages/ChapterEvents.vue
+++ b/dashboard/src/pages/ChapterEvents.vue
@@ -49,12 +49,14 @@ const chapter = createDocumentResource({
   auto: true,
 })
 
+const today = () => new Date().toISOString().split('T')[0]
+
 const upcoming_events = createListResource({
   doctype: 'FOSS Chapter Event',
   fields: ['*'],
   filters: [
     ['chapter', '=', route.params.id],
-    ['event_end_date', '>', new Date()],
+    ['event_end_date', '>', today()],
     ['status', 'in', ['Live', 'Draft', 'Cancelled']],
   ],
   orderBy: 'event_start_date asc',
@@ -66,7 +68,7 @@ const past_events = createListResource({
   fields: ['*'],
   filters: [
     ['chapter', '=', route.params.id],
-    ['event_start_date', '<', new Date()],
+    ['event_start_date', '<', today()],
     ['status', 'in', ['Concluded', 'Cancelled']],
   ],
   orderBy: 'event_start_date desc',

--- a/dashboard/src/pages/ChapterEvents.vue
+++ b/dashboard/src/pages/ChapterEvents.vue
@@ -49,6 +49,7 @@ const chapter = createDocumentResource({
   auto: true,
 })
 
+// Use ISO date string format for Frappe date filters
 const today = () => new Date().toISOString().split('T')[0]
 
 const upcoming_events = createListResource({

--- a/dashboard/src/pages/MyChapters.vue
+++ b/dashboard/src/pages/MyChapters.vue
@@ -23,6 +23,18 @@
       <div v-else class="text-base mt-6 text-gray-800">
         <div>There are no scheduled events.</div>
       </div>
+      <div class="mt-8">
+        <div class="prose pt-4 mb-4">
+          <h3 class="mb-0">Concluded Events</h3>
+          <p class="text-sm">View past events and manage post-event tasks.</p>
+        </div>
+        <div v-if="concluded_events.data && concluded_events.data.length > 0" class="mt-6 grid grid-cols-1 md:grid-cols-3 gap-4">
+          <EventCard v-for="event in concluded_events.data" :key="event.name" :event="event" />
+        </div>
+        <div v-else class="text-base mt-6 text-gray-800">
+          <div>No concluded events found.</div>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -33,6 +45,28 @@ import ChapterCard from '@/components/ChapterCard.vue'
 import EventCard from '@/components/EventCard.vue'
 
 const session = inject('$session')
+
+const concluded_events = createListResource({
+  doctype: 'FOSS Chapter Event',
+  fields: ['name', 'event_name', 'event_type', 'chapter_name', 'status', 'event_start_date'],
+  filters: {
+    event_end_date: ['<=', new Date()],
+    status: ['in', ['Concluded', 'Cancelled']],
+  },
+  orderBy: 'event_start_date desc',
+  pageLength: 999,
+})
+
+const scheduled_events = createListResource({
+  doctype: 'FOSS Chapter Event',
+  fields: ['name', 'event_name', 'event_type', 'chapter_name', 'status', 'event_start_date'],
+  filters: {
+    event_end_date: ['>', new Date()],
+    status: ['in', ['Draft', 'Live']],
+  },
+  orderBy: 'event_start_date',
+  pageLength: 999,
+})
 
 const chapters = createListResource({
   doctype: 'FOSS Chapter',
@@ -51,17 +85,16 @@ const chapters = createListResource({
       },
     })
     scheduled_events.fetch()
+    // update concluded events filters as well
+    concluded_events.update({
+      filters: {
+        ...concluded_events.filters,
+        chapter: ['in', data.map((d) => d.name)],
+      },
+    })
+    concluded_events.fetch()
   },
 })
 
-const scheduled_events = createListResource({
-  doctype: 'FOSS Chapter Event',
-  fields: ['name', 'event_name', 'event_type', 'chapter_name', 'status', 'event_start_date'],
-  filters: {
-    event_end_date: ['>', new Date()],
-    status: ['in', ['Draft', 'Live']],
-  },
-  orderBy: 'event_start_date',
-  pageLength: 999,
-})
+
 </script>

--- a/dashboard/src/pages/MyChapters.vue
+++ b/dashboard/src/pages/MyChapters.vue
@@ -46,6 +46,7 @@ import EventCard from '@/components/EventCard.vue'
 
 const session = inject('$session')
 
+// Use ISO date string format for Frappe date filters
 const today = () => new Date().toISOString().split('T')[0]
 
 const concluded_events = createListResource({

--- a/dashboard/src/pages/MyChapters.vue
+++ b/dashboard/src/pages/MyChapters.vue
@@ -46,11 +46,13 @@ import EventCard from '@/components/EventCard.vue'
 
 const session = inject('$session')
 
+const today = () => new Date().toISOString().split('T')[0]
+
 const concluded_events = createListResource({
   doctype: 'FOSS Chapter Event',
   fields: ['name', 'event_name', 'event_type', 'chapter_name', 'status', 'event_start_date'],
   filters: {
-    event_end_date: ['<=', new Date()],
+    event_end_date: ['<=', today()],
     status: ['in', ['Concluded', 'Cancelled']],
   },
   orderBy: 'event_start_date desc',
@@ -61,7 +63,7 @@ const scheduled_events = createListResource({
   doctype: 'FOSS Chapter Event',
   fields: ['name', 'event_name', 'event_type', 'chapter_name', 'status', 'event_start_date'],
   filters: {
-    event_end_date: ['>', new Date()],
+    event_end_date: ['>', today()],
     status: ['in', ['Draft', 'Live']],
   },
   orderBy: 'event_start_date',

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -545,6 +545,20 @@ class FOSSChapterEvent(WebsiteGenerator):
                 ]
         return formatted
 
+    def can_user_manage_event(self):
+        """Check if the current user can manage this event.
+        Returns True if user is a Core Team Member of the event or a chapter member.
+        Uses the existing API function to maintain consistency with the organization's patterns.
+        """
+        if frappe.session.user == "Guest":
+            return False
+
+        # Use the existing API function that checks both event lead and chapter membership
+        # This ensures consistency with other parts of the platform
+        from fossunited.api.chapter import check_if_chapter_or_event_core_member
+
+        return check_if_chapter_or_event_core_member(self.name)
+
     def get_context(self, context):
         context.chapter = frappe.get_doc(CHAPTER, self.chapter)
         context.sponsors_dict = self.get_sponsors()
@@ -570,6 +584,10 @@ class FOSSChapterEvent(WebsiteGenerator):
         context.social_links = frappe.get_doc(CHAPTER, self.chapter).get_social_links()
         context.status_concluded = self.status == "Concluded"
         context.status_live = self.status == "Live"
+
+        # Add permission check for managing event
+        context.can_manage_event = self.can_user_manage_event()
+        context.event_dashboard_url = f"/dashboard/event/{self.name}"
 
         context.map_lat = None
         context.map_lng = None

--- a/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
+++ b/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
@@ -483,6 +483,17 @@
                       <i class="ti ti-arrow-up-right" aria-hidden="true"></i>
                     </a>
                   {% endif %}
+
+                  {% if can_manage_event %}
+                    <a
+                      href="{{ event_dashboard_url }}"
+                      class="v3-btn v3-btn-secondary"
+                      aria-label="Edit event details"
+                    >
+                      <i class="ti ti-edit" aria-hidden="true"></i>
+                      <span>Edit Event</span>
+                    </a>
+                  {% endif %}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Fixes #1341

Brings back the "Edit Event" button so organizers can manage past events and create post-event campaigns.

### Changes
- [x] Added "Edit Event" button visible to Core Team Members
- [x] Uses existing permission API (`check_if_chapter_or_event_core_member`) for consistency
- [x] Works for all event statuses including concluded events

The button links to the event dashboard where organizers can manage all aspects of the event.