### PR TITLE
doctype(grant-dir): function to simply update manifest if modified

### DIFF
--- a/fossunited/fossunited/doctype/grants_funding_directory/grants_funding_directory.py
+++ b/fossunited/fossunited/doctype/grants_funding_directory/grants_funding_directory.py
@@ -3,7 +3,6 @@
 
 import json
 import re
-from email.utils import parsedate_to_datetime
 from typing import Dict, List, Tuple
 
 import frappe
@@ -41,6 +40,9 @@ class GrantsFundingDirectory(WebsiteGenerator):
 
         if not self.email:
             self.extract_email_from_json()
+
+    def onload(self):
+        self.refresh_if_stale()
 
     def fetch_and_validate_json(self):
         """Fetch and validate funding JSON from URL."""
@@ -126,7 +128,7 @@ class GrantsFundingDirectory(WebsiteGenerator):
 
     def get_context(self, context):
         """Prepare context for rendering the page."""
-        self.refresh_manifest_json()
+        self.refresh_if_stale()
         try:
             data = json.loads(self.json_data or "{}")
         except json.JSONDecodeError:
@@ -175,43 +177,54 @@ class GrantsFundingDirectory(WebsiteGenerator):
 
         return normalized_channels, channels_dict
 
-    def refresh_manifest_json(self):
+    def refresh_if_stale(self):
         """
-        Alternative to scheduler, so every page visit leads to re-fetching of data within a week.
+        Check and refresh manifest if stale (>7 days old).
+        Called on page visit, keeps it simple and automatic.
         """
-        if not self.last_updated:
-            return
-
-        if get_datetime(self.last_updated) > add_days(now_datetime(), -7):
+        if not self.last_updated or (
+            get_datetime(self.last_updated) > add_days(now_datetime(), -7)
+        ):
             return
 
         try:
             r = requests.head(self.funding_json, timeout=5, allow_redirects=True)
-            if not r.ok:
+            if r.status_code == 429 or not r.ok:
                 return
 
-            last_modified = r.headers.get("last-modified")
-            local_dt = get_datetime(self.last_updated)
-
-            if not last_modified:
-                self.fetch_and_validate_json()
-                self.save(ignore_permissions=True)
+            last_modified_header = r.headers.get("last-modified")
+            needs_fetch = False
+            if not last_modified_header:
+                needs_fetch = True
             else:
-                remote_dt = parsedate_to_datetime(last_modified)
+                from email.utils import parsedate_to_datetime
 
-                if remote_dt > local_dt:
-                    self.fetch_and_validate_json()
-                    self.save(ignore_permissions=True)
+                remote_dt = parsedate_to_datetime(last_modified_header)
+                local_dt = get_datetime(self.last_updated)
+                if remote_dt.tzinfo is not None:
+                    remote_dt = remote_dt.replace(tzinfo=None)
+                needs_fetch = remote_dt > local_dt
 
-            # Update timestamp so we don't recheck for another week
-            self.last_updated = now_datetime()
-            self.save(ignore_permissions=True)
+            if needs_fetch:
+                # Actually fetch and update
+                self.fetch_and_validate_json()
+                self.save(ignore_permissions=True, ignore_version=True)
+            else:
+                # Just bump timestamp to avoid rechecking for another week
+                frappe.db.set_value(
+                    self.doctype,
+                    self.name,
+                    "last_updated",
+                    now_datetime(),
+                    update_modified=False,
+                )
+
             frappe.db.commit()
 
         except Exception as e:
             frappe.log_error(
-                title="Manifest refresh failed",
-                message=(f"URL: {self.funding_json}\n{repr(e)}"),
+                title=f"Manifest refresh failed for {self.name}",
+                message=f"Doc: {self.name}\nURL: {self.funding_json}\n{str(e)}",
             )
 
 

--- a/fossunited/fossunited/doctype/grants_funding_directory/grants_funding_directory.py
+++ b/fossunited/fossunited/doctype/grants_funding_directory/grants_funding_directory.py
@@ -3,11 +3,12 @@
 
 import json
 import re
