### PR TITLE
dashboard: utilize common save action bar

### DIFF
--- a/dashboard/src/components/FormActionBar.vue
+++ b/dashboard/src/components/FormActionBar.vue
@@ -1,7 +1,7 @@
 <template>
   <Transition name="slide-up">
     <div
-      v-if="showActions"
+      v-if="hasChanges"
       class="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 shadow-lg px-4 py-3 z-50"
       style="height: 56px"
     >
@@ -32,29 +32,68 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { Button } from 'frappe-ui'
 
 const props = defineProps({
-  hasChanges: {
-    type: Boolean,
-    required: true,
+  documentResource: {
+    type: Object,
+    required: true, // only DocumentResource
   },
   isSaving: {
     type: Boolean,
     default: false,
   },
+  fieldsToWatch: {
+    type: Array,
+    default: null, // If null, watch all fields
+  },
 })
 
 const emit = defineEmits(['save', 'cancel'])
 
-const showActions = computed(() => props.hasChanges)
+const originalData = ref({})
+
+// Watch the document and store original values
+watch(
+  () => props.documentResource.doc,
+  (newDoc) => {
+    if (newDoc && Object.keys(originalData.value).length === 0) {
+      // Store initial values
+      originalData.value = JSON.parse(JSON.stringify(newDoc))
+    }
+  },
+  { immediate: true, deep: true },
+)
+
+// Detect changes
+const hasChanges = computed(() => {
+  if (!props.documentResource.doc || !originalData.value) return false
+
+  const fieldsToCheck = props.fieldsToWatch || Object.keys(originalData.value)
+
+  return fieldsToCheck.some((key) => {
+    return (
+      JSON.stringify(props.documentResource.doc[key]) !== JSON.stringify(originalData.value[key])
+    )
+  })
+})
 
 const handleSave = () => {
   emit('save')
+  // Reset original data after save
+  setTimeout(() => {
+    if (props.documentResource.doc) {
+      originalData.value = JSON.parse(JSON.stringify(props.documentResource.doc))
+    }
+  }, 100)
 }
 
 const handleCancel = () => {
+  // Reload the document to discard changes
+  props.documentResource.reload()
+  // Reset original data
+  originalData.value = {}
   emit('cancel')
 }
 </script>

--- a/dashboard/src/components/FormActionBar.vue
+++ b/dashboard/src/components/FormActionBar.vue
@@ -34,6 +34,7 @@
 <script setup>
 import { ref, computed, watch } from 'vue'
 import { Button } from 'frappe-ui'
+import { toast } from 'vue-sonner'
 
 const props = defineProps({
   documentResource: {
@@ -58,9 +59,11 @@ const originalData = ref({})
 watch(
   () => props.documentResource.doc,
   (newDoc) => {
-    if (newDoc && Object.keys(originalData.value).length === 0) {
-      // Store initial values
-      originalData.value = JSON.parse(JSON.stringify(newDoc))
+    if (newDoc) {
+      // Update original values when doc changes (includes after reload)
+      if (Object.keys(originalData.value).length === 0) {
+        originalData.value = JSON.parse(JSON.stringify(newDoc))
+      }
     }
   },
   { immediate: true, deep: true },
@@ -90,11 +93,14 @@ const handleSave = () => {
 }
 
 const handleCancel = () => {
-  // Reload the document to discard changes
-  props.documentResource.reload()
-  // Reset original data
+  // Reset original data first
   originalData.value = {}
-  emit('cancel')
+
+  // Reload the document resource
+  props.documentResource.reload().then(() => {
+    toast.info('Changes discarded')
+    emit('cancel')
+  })
 }
 </script>
 

--- a/dashboard/src/components/FormActionBar.vue
+++ b/dashboard/src/components/FormActionBar.vue
@@ -2,7 +2,7 @@
   <Transition name="slide-up">
     <div
       v-if="hasChanges"
-      class="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 shadow-lg px-4 py-3 z-50"
+      class="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 shadow-lg p-4 z-50"
       style="height: 56px"
     >
       <div
@@ -89,18 +89,20 @@ const handleSave = () => {
     if (props.documentResource.doc) {
       originalData.value = JSON.parse(JSON.stringify(props.documentResource.doc))
     }
-  }, 100)
+  }, 300)
 }
 
 const handleCancel = () => {
-  // Reset original data first
-  originalData.value = {}
-
-  // Reload the document resource
-  props.documentResource.reload().then(() => {
-    toast.info('Changes discarded')
-    emit('cancel')
-  })
+  props.documentResource
+    .reload()
+    .then(() => {
+      originalData.value = {}
+      toast.info('Changes discarded')
+      emit('cancel')
+    })
+    .catch((error) => {
+      toast.error('Failed to discard changes ' + error)
+    })
 }
 </script>
 

--- a/dashboard/src/components/ui/TextEditor.vue
+++ b/dashboard/src/components/ui/TextEditor.vue
@@ -155,7 +155,7 @@ import StarterKit from '@tiptap/starter-kit'
 import Underline from '@tiptap/extension-underline'
 import Placeholder from '@tiptap/extension-placeholder'
 import Link from '@tiptap/extension-link'
-import { defineProps, defineEmits, ref, reactive } from 'vue'
+import { defineProps, defineEmits, ref, reactive, watch } from 'vue'
 import {
   IconBold,
   IconItalic,
@@ -245,6 +245,18 @@ const editor = useEditor({
     }),
   ],
 })
