### PR TITLE
dashboard(localhost): make localhost layout act as parent

### DIFF
--- a/dashboard/src/components/localhost/LocalhostLayout.vue
+++ b/dashboard/src/components/localhost/LocalhostLayout.vue
@@ -1,39 +1,69 @@
 <template>
   <Dialog
-    :model-value="showDialog"
+    v-model="showDialog"
     class="z-50"
     :options="{
       title: 'Error',
       message: dialogMessage,
     }"
-    @update:model-value="$emit('update:showDialog', $event)"
   />
-  <Header />
-  <div v-if="isValidated" class="w-full p-4 flex items-center justify-center">
-    <div class="max-w-screen-xl w-full">
-      <slot />
+
+  <div v-show="isValidated" class="w-full min-h-screen flex overflow-x-hidden">
+    <SideNavbar title="Manage Localhost" :menu-items="sidebarMenuItems" />
+
+    <div class="flex-1 p-4 md:ml-[220px] min-w-0">
+      <div class="max-w-screen-xl mx-auto min-w-0">
+        <RouterView />
+      </div>
     </div>
   </div>
 </template>
 
 <script setup>
-import { Dialog } from 'frappe-ui'
-import Header from '@/components/Header.vue'
+import { ref, onMounted, inject } from 'vue'
+import { useRoute, useRouter, RouterView } from 'vue-router'
+import { Dialog, createResource } from 'frappe-ui'
+import SideNavbar from '@/components/NewAppSidebar.vue'
+import { LocalhostValidation } from '@/components/localhost/LocalhostValidation'
 
