### PR TITLE
rss(timeline): feeds for upcoming events

### DIFF
--- a/fossunited/hooks.py
+++ b/fossunited/hooks.py
@@ -33,10 +33,6 @@ website_route_rules = [
         "from_route": "/hack/<permalink>/projects/all",
         "to_route": "/hackathon/projects",
     },
-    {
-        "from_route": "/blog/rss.xml",
-        "to_route": "/rss.xml",
-    },
 ]
 
 # add methods and filters to jinja environment
@@ -92,10 +88,16 @@ website_redirects = [
         "source": r"c/(.+)/tickets",
         "target": r"/api/method/fossunited.api.pages.buy_tickets_page?route=c/\1",
     },
+    # grants pages
     {"source": r"^grants/project(/.*)?$", "target": r"/grants/projects\1"},
     {"source": r"^grants/event(/.*)?$", "target": r"/grants/events\1"},
     {"source": r"^grants/fellowship(/.*)?$", "target": r"/grants/fellowships\1"},
     {"source": r"^grants/grantee(/.*)?$", "target": r"/grants/grantees\1"},
+    # rss feeds
+    {"source": r"^blog/rss\.xml$", "target": r"/rss.xml"},
+    {"source": r"^blog/rss$", "target": r"/rss.xml"},
+    {"source": r"^rss$", "target": r"/rss.xml"},
+    {"source": r"^(?!.*\.xml$)(.*)/rss$", "target": r"/\1/rss.xml"},
 ]
 
 # Installation

--- a/fossunited/www/events/timeline/index.html
+++ b/fossunited/www/events/timeline/index.html
@@ -2,6 +2,17 @@
 {% from "fossunited/templates/macros/breadcrumb.html" import v3_navbar %}
 {% from "fossunited/templates/macros/event_card.html" import event_card %}
 
+{% block head %}
+  {{ super() }}
+  <link
+    rel="alternate"
+    type="application/rss+xml"
+    title="Upcoming Events – Foss United"
+    href="/events/timeline/rss.xml"
+  />
+{% endblock %}
+
+
 {% block page_content %}
   <div class="v3-page py-5">
     <div class="v3-container v3-container-wide">
@@ -41,7 +52,7 @@
         </div>
 
         <div class="v3-controls-right">
-          <a href="/events/timeline/rss" class="v3-text-secondary mr-4" title="Subscribe to Upcoming Events">
+          <a href="/events/timeline/rss.xml" class="v3-text-secondary mr-4" title="Subscribe to Upcoming Events">
             <i class="ti ti-rss"></i>
           </a>
 

--- a/fossunited/www/events/timeline/index.html
+++ b/fossunited/www/events/timeline/index.html
@@ -41,6 +41,10 @@
         </div>
 
         <div class="v3-controls-right">
+          <a href="/events/timeline/rss" class="v3-text-secondary mr-4" title="Subscribe to Upcoming Events">
+            <i class="ti ti-rss"></i>
+          </a>
+
           <span
             id="filter-toggle"
             class="d-flex v3-text-secondary align-items-center gap-1"

