### PR TITLE
api: implement team member check in project creation (fixes unauthori…

### DIFF
--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -219,6 +219,25 @@ def create_project(hackathon: str, team: str, project: dict) -> dict:
     Returns:
         dict: Project document as a dictionary
     """
+    team_doc = frappe.get_doc(HACKATHON_TEAM, team)
+    
+    is_member = False
+    user_email = frappe.session.user
+    
+    for member in team_doc.members:
+        if member.email == user_email:
+            is_member = True
+            break
+            
+        if member.member:
+            participant_email = frappe.db.get_value(HACKATHON_PARTICIPANT, member.member, "user")
+            if participant_email == user_email:
+                is_member = True
+                break
+
+    if not is_member:
+        frappe.throw("You are not authorized to create a project for this team", frappe.PermissionError)
+
     project_doc = frappe.get_doc(
         {
             "doctype": HACKATHON_PROJECT,

--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -220,15 +220,15 @@ def create_project(hackathon: str, team: str, project: dict) -> dict:
         dict: Project document as a dictionary
     """
     team_doc = frappe.get_doc(HACKATHON_TEAM, team)
-    
+
     is_member = False
     user_email = frappe.session.user
-    
+
     for member in team_doc.members:
         if member.email == user_email:
             is_member = True
             break
-            
+
         if member.member:
             participant_email = frappe.db.get_value(HACKATHON_PARTICIPANT, member.member, "user")
             if participant_email == user_email:
@@ -236,7 +236,9 @@ def create_project(hackathon: str, team: str, project: dict) -> dict:
                 break
 
     if not is_member:
-        frappe.throw("You are not authorized to create a project for this team", frappe.PermissionError)
+        frappe.throw(
+            "You are not authorized to create a project for this team", frappe.PermissionError
+        )
 
     project_doc = frappe.get_doc(
         {

--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -207,6 +207,7 @@ def get_team_from_participant_id(hackathon: str, id: str) -> dict:
 
 
 @frappe.whitelist()
+@frappe.rate_limiter.rate_limit(limit=3, seconds=60 * 60 * 12)
 def create_project(hackathon: str, team: str, project: dict) -> dict:
     """
     Create a project document


### PR DESCRIPTION
This PR primarily patches an access control vulnerability in the `create_project` API endpoint. Previously, any authenticated user could create a project for any team ID. This change creates a mandatory check to ensure the `frappe.session.user` is an active member of the specified team before allowing project creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Project creation now requires team membership: only members of a team can create projects for that team; unauthorized attempts are blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->