### PR TITLE
dashboard(rsvp-insight): add event check-in via attendees list view 

### DIFF
--- a/dashboard/src/helpers/utils.js
+++ b/dashboard/src/helpers/utils.js
@@ -44,3 +44,24 @@ export const isValidUrl = (link) => {
 }
 
 export const isSmallScreen = computed(() => window.innerWidth < 768)
+
+// "2025-12-29" -> "Monday, December 29, 2025"
+export const formatFullDate = (dateStr) => {
+  if (!dateStr) return ''
+  return new Date(dateStr).toLocaleDateString('en-US', {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+
+// "2025-12-29T14:30:45" -> "02:30:45 PM"
+export const formatTimeOnly = (datetime) => {
+  if (!datetime) return ''
+  return new Date(datetime).toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  })
+}

--- a/dashboard/src/pages/EventRsvpInsights.vue
+++ b/dashboard/src/pages/EventRsvpInsights.vue
@@ -396,36 +396,18 @@ const confirmUndoCheckIn = (row) => {
 
 const undoCheckIn = (row) => {
   createResource({
-    url: 'frappe.client.get',
+    url: 'fossunited.chapters.doctype.foss_event_rsvp_submission.foss_event_rsvp_submission.remove_checkin_for_today',
     params: {
-      doctype: 'FOSS Event RSVP Submission',
-      name: row.name,
-      fields: ['check_ins'],
+      submission_name: row.name,
     },
-    onSuccess(data) {
-      const today = new Date().toISOString().split('T')[0]
-      const updatedCheckIns = (data.check_ins || []).filter((c) => {
-        const checkInDate = new Date(c.check_in_time).toISOString().split('T')[0]
-        return checkInDate !== today
-      })
-
-      createResource({
-        url: 'frappe.client.set_value',
-        params: {
-          doctype: 'FOSS Event RSVP Submission',
-          name: row.name,
-          fieldname: { check_ins: updatedCheckIns },
-        },
-        onSuccess() {
-          toast.success('Check-in removed')
-          submissions.fetch()
-          checkins.reload()
-          eventStats.reload()
-        },
-        onError(err) {
-          toast.error(err.message || 'Failed to remove check-in')
-        },
-      }).fetch()
+    onSuccess() {
+      toast.success('Check-in removed')
+      submissions.reload()
+      checkins.reload()
+      eventStats.reload()
+    },
+    onError(err) {
+      toast.error(err.message || 'Failed to remove check-in')
     },
   }).fetch()
 }

--- a/dashboard/src/pages/EventRsvpInsights.vue
+++ b/dashboard/src/pages/EventRsvpInsights.vue
@@ -25,13 +25,13 @@
       >
         <template #group-header="{ group }">
           <span class="text-base font-medium leading-6 text-ink-gray-9">
-            {{ formatDate(group.group) }} - {{ group.rows.length }} check-ins
+            {{ formatFullDate(group.group) }} - {{ group.rows.length }} check-ins
           </span>
         </template>
 
         <template #cell="{ item, row, column }">
           <span v-if="column.key === 'check_in_time'" class="text-sm text-gray-700">
-            {{ formatTime(item) }}
+            {{ formatTimeOnly(item) }}
           </span>
           <span v-else class="text-base">{{ item }}</span>
         </template>
@@ -72,6 +72,24 @@
             {{ item ? 'Yes' : 'No' }}
           </span>
 
+          <div v-else-if="column.key === 'checkin_action'" class="flex gap-2">
+            <Button
+              v-if="!row.has_checked_in_today"
+              size="sm"
+              label="Check-in"
+              variant="solid"
+              @click="checkInAttendee(row)"
+            />
+            <Button
+              v-else
+              size="sm"
+              label="Checked-in today"
+              theme="green"
+              variant="outline"
+              @click="confirmUndoCheckIn(row)"
+            />
+          </div>
+
           <div v-else-if="column.key === 'actions'" class="flex gap-2">
             <Button
               size="sm"
@@ -89,7 +107,7 @@
             />
           </div>
 
-          <span v-else class="text-base" :title="item">{{ truncate(item, 30) }}</span>
+          <span v-else class="text-base" :title="item">{{ truncateStr(item, 30) }}</span>
         </template>
       </SearchListView>
     </div>
@@ -102,6 +120,7 @@ import { computed, ref, watchEffect } from 'vue'
 import { createResource, Button } from 'frappe-ui'
 import SearchListView from '@/components/ui/SearchListView.vue'
 import { toast } from 'vue-sonner'
+import { truncateStr, formatFullDate, formatTimeOnly } from '@/helpers/utils'
 
 const route = useRoute()
 
@@ -210,6 +229,9 @@ const attendeeColumns = computed(() => {
       width: '300px',
     })
   })
+  if (showCheckins.value) {
+    baseColumns.push({ label: 'Check-in', key: 'checkin_action', width: '180px' })
+  }
   if (rsvp_form.data?.requires_host_approval) {
     baseColumns.push({ label: 'Actions', key: 'actions', width: '200px' })
   }
@@ -222,23 +244,39 @@ const attendeeExportColumns = computed(() => {
   if (!data) return []
   return Object.keys(data)
     .filter(
-      (key) => key !== 'name' && !(key === 'status' && !rsvp_form.data?.requires_host_approval),
+      (key) =>
+        key !== 'name' &&
+        key !== 'has_checked_in_today' &&
+        !(key === 'status' && !rsvp_form.data?.requires_host_approval),
     )
     .map((key) => ({
       label: key.charAt(0).toUpperCase() + key.slice(1).replace(/_/g, ' '),
       key,
     }))
 })
-
 // Group attendees by status
 watchEffect(() => {
   const rows = submissions.data || []
   const requiresApproval = rsvp_form.data?.requires_host_approval
+  const checkedInSubmissions = new Set()
+  const today = new Date().toISOString().split('T')[0]
 
   const pending = []
   const accepted = []
   const rejected = []
   const notAttending = []
+
+  ;(checkins.data || []).forEach((c) => {
+    const date = new Date(c.check_in_time).toISOString().split('T')[0]
+    if (date === today) {
+      checkedInSubmissions.add(c.parent)
+    }
+  })
+
+  // Update all rows with check-in status
+  rows.forEach((row) => {
+    row.has_checked_in_today = checkedInSubmissions.has(row.name)
+  })
 
   rows.forEach((row) => {
     const confirmed = Boolean(row.confirm_attendance)
@@ -296,32 +334,6 @@ watchEffect(() => {
       ]
 })
 
-// Utilities
-const truncate = (text, maxLength = 30) => {
-  if (!text) return ''
-  const str = String(text).trim()
-  return str.length > maxLength ? str.substring(0, maxLength) + '…' : str
-}
-
-const formatDate = (dateStr) => {
-  if (!dateStr) return ''
-  return new Date(dateStr).toLocaleDateString('en-US', {
-    weekday: 'long',
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  })
-}
-
-const formatTime = (datetime) => {
-  if (!datetime) return ''
-  return new Date(datetime).toLocaleTimeString('en-US', {
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-  })
-}
-
 // Actions
 const refreshCheckins = () => {
   checkins.reload()
@@ -358,5 +370,63 @@ const confirmReject = (row) => {
   if (confirm(`Are you sure you want to reject ${row.name1 || 'this attendee'}?`)) {
     updateRsvpStatus(row, 'Rejected')
   }
+}
+
+const checkInAttendee = (row) => {
+  createResource({
+    url: 'fossunited.chapters.doctype.foss_event_rsvp_submission.foss_event_rsvp_submission.self_check_in',
+    params: { submission_name: row.name },
+    onSuccess() {
+      toast.success('Checked in successfully')
+      submissions.fetch()
+      checkins.reload()
+      eventStats.reload()
+    },
+    onError(err) {
+      toast.error(err.message || 'Check-in failed')
+    },
+  }).fetch()
+}
+
+const confirmUndoCheckIn = (row) => {
+  if (confirm(`Remove today's check-in for ${row.name1 || 'this attendee'}?`)) {
+    undoCheckIn(row)
+  }
+}
+
+const undoCheckIn = (row) => {
+  createResource({
+    url: 'frappe.client.get',
+    params: {
+      doctype: 'FOSS Event RSVP Submission',
+      name: row.name,
+      fields: ['check_ins'],
+    },
+    onSuccess(data) {
+      const today = new Date().toISOString().split('T')[0]
+      const updatedCheckIns = (data.check_ins || []).filter((c) => {
+        const checkInDate = new Date(c.check_in_time).toISOString().split('T')[0]
+        return checkInDate !== today
+      })
+
+      createResource({
+        url: 'frappe.client.set_value',
+        params: {
+          doctype: 'FOSS Event RSVP Submission',
+          name: row.name,
+          fieldname: { check_ins: updatedCheckIns },
+        },
+        onSuccess() {
+          toast.success('Check-in removed')
+          submissions.fetch()
+          checkins.reload()
+          eventStats.reload()
+        },
+        onError(err) {
+          toast.error(err.message || 'Failed to remove check-in')
+        },
+      }).fetch()
+    },
+  }).fetch()
 }
 </script>

--- a/fossunited/api/rsvp.py
+++ b/fossunited/api/rsvp.py
@@ -91,6 +91,7 @@ def get_rsvp_checkins(event_id: str) -> list:
             Submission.email,
             Submission.im_a,
             CheckIn.check_in_time,
+            CheckIn.parent,
         )
         .where(Submission.event == event_id)
         .where(Submission.status == "Accepted")

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
@@ -177,7 +177,6 @@ class FOSSEventRSVPSubmission(Document):
             document_type_event=EVENT,
         )
 
-    @frappe.whitelist()
     def add_check_in(self):
         """Add a check-in record for this submission"""
         # Check if event allows check-in (between start and end date)
@@ -217,6 +216,18 @@ class FOSSEventRSVPSubmission(Document):
                 return True
         return False
 
+    def remove_todays_checkin(self):
+        """Remove today's check-in record for this submission"""
+        today = getdate()
+
+        for i, check_in in enumerate(self.check_ins):
+            if getdate(check_in.check_in_time) == today:
+                self.remove(check_in)
+                self.save()
+                return {"success": True, "message": "Check-in removed successfully"}
+
+        frappe.throw("No check-in found for today")
+
 
 @frappe.whitelist()
 def self_check_in(submission_name):
@@ -226,3 +237,13 @@ def self_check_in(submission_name):
 
     doc = frappe.get_doc(RSVP_RESPONSE, submission_name)
     return doc.add_check_in()
+
+
+@frappe.whitelist()
+def remove_checkin_for_today(submission_name):
+    """API endpoint to remove today's check-in"""
+    if not frappe.session.user or frappe.session.user == "Guest":
+        frappe.throw("Not permitted", frappe.PermissionError)
+
+    doc = frappe.get_doc(RSVP_RESPONSE, submission_name)
+    return doc.remove_todays_checkin()


### PR DESCRIPTION
- Actually completes #634 

- Add action button for checkin to simply check them in or remove from check-in (acts as toggle)
- We already have self-checkin via their rsvp edit form (for logged users), but organizers can also easily to this quick via the insights list view shown.

- No backend changes were required, since client can handle this implemented in simple way.

<img width="1841" height="627" alt="image" src="https://github.com/user-attachments/assets/ab3f0613-0827-49be-92f9-de7313d4652e" />

Note: This button shows up only after event starts. and only can be done during event timeline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive check-in/check-out controls for event attendees with real-time status
  * Check-in column added to attendee table showing current day status
  * Ability to undo today's check-ins

* **Improvements**
  * Enhanced date and time formatting in event insights for clearer display
  * Exports no longer include transient per-attendee check-in flags

* **Backend**
  * Server support added to remove today's check-in entries for attendees

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->