### PR TITLE
api(ticket-checkin-insight): show checkins for event days

### DIFF
--- a/dashboard/src/components/event/TicketTierInsightCard.vue
+++ b/dashboard/src/components/event/TicketTierInsightCard.vue
@@ -11,6 +11,7 @@
         >
       </div>
       <div
+        v-if="tier.tickets_sold_today !== undefined && tier.tickets_sold_today !== null"
         class="flex items-center gap-1 text-sm mt-1 font-medium p-1 w-fit rounded-sm px-2"
         :class="
           tier.tickets_sold_today === 0

--- a/dashboard/src/components/ui/SearchListView.vue
+++ b/dashboard/src/components/ui/SearchListView.vue
@@ -96,9 +96,7 @@ const activeFilterApplied = computed(() => {
 })
 
 const isGrouped = computed(
-  () =>
-    props.rows.length > 0 &&
-    props.rows.every((row) => row.group && row.rows && Array.isArray(row.rows)),
+  () => props.rows.length > 0 && props.rows.every((row) => row && Array.isArray(row.rows)),
 )
 
 const getSearchableText = (row) => {

--- a/dashboard/src/pages/EventCheckins.vue
+++ b/dashboard/src/pages/EventCheckins.vue
@@ -4,6 +4,19 @@
     <EventHeader :event="event.data" class="p-4 md:p-8" />
     <hr />
     <div class="p-4 md:px-8 md:py-6">
+      <div v-if="ticket_checkin_insights.data?.daily_data" class="flex flex-col gap-4 my-2">
+        <div class="prose">
+          <h4>Daily Check-in Insights</h4>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+          <TicketTierInsightCard
+            v-for="day in ticket_checkin_insights.data.daily_data"
+            :key="day.title"
+            :tier="day"
+          />
+        </div>
+      </div>
+
       <div class="prose">
         <h2 class="mb-1">Attendee Check-Ins</h2>
         <p class="text-sm">Check in attendees as they arrive at the event.</p>
@@ -144,6 +157,7 @@ import { useRoute } from 'vue-router'
 import { inject, provide, ref, computed, watch, watchEffect } from 'vue'
 import { IconChecks } from '@tabler/icons-vue'
 import dayjs, { formatCheckinDateTime, getRelativeTime, isCheckedInToday } from '@/helpers/date'
+import { toast } from 'vue-sonner'
 
 const session = inject('$session')
 const route = useRoute()
@@ -183,6 +197,20 @@ const attendees = createResource({
     }
   },
   auto: true,
+})
+
+const ticket_checkin_insights = createResource({
+  url: 'fossunited.api.tickets.get_checkin_insights',
+  makeParams() {
+    return {
+      event_id: route.params.id,
+    }
+  },
+  loading: true,
+  auto: true,
+  onError(error) {
+    toast.error(error.message)
+  },
 })
 
 const loading = computed(() => attendees.loading || !attendees.data)

--- a/dashboard/src/pages/EventCheckins.vue
+++ b/dashboard/src/pages/EventCheckins.vue
@@ -4,7 +4,7 @@
     <EventHeader :event="event.data" class="p-4 md:p-8" />
     <hr />
     <div class="p-4 md:px-8 md:py-6">
-      <div v-if="ticket_checkin_insights.data?.daily_data" class="flex flex-col gap-4 my-2">
+      <div v-if="ticket_checkin_insights.data?.daily_data?.length" class="flex flex-col gap-4 my-2">
         <div class="prose">
           <h4>Daily Check-in Insights</h4>
         </div>

--- a/dashboard/src/pages/EventTicketInsights.vue
+++ b/dashboard/src/pages/EventTicketInsights.vue
@@ -19,6 +19,20 @@
           :tier="tier"
         />
       </div>
+
+      <div v-if="ticket_checkin_insights.data?.daily_data" class="flex flex-col gap-4 mt-4">
+        <div class="prose">
+          <h4>Daily Check-in Insights</h4>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+          <TicketTierInsightCard
+            v-for="day in ticket_checkin_insights.data.daily_data"
+            :key="day.title"
+            :tier="day"
+          />
+        </div>
+      </div>
+
       <div class="flex flex-col gap-4">
         <TicketList :event="event" />
       </div>
