### PR TITLE
doctype(localhost): add description to add more info

### DIFF
--- a/dashboard/src/pages/localhost/LocalhostEdit.vue
+++ b/dashboard/src/pages/localhost/LocalhostEdit.vue
@@ -59,6 +59,18 @@
 
         <!-- Right: Meta -->
         <div class="flex flex-col gap-4">
+          <!-- Accepting Attendees -->
+          <div class="md:col-span-2">
+            <div class="flex items-center justify-between p-3 border rounded-md">
+              <div class="flex flex-col">
+                <span class="font-medium text-gray-800"> Accepting Attendees </span>
+                <span class="text-sm text-gray-600">
+                  Allow attendees to register for this localhost.
+                </span>
+              </div>
+              <Switch v-model="localhost.doc.is_accepting_attendees" />
+            </div>
+          </div>
           <div class="grid grid-cols-2 gap-4">
             <div class="flex flex-col gap-1">
               <label class="text-sm font-medium text-gray-700">State</label>
@@ -105,20 +117,19 @@
         />
 
         <FormControl v-model="localhost.doc.map_link" type="url" label="Map Link" size="md" />
-
-        <!-- Accepting Attendees -->
-        <div class="md:col-span-2">
-          <div class="flex items-center justify-between p-3 border rounded-md">
-            <div class="flex flex-col">
-              <span class="font-medium text-gray-800"> Accepting Attendees </span>
-              <span class="text-sm text-gray-600">
-                Allow attendees to register for this localhost.
-              </span>
-            </div>
-            <Switch v-model="localhost.doc.is_accepting_attendees" />
-          </div>
-        </div>
       </div>
+    </div>
+    <!-- Description -->
+    <div class="rounded-sm border p-4 my-6">
+      <div class="text-sm uppercase font-medium mb-3">Localhost Description</div>
+
+      <TextEditor
+        label="Localhost Description"
+        class="col-span-2"
+        :model-value="localhost.doc.description"
+        @update:model-value="($event) => (localhost.doc.description = $event)"
+        placeholder="Write about this Localhost… schedule, venue details, what to expect…"
+      />
     </div>
   </div>
 </template>
@@ -128,6 +139,7 @@ import { createDocumentResource, FileUploader, FormControl, Button, Switch } fro
 import { computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { toast } from 'vue-sonner'
+import TextEditor from '@/components/ui/TextEditor.vue'
 
 import LocalhostHeader from '@/components/localhost/LocalhostHeader.vue'
 import CopyToClipboardComponent from '@/components/CopyToClipboardComponent.vue'

--- a/dashboard/src/pages/localhost/LocalhostEdit.vue
+++ b/dashboard/src/pages/localhost/LocalhostEdit.vue
@@ -121,16 +121,18 @@
     </div>
     <!-- Description -->
     <div class="rounded-sm border p-4 my-6">
-      <div class="text-sm uppercase font-medium mb-3">Localhost Description</div>
-
       <TextEditor
         label="Localhost Description"
-        class="col-span-2"
         :model-value="localhost.doc.description"
         @update:model-value="($event) => (localhost.doc.description = $event)"
         placeholder="Write about this Localhost… schedule, venue details, what to expect…"
       />
     </div>
+    <FormActionBar
+      :document-resource="localhost"
+      :is-saving="localhost.save.loading"
+      @save="updateLocalhost"
+    />
   </div>
 </template>
 
@@ -140,7 +142,7 @@ import { computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { toast } from 'vue-sonner'
 import TextEditor from '@/components/ui/TextEditor.vue'
-
+import FormActionBar from '@/components/FormActionBar.vue'
 import LocalhostHeader from '@/components/localhost/LocalhostHeader.vue'
 import CopyToClipboardComponent from '@/components/CopyToClipboardComponent.vue'
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.json
@@ -26,6 +26,8 @@
     "location",
     "column_break_sikv",
     "map_link",
+    "section_break_vvfj",
+    "description",
     "organizer_details_section",
     "organizers"
   ],
@@ -144,12 +146,21 @@
       "fieldtype": "Data",
       "label": "Email",
       "options": "Email"
+    },
+    {
+      "fieldname": "section_break_vvfj",
+      "fieldtype": "Section Break"
+    },
+    {
+      "fieldname": "description",
+      "fieldtype": "Text Editor",
+      "label": "Localhost Description"
     }
   ],
   "has_web_view": 1,
   "is_published_field": "is_published",
   "links": [],
-  "modified": "2025-01-28 10:43:38.977099",
+  "modified": "2026-02-05 11:17:43.823399",
   "modified_by": "Administrator",
   "module": "FOSS Hackathon",
   "name": "FOSS Hackathon LocalHost",
@@ -180,6 +191,8 @@
       "select": 1
     }
   ],
