### PR TITLE
dashboard(localhost): add mailing feature for localhost

### DIFF
--- a/dashboard/src/pages/mailing/LocalhostMailing.vue
+++ b/dashboard/src/pages/mailing/LocalhostMailing.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script setup>
-import { ref, watch, computed } from 'vue'
+import { ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { createDocumentResource, createResource } from 'frappe-ui'
 import MailingPage from '@/components/mailing/MailingPage.vue'

--- a/dashboard/src/pages/mailing/LocalhostMailing.vue
+++ b/dashboard/src/pages/mailing/LocalhostMailing.vue
@@ -1,49 +1,63 @@
 <template>
   <MailingPage
+    :key="campaignKey"
     doctype="FOSS Hackathon LocalHost"
     :header-component="LocalhostHeader"
-    document-type="FOSS Hackathon LocalHost"
     :get-campaign-params="getCampaignParams"
     info-text="Send mass emails to localhost participants."
   />
 </template>
 
 <script setup>
+import { ref, watch, computed } from 'vue'
+import { useRoute } from 'vue-router'
+import { createDocumentResource, createResource } from 'frappe-ui'
 import MailingPage from '@/components/mailing/MailingPage.vue'
 import LocalhostHeader from '@/components/localhost/LocalhostHeader.vue'
-import { createDocumentResource, createResource, LoadingText } from 'frappe-ui'
-import { useRoute } from 'vue-router'
-import { ref } from 'vue'
 
 const route = useRoute()
+const hackathonChapter = ref(null)
+const campaignKey = ref(0)
 
-const document = createDocumentResource({
+const localhost = createDocumentResource({
   doctype: 'FOSS Hackathon LocalHost',
   name: route.params.id,
   fields: ['parent_hackathon'],
   auto: true,
-  onSuccess(doc) {
-    hackathon.reload({
-      name: doc.parent_hackathon,
-    })
-  },
 })
-
-const hackathonChapter = ref(null)
 
 const hackathon = createResource({
   url: 'fossunited.api.hackathon.get_hackathon',
   auto: false,
-  onSuccess(doc) {
-    hackathonChapter.value = doc.chapter
-  },
 })
 
-const getCampaignParams = (doc) => {
-  return {
-    reference_document: doc.name,
-    chapter: hackathonChapter.value,
-    document_type: 'FOSS Hackathon LocalHost',
-  }
-}
+watch(
+  () => route.params.id,
+  () => {
+    hackathonChapter.value = null
+    localhost.reload()
+    campaignKey.value++
+  },
+)
+
+watch(
+  () => localhost.doc?.parent_hackathon,
+  (parent) => {
+    if (parent) {
+      hackathon.fetch({ name: parent }).then((data) => {
+        hackathonChapter.value = data.chapter
+        campaignKey.value++
+      })
+    } else {
+      hackathonChapter.value = null
+    }
+  },
+  { immediate: true },
+)
+
+const getCampaignParams = (doc) => ({
+  reference_document: doc.name,
+  chapter: hackathonChapter.value,
+  document_type: 'FOSS Hackathon LocalHost',
+})
 </script>

--- a/dashboard/src/pages/mailing/LocalhostMailing.vue
+++ b/dashboard/src/pages/mailing/LocalhostMailing.vue
@@ -1,0 +1,49 @@
+<template>
+  <MailingPage
+    doctype="FOSS Hackathon LocalHost"
+    :header-component="LocalhostHeader"
+    document-type="FOSS Hackathon LocalHost"
+    :get-campaign-params="getCampaignParams"
+    info-text="Send mass emails to localhost participants."
+  />
+</template>
+
+<script setup>
+import MailingPage from '@/components/mailing/MailingPage.vue'
+import LocalhostHeader from '@/components/localhost/LocalhostHeader.vue'
+import { createDocumentResource, createResource, LoadingText } from 'frappe-ui'
+import { useRoute } from 'vue-router'
+import { ref } from 'vue'
+
+const route = useRoute()
+
+const document = createDocumentResource({
+  doctype: 'FOSS Hackathon LocalHost',
+  name: route.params.id,
+  fields: ['parent_hackathon'],
+  auto: true,
+  onSuccess(doc) {
+    hackathon.reload({
+      name: doc.parent_hackathon,
+    })
+  },
+})
+
+const hackathonChapter = ref(null)
+
+const hackathon = createResource({
+  url: 'fossunited.api.hackathon.get_hackathon',
+  auto: false,
+  onSuccess(doc) {
+    hackathonChapter.value = doc.chapter
+  },
+})
+
+const getCampaignParams = (doc) => {
+  return {
+    reference_document: doc.name,
+    chapter: hackathonChapter.value,
+    document_type: 'FOSS Hackathon LocalHost',
+  }
+}
+</script>

--- a/dashboard/src/router.js
+++ b/dashboard/src/router.js
@@ -296,6 +296,11 @@ const routes = [
         name: 'LocalhostEdit',
         component: () => import('@/pages/localhost/LocalhostEdit.vue'),
       },
+      {
+        path: 'mailing',
+        name: 'LocalhostMailing',
+        component: () => import('@/pages/mailing/LocalhostMailing.vue'),
+      },
     ],
   },
   {


### PR DESCRIPTION
<img width="2431" height="1062" alt="image" src="https://github.com/user-attachments/assets/a2335d0b-702c-44cf-9855-fbc11d22eb99" />

Will work with shared component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a mailing page for Localhost hackathons, reachable from a Localhost detail view.
  * Mailing page pre-fills campaign parameters (reference document, chapter, document type) and shows contextual info text.
  * Page auto-refreshes when the selected Localhost or its associated hackathon changes to keep campaign data current.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->