--- a/fossunited/www/events/timeline/rss.py
+++ b/fossunited/www/events/timeline/rss.py
@@ -1,0 +1,137 @@
+from datetime import datetime
+from email.utils import format_datetime
+from urllib.parse import urljoin
+
+import frappe
+from frappe.utils import escape_html, get_request_site_address
+
+from fossunited.doctype_ids import EVENT, HACKATHON
+
+no_cache = 1
+base_template_path = "www/events/timeline/rss.xml"
+
+
+def get_context(context):
+    """Generate RSS feed for upcoming events"""
+
+    host = get_request_site_address()
+    now = frappe.utils.now_datetime()
+
+    # Get upcoming published events
+    events = frappe.get_all(
+        EVENT,
+        fields=[
+            "name",
+            "event_name",
+            "event_description",
+            "event_start_date",
+            "event_end_date",
+            "event_location",
+            "event_type",
+            "chapter",
+            "route",
+            "modified",
+            "banner_image",
+            "must_attend",
+        ],
+        filters={
+            "is_published": 1,
+            "event_end_date": (">=", now),
+        },
+        order_by="event_start_date asc",
+        limit=50,
+    )
+
+    # Get upcoming hackathons
+    hackathons = frappe.get_all(
+        HACKATHON,
+        fields=[
+            "name",
+            "hackathon_name as event_name",
+            "hackathon_description as event_description",
+            "start_date as event_start_date",
+            "end_date as event_end_date",
+            "hackathon_type as event_type",
+            "chapter",
+            "route",
+            "modified",
+            "hackathon_banner as banner_image",
+        ],
+        filters={
+            "is_published": 1,
+            "end_date": (">=", now),
+        },
+        order_by="start_date asc",
+        limit=10,
+    )
+
+    # Combine and process events
+    all_events = events + hackathons
+    all_events.sort(key=lambda x: x.event_start_date)
+
+    for event in all_events:
+        event.link = urljoin(host, event.route)
+        event.title = escape_html(event.event_name or "")
+        event.chapter_name = escape_html(event.chapter or "")
+        event.location = escape_html(event.event_location or "")
+        event.event_type_display = escape_html(event.event_type or "Event")
+
+        # Format dates
+        start_date = frappe.utils.get_datetime(event.event_start_date)
+        end_date = frappe.utils.get_datetime(event.event_end_date)
+
+        event.start_date_formatted = start_date.strftime("%d %B %Y, %I:%M %p")
+        event.end_date_formatted = end_date.strftime("%d %B %Y, %I:%M %p")
+        event.published_date = format_datetime(start_date)
+
+        # Process description
+        description = event.event_description or ""
+        # Convert HTML to text for RSS
+        from frappe.utils import strip_html
+
+        description_text = strip_html(description)
+
+        # Build RSS description with event details
+        event_details = f"""
+        <![CDATA[
+        <h3>{event.event_name}</h3>
+        <p><strong>Type:</strong> {event.event_type_display}</p>
+        <p><strong>Chapter:</strong> {event.chapter_name}</p>
+        <p><strong>Location:</strong> {event.location}</p>
+        <p><strong>Start:</strong> {event.start_date_formatted}</p>
+        <p><strong>End:</strong> {event.end_date_formatted}</p>
+        """
+
+        if event.must_attend:
+            event_details += "<p><strong>⭐ Must Attend Event</strong></p>"
+
+        if event.banner_image:
+            banner_url = urljoin(host, event.banner_image)
+            event_details += f"""<p><img src="{banner_url}" alt="{event.event_name}"
+            style="max-width: 600px; height: auto;"/></p>"""
+
+        if description_text:
+            event_details += f"<div>{description}</div>"
+
+        event_details += f'<p><a href="{event.link}">View Event Details →</a></p>'
+        event_details += "]]>"
+
+        event.content = event_details
+
+    # Get latest modification date
+    if all_events:
+        modified = format_datetime(max(e.modified for e in all_events))
+    else:
+        modified = format_datetime(datetime.now())
+
+    context = {
+        "title": "FOSS United - Upcoming Events",
+        "description": """Stay updated with upcoming FOSS events, conferences, meetups,
+        and hackathons across India""",
+        "modified": modified,
+        "items": all_events,
+        "link": host + "/events/timeline",
+        "feed_url": host + "/events/timeline/rss",
+    }
+
+    return context

--- a/fossunited/www/events/timeline/rss.py
+++ b/fossunited/www/events/timeline/rss.py
@@ -3,7 +3,7 @@ from email.utils import format_datetime
 from urllib.parse import urljoin
 
 import frappe
-from frappe.utils import escape_html, get_request_site_address
+from frappe.utils import escape_html, get_request_site_address, sanitize_html
 
 from fossunited.doctype_ids import EVENT, HACKATHON
 
