### PR TITLE
component(editLocalhost): page to edit localhost data

### DIFF
--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -64,6 +64,7 @@ declare module 'vue' {
     LikesIcon: typeof import('./src/components/icons/LikesIcon.vue')['default']
     LivePing: typeof import('./src/components/animation/LivePing.vue')['default']
     LocalhostHeader: typeof import('./src/components/localhost/LocalhostHeader.vue')['default']
+    LocalhostLayout: typeof import('./src/components/localhost/LocalhostLayout.vue')['default']
     ManageActions: typeof import('./src/components/mailing/ManageActions.vue')['default']
     ManageCampaignDrawer: typeof import('./src/components/mailing/ManageCampaignDrawer.vue')['default']
     ManageDates: typeof import('./src/components/event/schedule/ManageDates.vue')['default']

--- a/dashboard/src/components/localhost/LocalhostLayout.vue
+++ b/dashboard/src/components/localhost/LocalhostLayout.vue
@@ -1,0 +1,39 @@
+<template>
+  <Dialog
+    :model-value="showDialog"
+    class="z-50"
+    :options="{
+      title: 'Error',
+      message: dialogMessage,
+    }"
+    @update:model-value="$emit('update:showDialog', $event)"
+  />
+  <Header />
+  <div v-if="isValidated" class="w-full p-4 flex items-center justify-center">
+    <div class="max-w-screen-xl w-full">
+      <slot />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { Dialog } from 'frappe-ui'
+import Header from '@/components/Header.vue'
+
+defineProps({
+  isValidated: {
+    type: Boolean,
+    required: true,
+  },
+  showDialog: {
+    type: Boolean,
+    required: true,
+  },
+  dialogMessage: {
+    type: String,
+    default: '',
+  },
+})
+
+defineEmits(['update:showDialog'])
+</script>

--- a/dashboard/src/components/localhost/LocalhostValidation.js
+++ b/dashboard/src/components/localhost/LocalhostValidation.js
@@ -1,0 +1,41 @@
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { createResource } from 'frappe-ui'
+
+export function LocalhostValidation(localhostId, redirectRoute = 'MyLocalhosts') {
+  const router = useRouter()
+  const isValidated = ref(false)
+  const dialogMessage = ref('')
+  const showDialog = ref(false)
+
+  const validateSessionUser = (onSuccessCallback) => {
+    createResource({
+      url: 'fossunited.api.hackathon.validate_user_as_localhost_member',
+      params: {
+        localhost_id: localhostId,
+      },
+      auto: true,
+      onSuccess(data) {
+        isValidated.value = true
+        if (onSuccessCallback) {
+          onSuccessCallback(data)
+        }
+      },
+      onError(error) {
+        isValidated.value = false
+        dialogMessage.value = error.messages
+        showDialog.value = true
+        setTimeout(() => {
+          router.push({ name: redirectRoute })
+        }, 2000)
+      },
+    })
+  }
+
+  return {
+    isValidated,
+    dialogMessage,
+    showDialog,
+    validateSessionUser,
+  }
+}

--- a/dashboard/src/pages/localhost/LocalhostEdit.vue
+++ b/dashboard/src/pages/localhost/LocalhostEdit.vue
@@ -1,8 +1,10 @@
 <template>
-  <Header />
-
-  <div v-if="localhost.doc" class="w-full p-4 flex justify-center">
-    <div class="max-w-screen-xl w-full">
+  <LocalhostLayout
+    :is-validated="isValidated"
+    v-model:show-dialog="showDialog"
+    :dialog-message="dialogMessage"
+  >
+    <div v-if="localhost.doc">
       <!-- Page Header -->
       <div class="flex flex-col md:flex-row justify-between gap-2 mt-4">
         <div>
@@ -136,29 +138,42 @@
         </div>
       </div>
     </div>