+
+watch(
+  () => props.modelValue,
+  (newValue) => {
+    if (editor.value) {
+      const currentContent = editor.value.getHTML()
+      if (currentContent !== newValue) {
+        editor.value.commands.setContent(newValue || '', false)
+      }
+    }
+  },
+)
 
 const handleToggleLink = (editor) => {
   const selectedText = getSelectionText(editor)

--- a/dashboard/src/pages/ChapterDetails.vue
+++ b/dashboard/src/pages/ChapterDetails.vue
@@ -232,6 +232,13 @@
         </FormControl>
       </div>
     </div>
+
+    <FormActionBar
+      :document-resource="chapter"
+      :is-saving="chapter.save.loading"
+      @save="updateDetails"
+    />
+
   </div>
 </template>
 <script setup>
@@ -255,6 +262,8 @@ import {
   IconBrandWhatsapp,
   IconBrandDiscord,
 } from '@tabler/icons-vue'
+import FormActionBar from '@/components/FormActionBar.vue'
+
 
 const route = useRoute()
 

--- a/dashboard/src/pages/EventCfpEdit.vue
+++ b/dashboard/src/pages/EventCfpEdit.vue
@@ -198,6 +198,8 @@
         </div>
       </template>
     </Dialog>
+
+    <FormActionBar :document-resource="cfp" :is-saving="cfp.save.loading" @save="updateCfpForm" />
   </div>
 </template>
 <script setup>
@@ -207,6 +209,7 @@ import { useRoute } from 'vue-router'
 import { toast } from 'vue-sonner'
 import CopyToClipboardComponent from '@/components/CopyToClipboardComponent.vue'
 import TextEditor from '@/components/ui/TextEditor.vue'
+import FormActionBar from '@/components/FormActionBar.vue'
 
 const route = useRoute()
 

--- a/dashboard/src/pages/EventDetails.vue
+++ b/dashboard/src/pages/EventDetails.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="event.doc" class="px-4 py-8 md:p-8 w-full z-0 min-h-screen">
+  <div v-if="event.doc" class="px-4 py-8 md:p-8 w-full z-0 min-h-screen pb-24">
     <div class="flex flex-col md:flex-row gap-2 justify-between">
       <EventHeader
         :event="event.doc"
@@ -139,6 +139,7 @@
           :type="'checkbox'"
           size="md"
           label="Show Speakers Tab"
+          description="Show speakers (added in event schedule) profile linked to their proposals."
         />
         <TextEditor
           label="Event Description"
@@ -201,19 +202,21 @@
         />
       </div>
     </div>
+
+    <FormActionBar
+      :document-resource="event"
+      :is-saving="event.save.loading"
+      @save="updateDetails"
+    />
   </div>
 </template>
+
 <script setup>
 import EventHeader from '@/components/EventHeader.vue'
 import TextEditor from '@/components/ui/TextEditor.vue'
 import CopyToClipboardButton from '@/components/CopyToClipboardButton.vue'
-import {
-  createDocumentResource,
-  createListResource,
-  createResource,
-  FileUploader,
-  FormControl,
-} from 'frappe-ui'
+import FormActionBar from '@/components/FormActionBar.vue'
+import { createDocumentResource, createResource, FileUploader, FormControl } from 'frappe-ui'
 import { useRoute } from 'vue-router'
 import { toast } from 'vue-sonner'
 import { createAbsoluteUrlFromRoute } from '@/helpers/utils'

--- a/dashboard/src/pages/EventRsvpEdit.vue
+++ b/dashboard/src/pages/EventRsvpEdit.vue
@@ -37,7 +37,7 @@
                 <RouterLink :to="`/event/${route.params.id}/rsvp/insights`" class="underline">
                   insights
                 </RouterLink>
-                tab to confirm them via mail.
+                tab to confirm them. They will receive email based on rejection or acceptance.
               </span>
             </div>
 
@@ -207,6 +207,12 @@
         </div>
       </template>
     </Dialog>
+
+    <FormActionBar
+      :document-resource="rsvp"
+      :is-saving="rsvp.save.loading"
+      @save="updateRsvpForm"
+    />
   </div>
 </template>
 <script setup>
@@ -223,6 +229,7 @@ import { useRoute } from 'vue-router'
 import { toast } from 'vue-sonner'
 import CopyToClipboardComponent from '../components/CopyToClipboardComponent.vue'
 import TextEditor from '@/components/ui/TextEditor.vue'
+import FormActionBar from '@/components/FormActionBar.vue'
 
 const route = useRoute()
 


### PR DESCRIPTION
- Use a shared save action bar to be intuitive to save or cancel the data changes

- makes it look uniform on all pages and is sticky at bottom

Note: Only appears when there is change in the document data. save saves the CreateDocumentResource and cancel resets the changes.

<img width="1754" height="293" alt="image" src="https://github.com/user-attachments/assets/e5ac41bb-5593-480f-a543-9ca947f3d0c9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable form action bar across event, chapter and RSVP pages to surface Save/Cancel when edits exist.
  * Intelligent change detection with optional field-scoping and automatic reset after save.

* **Bug Fixes**
  * Text editor now stays synchronized with external model updates.

* **Style / UX**
  * Minor spacing tweaks and added toast feedback for save/cancel actions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->