### PR TITLE
doctype(hackathon-participant): add to localhost email group if accepted

### DIFF
--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -50,6 +50,7 @@ class FOSSHackathonParticipant(Document):
         if (
             self.has_value_changed("localhost_request_status")
             and self.localhost_request_status == "Accepted"
+            and self.localhost
         ):
             self.subscribe_to_localhost_email_group()
 
@@ -88,7 +89,7 @@ class FOSSHackathonParticipant(Document):
             emails=[self.email],
             chapter=event_doc.chapter,
             event=self.localhost,
-            subscribe_to_chapter=False,
+            subscribe_to_chapter=self.subscribe_chapter_mailing,
             subscribe_to_event=True,
             document_type_event=HACKATHON_LOCALHOST,
         )

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -47,6 +47,11 @@ class FOSSHackathonParticipant(Document):
             self.update_request_status()
         if self.has_value_changed("subscribe_chapter_mailing"):
             self.handle_add_to_email_group()
+        if (
+            self.has_value_changed("localhost_request_status")
+            and self.localhost_request_status == "Accepted"
+        ):
+            self.subscribe_to_localhost_email_group()
 
     def validate(self):
         if self.wants_to_attend_locally and not self.localhost:
@@ -74,6 +79,18 @@ class FOSSHackathonParticipant(Document):
             subscribe_to_chapter=self.subscribe_chapter_mailing,
             subscribe_to_event=self.subscribe_chapter_mailing,
             document_type_event=HACKATHON,
+        )
+
+    def subscribe_to_localhost_email_group(self):
+        event_doc = frappe.get_doc(HACKATHON, self.hackathon)
+
+        handle_email_group_subscription(
+            emails=[self.email],
+            chapter=event_doc.chapter,
+            event=self.localhost,
+            subscribe_to_chapter=False,
+            subscribe_to_event=True,
+            document_type_event=HACKATHON_LOCALHOST,
         )
 
     def update_request_status(self):


### PR DESCRIPTION
- helps for localhost mailing feature

#1363 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Participants are automatically subscribed to event-specific email notifications when their localhost request is accepted, ensuring they receive relevant communications related to their participation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->