-  </div>
+  </LocalhostLayout>
 </template>
 
 <script setup>
 import { createDocumentResource, FileUploader, FormControl, Button, Switch } from 'frappe-ui'
-import { ref } from 'vue'
-import { useRoute } from 'vue-router'
+import { ref, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { toast } from 'vue-sonner'
 
-import Header from '@/components/Header.vue'
 import LocalhostHeader from '@/components/localhost/LocalhostHeader.vue'
+import LocalhostLayout from '@/components/localhost/LocalhostLayout.vue'
 import CopyToClipboardComponent from '@/components/CopyToClipboardComponent.vue'
+import { LocalhostValidation } from '@/components/localhost/LocalhostValidation'
 
 const route = useRoute()
+const router = useRouter()
 const wholeRoute = ref('')
+
+const { isValidated, dialogMessage, showDialog, validateSessionUser } = LocalhostValidation(
+  route.params.id,
+  'MyLocalhosts',
+)
 
 const localhost = createDocumentResource({
   doctype: 'FOSS Hackathon LocalHost',
   name: route.params.id,
   fields: ['*'],
-  auto: true,
+  auto: false,
   onSuccess(doc) {
     wholeRoute.value = `${window.location.origin}/${doc.route}`
+  },
+  onError(error) {
+    toast.error('Failed to load localhost', { description: error.message })
+    setTimeout(() => {
+      router.push({ name: 'MyLocalhosts' })
+    }, 2000)
   },
 })
 
@@ -192,4 +207,10 @@ const updateLocalhost = () => {
     .then(() => toast.success('Localhost updated successfully'))
     .catch((err) => toast.error('Failed to update localhost', { description: err.message }))
 }
+
+onMounted(() => {
+  validateSessionUser(() => {
+    localhost.reload()
+  })
+})
 </script>

--- a/dashboard/src/pages/localhost/LocalhostEdit.vue
+++ b/dashboard/src/pages/localhost/LocalhostEdit.vue
@@ -1,0 +1,195 @@
+<template>
+  <Header />
+
+  <div v-if="localhost.doc" class="w-full p-4 flex justify-center">
+    <div class="max-w-screen-xl w-full">
+      <!-- Page Header -->
+      <div class="flex flex-col md:flex-row justify-between gap-2 mt-4">
+        <div>
+          <div class="text-base font-medium">Edit Localhost</div>
+          <div class="text-sm text-gray-600">Update venue details and visibility</div>
+        </div>
+
+        <div class="flex flex-wrap gap-2">
+          <RouterLink :to="{ name: 'ManageLocalhost', params: { id: route.params.id } }">
+            <Button variant="subtle" icon-left="arrow-left" label="Back to Manage" />
+          </RouterLink>
+
+          <Button
+            :theme="localhost.doc.is_published ? 'red' : 'green'"
+            :icon-left="localhost.doc.is_published ? 'slash' : 'upload'"
+            :label="localhost.doc.is_published ? 'Unpublish' : 'Publish'"
+            @click="togglePublish"
+          />
+          <Button variant="solid" label="Update Localhost" @click="updateLocalhost" />
+        </div>
+      </div>
+
+      <!-- Localhost Header -->
+      <LocalhostHeader :localhost="localhost.doc" />
+
+      <div class="rounded-sm border p-4 my-6">
+        <div class="text-sm uppercase font-medium mb-3">Localhost Overview</div>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <!-- Left: Image -->
+          <div>
+            <img
+              :src="getImage()"
+              class="w-[200px] aspect-square object-cover border rounded-lg"
+            />
+
+            <div class="flex gap-2 mt-3">
+              <FileUploader
+                file-types="image/*"
+                :validate-file="validateImage"
+                @success="setImage"
+              >
+                <template #default="{ uploading, progress, openFileSelector }">
+                  <Button
+                    variant="subtle"
+                    size="md"
+                    :label="uploading ? `Uploading ${progress}%` : 'Upload Image'"
+                    @click="openFileSelector"
+                  />
+                </template>
+              </FileUploader>
+
+              <Button
+                v-if="localhost.doc.image"
+                variant="subtle"
+                theme="red"
+                label="Remove Image"
+                @click="() => setImage({ file_url: '' })"
+              />
+            </div>
+
+            <div class="text-sm text-gray-600 mt-2">Recommended size: 1:1 square image</div>
+          </div>
+
+          <!-- Right: Meta -->
+          <div class="flex flex-col gap-4">
+            <div class="grid grid-cols-2 gap-4">
+              <div class="flex flex-col gap-1">
+                <label class="text-sm font-medium text-gray-700">State</label>
+                <div class="px-3 py-2 border rounded-md bg-gray-50">
+                  {{ localhost.doc.state || '—' }}
+                </div>
+              </div>
+
+              <div class="flex flex-col gap-1">
+                <label class="text-sm font-medium text-gray-700">City</label>
+                <div class="px-3 py-2 border rounded-md bg-gray-50">
+                  {{ localhost.doc.city || '—' }}
+                </div>
+              </div>
+            </div>
+
+            <div>
+              <label class="text-sm font-medium text-gray-700 mb-1 block"> Public Route </label>
+              <CopyToClipboardComponent :route="wholeRoute" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Details -->
+      <div class="rounded-sm border p-4 my-6">
+        <div class="text-sm uppercase font-medium mb-3">Localhost Details</div>
+
+        <div class="grid sm:grid-cols-1 md:grid-cols-2 gap-6">
+          <FormControl
+            v-model="localhost.doc.localhost_name"
+            type="text"
+            label="Localhost Name"
+            size="md"
+          />
+
+          <FormControl
+            v-model="localhost.doc.email"
+            type="email"
+            label="Contact Email"
+            size="md"
+          />
+
+          <FormControl
+            v-model="localhost.doc.location"
+            type="text"
+            label="Location Address"
+            size="md"
+          />
+
+          <FormControl v-model="localhost.doc.map_link" type="url" label="Map Link" size="md" />
+
+          <!-- Accepting Attendees -->
+          <div class="md:col-span-2">
+            <div class="flex items-center justify-between p-3 border rounded-md">
+              <div class="flex flex-col">
+                <span class="font-medium text-gray-800"> Accepting Attendees </span>
+                <span class="text-sm text-gray-600">
+                  Allow attendees to register for this localhost.
+                </span>
+              </div>
+              <Switch v-model="localhost.doc.is_accepting_attendees" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { createDocumentResource, FileUploader, FormControl, Button, Switch } from 'frappe-ui'
+import { ref } from 'vue'
+import { useRoute } from 'vue-router'
+import { toast } from 'vue-sonner'
+
+import Header from '@/components/Header.vue'
+import LocalhostHeader from '@/components/localhost/LocalhostHeader.vue'
+import CopyToClipboardComponent from '@/components/CopyToClipboardComponent.vue'
+
+const route = useRoute()
+const wholeRoute = ref('')
+
+const localhost = createDocumentResource({
+  doctype: 'FOSS Hackathon LocalHost',
+  name: route.params.id,
+  fields: ['*'],
+  auto: true,
+  onSuccess(doc) {
+    wholeRoute.value = `${window.location.origin}/${doc.route}`
+  },
+})
+
+const validateImage = (file) => {
+  const ext = file.name.split('.').pop().toLowerCase()
+  if (!['png', 'jpg', 'jpeg', 'webp'].includes(ext)) {
+    return 'Only PNG, Webp & JPG images are allowed'
+  }
+}
+
+const getImage = () => {
+  return localhost.doc.image || '/assets/fossunited/images/localhost_placeholder.svg'
+}
+
+const setImage = (file) => {
+  localhost.setValue.submit({ image: file.file_url })
+  toast.success(file.file_url ? 'Image updated' : 'Image removed')
+}
+
+const togglePublish = () => {
+  const newValue = !localhost.doc.is_published
+  localhost.setValue.submit({ is_published: newValue })
+  toast[newValue ? 'success' : 'warning'](
+    newValue ? 'Localhost published' : 'Localhost unpublished',
+  )
+}
+
+const updateLocalhost = () => {
+  localhost.save
+    .submit()
+    .then(() => toast.success('Localhost updated successfully'))
+    .catch((err) => toast.error('Failed to update localhost', { description: err.message }))
+}
+</script>

--- a/dashboard/src/pages/localhost/ManageLocalhost.vue
+++ b/dashboard/src/pages/localhost/ManageLocalhost.vue
@@ -1,17 +1,10 @@
 <template>
-  <Dialog
-    v-model="showDialog"
-    class="z-50"
-    :options="{
-      title: 'Error',
-      message: dialogMessage,
-    }"
-  />
-  <Header />
-  <div v-if="localhost.data && requests.data" class="w-full p-4 flex items-center justify-center">
-    <div class="max-w-screen-xl w-full">
-      <div class="text-base font-medium mt-4">Manage LocalHost</div>
-      <LocalhostHeader :localhost="localhost.data" />
+  <LocalhostLayout
+    :is-validated="isValidated"
+    v-model:show-dialog="showDialog"
+    :dialog-message="dialogMessage"
+  >
+    <div v-if="localhost.data && requests.data">
       <div class="flex items-center justify-between mt-4">
         <div class="text-base font-medium">Manage Localhost</div>
 
