### PR TITLE
dashboard(rsvp-insight): show error message + add docs info component to inform help

### DIFF
--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -29,6 +29,7 @@ declare module 'vue' {
     CopyToClipboardButton: typeof import('./src/components/CopyToClipboardButton.vue')['default']
     CopyToClipboardComponent: typeof import('./src/components/CopyToClipboardComponent.vue')['default']
     CreateCampaignDrawer: typeof import('./src/components/mailing/CreateCampaignDrawer.vue')['default']
+    DocsInfo: typeof import('./src/components/DocsInfo.vue')['default']
     Drawer: typeof import('./src/components/ui/Drawer.vue')['default']
     EditMember: typeof import('./src/components/chapter/EditMember.vue')['default']
     EmailFormTemplate: typeof import('./src/components/mailing/EmailFormTemplate.vue')['default']

--- a/dashboard/src/components/DocsInfo.vue
+++ b/dashboard/src/components/DocsInfo.vue
@@ -1,0 +1,40 @@
+<template>
+  <div
+    class="inline-flex self-start items-center gap-1 p-2 rounded bg-blue-50 border-2 border-dashed border-blue-600 text-sm"
+  >
+    <IconBook2 class="w-6 h-6 flex-shrink-0" />
+
+    <slot>
+      {{ message }}
+    </slot>
+
+    <a
+      v-if="docsUrl"
+      :href="docsUrl"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="text-blue-600 hover:underline ml-1"
+    >
+      {{ docsLabel }}
+    </a>
+  </div>
+</template>
+
+<script setup>
+import { IconBook2 } from '@tabler/icons-vue'
+
+defineProps({
+  message: {
+    type: String,
+    default: '',
+  },
+  docsUrl: {
+    type: String,
+    default: 'https://docs.fossunited.org/',
+  },
+  docsLabel: {
+    type: String,
+    default: 'Read more',
+  },
+})
+</script>

--- a/dashboard/src/pages/EventRsvpInsights.vue
+++ b/dashboard/src/pages/EventRsvpInsights.vue
@@ -40,10 +40,17 @@
 
     <!-- Attendance Status Section -->
     <div class="flex flex-col gap-4 mt-1">
-      <div v-if="rsvp_form.data?.requires_host_approval" class="text-sm text-gray-600">
-        Note: Host approval is enabled, attendees will receive an email notification when you
-        accept or reject their RSVP.
-      </div>
+      <DocsInfo
+        v-if="rsvp_form.data?.requires_host_approval"
+        message="Host approval is enabled, attendees will receive an email notification when you
+        accept or reject their RSVP."
+        docs-url="https://docs.fossunited.org/event-rsvp/#restrictive-access-to-event"
+      />
+
+      <DocsInfo
+        message="You can check-in attendees once the event starts."
+        docs-url="https://docs.fossunited.org/event-rsvp/#event-check-ins"
+      />
 
       <div class="font-semibold text-gray-800">Attendance Status</div>
 

--- a/dashboard/src/pages/EventRsvpInsights.vue
+++ b/dashboard/src/pages/EventRsvpInsights.vue
@@ -72,7 +72,10 @@
             {{ item ? 'Yes' : 'No' }}
           </span>
 
-          <div v-else-if="column.key === 'checkin_action'" class="flex gap-2">
+          <div
+            v-else-if="column.key === 'checkin_action' && row.is_attending === true"
+            class="flex gap-2"
+          >
             <Button
               v-if="!row.has_checked_in_today"
               size="sm"
@@ -121,6 +124,7 @@ import { createResource, Button } from 'frappe-ui'
 import SearchListView from '@/components/ui/SearchListView.vue'
 import { toast } from 'vue-sonner'
 import { truncateStr, formatFullDate, formatTimeOnly } from '@/helpers/utils'
+import DocsInfo from '@/components/DocsInfo.vue'
 
 const route = useRoute()
 
@@ -281,6 +285,7 @@ watchEffect(() => {
   rows.forEach((row) => {
     const confirmed = Boolean(row.confirm_attendance)
     const status = row.status || ''
+    row.is_attending = requiresApproval ? row.status === 'Accepted' && confirmed : confirmed
 
     if (requiresApproval) {
       if (status === 'Pending') pending.push(row)
@@ -361,7 +366,8 @@ const updateRsvpStatus = (row, status) => {
       submissions.fetch()
     },
     onError(err) {
-      toast.error(err.message || 'Update failed')
+      const message = err?.messages?.[0] || err?.message || 'RSVP status Update failed'
+      toast.error(message)
     },
   }).fetch()
 }
@@ -377,13 +383,14 @@ const checkInAttendee = (row) => {
     url: 'fossunited.chapters.doctype.foss_event_rsvp_submission.foss_event_rsvp_submission.self_check_in',
     params: { submission_name: row.name },
     onSuccess() {
-      toast.success('Checked in successfully')
+      toast.success(`Checked in ${row.name1} successfully`)
       submissions.fetch()
       checkins.reload()
       eventStats.reload()
     },
     onError(err) {
-      toast.error(err.message || 'Check-in failed')
+      const message = err?.messages?.[0] || err?.message || 'Check-in failed'
+      toast.error(message)
     },
   }).fetch()
 }
@@ -407,7 +414,8 @@ const undoCheckIn = (row) => {
       eventStats.reload()
     },
     onError(err) {
-      toast.error(err.message || 'Failed to remove check-in')
+      const message = err?.messages?.[0] || err?.message || 'Failed to remove check-in'
+      toast.error(message)
     },
   }).fetch()
 }


### PR DESCRIPTION
- Show direct frappe.throw error message rather than python validation error
  ^ Note: Check-ins is only available during event timeline (so it threw that)

- Add component to show help and point to docs page for more info on each page
  ^ TODO expand on all other pages to point there

<img width="1290" height="957" alt="image" src="https://github.com/user-attachments/assets/c1fadb36-d026-4dc9-a85d-75e55fc128b1" />

- Show Docs help card
- show error reason


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added documentation info badges throughout the RSVP management interface, providing quick access to relevant documentation with customizable links and labels.

* **Bug Fixes**
  * Enhanced error messaging for RSVP status updates and check-in operations with improved attendee information.
  * Refined check-in action display to appear only for confirmed attendees.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->