### PR TITLE
doctype(job-board): add publish_date field to handle scheduler and track dates

### DIFF
--- a/fossunited/job/doctype/job_board/job_board.json
+++ b/fossunited/job/doctype/job_board/job_board.json
@@ -8,6 +8,7 @@
   "job_view_page_section",
   "is_published",
   "route",
+  "publish_date",
   "company_location_section",
   "company_name",
   "status",
@@ -114,6 +115,11 @@
    "fieldname": "job_view_page_section",
    "fieldtype": "Section Break",
    "label": "Job view page"
+  },
+  {
+   "fieldname": "publish_date",
+   "fieldtype": "Datetime",
+   "label": "Published date"
   }
  ],
  "grid_page_length": 50,
@@ -121,7 +127,7 @@
  "index_web_pages_for_search": 1,
  "is_published_field": "is_published",
  "links": [],
- "modified": "2025-10-27 15:29:31.976514",
+ "modified": "2026-02-02 11:13:09.191440",
  "modified_by": "Administrator",
  "module": "Job",
  "name": "Job Board",

--- a/fossunited/job/doctype/job_board/job_board.py
+++ b/fossunited/job/doctype/job_board/job_board.py
@@ -49,7 +49,7 @@ class JobBoard(WebsiteGenerator):
             if not self.publish_date:
                 self.publish_date = now_datetime()
 
-        elif self.status in ["Expired", "Rejected", "Received"]:
+        elif self.status in ["Rejected", "Received"]:
             self.is_published = 0
 
     def get_context(self, context):

--- a/fossunited/job/doctype/job_board/job_board.py
+++ b/fossunited/job/doctype/job_board/job_board.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
+from frappe.utils import add_days, now_datetime
 from frappe.website.website_generator import WebsiteGenerator
 
 
@@ -22,11 +23,10 @@ class JobBoard(WebsiteGenerator):
         job_description: DF.MarkdownEditor | None
         job_location: DF.Data
         job_title: DF.Data
-        job_type: DF.Literal[
-            "Full Time", "Part Time", "Intern", "Freelance", "Contract"  # noqa: F722, F821
-        ]
+        job_type: DF.Literal["Full Time", "Part Time", "Intern", "Freelance", "Contract"]
+        publish_date: DF.Datetime | None
         route: DF.Data | None
-        status: DF.Literal["Received", "Approved", "Rejected", "Expired"]  # noqa: F722, F821
+        status: DF.Literal["Received", "Approved", "Rejected", "Expired"]
     # end: auto-generated types
 
     def before_save(self):
@@ -38,14 +38,22 @@ class JobBoard(WebsiteGenerator):
 
     def handle_publish_status(self):
         """
-        automatically publish/unpublish job based on status changes.
+        Automatically publish/unpublish job based on status changes.
         """
-        if self.has_value_changed("status"):
-            if self.status in ["Approved", "Expired"]:
-                self.is_published = 1
-            elif self.status in ["Rejected", "Received"]:
-                self.is_published = 0
+        if not self.has_value_changed("status"):
+            return
+
+        if self.status == "Approved":
+            self.is_published = 1
+
+            if not self.publish_date:
+                self.publish_date = now_datetime()
+
+        elif self.status in ["Expired", "Rejected", "Received"]:
+            self.is_published = 0
 
     def get_context(self, context):
         """Context for rendering job detail page"""
         context.title = f"{self.job_title} at {self.company_name}"
+        context.posted_on = self.publish_date or self.creation
+        context.closed_on = add_days(context.posted_on, 90)

--- a/fossunited/job/doctype/job_board/templates/job_board.html
+++ b/fossunited/job/doctype/job_board/templates/job_board.html
@@ -25,12 +25,13 @@
     <!-- Job Dates -->
     <div class="mb-4">
       <small class="text-muted">
-        Posted on {{ frappe.utils.format_date(doc.creation, "MMMM dd, yyyy") }}
+        Posted on {{ frappe.utils.format_date(posted_on, "MMMM dd, yyyy") }}
+
         {% if doc.status == 'Expired' %}
           |
-          <span class="text-danger"
-            >Closed on {{ frappe.utils.format_date(doc.modified, "MMMM dd, yyyy") }}</span
-          >
+          <span class="text-danger">
+            Closed on {{ frappe.utils.format_date(closed_on, "MMMM dd, yyyy") }}
+          </span>
         {% endif %}
       </small>
     </div>
@@ -74,9 +75,12 @@
   </div>
 
   <style>
