### PR TITLE
hackathon: add controller and permission checks for deterministic modification

### DIFF
--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -12,9 +12,14 @@ from fossunited.doctype_ids import (
     HACKATHON_PROJECT,
     HACKATHON_TEAM,
     HACKATHON_TEAM_MEMBER,
+    LOCALHOST_ORGANIZER,
     USER_PROFILE,
 )
 from fossunited.integrations.github import GithubHelper
+from fossunited.utils.decorators import (
+    require_hackathon_participant,
+    require_hackathon_team,
+)
 
 
 @frappe.whitelist(allow_guest=True)
@@ -100,7 +105,7 @@ def create_participant(hackathon, participant):
 
 
 @frappe.whitelist()
-def get_participant(hackathon: str, user: str) -> dict:
+def get_participant(hackathon: str) -> dict:
     """
     Get participant details
 
@@ -113,11 +118,13 @@ def get_participant(hackathon: str, user: str) -> dict:
     """
     return frappe.get_doc(
         HACKATHON_PARTICIPANT,
-        {"hackathon": hackathon, "user": user},
+        {"hackathon": hackathon, "user": frappe.session.user},
     )
 
 
 @frappe.whitelist()
+@require_hackathon_participant(hackathon_id="hackathon")
+@rate_limit(limit=3, seconds=60 * 60)
 def create_team(hackathon: str, team: dict) -> dict:
     """
     Create a team document
@@ -134,16 +141,15 @@ def create_team(hackathon: str, team: dict) -> dict:
             "doctype": HACKATHON_TEAM,
             "team_name": team.get("team_name"),
             "hackathon": hackathon,
-            "team_lead": team.get("team_lead"),
-            "members": team.get("members"),
+            "members": team.get("members", []),
         }
     )
-    team_doc.insert(ignore_permissions=True)
+    team_doc.insert()
     return team_doc
 
 
 @frappe.whitelist()
-def get_team_by_member_email(hackathon: str, email: str) -> dict:
+def get_team_by_member_email(hackathon: str) -> dict:
     """
     Get team details
 
@@ -154,7 +160,7 @@ def get_team_by_member_email(hackathon: str, email: str) -> dict:
     Returns:
         dict: Team document as a dictionary
     """
-    participant = get_participant(hackathon, email)
+    participant = get_participant(hackathon)
 
     try:
         team = frappe.get_doc(
@@ -208,6 +214,7 @@ def get_team_from_participant_id(hackathon: str, id: str) -> dict:
 
 
 @frappe.whitelist()
+@require_hackathon_team(team_id="team", hackathon_id="hackathon")
 @rate_limit(limit=3, seconds=60 * 60 * 12)
 def create_project(hackathon: str, team: str, project: dict) -> dict:
     """
@@ -221,28 +228,6 @@ def create_project(hackathon: str, team: str, project: dict) -> dict:
     Returns:
         dict: Project document as a dictionary
     """
-    team_doc = frappe.get_doc(HACKATHON_TEAM, team)
-
-    is_member = False
-    user_email = frappe.session.user
-
-    for member in team_doc.members:
-        if member.email == user_email:
-            is_member = True
-            break
-
-        if member.member:
-            participant_email = frappe.db.get_value(HACKATHON_PARTICIPANT, member.member, "user")
-            if participant_email == user_email:
-                is_member = True
-                break
-
-    if not is_member:
-        frappe.throw(
-            "You are not authorized to create a project for this team",
-            frappe.PermissionError,
-        )
-
     project_doc = frappe.get_doc(
         {
             "doctype": HACKATHON_PROJECT,
@@ -285,7 +270,7 @@ def get_project_by_team(hackathon: str, team: str) -> dict:
 
 
 @frappe.whitelist()
-def get_project_by_email(hackathon: str, email: str):
+def get_project_by_email(hackathon: str):
     """
     Get project details by email
 
@@ -296,7 +281,7 @@ def get_project_by_email(hackathon: str, email: str):
     Returns:
         dict: Project document as a dictionary
     """
-    team = get_team_by_member_email(hackathon, email)
+    team = get_team_by_member_email(hackathon)
     return get_project_by_team(hackathon, team.get("name"))
 
 
@@ -382,30 +367,29 @@ def get_localhost_requests_by_team(
 
 
 @frappe.whitelist()
-def join_team_via_code(team_code: str, user: str):
+@require_hackathon_participant(hackathon_id="hackathon")
+@rate_limit(limit=5, seconds=60 * 60)
+def join_team_via_code(team_code: str, hackathon: str):
     """
