### PR TITLE
dashboard(event-details): add toggle button on publishing event

### DIFF
--- a/dashboard/src/pages/EventDetails.vue
+++ b/dashboard/src/pages/EventDetails.vue
@@ -11,13 +11,23 @@
           },
         }"
       />
-      <Button
-        class="w-fit"
-        size="md"
-        label="Update Details"
-        icon-left="edit"
-        @click="updateDetails()"
-      ></Button>
+      <div class="flex items-center gap-2">
+        <Button
+          class="w-fit"
+          size="md"
+          :theme="event.doc.is_published ? 'red' : 'green'"
+          :icon-left="event.doc.is_published ? 'slash' : 'eye'"
+          :label="event.doc.is_published ? 'Unpublish Event' : 'Publish Event'"
+          @click="togglePublishEvent"
+        />
+        <Button
+          class="w-fit"
+          size="md"
+          label="Update Details"
+          icon-left="edit"
+          @click="updateDetails()"
+        ></Button>
+      </div>
     </div>
     <div class="flex flex-col gap-3 my-6">
       <div class="font-semibold text-gray-800 border-b-2 pb-2">Banner Image</div>
@@ -296,6 +306,23 @@ const sluggify = (text) => {
 const onPermalinkInput = (eventInput) => {
   const input = eventInput.target?.value ?? ''
   event.doc.event_permalink = sluggify(input)
+}
+
+const togglePublishEvent = async () => {
+  try {
+    if (event.doc.is_published) {
+      if (!confirm('Are you sure you want to unpublish this event?')) return
+    }
+    await event.setValue.submit({
+      is_published: !event.doc.is_published,
+    })
+
+    toast.success(event.doc.is_published ? 'Event published successfully' : 'Event unpublished')
+  } catch (err) {
+    toast.error('Failed to update publish status', {
+      description: err.message,
+    })
+  }
 }
 
 const getEventLink = () => {


### PR DESCRIPTION
- helps to unpublish event
- might think of adding deleting an event after seeing how it goes..?

- partially for #1364 

- For now, lets test drive if un-publishing works fine.
Its easy to add delete event button, but its an dangerous step that can delete data and and add missing field links to rsvp/cfp if already done.

<img width="1102" height="187" alt="image" src="https://github.com/user-attachments/assets/4acaf1e4-67e3-4038-b29f-828614591129" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a publish/unpublish toggle button for events, positioned alongside the existing "Update Details" button.
  * Button dynamically displays the current publication status with contextual styling and icon.
  * Includes confirmation prompts when unpublishing and provides success/error feedback messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->