### PR TITLE
macros(breadcrumb): add theme toggle and common v3_navbar

### DIFF
--- a/dashboard/src/pages/MyChapters.vue
+++ b/dashboard/src/pages/MyChapters.vue
@@ -29,7 +29,7 @@
           <EventCard v-for="event in concluded_events" :key="event.name" :event="event" />
         </div>
         <div v-else class="text-base mt-6 text-gray-800">
-          <div>No concluded events found.</div>
+          <div>No recently concluded events found.</div>
         </div>
       </div>
     </div>

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -509,6 +509,15 @@ class FOSSChapterEvent(WebsiteGenerator):
 
         return check_if_chapter_or_event_core_member(self.name)
 
+    def get_breadcrumb(self):
+        crumbs = [
+            {"route": "/", "label": "Home"},
+            {"route": "/events/timeline", "label": "Events"},
+            {"label": self.event_name},
+        ]
+
+        return crumbs
+
     def get_context(self, context):
         context.chapter = frappe.get_doc(CHAPTER, self.chapter)
         context.sponsors_dict = get_event_sponsors(self)
@@ -549,6 +558,8 @@ class FOSSChapterEvent(WebsiteGenerator):
                 context.map_lng = float(lng_str) if lng_str and lng_str != "None" else None
             except (ValueError, AttributeError):
                 pass
+
+        context.breadcrumbs = self.get_breadcrumb()
 
         context.no_cache = 1
 

--- a/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
+++ b/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
@@ -4,6 +4,7 @@
 {% from "fossunited/templates/macros/agenda_card.html" import agenda_card %}
 {% from "fossunited/templates/macros/sponsor_card.html" import sponsor_card %}
 {% from "fossunited/templates/macros/projects_card.html" import projects_card %}
+{% from "fossunited/templates/macros/breadcrumb.html" import breadcrumb, theme_toggle %}
 
 {% macro cfp_block(cfp_status_block, doc) %}
   {% if cfp_status_block.is_published and not cfp_status_block.closing_soon %}
@@ -315,21 +316,8 @@
   <div class="v3-page ev-page">
     <div class="v3-container">
       <div class="d-flex justify-content-between align-items-center">
-        <nav class="v3-breadcrumb" aria-label="Breadcrumb navigation">
-          <a href="/">Home</a> > <a href="/events/timeline">Events</a> >
-          <a href="" aria-current="page">{{ doc.event_name }}</a>
-        </nav>
-
-        <div>
-          <button
-            class="v3-theme-toggle"
-            id="theme-toggle"
-            title="Toggle theme"
-            aria-label="Toggle dark/light theme"
-          >
-            <i class="ti ti-moon" aria-hidden="true"></i>
-          </button>
-        </div>
+        {{ breadcrumb(breadcrumbs) }}
+        {{ theme_toggle() }}
       </div>
 
       <!-- Main Event Card - Fixed 840px -->
@@ -716,9 +704,6 @@
         })
       }
 
-      document.addEventListener('DOMContentLoaded', function () {
-        initThemeToggle('theme-toggle')
-      })
     </script>
   </div>
 {% endblock %}

--- a/fossunited/fossunited/doctype/grants_funding_directory/templates/grants_funding_directory.html
+++ b/fossunited/fossunited/doctype/grants_funding_directory/templates/grants_funding_directory.html
@@ -1,3 +1,5 @@
+{% from "fossunited/templates/macros/breadcrumb.html" import v3_navbar %}
+
 {% extends "templates/foss_base.html" %}
 
 {% block title %}{{ entity.name }} – Funding Profile{% endblock %}
@@ -25,17 +27,7 @@
   <div class="v3-page">
     <div class="v3-container">
       <!-- Breadcrumb -->