-    Join a team using a team code
-
-    Args:
-        code (str): Team code
-        user (str): User email
-
-    Returns:
-        dict: Team document as a dictionary
+    Join a team - validation happens in controller.
     """
-    try:
-        team = frappe.get_doc(HACKATHON_TEAM, team_code)
-    except frappe.exceptions.DoesNotExistError:
-        frappe.throw("Team not found")
-        return "Invalid Code. Team with this code does not exist."
+    current_user = frappe.session.user
 
-    participant = get_participant(team.hackathon, user)
-    if not participant:
-        frappe.throw("Participant not found")
-        return "Participant not found."
+    team = frappe.get_doc(HACKATHON_TEAM, team_code)
 
+    # Verify team belongs to hackathon
+    if team.hackathon != hackathon:
+        frappe.throw("Team does not belong to this hackathon")
+
+    participant = frappe.get_doc(
+        HACKATHON_PARTICIPANT, {"hackathon": hackathon, "user": current_user}
+    )
+
+    # Add member - controller will validate everything
     team.append("members", {"member": participant.name})
     team.save()
+
+    return team
 
 
 @frappe.whitelist()
@@ -447,7 +431,7 @@ def get_session_user_localhosts():
         HACKATHON_LOCALHOST,
         filters=[
             [
-                "FOSS Hackathon LocalHost Organizer",
+                LOCALHOST_ORGANIZER,
                 "profile",
                 "=",
                 profile,
@@ -493,6 +477,7 @@ def get_session_participant(hackathon: str) -> dict:
 
 
 @frappe.whitelist()
+@require_hackathon_team(team_id="team", hackathon_id="hackathon")
 def delete_project(hackathon: str, team: str):
     """
     Delete team project
@@ -501,18 +486,9 @@ def delete_project(hackathon: str, team: str):
         hackathon (str): Hackathon ID
         team (str): Team ID
     """
-    team_doc = frappe.get_doc(HACKATHON_TEAM, team)
-    if frappe.session.user not in [member.email for member in team_doc.members]:
-        frappe.throw("You are not authorized to delete this project")
-
-    project = get_project_by_team(hackathon, team)
-
-    try:
-        frappe.db.set_value(HACKATHON_TEAM, team, "project", None)
-        frappe.db.delete(HACKATHON_PROJECT, project.name)
-        return True
-    except Exception:
-        frappe.throw("Error deleting project")
+    project = frappe.get_doc(HACKATHON_PROJECT, {"hackathon": hackathon, "team": team})
+    project.delete()  # controller has_permission checks authorization
+    return True
 
 
 @frappe.whitelist()
@@ -587,7 +563,7 @@ def validate_user_as_localhost_member(localhost_id: str):
         frappe.throw("You are not a Localhost Organizer. You are not authorized to view this page")
 
     if not frappe.db.exists(
-        "FOSS Hackathon LocalHost Organizer",
+        LOCALHOST_ORGANIZER,
         {
             "parent": localhost_id,
             "profile": frappe.db.get_value(
@@ -602,24 +578,6 @@ def validate_user_as_localhost_member(localhost_id: str):
         )
 
     return True
-
-
-@frappe.whitelist()
-def remove_pr_issue_from_project(project: str, issue_pr: str) -> None:
-    """
-    Remove a PR/Issue from a project
-
-    Args:
-        project (str): Project ID
-        issue_pr (str): Issue/PR ID
-    """
-    if not frappe.db.exists(HACKATHON_PROJECT, project):
-        frappe.throw("Project does not exist")
-
-    if not frappe.db.exists("Hackathon Project Issue PR", issue_pr):
-        frappe.throw("Issue/PR does not exist")
-
-    frappe.db.delete("Hackathon Project Issue PR", issue_pr)
 
 
 @frappe.whitelist()

--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -111,7 +111,6 @@ def get_participant(hackathon: str) -> dict:
 
     Args:
         hackathon (str): Hackathon ID
-        user (str): User email
 
     Returns:
         dict: Participant document as a dictionary
@@ -276,12 +275,13 @@ def get_project_by_email(hackathon: str):
 
     Args:
         hackathon (str): Hackathon ID
-        email (str): Email of the person
 
     Returns:
         dict: Project document as a dictionary
     """
     team = get_team_by_member_email(hackathon)
+    if not team:
+        return None
     return get_project_by_team(hackathon, team.get("name"))
 
 

--- a/fossunited/api/rsvp.py
+++ b/fossunited/api/rsvp.py
@@ -1,5 +1,4 @@
 import frappe
-from fossunited.utils.decorators import require_chapter_or_event_member
 from frappe.query_builder import DocType, Order
 from frappe.query_builder.functions import Coalesce
 from frappe.utils import getdate, nowdate
@@ -10,6 +9,7 @@ from fossunited.doctype_ids import (
     RSVP_CUSTOM_FIELD,
     RSVP_RESPONSE,
 )
+from fossunited.utils.decorators import require_chapter_or_event_member
 
 
 @frappe.whitelist()

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.json
@@ -136,7 +136,7 @@
   }
  ],
  "links": [],
- "modified": "2025-10-14 16:06:43.666875",
+ "modified": "2026-02-10 14:29:00.719548",
  "modified_by": "Administrator",
  "module": "FOSS Hackathon",
  "name": "FOSS Hackathon Participant",