+from email.utils import parsedate_to_datetime
 from typing import Dict, List, Tuple
 
 import frappe
 import requests
-from frappe.utils import now_datetime
+from frappe.utils import add_days, get_datetime, now_datetime
 from frappe.website.website_generator import WebsiteGenerator
 
 EMAIL_REGEX = re.compile(r"[^@]+@[^@]+\.[^@]+")
@@ -125,6 +126,7 @@ class GrantsFundingDirectory(WebsiteGenerator):
 
     def get_context(self, context):
         """Prepare context for rendering the page."""
+        self.refresh_manifest_json()
         try:
             data = json.loads(self.json_data or "{}")
         except json.JSONDecodeError:
@@ -171,6 +173,45 @@ class GrantsFundingDirectory(WebsiteGenerator):
         channels_dict = {ch["guid"]: ch for ch in normalized_channels if ch.get("guid")}
 
         return normalized_channels, channels_dict
+
+    def refresh_manifest_json(self):
+        """
+        Alternative to scheduler, so every page visit leads to re-fetching of data within a week.
+        """
+        if not self.last_updated:
+            return
+
+        if get_datetime(self.last_updated) > add_days(now_datetime(), -7):
+            return
+
+        try:
+            r = requests.head(self.funding_json, timeout=5, allow_redirects=True)
+            if not r.ok:
+                return
+
+            last_modified = r.headers.get("last-modified")
+            local_dt = get_datetime(self.last_updated)
+
+            if not last_modified:
+                self.fetch_and_validate_json()
+                self.save(ignore_permissions=True)
+            else:
+                remote_dt = parsedate_to_datetime(last_modified)
+
+                if remote_dt > local_dt:
+                    self.fetch_and_validate_json()
+                    self.save(ignore_permissions=True)
+
+            # Update timestamp so we don't recheck for another week
+            self.last_updated = now_datetime()
+            self.save(ignore_permissions=True)
+            frappe.db.commit()
+
+        except Exception as e:
+            frappe.log_error(
+                title="Manifest refresh failed",
+                message=(f"URL: {self.funding_json}\n{repr(e)}"),
+            )
 
 
 @frappe.whitelist()

--- a/fossunited/fossunited/doctype/grants_funding_directory/grants_funding_directory.py
+++ b/fossunited/fossunited/doctype/grants_funding_directory/grants_funding_directory.py
@@ -147,6 +147,7 @@ class GrantsFundingDirectory(WebsiteGenerator):
         context.page_title = f"{entity_name} – Funding Profile"
         context.doctype_name = self.doctype
         context.doc_name = self.name
+        context.no_cache = 1
 
         return context
 

--- a/fossunited/www/grants/directory/index.py
+++ b/fossunited/www/grants/directory/index.py
@@ -29,7 +29,7 @@ def get_context(context):
         short_desc = (description[:150] + "…") if len(description) > 150 else description
 
         # inline date formatting (converted to datetime by frappe)
-        dt = d.get("last_updated") or d.get("modified")
+        dt = d.get("modified")
         dt_fmt = dt.strftime("%d %b %Y") if dt else ""
 
         items.append(


### PR DESCRIPTION
- re-fetch or update last modified if manifest json data has been updated
- instead of using scheduler we can simply invoke trigger for every page visit so it has less burden on server

- We check for 7 days as buffer, so if new page visit, then re-fetch or update the date.

- Should be easy on server as more items are added here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Grants funding directory now automatically refreshes stale data on page load and before rendering, ensuring users see up-to-date opportunities.
  * Successful checks briefly defer rechecking to reduce unnecessary network activity.

* **Bug Fixes**
  * Refresh failures are logged but no longer block viewing the directory.
  * Date handling changed to rely on the "modified" field for timestamps; if absent, the date will be empty rather than falling back to prior fields.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->