### PR TITLE
fix(fh26): fix layout of hackathon dashboard page

### DIFF
--- a/dashboard/src/components/Header.vue
+++ b/dashboard/src/components/Header.vue
@@ -2,9 +2,14 @@
   <header
     class="sticky top-0 z-50 flex items-center justify-between border-b bg-white px-5 py-2.5"
   >
-    <div class="flex gap-1">
-      <FossUnitedLogo class="w-auto h-8" fill="black"></FossUnitedLogo>
-    </div>
+    <router-link
+      to="/"
+      aria-label="Go to homepage"
+      class="flex gap-1 items-center focus:outline-none focus:ring-2 focus:ring-blue-500"
+    >
+      <FossUnitedLogo class="w-auto h-8" fill="black" />
+    </router-link>
+
     <div v-if="session.isLoggedIn" class="flex items-center">
       <Dropdown
         :options="[

--- a/dashboard/src/components/hackathon/HackathonAttendanceMode.vue
+++ b/dashboard/src/components/hackathon/HackathonAttendanceMode.vue
@@ -17,6 +17,7 @@
           organizers due to limited on-site availability.
         </p>
       </div>
+
       <FormControl
         v-model="attendanceMode"
         label="Mode of Attendance"
@@ -24,6 +25,7 @@
         class="mt-4"
         :options="attendanceModeOptions"
       />
+
       <FormControl
         v-if="attendanceMode == 'local'"
         v-model="participant_localhost.data.localhost_name"
@@ -32,6 +34,17 @@
         class="mt-4"
       />
       <div v-if="attendanceMode == 'local-pending'">
+        <div
+          v-if="localhosts.data.length <= 9"
+          class="flex flex-col p-3 mt-4 items-center text-center rounded w-full bg-blue-50 text-blue-600 border-2 border-dashed border-blue-600 text-xs"
+        >
+          <p>
+            <b>Note:</b> This hackathon has a total of
+            <b>10 local host slots</b> available.<br /><br />
+            All localhosts will be added shortly.
+          </p>
+        </div>
+
         <FormControl
           v-if="localhosts.data.length > 0"
           v-model="selectedLocalhost"
@@ -40,7 +53,7 @@
           class="mt-4"
           :options="
             localhosts.data.map((localhost) => ({
-              label: `${localhost.localhost_name}`,
+              label: `${localhost.city} - ${localhost.localhost_name}`,
               value: localhost.name,
             }))
           "

--- a/dashboard/src/components/hackathon/HackathonParticipantHeader.vue
+++ b/dashboard/src/components/hackathon/HackathonParticipantHeader.vue
@@ -5,7 +5,9 @@
     alt="Hackathon banner"
     class="w-full h-32 md:h-full md:max-h-72 object-cover rounded-sm"
   />
-  <img :src="hackathon.data.hackathon_logo" alt="Logo" class="h-10 md:h-14 mt-6 mb-4" />
+  <a :href="hackathon.data.external_website_url" target="_blank" rel="noopener noreferrer">
+    <img :src="hackathon.data.hackathon_logo" alt="Logo" class="h-10 md:h-14 mt-6 mb-4" />
+  </a>
   <div
     class="flex gap-4 items-center rounded-sm w-fit py-2 mt-4 font-medium text-base text-gray-900 stroke-gray-900"
   >

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/templates/foss_hackathon_localhost.html
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/templates/foss_hackathon_localhost.html
@@ -38,7 +38,7 @@
   <span class="z-10 absolute top-3 left-3 p-2 font-mono text-base font-semibold lowercase text-white bg-gray-900">localhost:{{ doc.city }}</span>
   {% set src = doc.image or "/assets/fossunited/images/localhost_placeholder.svg" %}
   <img
-    class="!border-gray-800 border w-96 h-auto aspect-square"
+    class="!border-gray-800 border w-full h-auto aspect-square"
     src="{{ src }}"
     alt="Localhost Image"
   />
@@ -46,8 +46,10 @@
 {% endmacro %}
 
 {% macro hero_section() %}