@@ -157,6 +157,7 @@
   },
   {
    "create": 1,
+   "if_owner": 1,
    "read": 1,
    "role": "All",
    "write": 1

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -27,7 +27,7 @@ class FOSSHackathonParticipant(Document):
         is_student: DF.Check
         localhost: DF.Link | None
         localhost_request_status: DF.Literal[
-            "Pending", "Pending Confirmation", "Accepted", "Rejected"  # noqa: F722, F821
+            "Pending", "Pending Confirmation", "Accepted", "Rejected"
         ]
         organization: DF.Data | None
         subscribe_chapter_mailing: DF.Check
@@ -126,3 +126,22 @@ class FOSSHackathonParticipant(Document):
             )
 
         self.localhost_request_status = "Pending"
+
+    def has_permission(self, ptype="read", user=None):
+        """Participants can only edit their own record"""
+        # note: we already has "if owner" perm, but safer side to have this.
+        user = user or frappe.session.user
+
+        if ptype == "read":
+            return True
+
+        if user == "Guest":
+            return False
+
+        if self.user:
+            return self.user == user
+
+        if self.email:
+            return self.email == user
+
+        return False

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -129,19 +129,17 @@ class FOSSHackathonParticipant(Document):
 
     def has_permission(self, ptype="read", user=None):
         """Participants can only edit their own record"""
-        # note: we already has "if owner" perm, but safer side to have this.
+        # note: we already set "if owner" perm, but safer side to have this.
         user = user or frappe.session.user
 
+        if user == "Administrator":
+            return True
+        if {"System Manager", "Localhost Organizer"} & set(frappe.get_roles(user)):
+            return True
         if ptype == "read":
             return True
-
         if user == "Guest":
             return False
-
-        if self.user:
-            return self.user == user
-
-        if self.email:
-            return self.email == user
-
-        return False
+        if ptype == "create":
+            return True
+        return user in {self.user, self.email}

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/test_foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/test_foss_hackathon_participant.py
@@ -7,6 +7,7 @@ from fossunited.tests.utils import (
     insert_test_hackathon,
     insert_test_hackathon_localhost,
     insert_test_hackathon_participant,
+    insert_user_profile,
 )
 
 
@@ -15,6 +16,10 @@ class TestFOSSHackathonParticipant(FrappeTestCase):
         self.LOCALHOST_ORGANIZER = "test3@example.com"
         self.PARTICIPANT_1 = "test4@example.com"
         self.PARTICIPANT_2 = "test2@example.com"
+        self.localhost_org = insert_user_profile(self.LOCALHOST_ORGANIZER)
+        frappe.get_doc("User", self.LOCALHOST_ORGANIZER).add_roles("Localhost Organizer")
+        self.user1 = insert_user_profile(self.PARTICIPANT_1)
+        self.user2 = insert_user_profile(self.PARTICIPANT_2)
         self.chapter = insert_test_chapter()
         self.hackathon = insert_test_hackathon(chapter=self.chapter.name)
         self.participant_1 = insert_test_hackathon_participant(
@@ -22,14 +27,12 @@ class TestFOSSHackathonParticipant(FrappeTestCase):
             email=self.PARTICIPANT_1,
             user=self.PARTICIPANT_1,
         )
+
         self.localhost = insert_test_hackathon_localhost(
             parent_hackathon=self.hackathon.name,
             organizers=[
                 {
-                    "profile": frappe.get_doc(
-                        USER_PROFILE,
-                        {"user": self.LOCALHOST_ORGANIZER},
-                    ),
+                    "profile": self.localhost_org,
                 }
             ],
         )
@@ -40,6 +43,12 @@ class TestFOSSHackathonParticipant(FrappeTestCase):
         self.localhost.delete(force=True)
         self.hackathon.delete(force=True)
         self.chapter.delete(force=True)
+        frappe.delete_doc(USER_PROFILE, self.localhost_org, force=True)
+        frappe.delete_doc(USER_PROFILE, self.user1, force=True)
+        frappe.delete_doc(USER_PROFILE, self.user2, force=True)
+        for email in [self.LOCALHOST_ORGANIZER, self.PARTICIPANT_1, self.PARTICIPANT_2]:
+            if frappe.db.exists("User", email):
+                frappe.delete_doc("User", email, force=True)
 
     def test_participant_creation(self):
         # Testing that website users have the permission to create Participant doctype
@@ -192,3 +201,38 @@ class TestFOSSHackathonParticipant(FrappeTestCase):
                 {"email_group": email_group_id, "email": frappe.session.user},
             )
         )