@@ -63,6 +77,20 @@ const ticket_insights = createResource({
     today_stats.total_sold = data.total_sold
     today_stats.tickets_sold_today = data.tickets_sold_today
   },
+  onError(error) {
+    toast.error(error.message)
+  },
+})
+
+const ticket_checkin_insights = createResource({
+  url: 'fossunited.api.tickets.get_checkin_insights',
+  makeParams() {
+    return {
+      event_id: props.event.data.name,
+    }
+  },
+  loading: true,
+  auto: true,
   onError(error) {
     toast.error(error.message)
   },

--- a/dashboard/src/pages/EventTicketInsights.vue
+++ b/dashboard/src/pages/EventTicketInsights.vue
@@ -20,7 +20,10 @@
         />
       </div>
 
-      <div v-if="ticket_checkin_insights.data?.daily_data" class="flex flex-col gap-4 mt-4">
+      <div
+        v-if="ticket_checkin_insights.data?.daily_data?.length"
+        class="flex flex-col gap-4 my-2"
+      >
         <div class="prose">
           <h4>Daily Check-in Insights</h4>
         </div>

--- a/fossunited/api/tickets.py
+++ b/fossunited/api/tickets.py
@@ -169,8 +169,9 @@ def get_checkin_insights(event_id: str) -> dict:
     Returns:
         dict: {"daily_data": [{"title": date, "total_sold": count, "tickets_sold_today": 0}, ...]}
     """
-    # Get event details
-    event = frappe.get_doc(EVENT, event_id)
+    event_start_date, event_end_date = frappe.db.get_value(
+        EVENT, event_id, ["event_start_date", "event_end_date"]
+    )
 
     # Get all tickets for this event
     tickets = frappe.get_all(EVENT_TICKET, filters={"event": event_id}, pluck="name")
@@ -178,8 +179,8 @@ def get_checkin_insights(event_id: str) -> dict:
     if not tickets:
         return {"daily_data": []}
 
-    start_date = frappe.utils.get_datetime(event.event_start_date).date()
-    end_date = frappe.utils.get_datetime(event.event_end_date).date()
+    start_date = frappe.utils.get_datetime(event_start_date).date()
+    end_date = frappe.utils.get_datetime(event_end_date).date()
 
     daily_data = []
     current_date = start_date
@@ -189,6 +190,8 @@ def get_checkin_insights(event_id: str) -> dict:
             EVENT_CHECKIN,
             filters={
                 "parent": ["in", tickets],
+                "parenttype": EVENT_TICKET,
+                "parentfield": "check_ins",
                 "check_in_time": [
                     "between",
                     [f"{date_str} 00:00:00", f"{date_str} 23:59:59"],

--- a/fossunited/api/tickets.py
+++ b/fossunited/api/tickets.py
@@ -2,12 +2,15 @@
 APIs for Tickets and Transfer Tickets
 """
 
+from datetime import timedelta
+
 import frappe
 from frappe.utils import add_days, now_datetime
 
 from fossunited.api.chapter import check_if_chapter_member
 from fossunited.doctype_ids import (
     EVENT,
+    EVENT_CHECKIN,
     EVENT_TICKET,
     FREE_TICKET_APPLY,
     FREE_TICKET_CODE,
@@ -156,6 +159,51 @@ def get_tickets_insights(event_id: str) -> dict:
         "total_percentage_change": percentage_change,
         "tier_data": combined_tier_data,
     }
+
+
+@frappe.whitelist()
+def get_checkin_insights(event_id: str) -> dict:
+    """
+    Get check-in counts for each day from event start to end date
+
+    Returns:
+        dict: {"daily_data": [{"title": date, "total_sold": count, "tickets_sold_today": 0}, ...]}
+    """
+    # Get event details
+    event = frappe.get_doc(EVENT, event_id)
+
+    # Get all tickets for this event
+    tickets = frappe.get_all(EVENT_TICKET, filters={"event": event_id}, pluck="name")
+
+    if not tickets:
+        return {"daily_data": []}
+
+    start_date = frappe.utils.get_datetime(event.event_start_date).date()
+    end_date = frappe.utils.get_datetime(event.event_end_date).date()
+
+    daily_data = []
+    current_date = start_date
+    while current_date <= end_date:
+        date_str = current_date.strftime("%Y-%m-%d")
+        count = frappe.db.count(
+            EVENT_CHECKIN,
+            filters={
+                "parent": ["in", tickets],
+                "check_in_time": [
+                    "between",
+                    [f"{date_str} 00:00:00", f"{date_str} 23:59:59"],
+                ],
+            },
+        )
+        daily_data.append(
+            {
+                "title": frappe.utils.formatdate(date_str, "dd MMM"),
+                "total_sold": count,  # Using total_sold to match checked-in
+            }
+        )
+        current_date += timedelta(days=1)
+
+    return {"daily_data": daily_data}
 
 
 def get_tshirt_insights(event_id: str) -> dict:


### PR DESCRIPTION
- Shows in Ticket insight page and in Event checkin page as well.

<img width="3360" height="442" alt="image" src="https://github.com/user-attachments/assets/1fb28e6b-9d04-47b1-9d68-6d198b7833ec" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added daily check-in insights feature displaying daily event attendance breakdown by ticket tier with formatted dates and counts.

* **Bug Fixes**
  * Fixed conditional rendering to prevent "tickets sold today" block from displaying when data is unavailable.

* **Refactor**
  * Updated grouping detection logic to improve list filtering and data handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->