-      <div class="d-flex justify-content-between align-items-center">
-        <nav class="v3-breadcrumb">
-          <a href="/">Home</a> > <a href="/grants/">Grants</a> >
-          <a href="/grants/directory">Directory</a> > <a href="">{{ entity.name }}</a>
-        </nav>
-        <div>
-          <button class="v3-theme-toggle" id="theme-toggle" title="Toggle theme">
-            <i class="ti ti-moon"></i>
-          </button>
-        </div>
-      </div>
+      {{ v3_navbar() }}
 
       <!-- Header Card -->
       {# helper macro to avoid repeating URL checks #}
@@ -332,9 +324,4 @@
     </div>
   </div>
 
-  <script>
-    document.addEventListener('DOMContentLoaded', function () {
-      initThemeToggle('theme-toggle')
-    })
-  </script>
 {% endblock %}

--- a/fossunited/fossunited/web_template/first_commit/first_commit.html
+++ b/fossunited/fossunited/web_template/first_commit/first_commit.html
@@ -1,3 +1,5 @@
+{% from "fossunited/templates/macros/breadcrumb.html" import v3_navbar %}
+
 {% block foss_base %}
 <link
   rel="stylesheet"
@@ -193,12 +195,7 @@
 
   <div class="v3-page">
     <div class="v3-container">
-      <div class="d-flex justify-content-between align-items-center">
-        <nav class="v3-breadcrumb"><a href="/">Home</a> > First-commit</nav>
-          <button class="v3-theme-toggle" id="theme-toggle" title="Toggle theme">
-            <i class="ti ti-moon"></i>
-          </button>
-      </div>
+      {{ v3_navbar() }}
 
       <!-- Banner Section -->
       <div class="">
@@ -233,9 +230,4 @@
     </div>
   </div>
 
-  <script>
-    document.addEventListener('DOMContentLoaded', function () {
-      initThemeToggle('theme-toggle')
-    })
-  </script>
 {% endblock %}

--- a/fossunited/fossunited/web_template/get_event_tickets/get_event_tickets.html
+++ b/fossunited/fossunited/web_template/get_event_tickets/get_event_tickets.html
@@ -1,3 +1,5 @@
+{% from "fossunited/templates/macros/breadcrumb.html" import v3_navbar %}
+
 {% block foss_base %}
 <link
   rel="stylesheet"
@@ -19,14 +21,7 @@
 
   <div class="v3-page">
     <div class="v3-container mb-5">
-      <div
-        style="display:flex; justify-content:space-between; align-items:center; margin-bottom:1rem;"
-      >
-        <nav class="v3-breadcrumb"><a href="/">Home</a> > <a href="">{{ page_title }}</a></nav>
-        <button class="v3-theme-toggle" id="theme-toggle" title="Toggle theme">
-          <i class="ti ti-moon"></i>
-        </button>
-      </div>
+      {{ v3_navbar() }}
 
       <div class="v3-card v3-main-card">
         <div class="mb-5">
@@ -104,8 +99,6 @@
     let foundTickets = []
 
     document.addEventListener('DOMContentLoaded', function () {
-      if (typeof initThemeToggle === 'function') initThemeToggle('theme-toggle')
-
       loadEvents()
 
       const urlParams = new URLSearchParams(window.location.search)

--- a/fossunited/fossunited/web_template/grants_thesis/grants_thesis.html
+++ b/fossunited/fossunited/web_template/grants_thesis/grants_thesis.html
@@ -1,3 +1,5 @@
+{% from "fossunited/templates/macros/breadcrumb.html" import v3_navbar %}
+
 {% block foss_base %}
 <link
   rel="stylesheet"
@@ -62,14 +64,9 @@
 
   <div class="v3-page">
     <div class="v3-container">
-      <div class="d-flex justify-content-between align-items-center">
-        <nav class="v3-breadcrumb"><a href="/">Home</a> > <a href="/grants">Grants</a> > {{ page_title }}</nav>
-        <button class="v3-theme-toggle" id="theme-toggle" title="Toggle theme">
-          <i class="ti ti-moon"></i>
-        </button>
-      </div>
+      {{ v3_navbar() }}
 
-      <div style="display: flex; flex-direction: column; gap: 4rem; padding: 1.5rem 0;">
+      <div style="display: flex; flex-direction: column; gap: 4rem;">
 
         <div style="display: flex; flex-direction: column; gap: 2rem;">
           <h1 class="v3-text-primary" style="font-size: 2.5rem; font-weight: 700; line-height: 1.2; margin: 0;">
@@ -156,9 +153,4 @@
     </div>
   </div>
 
-  <script>
-    document.addEventListener('DOMContentLoaded', function () {
-      initThemeToggle('theme-toggle')
-    })
-  </script>
 {% endblock %}

--- a/fossunited/fossunited/web_template/volunteers_page/volunteers_page.html
+++ b/fossunited/fossunited/web_template/volunteers_page/volunteers_page.html
@@ -1,3 +1,5 @@
+{% from "fossunited/templates/macros/breadcrumb.html" import v3_navbar %}
+
 {% block foss_base %}
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/tabler-icons.min.css" />
 <style>{% include "public/css/custom.css" %}</style>
@@ -110,10 +112,7 @@
 
 <div class="v3-page">
   <div class="v3-container">
-    <div class="d-flex justify-content-between align-items-center">
-      <nav class="v3-breadcrumb"><a href="/">Home</a> > <a href="">Volunteers</a></nav>
-      <button class="v3-theme-toggle" id="theme-toggle"><i class="ti ti-moon"></i></button>
-    </div>
+    {{ v3_navbar() }}
 
     <div class="vol-hero-section">
       <div>
@@ -348,8 +347,6 @@
   });
 
   document.getElementById('surprise').addEventListener('click', surpriseMe);
-
-  document.addEventListener('DOMContentLoaded', () => initThemeToggle('theme-toggle'));
 
   // Initial render
   renderMembers();

--- a/fossunited/public/js/common_functions.js
+++ b/fossunited/public/js/common_functions.js
@@ -226,30 +226,32 @@ function resetTooltip() {
   $('.tooltip-text').html('Copy Link')
 }
 
-window.initThemeToggle = function (toggleButtonId) {
-  const themeToggle = document.getElementById(toggleButtonId)
-  const themeIcon = themeToggle.querySelector('i')
-  let savedTheme = localStorage.getItem('theme')
+document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.getElementById('theme-toggle')
+  if (!toggle) return
 
+  const icon = toggle.querySelector('i')
+  const lightIcon = toggle.dataset.lightIcon || 'ti-moon'
+  const darkIcon = toggle.dataset.darkIcon || 'ti-sun'
+
+  let savedTheme = localStorage.getItem('theme')
   if (!savedTheme) {
     savedTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
   }
 
-  document.documentElement.setAttribute('data-theme', savedTheme)
-  updateThemeIcon(savedTheme)
+  apply(savedTheme)
 
-  themeToggle.addEventListener('click', () => {
-    const currentTheme = document.documentElement.getAttribute('data-theme')
-    const newTheme = currentTheme === 'dark' ? 'light' : 'dark'
-    document.documentElement.setAttribute('data-theme', newTheme)
-    localStorage.setItem('theme', newTheme)
-    updateThemeIcon(newTheme)
+  toggle.addEventListener('click', () => {
+    savedTheme = savedTheme === 'dark' ? 'light' : 'dark'
+    localStorage.setItem('theme', savedTheme)
+    apply(savedTheme)
   })
 
-  function updateThemeIcon(theme) {
-    themeIcon.className = theme === 'dark' ? 'ti ti-sun' : 'ti ti-moon'
+  function apply(theme) {
+    document.documentElement.setAttribute('data-theme', theme)
+    icon.className = `ti ${theme === 'dark' ? darkIcon : lightIcon}`
   }
-}
+})
 
 // "2025-12-29" -> "Monday, December 29, 2025"
 function formatFullDate(dateInput, locale = 'en-IN') {

--- a/fossunited/templates/grants_details.html
+++ b/fossunited/templates/grants_details.html
@@ -1,18 +1,13 @@
 {% extends "templates/foss_base.html" %}
 {% from "fossunited/templates/macros/grants_card.html" import grant_item_card %}
-{% from "fossunited/templates/macros/breadcrumb.html" import breadcrumb %}
+{% from "fossunited/templates/macros/breadcrumb.html" import v3_navbar %}
 
 {% block title %}{{ page_title }} | FOSS United{% endblock %}
 
 {% block page_content %}
   <div class="v3-page">
     <div class="v3-container mb-5">
-      <div class="d-flex justify-content-between align-items-center">
-        {{ breadcrumb(breadcrumbs) }}
-        <button class="v3-theme-toggle" id="theme-toggle" title="Toggle theme">
-          <i class="ti ti-moon"></i>
-        </button>
-      </div>
+      {{ v3_navbar() }}
 
       <div class="v3-card mb-4">
         <!-- Header: Title, Description, Count -->

--- a/fossunited/templates/macros/breadcrumb.html
+++ b/fossunited/templates/macros/breadcrumb.html
@@ -27,3 +27,22 @@
     {% endif %}
   </nav>
 {% endmacro %}
+
+{% macro theme_toggle(dark_icon="ti-sun", light_icon="ti-moon") %}
+  <button
+    class="v3-theme-toggle"
+    id="theme-toggle"
+    data-dark-icon="{{dark_icon}}"
+    data-light-icon="{{light_icon}}"
+    title="Toggle theme"
+  >
+    <i class="ti"></i>
+  </button>
+{% endmacro %}
+
+{% macro v3_navbar(class) %}
+  <div class="d-flex justify-content-between align-items-center {{ class }}">
+    {{ breadcrumb() }}
+    {{ theme_toggle() }}
+  </div>
+{% endmacro %}

--- a/fossunited/www/grants/directory/index.html
+++ b/fossunited/www/grants/directory/index.html
@@ -1,3 +1,5 @@
+{% from "fossunited/templates/macros/breadcrumb.html" import v3_navbar %}
+
 {% extends "templates/foss_base.html" %}
 
 {% block title %}{{ page_title or "FOSS Grants & Funding" }}{% endblock %}
@@ -5,14 +7,7 @@
 {% block page_content %}
   <div class="v3-page">
     <div class="v3-container mb-5">
-      <div class="d-flex justify-content-between align-items-center mb-3">
-        <nav class="v3-breadcrumb">
-          <a href="/">Home</a> > <a href="/grants/">Grants</a> > <a href="">Directory</a>
-        </nav>
-        <button class="v3-theme-toggle" id="theme-toggle" title="Toggle theme">
-          <i class="ti ti-moon"></i>
-        </button>
-      </div>
+      {{ v3_navbar() }}
 
       <div class="v3-card mb-4">
         <!-- Header: Title, Description, Count -->

--- a/fossunited/www/grants/directory/index.js
+++ b/fossunited/www/grants/directory/index.js
@@ -1,8 +1,4 @@
 document.addEventListener('DOMContentLoaded', () => {
-  if (typeof initThemeToggle === 'function') {
-    initThemeToggle('theme-toggle')
-  }
-
   const searchInput = document.getElementById('search')
   const sortSelect = document.getElementById('sort')
   const listEl = document.getElementById('grants-list')

--- a/fossunited/www/grants/grantees/index.py
+++ b/fossunited/www/grants/grantees/index.py
@@ -87,19 +87,6 @@ def get_context(context):
     context.all_grants = all_grants
     context.total_grants = len(all_grants)
     # Page metadata
-    context.breadcrumbs = [
-        {
-            "route": "/",
-            "label": "Home",
-        },
-        {
-            "route": "/grants",
-            "label": "Grants",
-        },
-        {
-            "label": "All Grantees",
-        },
-    ]
     context.grant_type = "All Grantees"
     context.grant_icon = "ti ti-list-search"
     context.grant_description = """

--- a/fossunited/www/grants/index.html
+++ b/fossunited/www/grants/index.html
@@ -1,5 +1,6 @@
 {% extends "templates/foss_base.html" %}
 {% from "fossunited/templates/macros/grants_card.html" import grant_section %}
+{% from "fossunited/templates/macros/breadcrumb.html" import v3_navbar %}
 
 {% block title %}Funding and Grants | FOSS United{% endblock %}
 
@@ -54,12 +55,7 @@
 {% block page_content %}
   <div class="v3-page">
     <div class="v3-container v3-container-wide mb-5">
-      <div class="d-flex justify-content-between align-items-center">
-        <nav class="v3-breadcrumb"><a href="/">Home</a> > <a href="">Grants</a></nav>
-        <button class="v3-theme-toggle" id="theme-toggle">
-          <i class="ti ti-moon"></i>
-        </button>
-      </div>
+      {{v3_navbar()}}
 
       <div class="v3-card mb-8">
         <div class="mb-4">
@@ -93,20 +89,21 @@
             maintainers, projects and events all over India. To date, we have disbursed over INR 3
             crores towards Indian FOSS projects and maintainers. All FOSS United grantees are
             listed <a class="underline" href="/grants/grantees">here</a>.
-            <br>
-            We fund FOSS projects by raising funds from the tech industry,
-            either through our Industry Partnership Program, individual donations, or by reaching
-            out to companies that might be interested in co-sponsoring certain projects or
-            organizations.
+            <br />
+            We fund FOSS projects by raising funds from the tech industry, either through our
+            Industry Partnership Program, individual donations, or by reaching out to companies
+            that might be interested in co-sponsoring certain projects or organizations.
           </p>
           <p class="mb-3">
             To read more about the structure of the grants program, evaluation criteria and more,
-            please go through our <a class="underline" href="https://fossunited.org/grants/thesis">grants thesis</a>.
+            please go through our
+            <a class="underline" href="https://fossunited.org/grants/thesis">grants thesis</a>.
           </p>
           <p>
             If you're a FOSS project or developer in need of financial support, please
-            <a class="underline" href="https://fossunited.org/grants/apply/new">apply</a>. For any questions, please reach out
-            to us at <a class="underline" href="mailto:grants@fossunited.org">grants@fossunited.org</a>.
+            <a class="underline" href="https://fossunited.org/grants/apply/new">apply</a>. For any
+            questions, please reach out to us at
+            <a class="underline" href="mailto:grants@fossunited.org">grants@fossunited.org</a>.
           </p>
         </div>
 
@@ -157,9 +154,4 @@
     </div>
   </div>
 
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      if (typeof initThemeToggle === 'function') initThemeToggle('theme-toggle')
-    })
-  </script>
 {% endblock %}


### PR DESCRIPTION
- Let all page use common macro for theme_toggle or breadcrumbs or v3_navbar which adds both

- reusability!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified navbar added across pages, combining breadcrumb navigation and theme toggle for a consistent header.

* **Improvements**
  * Theme toggle behavior centralized for consistent user experience.
  * Updated messaging: "No recently concluded events found."
  * External links now include safer handling for improved browsing security.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->