+
+    def test_participant_has_permission(self):
+        """Check for Participant has_permission as expected"""
+
+        frappe.set_user(self.PARTICIPANT_1)
+        self.participant_1.full_name = "Owner Edit"
+        self.participant_1.save()  # should succeed
+
+        # --- other user cannot edit ---
+        frappe.set_user(self.PARTICIPANT_2)
+        self.participant_1.full_name = "Hacker Edit"
+        with self.assertRaises(frappe.PermissionError):
+            self.participant_1.save()
+
+        # --- organizer can edit ---
+        frappe.set_user(self.LOCALHOST_ORGANIZER)
+        self.participant_1.full_name = "Organizer Edit"
+        self.participant_1.save()  # should succeed
+
+        # --- guest cannot create ---
+        frappe.set_user("Guest")
+        with self.assertRaises(frappe.PermissionError):
+            insert_test_hackathon_participant(
+                hackathon_id=self.hackathon.name, email="guest@test.com"
+            )
+
+        # --- logged-in user can create ---
+        frappe.set_user(self.PARTICIPANT_2)
+        participant = insert_test_hackathon_participant(
+            hackathon_id=self.hackathon.name,
+            email=frappe.session.user,
+            user=frappe.session.user,
+        )
+
+        participant.delete(force=True, ignore_permissions=True)

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_project/foss_hackathon_project.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_project/foss_hackathon_project.py
@@ -7,6 +7,7 @@ from fossunited.doctype_ids import (
     HACKATHON,
     HACKATHON_PARTICIPANT,
     HACKATHON_PARTNER_PROJECT,
+    HACKATHON_PROJECT,
     HACKATHON_TEAM,
     USER_PROFILE,
 )
@@ -43,7 +44,10 @@ class FOSSHackathonProject(WebsiteGenerator):
 
     # end: auto-generated types
     def validate(self):
+        """Validate project data"""
         self.description = sanitize_text_content(self.description)
+        self.validate_one_project_per_team()
+        self.validate_team_belongs_to_hackathon()
 
     def before_save(self):
         self.set_route()
@@ -51,6 +55,54 @@ class FOSSHackathonProject(WebsiteGenerator):
     def set_route(self):
         hackathon = frappe.get_doc(HACKATHON, self.hackathon)
         self.route = f"{hackathon.route}/p/{self.name}"
+
+    def validate_one_project_per_team(self):
+        """Ensure only one project per team"""
+        if self.is_new():
+            existing = frappe.db.exists(
+                HACKATHON_PROJECT,
+                {
+                    "hackathon": self.hackathon,
+                    "team": self.team,
+                    "name": ["!=", self.name],
+                },
+            )
+            if existing:
+                frappe.throw("This team already has a project for this hackathon")
+
+    def validate_team_belongs_to_hackathon(self):
+        """Ensure team belongs to the same hackathon"""
+        team_hackathon = frappe.db.get_value(HACKATHON_TEAM, self.team, "hackathon")
+        if team_hackathon != self.hackathon:
+            frappe.throw("Team does not belong to this hackathon")
+
+    def has_permission(self, ptype="read", user=None):
+        """Only team members can edit/delete project"""
+        user = user or frappe.session.user
+        # everyone can read
+        if ptype not in ["write", "delete"]:
+            return True
+
+        if not self.team:
+            return False
+
+        team_doc = frappe.get_doc(HACKATHON_TEAM, self.team)
+
+        team_emails = {m.email for m in team_doc.members if m.email}
+        if user in team_emails:
+            return True
+
+        participant_ids = [m.member for m in team_doc.members if m.member]
+        if not participant_ids:
+            return False
+
+        participant_users = frappe.get_all(
+            HACKATHON_PARTICIPANT,
+            filters={"name": ["in", participant_ids]},
+            pluck="user",
+        )
+
+        return user in participant_users
 
     def get_context(self, context):
         context.no_cache = 1

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_project/foss_hackathon_project.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_project/foss_hackathon_project.py
@@ -82,6 +82,8 @@ class FOSSHackathonProject(WebsiteGenerator):
         # everyone can read
         if ptype not in ["write", "delete"]:
             return True
+        if user == "Administrator" or "System Manager" in frappe.get_roles(user):
+            return True
 
         if not self.team:
             return False

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_team/foss_hackathon_team.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_team/foss_hackathon_team.py
@@ -8,6 +8,7 @@ from fossunited.doctype_ids import (
     HACKATHON,
     HACKATHON_PARTICIPANT,
     HACKATHON_TEAM,
+    HACKATHON_TEAM_MEMBER,
 )
 
 
@@ -53,9 +54,14 @@ class FOSSHackathonTeam(Document):
                     f"Maximum team size of {max_size} members reached. Cannot add more members."
                 )
 
+    def on_update(self):
+        self.delete_if_empty_team()
+
     def validate_team_size(self):
         """Check team size limits"""
         max_size = frappe.db.get_value(HACKATHON, self.hackathon, "max_team_members")
+        if not max_size:
+            return
         if len(self.members) > max_size:
             frappe.throw(f"Team cannot have more than {max_size} members")
 
@@ -102,8 +108,10 @@ class FOSSHackathonTeam(Document):
         """Only team members can edit"""
 
         user = user or frappe.session.user
+        if user == "Administrator" or "System Manager" in frappe.get_roles(user):
+            return True
 
-        if ptype != "write":
+        if ptype not in ("write", "delete"):
             return True
 
         team_emails = {m.email for m in self.members if m.email}
@@ -121,3 +129,27 @@ class FOSSHackathonTeam(Document):
         )
 
         return user in participant_users