-defineProps({
-  isValidated: {
-    type: Boolean,
-    required: true,
+const route = useRoute()
+const router = useRouter()
+const session = inject('$session')
+
+const { isValidated, dialogMessage, showDialog, validateSessionUser } = LocalhostValidation(
+  route.params.id,
+  'MyLocalhosts',
+)
+
+const sidebarMenuItems = [
+  {
+    items: [
+      {
+        icon: 'arrow-left',
+        label: 'Go Back',
+        route: '/localhost',
+      },
+    ],
   },
-  showDialog: {
-    type: Boolean,
-    required: true,
+  {
+    items: [
+      {
+        label: 'Edit Localhost',
+        route: `/localhost/${route.params.id}/edit`,
+      },
+      {
+        label: 'Manage Attendees',
+        route: `/localhost/${route.params.id}`,
+      },
+      {
+        label: 'Localhost Mailing',
+        route: `/localhost/${route.params.id}/mailing`,
+      },
+    ],
   },
-  dialogMessage: {
-    type: String,
-    default: '',
-  },
+]
+
+onMounted(() => {
+  validateSessionUser()
 })
-
-defineEmits(['update:showDialog'])
 </script>

--- a/dashboard/src/components/localhost/LocalhostLayout.vue
+++ b/dashboard/src/components/localhost/LocalhostLayout.vue
@@ -8,7 +8,7 @@
     }"
   />
 
-  <div v-show="isValidated" class="w-full min-h-screen flex overflow-x-hidden">
+  <div v-if="isValidated" class="w-full min-h-screen flex overflow-x-hidden">
     <SideNavbar title="Manage Localhost" :menu-items="sidebarMenuItems" />
 
     <div class="flex-1 p-4 md:ml-[220px] min-w-0">

--- a/dashboard/src/components/localhost/LocalhostLayout.vue
+++ b/dashboard/src/components/localhost/LocalhostLayout.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, inject } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useRoute, useRouter, RouterView } from 'vue-router'
 import { Dialog, createResource } from 'frappe-ui'
 import SideNavbar from '@/components/NewAppSidebar.vue'
@@ -28,14 +28,13 @@ import { LocalhostValidation } from '@/components/localhost/LocalhostValidation'
 
 const route = useRoute()
 const router = useRouter()
-const session = inject('$session')
 
 const { isValidated, dialogMessage, showDialog, validateSessionUser } = LocalhostValidation(
   route.params.id,
   'MyLocalhosts',
 )
 
-const sidebarMenuItems = [
+const sidebarMenuItems = computed(() => [
   {
     items: [
       {
@@ -61,7 +60,7 @@ const sidebarMenuItems = [
       },
     ],
   },
-]
+])
 
 onMounted(() => {
   validateSessionUser()

--- a/dashboard/src/pages/localhost/LocalhostEdit.vue
+++ b/dashboard/src/pages/localhost/LocalhostEdit.vue
@@ -1,180 +1,155 @@
 <template>
-  <LocalhostLayout
-    :is-validated="isValidated"
-    v-model:show-dialog="showDialog"
-    :dialog-message="dialogMessage"
-  >
-    <div v-if="localhost.doc">
-      <!-- Page Header -->
-      <div class="flex flex-col md:flex-row justify-between gap-2 mt-4">
+  <div v-if="localhost.doc">
+    <!-- Page Header -->
+    <div class="flex flex-col md:flex-row justify-between gap-2 mt-4">
+      <div>
+        <div class="text-base font-medium">Edit Localhost</div>
+        <div class="text-sm text-gray-600">Update venue details and visibility</div>
+      </div>
+
+      <div class="flex flex-wrap gap-2">
+        <RouterLink :to="{ name: 'ManageLocalhost', params: { id: route.params.id } }">
+          <Button variant="subtle" icon-left="arrow-left" label="Back to Manage" />
+        </RouterLink>
+
+        <Button
+          :theme="localhost.doc.is_published ? 'red' : 'green'"
+          :icon-left="localhost.doc.is_published ? 'slash' : 'upload'"
+          :label="localhost.doc.is_published ? 'Unpublish' : 'Publish'"
+          @click="togglePublish"
+        />
+        <Button variant="solid" label="Update Localhost" @click="updateLocalhost" />
+      </div>
+    </div>
+
+    <!-- Localhost Header -->
+    <LocalhostHeader :localhost="localhost.doc" />
+
+    <div class="rounded-sm border p-4 my-6">
+      <div class="text-sm uppercase font-medium mb-3">Localhost Overview</div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <!-- Left: Image -->
         <div>
-          <div class="text-base font-medium">Edit Localhost</div>
-          <div class="text-sm text-gray-600">Update venue details and visibility</div>
-        </div>
+          <img :src="getImage()" class="w-[200px] aspect-square object-cover border rounded-lg" />
 
-        <div class="flex flex-wrap gap-2">
-          <RouterLink :to="{ name: 'ManageLocalhost', params: { id: route.params.id } }">
-            <Button variant="subtle" icon-left="arrow-left" label="Back to Manage" />
-          </RouterLink>
+          <div class="flex gap-2 mt-3">
+            <FileUploader file-types="image/*" :validate-file="validateImage" @success="setImage">
+              <template #default="{ uploading, progress, openFileSelector }">
+                <Button
+                  variant="subtle"
+                  size="md"
+                  :label="uploading ? `Uploading ${progress}%` : 'Upload Image'"
+                  @click="openFileSelector"
+                />
+              </template>
+            </FileUploader>
 
-          <Button
-            :theme="localhost.doc.is_published ? 'red' : 'green'"
-            :icon-left="localhost.doc.is_published ? 'slash' : 'upload'"
-            :label="localhost.doc.is_published ? 'Unpublish' : 'Publish'"
-            @click="togglePublish"
-          />
-          <Button variant="solid" label="Update Localhost" @click="updateLocalhost" />
-        </div>
-      </div>
-
-      <!-- Localhost Header -->
-      <LocalhostHeader :localhost="localhost.doc" />
-
-      <div class="rounded-sm border p-4 my-6">
-        <div class="text-sm uppercase font-medium mb-3">Localhost Overview</div>
-
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <!-- Left: Image -->
-          <div>
-            <img
-              :src="getImage()"
-              class="w-[200px] aspect-square object-cover border rounded-lg"
+            <Button
+              v-if="localhost.doc.image"
+              variant="subtle"
+              theme="red"
+              label="Remove Image"
+              @click="() => setImage({ file_url: '' })"
             />
-
-            <div class="flex gap-2 mt-3">
-              <FileUploader
-                file-types="image/*"
-                :validate-file="validateImage"
-                @success="setImage"
-              >
-                <template #default="{ uploading, progress, openFileSelector }">
-                  <Button
-                    variant="subtle"
-                    size="md"
-                    :label="uploading ? `Uploading ${progress}%` : 'Upload Image'"
-                    @click="openFileSelector"
-                  />
-                </template>
-              </FileUploader>
-
-              <Button
-                v-if="localhost.doc.image"
-                variant="subtle"
-                theme="red"
-                label="Remove Image"
-                @click="() => setImage({ file_url: '' })"
-              />
-            </div>
-
-            <div class="text-sm text-gray-600 mt-2">Recommended size: 1:1 square image</div>
           </div>
 
-          <!-- Right: Meta -->
-          <div class="flex flex-col gap-4">
-            <div class="grid grid-cols-2 gap-4">
-              <div class="flex flex-col gap-1">
-                <label class="text-sm font-medium text-gray-700">State</label>
-                <div class="px-3 py-2 border rounded-md bg-gray-50">
-                  {{ localhost.doc.state || '—' }}
-                </div>
-              </div>
-
-              <div class="flex flex-col gap-1">
-                <label class="text-sm font-medium text-gray-700">City</label>
-                <div class="px-3 py-2 border rounded-md bg-gray-50">
-                  {{ localhost.doc.city || '—' }}
-                </div>
-              </div>
-            </div>
-
-            <div>
-              <label class="text-sm font-medium text-gray-700 mb-1 block"> Public Route </label>
-              <CopyToClipboardComponent :route="wholeRoute" />
-            </div>
-          </div>
+          <div class="text-sm text-gray-600 mt-2">Recommended size: 1:1 square image</div>
         </div>
-      </div>
 
-      <!-- Details -->
-      <div class="rounded-sm border p-4 my-6">
-        <div class="text-sm uppercase font-medium mb-3">Localhost Details</div>
-
-        <div class="grid sm:grid-cols-1 md:grid-cols-2 gap-6">
-          <FormControl
-            v-model="localhost.doc.localhost_name"
-            type="text"
-            label="Localhost Name"
-            size="md"
-          />
-
-          <FormControl
-            v-model="localhost.doc.email"
-            type="email"
-            label="Contact Email"
-            size="md"
-          />
-
-          <FormControl
-            v-model="localhost.doc.location"
-            type="text"
-            label="Location Address"
-            size="md"
-          />
-
-          <FormControl v-model="localhost.doc.map_link" type="url" label="Map Link" size="md" />
-
-          <!-- Accepting Attendees -->
-          <div class="md:col-span-2">
-            <div class="flex items-center justify-between p-3 border rounded-md">
-              <div class="flex flex-col">
-                <span class="font-medium text-gray-800"> Accepting Attendees </span>
-                <span class="text-sm text-gray-600">
-                  Allow attendees to register for this localhost.
-                </span>
+        <!-- Right: Meta -->
+        <div class="flex flex-col gap-4">
+          <div class="grid grid-cols-2 gap-4">
+            <div class="flex flex-col gap-1">
+              <label class="text-sm font-medium text-gray-700">State</label>
+              <div class="px-3 py-2 border rounded-md bg-gray-50">
+                {{ localhost.doc.state || '—' }}
               </div>
-              <Switch v-model="localhost.doc.is_accepting_attendees" />
             </div>
+
+            <div class="flex flex-col gap-1">
+              <label class="text-sm font-medium text-gray-700">City</label>
+              <div class="px-3 py-2 border rounded-md bg-gray-50">
+                {{ localhost.doc.city || '—' }}
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <label class="text-sm font-medium text-gray-700 mb-1 block"> Public Route </label>
+            <CopyToClipboardComponent :route="wholeRoute" />
           </div>
         </div>
       </div>
     </div>
-  </LocalhostLayout>
+
+    <!-- Details -->
+    <div class="rounded-sm border p-4 my-6">
+      <div class="text-sm uppercase font-medium mb-3">Localhost Details</div>
+
+      <div class="grid sm:grid-cols-1 md:grid-cols-2 gap-6">
+        <FormControl
+          v-model="localhost.doc.localhost_name"
+          type="text"
+          label="Localhost Name"
+          size="md"
+        />
+
+        <FormControl v-model="localhost.doc.email" type="email" label="Contact Email" size="md" />
+
+        <FormControl
+          v-model="localhost.doc.location"
+          type="text"
+          label="Location Address"
+          size="md"
+        />
+
+        <FormControl v-model="localhost.doc.map_link" type="url" label="Map Link" size="md" />
+
+        <!-- Accepting Attendees -->
+        <div class="md:col-span-2">
+          <div class="flex items-center justify-between p-3 border rounded-md">
+            <div class="flex flex-col">
+              <span class="font-medium text-gray-800"> Accepting Attendees </span>
+              <span class="text-sm text-gray-600">
+                Allow attendees to register for this localhost.
+              </span>
+            </div>
+            <Switch v-model="localhost.doc.is_accepting_attendees" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script setup>
 import { createDocumentResource, FileUploader, FormControl, Button, Switch } from 'frappe-ui'
-import { ref, onMounted } from 'vue'
+import { ref, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { toast } from 'vue-sonner'
 
 import LocalhostHeader from '@/components/localhost/LocalhostHeader.vue'
-import LocalhostLayout from '@/components/localhost/LocalhostLayout.vue'
 import CopyToClipboardComponent from '@/components/CopyToClipboardComponent.vue'
-import { LocalhostValidation } from '@/components/localhost/LocalhostValidation'
 
 const route = useRoute()
 const router = useRouter()
-const wholeRoute = ref('')
-
-const { isValidated, dialogMessage, showDialog, validateSessionUser } = LocalhostValidation(
-  route.params.id,
-  'MyLocalhosts',
-)
 
 const localhost = createDocumentResource({
   doctype: 'FOSS Hackathon LocalHost',
   name: route.params.id,
   fields: ['*'],
-  auto: false,
-  onSuccess(doc) {
-    wholeRoute.value = `${window.location.origin}/${doc.route}`
-  },
+  auto: true,
   onError(error) {
     toast.error('Failed to load localhost', { description: error.message })
     setTimeout(() => {
       router.push({ name: 'MyLocalhosts' })
     }, 2000)
   },
+})
+const wholeRoute = computed(() => {
+  if (!localhost.doc?.route) return ''
+  return `${window.location.origin}/${localhost.doc.route}`
 })
 
 const validateImage = (file) => {
@@ -207,10 +182,4 @@ const updateLocalhost = () => {
     .then(() => toast.success('Localhost updated successfully'))
     .catch((err) => toast.error('Failed to update localhost', { description: err.message }))
 }
-
-onMounted(() => {
-  validateSessionUser(() => {
-    localhost.reload()
-  })
-})
 </script>

--- a/dashboard/src/pages/localhost/LocalhostEdit.vue
+++ b/dashboard/src/pages/localhost/LocalhostEdit.vue
@@ -125,7 +125,7 @@
 
 <script setup>
 import { createDocumentResource, FileUploader, FormControl, Button, Switch } from 'frappe-ui'
-import { ref, computed } from 'vue'
+import { computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { toast } from 'vue-sonner'
 

--- a/dashboard/src/pages/localhost/ManageLocalhost.vue
+++ b/dashboard/src/pages/localhost/ManageLocalhost.vue
@@ -1,100 +1,90 @@
 <template>
-  <LocalhostLayout
-    :is-validated="isValidated"
-    v-model:show-dialog="showDialog"
-    :dialog-message="dialogMessage"
-  >
-    <div v-if="localhost.data && requests.data">
-      <div class="flex items-center justify-between mt-4">
-        <div class="text-base font-medium">Manage Localhost</div>
+  <div v-if="localhost.data && requests.data">
+    <div class="flex items-center justify-between mt-4">
+      <div class="text-base font-medium">Manage Localhost</div>
 
-        <RouterLink :to="{ name: 'LocalhostEdit', params: { id: route.params.id } }">
-          <Button label="Edit Details" icon-left="edit" />
-        </RouterLink>
-      </div>
+      <RouterLink :to="{ name: 'LocalhostEdit', params: { id: route.params.id } }">
+        <Button label="Edit Details" icon-left="edit" />
+      </RouterLink>
+    </div>
 
-      <LocalhostHeader :localhost="localhost.data" />
+    <LocalhostHeader :localhost="localhost.data" />
 
-      <div class="grid grid-cols-1 md:grid-cols-2">
-        <div class="rounded-sm border-2 border-dashed border-gray-400 p-4 my-2">
-          <div class="text-sm uppercase font-medium">Current Status</div>
-          <div class="flex items-center justify-between w-full">
-            <div
-              class="flex items-center gap-2 text-lg font-medium pt-4"
-              :class="localhost.data.is_accepting_attendees ? 'text-green-700' : ''"
-            >
-              <span v-if="localhost.data.is_accepting_attendees" class="relative flex h-3 w-3">
-                <span
-                  class="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"
-                ></span>
-                <span class="relative inline-flex rounded-full h-3 w-3 bg-green-500"></span>
-              </span>
-              <span>
-                {{
-                  localhost.data.is_accepting_attendees
-                    ? 'Accepting Participants'
-                    : 'Not Accepting Participants'
-                }}
-              </span>
-            </div>
-            <Button
-              :label="localhost.data.is_accepting_attendees ? 'Disable' : 'Enable'"
-              @click="toggleAcceptingAttendees"
-            />
+    <div class="grid grid-cols-1 md:grid-cols-2">
+      <div class="rounded-sm border-2 border-dashed border-gray-400 p-4 my-2">
+        <div class="text-sm uppercase font-medium">Current Status</div>
+        <div class="flex items-center justify-between w-full">
+          <div
+            class="flex items-center gap-2 text-lg font-medium pt-4"
+            :class="localhost.data.is_accepting_attendees ? 'text-green-700' : ''"
+          >
+            <span v-if="localhost.data.is_accepting_attendees" class="relative flex h-3 w-3">
+              <span
+                class="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"
+              ></span>
+              <span class="relative inline-flex rounded-full h-3 w-3 bg-green-500"></span>
+            </span>
+            <span>
+              {{
+                localhost.data.is_accepting_attendees
+                  ? 'Accepting Participants'
+                  : 'Not Accepting Participants'
+              }}
+            </span>
           </div>
+          <Button
+            :label="localhost.data.is_accepting_attendees ? 'Disable' : 'Enable'"
+            @click="toggleAcceptingAttendees"
+          />
         </div>
-      </div>
-
-      <div class="grid grid-cols-1 sm:grid-cols-5 mt-6 mb-4 gap-4">
-        <div class="flex flex-col gap-2 bg-gray-50 w-full p-4 rounded border">
-          <div class="text-base font-medium">Total Requests</div>
-          <div class="text-2xl">
-            {{ requests.originalData.length }}
-          </div>
-        </div>
-        <div class="flex flex-col gap-2 w-full p-4 rounded border">
-          <div class="text-base font-medium">Pending Requests</div>
-          <div class="text-2xl text-orange-600">
-            {{ requests.data['Pending'].length }}
-          </div>
-        </div>
-        <div class="flex flex-col gap-2 w-full p-4 rounded border">
-          <div class="text-base font-medium">Pending Confirmation</div>
-          <div class="text-2xl text-blue-600">
-            {{ requests.data['Pending Confirmation'].length }}
-          </div>
-        </div>
-        <div class="flex flex-col gap-2 w-full p-4 rounded border">
-          <div class="text-base font-medium">Accepted Participants</div>
-          <div class="text-2xl text-green-600">
-            {{ requests.data['Accepted'].length }}
-          </div>
-        </div>
-        <div class="flex flex-col gap-2 w-full p-4 rounded border">
-          <div class="text-base font-medium">Rejected Participants</div>
-          <div class="text-2xl text-red-600">
-            {{ requests.data['Rejected'].length }}
-          </div>
-        </div>
-      </div>
-
-      <hr />
-
-      <div class="flex flex-col gap-2 py-4">
-        <AttendeeRequestList :localhost="localhost" @update-request="requests.reload()" />
       </div>
     </div>
-  </LocalhostLayout>
+
+    <div class="grid grid-cols-1 sm:grid-cols-5 mt-6 mb-4 gap-4">
+      <div class="flex flex-col gap-2 bg-gray-50 w-full p-4 rounded border">
+        <div class="text-base font-medium">Total Requests</div>
+        <div class="text-2xl">
+          {{ requests.originalData.length }}
+        </div>
+      </div>
+      <div class="flex flex-col gap-2 w-full p-4 rounded border">
+        <div class="text-base font-medium">Pending Requests</div>
+        <div class="text-2xl text-orange-600">
+          {{ requests.data['Pending'].length }}
+        </div>
+      </div>
+      <div class="flex flex-col gap-2 w-full p-4 rounded border">
+        <div class="text-base font-medium">Pending Confirmation</div>
+        <div class="text-2xl text-blue-600">
+          {{ requests.data['Pending Confirmation'].length }}
+        </div>
+      </div>
+      <div class="flex flex-col gap-2 w-full p-4 rounded border">
+        <div class="text-base font-medium">Accepted Participants</div>
+        <div class="text-2xl text-green-600">
+          {{ requests.data['Accepted'].length }}
+        </div>
+      </div>
+      <div class="flex flex-col gap-2 w-full p-4 rounded border">
+        <div class="text-base font-medium">Rejected Participants</div>
+        <div class="text-2xl text-red-600">
+          {{ requests.data['Rejected'].length }}
+        </div>
+      </div>
+    </div>
+
+    <hr />
+
+    <div class="flex flex-col gap-2 py-4">
+      <AttendeeRequestList :localhost="localhost" @update-request="requests.reload()" />
+    </div>
+  </div>
 </template>
 
 <script setup>
 import { useRoute } from 'vue-router'
 import { createListResource, createResource, usePageMeta } from 'frappe-ui'
-import { onMounted } from 'vue'
 import AttendeeRequestList from '@/components/localhost/AttendeeRequestList.vue'
-import LocalhostHeader from '@/components/localhost/LocalhostHeader.vue'
-import LocalhostLayout from '@/components/localhost/LocalhostLayout.vue'
-import { LocalhostValidation } from '@/components/localhost/LocalhostValidation'
 
 const route = useRoute()
 
@@ -104,17 +94,13 @@ usePageMeta(() => {
   }
 })
 
-const { isValidated, dialogMessage, showDialog, validateSessionUser } = LocalhostValidation(
-  route.params.id,
-  'MyLocalhosts',
-)
-
 const requests = createListResource({
   doctype: 'FOSS Hackathon Participant',
   fields: ['*'],
   filters: {
     localhost: route.params.id,
   },
+  auto: true,
   transform(data) {
     data = data.reduce((acc, curr) => {
       if (!acc[curr.localhost_request_status]) {
@@ -134,6 +120,7 @@ const requests = createListResource({
 
 const localhost = createResource({
   url: 'frappe.client.get',
+  auto: true,
   makeParams() {
     return {
       doctype: 'FOSS Hackathon LocalHost',
@@ -158,11 +145,4 @@ const toggleAcceptingAttendees = () => {
     auto: true,
   })
 }
-
-onMounted(() => {
-  validateSessionUser(() => {
-    localhost.fetch()
-    requests.fetch()
-  })
-})
 </script>

--- a/dashboard/src/router.js
+++ b/dashboard/src/router.js
@@ -284,6 +284,7 @@ const routes = [
   },
   {
     path: '/localhost/:id',
+    component: () => import('@/components/localhost/LocalhostLayout.vue'),
     children: [
       {
         path: '',


### PR DESCRIPTION
- Make localhost layout as base with sidenavbar so all related pages use this to navigate.

- helps to add mailing feature for localhost participants

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent two-column layout with a sidebar navigation (Go Back, Edit, Manage Attendees, Mailing) and router-driven main content.

* **Improvements**
  * Pages now auto-fetch localhost data on load for faster, consistent display.
  * Public route display and image upload UI reorganized for clearer placement.
  * Simplified page layouts for improved navigation and usability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->