### PR TITLE
api(hackathon): create_participant only based on session user request

### DIFF
--- a/dashboard/src/pages/hackathon/Register.vue
+++ b/dashboard/src/pages/hackathon/Register.vue
@@ -49,6 +49,8 @@
             type="email"
             label="Email &ast;"
             placeholder="john@fossunited.org"
+            :disabled="true"
+            class="bg-gray-50"
           />
           <FormControl v-model="participant.is_student" type="checkbox" label="I am a student" />
           <FormControl
@@ -196,7 +198,6 @@ let participant = reactive({
   organization: '',
   wants_to_attend_locally: '',
   localhost: '',
-  subscribe_chapter_mailing: 1,
 })
 
 const hackathonId = ref(null)
@@ -286,6 +287,7 @@ onMounted(() => {
   }
   if (session.user != 'Administrator' && session.user != 'Guest') {
     participant.user = session.user
+    participant.email = session.user
     user_profile.update({
       params: {
         email: session.user,
@@ -313,9 +315,6 @@ const registrationErrors = computed(() => {
 
   if (!participant.full_name) {
     errors.push('Name is required.')
-  }
-  if (!participant.email) {
-    errors.push('Email is required.')
   }
   if (!participant.organization) {
     errors.push('Organization / Institute is required.')

--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -44,7 +44,8 @@ def get_hackathon_from_permalink(permalink: str) -> dict:
     return frappe.get_doc(HACKATHON, {"permalink": permalink})
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
+@frappe.rate_limiter.rate_limit(limit=3, seconds=60 * 60 * 12)
 def create_participant(hackathon, participant):
     """
     This method is used to create a participant for a hackathon.
@@ -56,21 +57,41 @@ def create_participant(hackathon, participant):
     return:
         dict: participant doc object
     """
+    current_user = frappe.session.user
+    if current_user == "Guest":
+        frappe.throw("Authentication required", frappe.PermissionError)
+
+    hackathon_name = hackathon.get("data", {}).get("name")
+    if not hackathon_name:
+        frappe.throw("Invalid hackathon")
+
+    if frappe.db.exists(
+        HACKATHON_PARTICIPANT, {"hackathon": hackathon_name, "user": current_user}
+    ):
+        frappe.throw("You have already registered for this hackathon")
+
+    user_profile_data = frappe.db.get_value(
+        USER_PROFILE,
+        {"user": current_user},
+        ["name", "full_name"],
+        as_dict=True,
+    )
 
     participant_doc = frappe.get_doc(
         {
             "doctype": HACKATHON_PARTICIPANT,
-            "hackathon": hackathon.get("data").get("name"),
-            "user": participant.get("user"),
-            "user_profile": participant.get("user_profile"),
-            "full_name": participant.get("full_name"),
-            "email": participant.get("email"),
-            "is_student": participant.get("is_student"),
-            "organization": participant.get("organization"),
-            "git_profile": participant.get("git_profile"),
-            "wants_to_attend_locally": participant.get("wants_to_attend_locally"),
-            "localhost": participant.get("localhost"),
-            "subscribe_chapter_mailing": participant.get("subscribe_chapter_mailing"),
+            "hackathon": hackathon_name,
+            "user": current_user,
+            "user_profile": user_profile_data.get("name") if user_profile_data else "",
+            "full_name": participant.get("full_name")
+            or (user_profile_data.get("full_name") if user_profile_data else ""),
+            "email": current_user,
+            "is_student": participant.get("is_student", 0),
+            "organization": participant.get("organization", ""),
+            "git_profile": participant.get("git_profile", ""),
+            "wants_to_attend_locally": participant.get("wants_to_attend_locally", 0),
+            "localhost": participant.get("localhost", ""),
+            "subscribe_chapter_mailing": participant.get("subscribe_chapter_mailing", 0),
         }
     )
     participant_doc.insert(ignore_permissions=True)

--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -82,9 +82,8 @@ def create_participant(hackathon, participant):
             "doctype": HACKATHON_PARTICIPANT,
             "hackathon": hackathon_name,
             "user": current_user,
-            "user_profile": user_profile_data.get("name") if user_profile_data else "",
-            "full_name": participant.get("full_name")
-            or (user_profile_data.get("full_name") if user_profile_data else ""),
+            "user_profile": user_profile_data.get("name"),
+            "full_name": participant.get("full_name") or (user_profile_data.get("full_name")),
             "email": current_user,
             "is_student": participant.get("is_student", 0),
             "organization": participant.get("organization", ""),


### PR DESCRIPTION
- avoid people misusing function to create any other participant
- only act based on session user, lets not give option to manipulate email or user profile



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Email field in registration form is now pre-filled from your account and locked from editing.
  * Added rate limiting to registration to prevent abuse.
  * Duplicate registrations for the same hackathon are now prevented.
  * Authentication is now required to register for hackathons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->