+
+    def delete_if_empty_team(self):
+        """Auto-delete team if it becomes empty after having content."""
+        prev_doc = self.get_doc_before_save()
+
+        if not prev_doc:
+            return
+        # Only delete if team had members before
+        previously_had_content = bool(
+            prev_doc.members or prev_doc.project or prev_doc.partner_project
+        )
+
+        if not previously_had_content:
+            return
+
+        is_now_empty = not (self.members or self.project or self.partner_project)
+
+        if is_now_empty:
+            frappe.delete_doc(
+                HACKATHON_TEAM,
+                self.name,
+                ignore_permissions=True,
+                force=True,
+            )

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_team/foss_hackathon_team.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_team/foss_hackathon_team.py
@@ -4,6 +4,11 @@ import frappe
 from frappe.model.document import Document
 
 from fossunited.api.hackathon import get_count_team_members_and_max_count
+from fossunited.doctype_ids import (
+    HACKATHON,
+    HACKATHON_PARTICIPANT,
+    HACKATHON_TEAM,
+)
 
 
 class FOSSHackathonTeam(Document):
@@ -28,14 +33,17 @@ class FOSSHackathonTeam(Document):
         team_name: DF.Data
         working_on_partner_project: DF.Check
     # end: auto-generated types
-    pass
+
+    def validate(self):
+        """Validate runs on both insert and save"""
+        self.validate_team_size()
+        self.validate_no_duplicate_members()
+        self.validate_new_members_not_in_other_teams()
 
     def before_save(self):
-        # Handle the case for a newly created team
-        if self.is_new():
-            return
-
-        if self.has_value_changed("members"):
+        """Runs on both insert and save"""
+        # Your existing code for team size check
+        if not self.is_new() and self.has_value_changed("members"):
             team_count = get_count_team_members_and_max_count(self.hackathon, self.name)
             current_members = len(self.members)
             max_size = team_count["max_team_size"]
@@ -44,3 +52,72 @@ class FOSSHackathonTeam(Document):
                 frappe.throw(
                     f"Maximum team size of {max_size} members reached. Cannot add more members."
                 )
+
+    def validate_team_size(self):
+        """Check team size limits"""
+        max_size = frappe.db.get_value(HACKATHON, self.hackathon, "max_team_members")
+        if len(self.members) > max_size:
+            frappe.throw(f"Team cannot have more than {max_size} members")
+
+    def validate_no_duplicate_members(self):
+        """Ensure no duplicate members in this team"""
+        member_ids = [m.member for m in self.members if m.member]
+        if len(member_ids) != len(set(member_ids)):
+            frappe.throw("Cannot add the same member twice to a team")
+
+    def check_member_not_in_other_team(self, member_id):
+        """Check if member is already in another team for this hackathon"""
+        other_team = frappe.db.exists(
+            HACKATHON_TEAM,
+            [
+                [HACKATHON_TEAM_MEMBER, "member", "=", member_id],
+                ["hackathon", "=", self.hackathon],
+                ["name", "!=", self.name],
+            ],
+        )
+
+        if other_team:
+            member_email = frappe.db.get_value(HACKATHON_PARTICIPANT, member_id, "email")
+            other_team = frappe.db.get_value(HACKATHON_TEAM, other_team, "team_name")
+            frappe.throw(
+                f"Member {member_email} is already part of team '{other_team}' in this hackathon"
+            )
+
+    def validate_new_members_not_in_other_teams(self):
+        """Only validate newly added members"""
+        old_doc = self.get_doc_before_save()
+
+        if self.is_new() or not old_doc:
+            members_to_check = [m.member for m in self.members if m.member]
+        else:
+            old_member_ids = {m.member for m in old_doc.members if m.member}
+            members_to_check = [
+                m.member for m in self.members if m.member and m.member not in old_member_ids
+            ]
+
+        for member_id in members_to_check:
+            self.check_member_not_in_other_team(member_id)
+
+    def has_permission(self, ptype="read", user=None):
+        """Only team members can edit"""
+
+        user = user or frappe.session.user
+
+        if ptype != "write":
+            return True
+
+        team_emails = {m.email for m in self.members if m.email}
+        if user in team_emails:
+            return True
+
+        participant_ids = [m.member for m in self.members if m.member]
+        if not participant_ids:
+            return False
+
+        participant_users = frappe.get_all(
+            HACKATHON_PARTICIPANT,
+            filters={"name": ["in", participant_ids]},
+            pluck="user",
+        )
+
+        return user in participant_users

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_team/test_foss_hackathon_team.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_team/test_foss_hackathon_team.py
@@ -7,6 +7,7 @@ from fossunited.tests.utils import (
     insert_test_hackathon,
     insert_test_hackathon_participant,
     insert_test_hackathon_team,
+    insert_user_profile,
 )
 
 
@@ -20,8 +21,16 @@ class TestFOSSHackathonTeam(FrappeTestCase):
         self.team = insert_test_hackathon_team(hackathon=self.hackathon)
 
         self.participants = []
