### PR TITLE
utils: sort event sponsors - keep patrons on top

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -22,6 +22,7 @@ from fossunited.doctype_ids import (
     SPEAKER,
     USER_PROFILE,
 )
+from fossunited.fossunited.utils import get_event_sponsors
 
 now = datetime.now()
 
@@ -245,57 +246,6 @@ class FOSSChapterEvent(WebsiteGenerator):
         )
 
         return pagetitle, description, image
-
-    def get_sponsors(self):
-        # Get industry partners with joining_date (normalize company names, normalize dates)
-        ip_records = frappe.db.get_all("Industry Partners", fields=["company", "joining_date"])
-        ip_lookup = {
-            (ip.get("company") or "").strip().lower(): frappe.utils.getdate(ip.get("joining_date"))
-            if ip.get("joining_date")
-            else None
-            for ip in ip_records
-        }
-        # Define tier sort order (include Venue Partner per spec)
-        sort_order = {
-            "Platinum": 0,
-            "Gold": 1,
-            "Silver": 2,
-            "Bronze": 3,
-            "Venue Partner": 4,
-        }
-
-        # Group sponsors by tier (do not mutate persisted fields like `tier`)
-        sponsors_by_tier = {}
-        for s in self.sponsor_list:
-            tier_key = (s.custom_tier or "Custom").strip() if s.tier == "Custom" else s.tier
-            sponsor_key = (s.sponsor_name or "").strip().lower()
-            s.is_ip = sponsor_key in ip_lookup
-            s.sort_date = (
-                ip_lookup.get(sponsor_key)
-                if s.is_ip
-                else (frappe.utils.getdate(s.date_of_confirm) if s.date_of_confirm else None)
-            )
-            sponsors_by_tier.setdefault(tier_key, []).append(s)
-
-        # Sort sponsors within each tier
-        fallback_date = frappe.utils.getdate(frappe.utils.today())
-        for sponsor_group in sponsors_by_tier.values():
-            sponsor_group.sort(
-                key=lambda s: (
-                    not s.is_ip,
-                    s.sort_date is None,
-                    s.sort_date or fallback_date,
-                    (s.sponsor_name or "").lower(),
-                )
-            )
-
-        # Return sponsors_by_tier dict in sorted tier order
-        return dict(
-            sorted(
-                sponsors_by_tier.items(),
-                key=lambda x: sort_order.get(x[0], float("inf")),
-            )
-        )
 
     def get_volunteers(self):
         """Get volunteers with profile information. Batch fetch profiles for performance."""
@@ -547,7 +497,7 @@ class FOSSChapterEvent(WebsiteGenerator):
 
     def get_context(self, context):
         context.chapter = frappe.get_doc(CHAPTER, self.chapter)
-        context.sponsors_dict = self.get_sponsors()
+        context.sponsors_dict = get_event_sponsors(self)
         context.volunteers = self.get_volunteers()
         context.speakers, context.submissions = self.get_speakers()
         context.rsvp_status_block = self.get_rsvp_status_block()

--- a/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
@@ -13,8 +13,7 @@ from fossunited.doctype_ids import (
     PROPOSAL,
     USER_PROFILE,
 )
-
-no_cache = 1
+from fossunited.fossunited.utils import get_event_sponsors
 
 BASE_DATE = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
 
@@ -96,7 +95,7 @@ class FOSSHackathon(WebsiteGenerator):
             context.chapter = frappe.get_doc(CHAPTER, self.chapter)
 
         context.nav_items = self.get_nav_items()
-        context.sponsors_dict = self.get_sponsors()
+        context.sponsors_dict = get_event_sponsors(self)
         context.tag_icon = {
             "Remote": "world",
             "In-person": "building",
@@ -111,6 +110,7 @@ class FOSSHackathon(WebsiteGenerator):
         )
 
         context.volunteers = self.get_volunteers()
+        context.no_cache = 1
 
     def get_nav_items(self):
         nav_items = ["information", "submissions"]
@@ -118,57 +118,6 @@ class FOSSHackathon(WebsiteGenerator):
             nav_items.append("schedule")
 
         return nav_items