+  "route": "host",
+  "row_format": "Dynamic",
   "show_title_field_in_link": 1,
   "sort_field": "modified",
   "sort_order": "DESC",

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.py
@@ -27,6 +27,7 @@ class FOSSHackathonLocalHost(WebsiteGenerator):
         )
 
         city: DF.Link | None
+        description: DF.TextEditor | None
         email: DF.Data | None
         image: DF.AttachImage | None
         is_accepting_attendees: DF.Check

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/foss_hackathon_localhost.py
@@ -11,6 +11,7 @@ from fossunited.doctype_ids import (
     LOCALHOST_ORGANIZER,
     USER_PROFILE,
 )
+from fossunited.fossunited.utils import sanitize_text_content
 
 
 class FOSSHackathonLocalHost(WebsiteGenerator):
@@ -42,7 +43,8 @@ class FOSSHackathonLocalHost(WebsiteGenerator):
         state: DF.Link | None
     # end: auto-generated types
 
-    pass
+    def validate(self):
+        self.description = sanitize_text_content(self.description)
 
     def before_insert(self):
         member_profiles = [member.profile for member in self.organizers]

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/templates/foss_hackathon_localhost.html
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_localhost/templates/foss_hackathon_localhost.html
@@ -11,7 +11,7 @@
 
       <div class="flex flex-col gap-6 mt-5">
         <div class="flex flex-col md:flex-row gap-6 md:gap-8 mb-5">
-          <div class="md:w-2/3 w-full flex flex-col gap-2">
+          <div class="md:w-1/2 w-full flex flex-col gap-2">
             {{ hero_image() }}
 
             <div class="v3-tag v3-tag--must">
@@ -26,11 +26,12 @@
             </div>
           </div>
 
-          <div class="md:w-2/3 w-full flex flex-col justify-between gap-4">
+          <div class="md:w-1/2 w-full flex flex-col justify-between gap-4">
             {{ hero_section() }}
 
             <div
-              class=" flex flex-col md:flex-row justify-center items-stretch gap-2 md:px-0 w-full "
+              class="d-flex flex-column flex-md-row justify-content-center justify-content-md-start align-items-stretch
+                     gap-2 md:px-0 w-full"
             >
               {% if hackathon.is_registration_live %}
                 {{ primary_button("Register", registration_link) }}
@@ -52,8 +53,8 @@
         </div>
 
         <div class="flex flex-col md:flex-row gap-6 md:gap-8">
-          <div class="md:w-1/3 w-full min-w-0">{{ organizers_section() }}</div>
-          <div class="md:w-2/3 w-full min-w-0">{{ about_section() }}</div>
+          <div class="md:w-1/2 w-full min-w-0">{{ organizers_section() }}</div>
+          <div class="md:w-1/2 w-full min-w-0">{{ about_section() }}</div>
         </div>
       </div>
     </div>
@@ -112,7 +113,7 @@
 {% endmacro %}
 
 {% macro hero_section() %}
-    <div class="flex flex-col justify-between gap-4 w-full px-2 px-md-0">
+  <div class="flex flex-col justify-between gap-4 w-full px-2 px-md-0">
     <div class="flex flex-col gap-2">
       <a href="{{ hackathon.external_website_url or '/' + hackathon.route }}" class="inline-block">
         {% if hackathon.hackathon_logo %}
@@ -213,15 +214,22 @@
 {% endmacro %}
 
 {% macro about_section() %}
-<div class="d-flex flex-column mt-3 mt-md-0">
-    <div>
-      <h4 class="text-base font-semibold">About the Event</h4>
-      <p>{{ hackathon.hackathon_description }}</p>
-    </div>
-    <div>
-      <h4 class="text-base font-semibold">Rules</h4>
-      <p>{{ hackathon.hackathon_rules }}</p>
-    </div>
+  <div class="d-flex flex-column mt-3 mt-md-0">
+    {% if doc.description %}
+      <h1 class="text-2xl font-semibold mb-4">Localhost Description</h1>
+      <span class="v3-text-primary prose" style="font-size: 1rem; line-height: 1.5rem;">
+      {{ doc.description }}
+      </span>
+    {% else %}
+      <div>
+        <h2 class="text-base font-semibold">About the Event</h2>
+        <p>{{ hackathon.hackathon_description }}</p>
+      </div>
+      <div>
+        <h2 class="text-base font-semibold">Rules</h2>
+        <p>{{ hackathon.hackathon_rules }}</p>
+      </div>
+    {% endif %}
   </div>
 {% endmacro %}
 


### PR DESCRIPTION
- Description field helps localhost to inform what's happening and provide schedule of events.

- The web page will also render the same 
- Dashboard has text editor to add content for organizers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Localhost Description section with rich text editing capability.
  * Reorganized attendee acceptance toggle to the interface metadata panel.

* **Style**
  * Updated layout proportions from asymmetric to equal-width column splits for improved visual balance on medium and larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->