-        for _ in range(4):  # since max_team_size is 3, we need 4 participants to test the code
-            participant = insert_test_hackathon_participant(hackathon_id=self.hackathon.name)
+        for i in range(4):
+            email = f"team_user_{i}@test.com"
+            insert_user_profile(email)
+
+            participant = insert_test_hackathon_participant(
+                hackathon_id=self.hackathon.name,
+                email=email,
+                user=email,
+            )
+
             self.participants.append(participant)
 
     def tearDown(self):
@@ -31,6 +40,14 @@ class TestFOSSHackathonTeam(FrappeTestCase):
         for participant in self.participants:
             participant.delete(force=True)
         self.hackathon.delete(force=True)
+
+        for i in range(4):
+            email = f"team_user_{i}@test.com"
+            profile = frappe.db.get_value("User Profile", {"user": email}, "name")
+            if profile:
+                frappe.delete_doc("User Profile", profile, force=True)
+            if frappe.db.exists("User", email):
+                frappe.delete_doc("User", email, force=True)
 
     def test_add_member_to_team(self):
         # Given a hackathon with a defined max_team_members size
@@ -58,3 +75,56 @@ class TestFOSSHackathonTeam(FrappeTestCase):
             self.team.append("members", {"member": self.participants[i].name})
         # Then a validation error should be raised.
         self.assertRaises(frappe.exceptions.ValidationError, self.team.save)
+
+    def test_cannot_add_duplicate_member(self):
+        participant = self.participants[0]
+
+        self.team.append("members", {"member": participant.name})
+        self.team.append("members", {"member": participant.name})
+
+        with self.assertRaises(frappe.ValidationError):
+            self.team.save()
+
+    def test_member_cannot_join_multiple_teams(self):
+        """starting from 2027 ideally they should not be in multiple teams"""
+        participant = self.participants[0]
+
+        # Add member to first team
+        self.team.append("members", {"member": participant.name})
+        self.team.save()
+
+        # Create second team
+        team2 = insert_test_hackathon_team(hackathon=self.hackathon)
+
+        team2.append("members", {"member": participant.name})
+
+        with self.assertRaises(frappe.ValidationError):
+            team2.save()
+
+        team2.delete(force=True)
+
+    def test_team_member_can_edit_team(self):
+        participant = self.participants[0]
+
+        # add participant to team
+        self.team.append("members", {"member": participant.name})
+        self.team.save()
+
+        # switch to participant user
+        frappe.set_user(participant.user)
+
+        self.team.team_name = "Updated by member"
+        self.team.save()
+
+    def test_non_member_cannot_edit_team(self):
+        participant = self.participants[0]
+        other_participant = self.participants[1]
+
+        self.team.append("members", {"member": participant.name})
+        self.team.save()
+
+        frappe.set_user(other_participant.user)
+        team = frappe.get_doc("FOSS Hackathon Team", self.team.name)
+        team.team_name = "Hacked name"
+        with self.assertRaises(frappe.PermissionError):
+            team.save()

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_team/test_foss_hackathon_team.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_team/test_foss_hackathon_team.py
@@ -1,7 +1,7 @@
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from fossunited.doctype_ids import HACKATHON_TEAM_MEMBER
+from fossunited.doctype_ids import HACKATHON_TEAM, HACKATHON_TEAM_MEMBER, USER_PROFILE
 from fossunited.tests.utils import (
     insert_test_chapter,
     insert_test_hackathon,
@@ -43,9 +43,9 @@ class TestFOSSHackathonTeam(FrappeTestCase):
 
         for i in range(4):
             email = f"team_user_{i}@test.com"
-            profile = frappe.db.get_value("User Profile", {"user": email}, "name")
+            profile = frappe.db.get_value(USER_PROFILE, {"user": email}, "name")
             if profile:
-                frappe.delete_doc("User Profile", profile, force=True)
+                frappe.delete_doc(USER_PROFILE, profile, force=True)
             if frappe.db.exists("User", email):
                 frappe.delete_doc("User", email, force=True)
 
@@ -124,7 +124,7 @@ class TestFOSSHackathonTeam(FrappeTestCase):
         self.team.save()
 
         frappe.set_user(other_participant.user)
-        team = frappe.get_doc("FOSS Hackathon Team", self.team.name)
+        team = frappe.get_doc(HACKATHON_TEAM, self.team.name)
         team.team_name = "Hacked name"
         with self.assertRaises(frappe.PermissionError):
             team.save()

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_team/test_foss_hackathon_team.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_team/test_foss_hackathon_team.py
@@ -128,3 +128,20 @@ class TestFOSSHackathonTeam(FrappeTestCase):
         team.team_name = "Hacked name"
         with self.assertRaises(frappe.PermissionError):
             team.save()
+
+    def test_team_deleted_only_when_empty(self):
+        participant = self.participants[0]
+
+        self.team.append("members", {"member": participant.name})
+        self.team.save()
+
+        team_name = self.team.name
+        self.assertTrue(frappe.db.exists(HACKATHON_TEAM, team_name))
+
+        team = frappe.get_doc(HACKATHON_TEAM, team_name)
+        team.project = None
+        team.partner_project = None
+        team.members = []
+        team.save()
+
+        self.assertFalse(frappe.db.exists(HACKATHON_TEAM, team_name))

--- a/fossunited/tests/test_rsvp_insights.py
+++ b/fossunited/tests/test_rsvp_insights.py
@@ -60,13 +60,13 @@ class TestRSVPInsightsAPI(FrappeTestCase):
         """Guest users should not access RSVP submissions."""
         frappe.set_user("Guest")
         with self.assertRaises(frappe.PermissionError):
-            get_submissions_with_answers(self.event.name)
+            get_submissions_with_answers(event_id=self.event.name)
 
     def test_get_submissions_other_chapter_core_denied(self):
         """Core members from other chapters should not access submissions."""
         frappe.set_user(self.other_chapter_core)
         with self.assertRaises(frappe.PermissionError):
-            get_submissions_with_answers(self.event.name)
+            get_submissions_with_answers(event_id=self.event.name)
 
     def test_get_submissions_chapter_core_allowed(self):
         """Chapter core team should access submissions."""
@@ -80,7 +80,7 @@ class TestRSVPInsightsAPI(FrappeTestCase):
         self._submissions.append(sub)
 
         frappe.set_user(self.core_team_email)
-        result = get_submissions_with_answers(self.event.name)
+        result = get_submissions_with_answers(event_id=self.event.name)
 
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 1)
@@ -102,7 +102,7 @@ class TestRSVPInsightsAPI(FrappeTestCase):
         self._submissions.append(sub)
 
         frappe.set_user(self.core_team_email)