-
-    def get_sponsors(self):
-        # Get industry partners with joining_date (normalize company names, normalize dates)
-        ip_records = frappe.db.get_all("Industry Partners", fields=["company", "joining_date"])
-        ip_lookup = {
-            (ip.get("company") or "").strip().lower(): frappe.utils.getdate(ip.get("joining_date"))
-            if ip.get("joining_date")
-            else None
-            for ip in ip_records
-        }
-        # Define tier sort order (include Venue Partner per spec)
-        sort_order = {
-            "Platinum": 0,
-            "Gold": 1,
-            "Silver": 2,
-            "Bronze": 3,
-            "Venue Partner": 4,
-        }
-
-        # Group sponsors by tier (do not mutate persisted fields like `tier`)
-        sponsors_by_tier = {}
-        for s in self.sponsor_list:
-            tier_key = (s.custom_tier or "Custom").strip() if s.tier == "Custom" else s.tier
-            sponsor_key = (s.sponsor_name or "").strip().lower()
-            s.is_ip = sponsor_key in ip_lookup
-            s.sort_date = (
-                ip_lookup.get(sponsor_key)
-                if s.is_ip
-                else (frappe.utils.getdate(s.date_of_confirm) if s.date_of_confirm else None)
-            )
-            sponsors_by_tier.setdefault(tier_key, []).append(s)
-
-        # Sort sponsors within each tier
-        fallback_date = frappe.utils.getdate(frappe.utils.today())
-        for sponsor_group in sponsors_by_tier.values():
-            sponsor_group.sort(
-                key=lambda s: (
-                    not s.is_ip,
-                    s.sort_date is None,
-                    s.sort_date or fallback_date,
-                    (s.sponsor_name or "").lower(),
-                )
-            )
-
-        # Return sponsors_by_tier dict in sorted tier order
-        return dict(
-            sorted(
-                sponsors_by_tier.items(),
-                key=lambda x: sort_order.get(x[0], float("inf")),
-            )
-        )
 
     def get_schedule_dict(self):
         schedule_dict = {}

--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -546,3 +546,52 @@ def get_volunteers_stats():
         "active_count": len(unique_members),
         "communities_count": len(unique_chapters),
     }
+
+
+def get_event_sponsors(self):
+    """
+    Get event sponsors in sorted order (date of confirm).
+    """
+    # Get IP dates
+    ip_dates = {
+        ip["company"].strip().lower(): ip["joining_date"]
+        for ip in frappe.db.get_all("Industry Partners", fields=["company", "joining_date"])
+        if ip.get("company") and ip.get("joining_date")
+    }
+
+    # Tier order
+    tier_rank = {
+        "Patrons": 0,
+        "Platinum": 1,
+        "Gold": 2,
+        "Silver": 3,
+        "Bronze": 4,
+        "Venue Partner": 5,
+    }
+
+    # Group by tier
+    groups = {}
+    for sponsor in self.sponsor_list:
+        # Get tier name
+        tier = sponsor.custom_tier.strip() if sponsor.tier == "Custom" else sponsor.tier
+
+        # Get sort date (confirm date first, then IP date)
+        name_key = (sponsor.sponsor_name or "").strip().lower()
+        sponsor.sort_date = sponsor.date_of_confirm or ip_dates.get(name_key)
+        sponsor.is_ip = name_key in ip_dates
+
+        groups.setdefault(tier, []).append(sponsor)
+
+    # Sort within each tier
+    for sponsors in groups.values():
+        sponsors.sort(
+            key=lambda s: (
+                s.sort_date is None,  # No date last
+                s.sort_date,  # Sort by date
+                not s.is_ip,  # IP first
+                (s.sponsor_name or "").lower(),  # Then by name
+            )
+        )
+
+    # Sort tiers
+    return dict(sorted(groups.items(), key=lambda x: tier_rank.get(x[0], 999)))

--- a/fossunited/www/fosshack/2026/index.html
+++ b/fossunited/www/fosshack/2026/index.html
@@ -338,7 +338,7 @@
 
         {% for tier in sponsors %}
           {% set tier_name = tier.tier | lower %}
-          {% if tier_name == 'platinum' %}
+          {% if tier_name == 'platinum' or 'Patrons' %}
             {% set bars = 3 %}
             {% set tier_index = 0 %}
             {% set logo_class = 'fh-logo-plat' %}

--- a/fossunited/www/fosshack/2026/index.py
+++ b/fossunited/www/fosshack/2026/index.py
@@ -1,5 +1,7 @@
 import frappe
 
+from fossunited.fossunited.utils import get_event_sponsors
+
 
 def get_context(context):
     """Context for FOSS Hack 2026 page"""
@@ -118,7 +120,7 @@ def get_context(context):
     # Fetch Sponsors
     context.sponsors = [
         {"tier": tier, "sponsor_list": sponsor_list}
-        for tier, sponsor_list in hackathon.get_sponsors().items()
+        for tier, sponsor_list in get_event_sponsors(hackathon).items()
     ]
 
     # Fetch Partners


### PR DESCRIPTION
- Move function to utils since used commonly by event and hackathon doctype
- reuse in foss hack 2026 page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Sponsor data retrieval has been consolidated into a shared utility function for improved consistency across events.
  * Sponsor tier organization and sorting logic has been updated to provide a more standardized display of event sponsors.

* **Updates**
  * Enhanced sponsor display rendering for hackathon events with improved tier-based presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->