@@ -19,6 +12,8 @@
           <Button label="Edit Details" icon-left="edit" />
         </RouterLink>
       </div>
+
+      <LocalhostHeader :localhost="localhost.data" />
 
       <div class="grid grid-cols-1 md:grid-cols-2">
         <div class="rounded-sm border-2 border-dashed border-gray-400 p-4 my-2">
@@ -49,7 +44,8 @@
           </div>
         </div>
       </div>
-      <div v-if="requests.data" class="grid grid-cols-1 sm:grid-cols-5 mt-6 mb-4 gap-4">
+
+      <div class="grid grid-cols-1 sm:grid-cols-5 mt-6 mb-4 gap-4">
         <div class="flex flex-col gap-2 bg-gray-50 w-full p-4 rounded border">
           <div class="text-base font-medium">Total Requests</div>
           <div class="text-2xl">
@@ -81,26 +77,24 @@
           </div>
         </div>
       </div>
+
       <hr />
+
       <div class="flex flex-col gap-2 py-4">
         <AttendeeRequestList :localhost="localhost" @update-request="requests.reload()" />
       </div>
     </div>
-  </div>
+  </LocalhostLayout>
 </template>
+
 <script setup>
 import { useRoute } from 'vue-router'
-import {
-  createDocumentResource,
-  createListResource,
-  createResource,
-  usePageMeta,
-  Dialog,
-} from 'frappe-ui'
-import { onMounted, ref } from 'vue'
+import { createListResource, createResource, usePageMeta } from 'frappe-ui'
+import { onMounted } from 'vue'
 import AttendeeRequestList from '@/components/localhost/AttendeeRequestList.vue'
 import LocalhostHeader from '@/components/localhost/LocalhostHeader.vue'