-    h1, h2, h3, h4, h5 {
-        font-size: 1.3em;
+    h1,
+    h2,
+    h3,
+    h4,
+    h5 {
+      font-size: 1.3em;
     }
   </style>
-
 {% endblock %}

--- a/fossunited/scheduled_tasks.py
+++ b/fossunited/scheduled_tasks.py
@@ -1,7 +1,5 @@
-from datetime import datetime, timedelta
-
 import frappe
-from frappe.utils import now_datetime
+from frappe.utils import add_days, now_datetime
 
 from fossunited.doctype_ids import (
     EVENT,
@@ -55,51 +53,47 @@ def conclude_events():
 
 def update_past_job_status():
     """
-    Updates the job status to Expired, if they are Approved (active) and
-    were last modified more than 3 months ago (90 days).
+    Expire jobs that were published more than 90 days ago.
     """
-    cutoff_date = datetime.now() - timedelta(days=90)
+    cutoff_date = add_days(now_datetime(), -90)
+
     past_active_jobs = frappe.get_all(
         JOB,
-        filters={"status": JOB_STATUS_APPROVED, "modified": ["<", cutoff_date]},
+        filters=[
+            ["status", "=", JOB_STATUS_APPROVED],
+            ["publish_date", "is", "set"],
+            ["publish_date", "<=", cutoff_date],
+        ],
         fields=["name"],
     )
 
-    for jobs in past_active_jobs:
+    for job in past_active_jobs:
         try:
-            # Get the actual document object
-            job_doc = frappe.get_doc(JOB, jobs.name)
+            job_doc = frappe.get_doc(JOB, job.name)
             job_doc.status = JOB_STATUS_EXPIRED
             job_doc.save(ignore_permissions=True)
 
-            # Send notification email after successful update
             if job_doc.email:
-                cc_email = ["foundation@fossunited.org"]
-                subject = (
-                    f"Job Posting Auto-Expiry Notice: "
-                    f"{frappe.utils.escape_html(job_doc.name)} | "
-                    f"{frappe.utils.escape_html(job_doc.job_title)}"
-                )
-
-                message = (
-                    f"<p>Dear {frappe.utils.escape_html(job_doc.company_name)},</p>"
-                    f"<p>Your job posting titled"
-                    f"<strong>{frappe.utils.escape_html(job_doc.job_title)}</strong> "
-                    f"has been up for 90 days and "
-                    f"will now be automatically marked as "
-                    f"<strong>Expired</strong>.</p>"
-                    f"<p>If you wish to keep this job open, please reply over this email.</p>"
-                    f"<p>Regards,<br>FOSS United Team</p>"
-                )
                 frappe.sendmail(
                     recipients=[job_doc.email],
-                    cc=cc_email,
-                    subject=subject,
-                    message=message,
+                    cc=["foundation@fossunited.org"],
+                    subject=(
+                        f"Job Posting Auto-Expiry Notice: "
+                        f"{frappe.utils.escape_html(job_doc.job_title)}"
+                    ),
+                    message=(
+                        f"<p>Dear {frappe.utils.escape_html(job_doc.company_name)},</p>"
+                        f"<p>Your job posting "
+                        f"<strong>{frappe.utils.escape_html(job_doc.job_title)}</strong> "
+                        f"has been live for 90 days and is now marked "
+                        f"<strong>Expired</strong>.</p>"
+                        f"<p>If you wish to keep it open, please reply to this email.</p>"
+                        f"<p>Regards,<br>FOSS United Team</p>"
+                    ),
                 )
-        except Exception as e:
+
+        except Exception:
             frappe.log_error(
                 frappe.get_traceback(),
-                f"Error updating job status - ID:{job_doc.name}\nError:{str(e)}",
+                f"Error updating job status - ID:{job.name}",
             )
-            continue

--- a/fossunited/www/jobs/index.html
+++ b/fossunited/www/jobs/index.html
@@ -50,9 +50,14 @@
           <div class="card h-100">
             <div class="card-body d-flex flex-column">
               <h5 class="card-title">{{ job.job_title }}</h5>
-              <small class="text-muted">Posted on {{ job.creation.strftime("%B %d, %Y") }}</small>
-              <small class="text-muted d-block">Closed on {{ job.modified.strftime("%B %d, %Y") }}</small>
-
+              {% set posted_on = job.publish_date or job.creation %}
+              {% set closed_on = frappe.utils.add_days(posted_on, 90) %}
+              <small class="text-muted">
+                Posted on {{ frappe.utils.format_date(posted_on, "MMMM dd, yyyy") }}
+              </small>
+              <small class="text-muted d-block">
+                Closed on {{ frappe.utils.format_date(closed_on, "MMMM dd, yyyy") }}
+              </small>
               <div class="d-flex align-items-center mb-1 mt-2">
                 <i class="ti ti-building mr-2"></i>
                 <a href="{{ job.company_website }}" target="_blank">{{ job.company_name }}</a>

--- a/fossunited/www/jobs/index.py
+++ b/fossunited/www/jobs/index.py
@@ -1,11 +1,17 @@
 import frappe
 
+from fossunited.doctype_ids import (
+    JOB,
+    JOB_STATUS_APPROVED,
+    JOB_STATUS_EXPIRED,
+)
+
 
 def get_context(context):
     context.no_cache = 1
     context.active_jobs = frappe.get_all(
-        "Job Board",
-        filters={"status": "Approved", "is_published": 1},
+        JOB,
+        filters={"status": JOB_STATUS_APPROVED, "is_published": 1},
         fields=[
             "name",
             "job_title",
@@ -18,8 +24,8 @@ def get_context(context):
         order_by="creation desc",
     )
     context.expired_jobs = frappe.get_all(
-        "Job Board",
-        filters={"status": "Expired", "is_published": 1},
+        JOB,
+        filters={"status": JOB_STATUS_EXPIRED, "is_published": 1},
         fields=[
             "name",
             "job_title",


### PR DESCRIPTION
- Recently did a accidental deletion of doctype items, but thankfully recovered them via "Deleted document"

- We need to reliably track date to make expiry via scheduler and be logical.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added published date tracking to job listings, clearly showing when jobs become available and when they expire.
  * Job expiration is now calculated as 90 days from the publication date, ensuring consistent visibility windows across all postings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->