-        result = get_submissions_with_answers(self.event.name)
+        result = get_submissions_with_answers(event_id=self.event.name)
 
         self.assertEqual(len(result), 1)
         self.assertIn("What's your goal?", result[0])
@@ -124,7 +124,7 @@ class TestRSVPInsightsAPI(FrappeTestCase):
         self._submissions.append(sub)
 
         frappe.set_user(self.core_team_email)
-        result = get_submissions_with_answers(self.event.name)
+        result = get_submissions_with_answers(event_id=self.event.name)
 
         self.assertIn("Optional question?", result[0])
         self.assertEqual(result[0]["Optional question?"], "")
@@ -146,7 +146,7 @@ class TestRSVPInsightsAPI(FrappeTestCase):
         self._submissions.extend([sub1, sub2])
 
         frappe.set_user(self.core_team_email)
-        result = get_submissions_with_answers(self.event.name)
+        result = get_submissions_with_answers(event_id=self.event.name)
 
         self.assertEqual(len(result), 2)
         names = {r["name1"] for r in result}
@@ -156,13 +156,13 @@ class TestRSVPInsightsAPI(FrappeTestCase):
         """Guest users should not access check-ins."""
         frappe.set_user("Guest")
         with self.assertRaises(frappe.PermissionError):
-            get_rsvp_checkins(self.event.name)
+            get_rsvp_checkins(event_id=self.event.name)
 
     def test_get_checkins_other_chapter_core_denied(self):
         """Core members from other chapters should not access check-ins."""
         frappe.set_user(self.other_chapter_core)
         with self.assertRaises(frappe.PermissionError):
-            get_rsvp_checkins(self.event.name)
+            get_rsvp_checkins(event_id=self.event.name)
 
     def test_get_checkins_returns_accepted_attendees_only(self):
         """Should only return check-ins for accepted attendees."""
@@ -191,7 +191,7 @@ class TestRSVPInsightsAPI(FrappeTestCase):
         self._submissions.extend([accepted_sub, rejected_sub])
 
         frappe.set_user(self.core_team_email)
-        result = get_rsvp_checkins(self.event.name)
+        result = get_rsvp_checkins(event_id=self.event.name)
 
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["name1"], "Checked In User")
@@ -225,7 +225,7 @@ class TestRSVPInsightsAPI(FrappeTestCase):
         self._submissions.extend([sub1, sub2])
 
         frappe.set_user(self.core_team_email)
-        result = get_rsvp_checkins(self.event.name)
+        result = get_rsvp_checkins(event_id=self.event.name)
 
         # Most recent should be first
         self.assertEqual(result[0]["name1"], "Recent Check-in")
@@ -234,14 +234,14 @@ class TestRSVPInsightsAPI(FrappeTestCase):
     def test_show_checkins_returns_true_for_started_event(self):
         """Should return True if event has started."""
         frappe.set_user(self.core_team_email)
-        result = if_rsvp_show_checkins(self.event.name)
+        result = if_rsvp_show_checkins(event_id=self.event.name)
         self.assertTrue(result)
 
     def test_get_stats_guest_denied(self):
         """Guest users should not access stats."""
         frappe.set_user("Guest")
         with self.assertRaises(frappe.PermissionError):