-import Header from '@/components/Header.vue'
+import LocalhostLayout from '@/components/localhost/LocalhostLayout.vue'
+import { LocalhostValidation } from '@/components/localhost/LocalhostValidation'
 
 const route = useRoute()
 
@@ -110,33 +104,10 @@ usePageMeta(() => {
   }
 })
 
-onMounted(() => {
-  validateSessionUser()
-})
-
-const dialogMessage = ref('')
-const showDialog = ref(false)
-
-const validateSessionUser = () => {
-  createResource({
-    url: 'fossunited.api.hackathon.validate_user_as_localhost_member',
-    params: {
-      localhost_id: route.params.id,
-    },
-    auto: true,
-    onSuccess(data) {
-      localhost.fetch()
-      requests.fetch()
-    },
-    onError(error) {
-      dialogMessage.value = error.messages
-      showDialog.value = true
-      setTimeout(() => {
-        window.location.href = '/dashboard'
-      }, 2000)
-    },
-  })
-}
+const { isValidated, dialogMessage, showDialog, validateSessionUser } = LocalhostValidation(
+  route.params.id,
+  'MyLocalhosts',
+)
 
 const requests = createListResource({
   doctype: 'FOSS Hackathon Participant',
@@ -152,18 +123,10 @@ const requests = createListResource({
       acc[curr.localhost_request_status].push(curr)
       return acc
     }, {})
-    if (!data['Pending']) {
-      data['Pending'] = []
-    }
-    if (!data['Accepted']) {
-      data['Accepted'] = []
-    }
-    if (!data['Rejected']) {
-      data['Rejected'] = []
-    }
-    if (!data['Pending Confirmation']) {
-      data['Pending Confirmation'] = []
-    }
+    if (!data['Pending']) data['Pending'] = []
+    if (!data['Accepted']) data['Accepted'] = []
+    if (!data['Rejected']) data['Rejected'] = []
+    if (!data['Pending Confirmation']) data['Pending Confirmation'] = []
     return data
   },
   pageLength: 99999,
@@ -195,4 +158,11 @@ const toggleAcceptingAttendees = () => {
     auto: true,
   })
 }