@@ -84,13 +84,6 @@ def get_context(context):
         event.end_date_formatted = end_date.strftime("%d %B %Y, %I:%M %p")
         event.published_date = format_datetime(start_date)
 
-        # Process description
-        description = event.event_description or ""
-        # Convert HTML to text for RSS
-        from frappe.utils import strip_html
-
-        description_text = strip_html(description)
-
         # Build RSS description with event details
         event_details = f"""
         <![CDATA[
@@ -110,8 +103,9 @@ def get_context(context):
             event_details += f"""<p><img src="{banner_url}" alt="{event.event_name}"
             style="max-width: 600px; height: auto;"/></p>"""
 
-        if description_text:
-            event_details += f"<div>{description}</div>"
+        if event_description:
+            description_html = sanitize_html(description)
+            event_details += f"<div>{description_html}</div>"
 
         event_details += f'<p><a href="{event.link}">View Event Details →</a></p>'
         event_details += "]]>"

--- a/fossunited/www/events/timeline/rss.py
+++ b/fossunited/www/events/timeline/rss.py
@@ -83,6 +83,7 @@ def get_context(context):
         event.start_date_formatted = start_date.strftime("%d %B %Y, %I:%M %p")
         event.end_date_formatted = end_date.strftime("%d %B %Y, %I:%M %p")
         event.published_date = format_datetime(start_date)
+        location = event.location or ("Online" if event.event_type == "Online" else "TBA")
 
         # Build RSS description with event details
         event_details = f"""
@@ -90,7 +91,7 @@ def get_context(context):
         <h3>{event.event_name}</h3>
         <p><strong>Type:</strong> {event.event_type_display}</p>
         <p><strong>Chapter:</strong> {event.chapter_name}</p>
-        <p><strong>Location:</strong> {event.location}</p>
+        <p><strong>Location:</strong> {location}</p>
         <p><strong>Start:</strong> {event.start_date_formatted}</p>
         <p><strong>End:</strong> {event.end_date_formatted}</p>
         """
@@ -103,8 +104,8 @@ def get_context(context):
             event_details += f"""<p><img src="{banner_url}" alt="{event.event_name}"
             style="max-width: 600px; height: auto;"/></p>"""
 
-        if event_description:
-            description_html = sanitize_html(description)
+        if event.event_description:
+            description_html = sanitize_html(event.event_description)
             event_details += f"<div>{description_html}</div>"
 
         event_details += f'<p><a href="{event.link}">View Event Details →</a></p>'

--- a/fossunited/www/events/timeline/rss.xml
+++ b/fossunited/www/events/timeline/rss.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>{{ title }}</title>
+    <description>{{ description }}</description>
+    <link>{{ link }}</link>
+    <language>en-us</language>
+    <lastBuildDate>{{ modified }}</lastBuildDate>
+    <pubDate>{{ modified }}</pubDate>
+    <ttl>3600</ttl>
+    <atom:link href="{{ feed_url }}" rel="self" type="application/rss+xml" />
+    {% for event in items %}
+    <item>
+      <title>{{ event.title }} - {{ event.location }}</title>
+      <description>{{ event.content }}</description>
+      <dc:creator>{{ event.chapter_name }}</dc:creator>
+      <link>{{ event.link }}</link>
+      <guid>{{ event.link }}</guid>
+      <pubDate>{{ event.published_date }}</pubDate>
+      <category>{{ event.event_type_display }}</category>
+    </item>
+    {% endfor %}
+  </channel>
+</rss>


### PR DESCRIPTION
- Show feeds for upcoming events

- Str is like

```
Event Name

Type: <type>

Chapter: LetsMakePy-Virtual

Location: Online | TBA

Start: 19 January 2026, 03:59 PM

End: 31 January 2026, 03:59 PM

⭐ Must Attend Event

Event Description:

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RSS subscription links added to the events timeline UI
  * New RSS feed publishing upcoming events and hackathons with full event details

* **Chores**
  * Updated URL redirect rules: added grant-related redirects and expanded RSS-related redirect patterns; removed an outdated blog-to-rss redirect

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->