-            get_rsvp_checkin_stats(self.event.name)
+            get_rsvp_checkin_stats(event_id=self.event.name)
 
     def test_get_stats_counts_accepted_confirmed_only(self):
         """Should only count accepted submissions with confirmed attendance."""
@@ -276,11 +276,11 @@ class TestRSVPInsightsAPI(FrappeTestCase):
         self._submissions.extend([accepted1, accepted2, not_confirmed])
 
         frappe.set_user(self.core_team_email)
-        result = get_rsvp_checkin_stats(self.event.name)
+        result = get_rsvp_checkin_stats(event_id=self.event.name)
         self.assertEqual(result["total_accepted"], 2)
 
     def test_get_stats_returns_zero_for_no_submissions(self):
         """Should return 0 when no accepted submissions exist."""
         frappe.set_user(self.core_team_email)
-        result = get_rsvp_checkin_stats(self.event.name)
+        result = get_rsvp_checkin_stats(event_id=self.event.name)
         self.assertEqual(result["total_accepted"], 0)

--- a/fossunited/tests/utils.py
+++ b/fossunited/tests/utils.py
@@ -21,7 +21,6 @@ from fossunited.doctype_ids import (
     TICKET_TIER,
     USER_PROFILE,
 )
-from fossunited.fossunited.user_utils import create_profile_on_user_create
 from fossunited.ticketing.doctype.foss_ticket_tier.foss_ticket_tier import (
     FOSSTicketTier,
 )
@@ -30,61 +29,39 @@ fake = Faker()
 
 
 def insert_user_profile(email=None, **kwargs):
-    """
-    Create a test user and their profile.
+    """Ensure User + User Profile exist for tests. Return User Profile doc."""
 
-    Args:
-        email (str, optional): Email for the user. If not provided, generates a fake email.
-
-    Returns:
-        str: Name of the created User Profile
-    """
     if not email:
         email = fake.email()
 
-    # Check if profile already exists
-    profile = frappe.db.get_value(USER_PROFILE, {"user": email}, "name")
-    if profile:
-        return profile
-
-    # Create Frappe User if it doesn't exist
     if not frappe.db.exists("User", email):
         name_parts = email.split("@")[0].title()
-        user_data = {
-            "doctype": "User",
-            "email": email,
-            "first_name": kwargs.get("first_name", name_parts),
-            "last_name": kwargs.get("last_name", name_parts),
-        }
-        for key, value in kwargs.items():
-            if key not in user_data:
-                user_data[key] = value
+        frappe.get_doc(
+            {
+                "doctype": "User",
+                "email": email,
+                "first_name": kwargs.get("first_name", name_parts),
+                "last_name": kwargs.get("last_name", name_parts),
+                "enabled": 1,
+            }
+        ).insert(ignore_permissions=True)
 
-        frappe_user = frappe.get_doc(user_data).insert(ignore_permissions=True)
-        frappe_user.reload()
+    profile_name = frappe.db.get_value(USER_PROFILE, {"user": email}, "name")
 
-    # User Profile gets created automatically via hooks "create_profile_on_user_create"
-    profile = frappe.db.get_value(USER_PROFILE, {"user": email}, "name")
-    user = None
-    try:
-        user = frappe.get_doc("User", email)
-    except Exception:
-        user = None
+    if not profile_name:
+        profile_doc = frappe.get_doc(
+            {
+                "doctype": USER_PROFILE,
+                "user": email,
+                "full_name": email.split("@")[0].title(),
+                "username": email.split("@")[0],
+                "is_published": 1,
+            }
+        ).insert(ignore_permissions=True)
+    else:
+        profile_doc = frappe.get_doc(USER_PROFILE, profile_name)
 
-    if not profile:
-        if user:
-            # attempt to create the profile via hook, then re-query
-            create_profile_on_user_create(user, None)
-            # re-query the DB to fetch the newly created profile
-            profile = frappe.db.get_value(USER_PROFILE, {"user": email}, "name")
-            if not profile:
-                raise ValueError(f"User Profile was not auto-created for {email} after hook call.")
-        else:
-            raise ValueError(
-                f"User Profile was not auto-created for {email} and User doc not found"
-            )
-
-    return profile
+    return profile_doc.name
 
 
 def insert_test_chapter(**kwargs):


### PR DESCRIPTION
- doctype(participant): allow perm only if owner

+ add has_permission for modifications

doctype(project): validate one project per team

- easy controller so api endpoint stay simple

doctype(hack-team): add validation and has_permission

- check on team size
- dont allow if participant already in another team


api(hackathon): simplify and let doctype controller handle perm check

- add decorators for primary permission checks



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stronger access controls via session-based participant/team checks; organizers retain elevated edit rights.
  * Auto-remove empty teams and enforce one project per team; team membership and project-hackathon validations added.

* **Bug Fixes**
  * Prevent duplicate team members, enforce team size limits, and block members joining multiple teams.
  * Consistent authorization for project/team actions and streamlined session-user handling.

* **Tests / Chores**
  * Test helpers now create user profiles; RSVP APIs now accept event_id; permission flags updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->