+
+onMounted(() => {
+  validateSessionUser(() => {
+    localhost.fetch()
+    requests.fetch()
+  })
+})
 </script>

--- a/dashboard/src/pages/localhost/ManageLocalhost.vue
+++ b/dashboard/src/pages/localhost/ManageLocalhost.vue
@@ -12,6 +12,14 @@
     <div class="max-w-screen-xl w-full">
       <div class="text-base font-medium mt-4">Manage LocalHost</div>
       <LocalhostHeader :localhost="localhost.data" />
+      <div class="flex items-center justify-between mt-4">
+        <div class="text-base font-medium">Manage Localhost</div>
+
+        <RouterLink :to="{ name: 'LocalhostEdit', params: { id: route.params.id } }">
+          <Button label="Edit Details" icon-left="edit" />
+        </RouterLink>
+      </div>
+
       <div class="grid grid-cols-1 md:grid-cols-2">
         <div class="rounded-sm border-2 border-dashed border-gray-400 p-4 my-2">
           <div class="text-sm uppercase font-medium">Current Status</div>

--- a/dashboard/src/router.js
+++ b/dashboard/src/router.js
@@ -290,6 +290,11 @@ const routes = [
         name: 'ManageLocalhost',
         component: () => import('@/pages/localhost/ManageLocalhost.vue'),
       },
+      {
+        path: 'edit',
+        name: 'LocalhostEdit',
+        component: () => import('@/pages/localhost/LocalhostEdit.vue'),
+      },
     ],
   },
   {


### PR DESCRIPTION
- reduce staff to use dashboard for editing localhost items

- let them edit on their own!

<img width="1972" height="613" alt="image" src="https://github.com/user-attachments/assets/ee208caf-ee0a-49aa-904b-e4ba53aa6117" />

<img width="1972" height="1198" alt="image" src="https://github.com/user-attachments/assets/1a42c5d4-38d7-43ba-bf32-8b76cecaa5e5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full edit page for localhost profiles (fields, image upload, publish toggle, attendee settings, copy-to-clipboard).
  * Added an in-header "Edit Details" action and a route to access the edit page.

* **Refactor / Layout**
  * Introduced a validated localhost layout wrapper that centralizes dialog and header behavior.
  * Added a reusable validation utility to manage session validation and dialog-driven redirects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->