-  <div class="flex flex-col md:flex-row gap-6">
-    {{ hero_image() }}
+<div class="flex flex-col md:flex-row gap-6">
+    <div class="max-w-96 w-full shrink pr-md-8 pr-0">
+      {{ hero_image() }}
+    </div>
     <div class="flex flex-col justify-between gap-2 w-full">
       <div class="flex flex-col gap-2 w-full items-start">
         {% if hackathon.hackathon_logo %}
@@ -99,7 +101,8 @@
 {% endmacro %}
 
 {% macro primary_button(label, link) %}
-<a class="text-sm text-center basis-2/3 uppercase font-semibold bg-gray-900 hover:bg-gray-800 text-white py-3 px-4 hover:no-underline" href="{{ link }}" target="_blank">
+<a class="text-sm text-center uppercase font-semibold bg-gray-900 hover:bg-gray-800 text-white py-3 px-4 hover:no-underline" href="{{ link }}" target="_blank"
+style="width: 200px;">
   {{ label }}
 </a>
 {% endmacro %}

--- a/fossunited/www/fosshack/2026/index.css
+++ b/fossunited/www/fosshack/2026/index.css
@@ -413,6 +413,10 @@ a:hover,
   background: hsl(0, 0%, 94%);
 }
 
+.margin-10 {
+  margin: 4rem 0rem 1rem 0rem;
+}
+
 /* Logo sizes by tier */
 .fh-logo-plat {
   width: 240px;

--- a/fossunited/www/fosshack/2026/index.html
+++ b/fossunited/www/fosshack/2026/index.html
@@ -308,7 +308,7 @@
                         <div class="localhost-title v3-text">{{ localhost.localhost_name }}</div>
 
                         <div class="d-flex justify-content-between align-items-center">
-                          <small class="v3-text-light">{{ localhost.location }}</small>
+                          <small class="v3-text-light">{{ localhost.location or "" }}</small>
                           <div class="text-end">
                             {% if localhost.attending > 0 %}
                               <small class="text-success d-block">

--- a/fossunited/www/fosshack/2026/index.html
+++ b/fossunited/www/fosshack/2026/index.html
@@ -138,6 +138,7 @@
               >
               <a
                 href="{{ hackathon.event_page_url }}"
+                target="_blank"
                 class="btn v3-bg-muted v3-text text-uppercase font-weight-semibold rounded-0"
                 style="letter-spacing: 1.12px; width: 200px; padding: 12px 16px; border: 1px solid var(--v3-text)"
                 aria-label="Project ideas for {{hackathon.name}}"
@@ -200,7 +201,7 @@
     <div class="grid-2col mb-4">
       <div>
         <div class="v3-card p-4">
-          <h2 class="h4 font-weight-semibold v3-text mb-4">Timeline</h2>
+          <h2 class="h3 font-weight-semibold v3-text mb-4">Timeline</h2>
           {% for item in timeline %}
             <div class="timeline-item">
               <div class="timeline-header" onclick="toggleTimeline(this)" aria-label="Click to Know about {{item.event}} details">
@@ -261,7 +262,7 @@
 
       <div class="v3-card v3-fh-card h-100 d-flex flex-column">
         <div class="p-5 v3-border border">
-          <h2 class="h4 font-weight-semibold v3-text mb-4">Why Participate?</h2>
+          <h2 class="h3 font-weight-semibold v3-text mb-4">Why Participate?</h2>
           <ul class="v3-text-muted pl-4">
             {% for reason in why_participate %}
               <li class="mb-2">{{ reason }}</li>
@@ -270,7 +271,7 @@
         </div>
 
         <div class="p-5 v3-border border flex-grow-1">
-          <h2 class="h4 font-weight-semibold v3-text mb-4">Rules in a nutshell</h2>
+          <h2 class="h3 font-weight-semibold v3-text mb-4">Rules in a nutshell</h2>
           <ul class="v3-text-muted pl-4">
             {% for rule in rules %}
               <li class="mb-2">{{ rule }}</li>
@@ -286,7 +287,7 @@
     {# localhosts #}
     {% if localhosts_by_city %}
       <div class="mb-5">
-        <h2 class="h4 font-weight-semibold v3-text mb-3">Localhosts</h2>
+        <h1 class="h1 font-weight-bold v3-text margin-10">Localhosts</h1>
         <p class="v3-text-muted mb-4">
           FOSS Hack Localhosts are localized, in-person editions of the broader hybrid version.
           Hackers can choose to hack at a localhost in your region.
@@ -334,7 +335,7 @@
 
     {% if sponsors %}
       <div class="mb-5">
-        <h2 class="h4 font-weight-semibold v3-text mb-4">Sponsors</h2>
+        <h1 class="h1 font-weight-bold v3-text margin-10">Sponsors</h1>
 
         {% for tier in sponsors %}
           {% set tier_name = tier.tier | lower %}
@@ -365,7 +366,7 @@
     {# community partners #}
     {% if partners %}
       <div class="mb-5">
-        <h2 class="h4 font-weight-semibold v3-text mb-4">Community Partners</h2>
+        <h1 class="h1 font-weight-bold v3-text margin-10">Community Partners</h1>
         <div class="tier-content">
           {{ logo_grid(partners, 'fh-sponsor-grid-5', 'fh-logo-partner', 7) }}
         </div>
@@ -446,6 +447,7 @@
         <ul class="list-unstyled text-start">
           <li class="mb-2"><a href="https://fossunited.org/code-of-conduct" target="_blank" class="text-decoration-none">Code of Conduct</a></li>
           <li class="mb-2"><a href="https://fossunited.org/fosshack/rules" target="_blank" class="text-decoration-none">Rules</a></li>
+          <li class="mb-2"><a href="https://forum.fossunited.org/t/hackathon-ideas/159" target="_blank" class="text-decoration-none">Project Ideas</a></li>
           <li class="mb-2"><a href="https://forum.fossunited.org/t/foss-hack-rules-guidelines-faq/3334" target="_blank" class="text-decoration-none">Guidelines & FAQ</a></li>
         </ul>
       </div>

--- a/fossunited/www/fosshack/2026/index.py
+++ b/fossunited/www/fosshack/2026/index.py
@@ -139,7 +139,7 @@ def get_context(context):
     ]
 
     context.why_participate = [
-        "Win up to ₹5,00,000 lakhs in cash",
+        "Win up to ₹5,00,000 in cash",
         "Build your reputation as a hacker",
         "Get recognized by recruiters",
         "Grants for your FOSS project",

--- a/fossunited/www/fosshack/2026/index.py
+++ b/fossunited/www/fosshack/2026/index.py
@@ -23,9 +23,9 @@ def get_context(context):
         FOSS Hack 2026 is the sixth edition of FOSS Hack, a hybrid hackathon to promote
         Free and Open Source Software by bringing together students and professionals
         to build or extend FOSS projects""",
-        "prize_pool": "₹10,00,000+",
+        "prize_pool": "₹5,00,000",
         "register_url": f"/dashboard/register-for-hackathon?id={hackathon_id}",
-        "event_page_url": f"/{hackathon.route}",
+        "event_page_url": "https://forum.fossunited.org/t/hackathon-ideas/159",
         "status": "Registrations Open"
         if hackathon.is_registration_live
         else "Opening on Jan 2026",
@@ -58,7 +58,7 @@ def get_context(context):
 
     # Stats
     context.stats = {
-        "prize_pool": "₹ 10,00,000+",
+        "prize_pool": "₹ 5,00,000",
         "local_hosts": "10",
         "participants": member_count,
         "teams": teams_count,
@@ -139,7 +139,7 @@ def get_context(context):
     ]
 
     context.why_participate = [
-        "Win up to ₹TBA lakhs in cash",
+        "Win up to ₹5,00,000 lakhs in cash",
         "Build your reputation as a hacker",
         "Get recognized by recruiters",
         "Grants for your FOSS project",


### PR DESCRIPTION
- Just some minor hackathon pages fix as discussed on "FOSS In Education" call today!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Logo now links to the homepage; hackathon logo opens the event site in a new tab
  * New localhost selection and local-host guidance for participants
  * Added Project Ideas links that open externally

* **UI/Design Updates**
  * Restructured heading levels for clearer visual hierarchy
  * Adjusted hero image and button sizing, spacing, and container layout
  * Added a new margin utility class

* **Bug Fixes**
  * Corrected displayed prize pool amount

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->