### PR TITLE
redesign: listing all hackathon projects page

### DIFF
--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -911,13 +911,6 @@ h6 {
   gap: 0.5rem;
 }
 
-.projects-grid {
-  display: grid;
-  padding: 1rem 0rem;
-  grid-template-columns: repeat(3, minmax(300px, 1fr));
-  gap: 1rem;
-}
-
 .project-container {
   display: flex;
   flex-direction: column;
@@ -1354,13 +1347,6 @@ h6 {
   color: hsl(var(--clr-foss-mint-500));
 }
 
-.header--event-title {
-  padding-top: 1rem;
-  font-size: var(--text-3xl);
-  font-weight: var(--fw-bold);
-  color: hsl(var(--clr-code-night-800));
-}
-
 .header--tags {
   display: flex;
   gap: 0.94rem;
@@ -1768,7 +1754,7 @@ h6 {
 
 .projects-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(200px, 1fr));
+  grid-template-columns: repeat(2, minmax(360px, 1fr));
   gap: 1rem;
   margin: 1rem 0 3rem 0;
 }

--- a/fossunited/public/js/common_functions.js
+++ b/fossunited/public/js/common_functions.js
@@ -230,7 +230,10 @@ function resetTooltip() {
 
 document.addEventListener('DOMContentLoaded', () => {
   const toggle = document.getElementById('theme-toggle')
-  if (!toggle) return
+  if (!toggle) {
+    document.documentElement.setAttribute('data-theme', 'light')
+    return
+  }
 
   const icon = toggle.querySelector('i')
   const lightIcon = toggle.dataset.lightIcon || 'ti-moon'

--- a/fossunited/templates/foss_base.html
+++ b/fossunited/templates/foss_base.html
@@ -1,12 +1,11 @@
 <!-- prettier-ignore-start -->
 {% extends "templates/base.html" %} {% block head_include %} {{ super() }}
-<script>
- document.addEventListener('DOMContentLoaded', function() {
-    if (!document.querySelector('.v3-theme-toggle#theme-toggle')) return;
+<script> // Apply theme immediately before page renders
+  (function() {
     const savedTheme = localStorage.getItem('theme') ||
       (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
     document.documentElement.setAttribute('data-theme', savedTheme);
-  });
+  })();
 </script>
 <link
   rel="stylesheet"

--- a/fossunited/templates/foss_base.html
+++ b/fossunited/templates/foss_base.html
@@ -1,12 +1,12 @@
 <!-- prettier-ignore-start -->
 {% extends "templates/base.html" %} {% block head_include %} {{ super() }}
-<script> // Apply theme immediately before page renders
-  (function() {
+<script>
+ document.addEventListener('DOMContentLoaded', function() {
     if (!document.querySelector('.v3-theme-toggle#theme-toggle')) return;
     const savedTheme = localStorage.getItem('theme') ||
       (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
     document.documentElement.setAttribute('data-theme', savedTheme);
-  })();
+  });
 </script>
 <link
   rel="stylesheet"

--- a/fossunited/www/hackathon/projects.html
+++ b/fossunited/www/hackathon/projects.html
@@ -57,7 +57,6 @@
             <option value="newest">Newest First</option>
             <option value="oldest">Oldest First</option>
             <option value="updated">Recently Updated</option>
-            <option value="contributions">Most Contributions</option>
           </select>
         </div>
       </div>
@@ -77,14 +76,8 @@
             data-title="{{ project.title }}"
             data-created="{{ project.creation }}"
             data-modified="{{ project.modified }}"
-            data-contributions="{{ project.issue_pr_table|length if project.issue_pr_table else 0 }}"
           >
-            <div class="d-flex justify-content-between align-items-start">
-              <h3 class="project-card--title p-0">{{ project.title }}</h3>
-              <span class="badge badge-secondary contribution-badge" style="display: none;">
-                {{ project.issue_pr_table|length if project.issue_pr_table else 0 }} contributions
-              </span>
-            </div>
+            <h3 class="project-card--title p-0">{{ project.title }}</h3>
             <p class="v3-text-secondary">{{ project.short_description | truncate(150, true) }}</p>
             <span class="v3-text-secondary project-card--team">{{ project.team_name }}</span>
           </div>
@@ -140,14 +133,6 @@
       const sortBy = e.target.value
       const projectsGrid = document.querySelector('.projects-grid')
       const cards = Array.from(document.querySelectorAll('.project-card'))
-      const contributionBadges = document.querySelectorAll('.contribution-badge')
-
-      // Show/hide contribution badges
-      if (sortBy === 'contributions') {
-        contributionBadges.forEach((badge) => (badge.style.display = 'block'))
-      } else {
-        contributionBadges.forEach((badge) => (badge.style.display = 'none'))
-      }
 
       cards.sort((a, b) => {
         switch (sortBy) {
@@ -164,9 +149,6 @@
 
           case 'updated':
             return new Date(b.dataset.modified) - new Date(a.dataset.modified)
-
-          case 'contributions':
-            return parseInt(b.dataset.contributions) - parseInt(a.dataset.contributions)
 
           default:
             return 0

--- a/fossunited/www/hackathon/projects.html
+++ b/fossunited/www/hackathon/projects.html
@@ -12,7 +12,7 @@
         {{ theme_toggle() }}
       </div>
 
-      <div class="v3-text-primary mt-6 p-0">
+      <div class="v3-text-primary p-0">
         <div>
           {% if hackathon.chapter and not hackathon.hackathon_logo %}
             {%
@@ -21,17 +21,21 @@
             %}
             {{ chapter_branding_block(hackathon.chapter) }}
           {% endif %}
-          <div class="hackathon-name--header align-items-end my-2">
+          <div class="hackathon-name--header align-items-end">
             {% if hackathon.hackathon_logo %}
-              <img
-                src="{{ hackathon.hackathon_logo }}"
-                alt="Hackathon Logo"
-                style="height: 4rem; width: auto"
-                class="mr-4"
-              />
+              <div class="d-inline-block p-2 bg-white rounded">
+                <img
+                  src="{{ hackathon.hackathon_logo }}"
+                  alt="Hackathon Logo"
+                  style="width: 150px"
+                />
+              </div>
             {% endif %}
           </div>
-          <h1 class="my-4">{{ hackathon.hackathon_name }} - Project Submissions</h1>
+          <h1 class="my-4">
+            {{ hackathon.hackathon_name }} - Project Submissions
+            <span class="v3-text-tertiary">({{ projects|length }})</span>
+          </h1>
         </div>
       </div>
 
@@ -50,8 +54,10 @@
           <span style="color: var(--v3-text-color3); font-size: 14px;">Sort by:</span>
           <select class="v3-select" id="sort">
             <option value="alpha">Alphabetical</option>
-            <option value="chapter">Chapter</option>
-            <option value="city">City</option>
+            <option value="newest">Newest First</option>
+            <option value="oldest">Oldest First</option>
+            <option value="updated">Recently Updated</option>
+            <option value="contributions">Most Contributions</option>
           </select>
         </div>
       </div>
@@ -61,21 +67,35 @@
           <h3>No projects found</h3>
         </div>
       {% endif %}
-      <div class="projects-grid">
+      <div class="projects-grid mt-6">
         {% for project in projects %}
-          <div class="v3-card project-card v3-text-primary" onClick="window.location.href='/{{ project.route }}'">
-            <h3>{{ project.title }}</h3>
-            <p class="v3-text-secondary">
-              {{ project.short_description | truncate(150, true) }}
-            </p>
-            <span class="v3-text-secondary">{{ project.team_name }}</span>
+          <div
+            class="v3-card project-card v3-text-primary"
+            onClick="window.location.href='/{{ project.route }}'"
+            data-title="{{ project.title }}"
+            data-created="{{ project.creation }}"
+            data-modified="{{ project.modified }}"
+            data-contributions="{{ project.issue_pr_table|length if project.issue_pr_table else 0 }}"
+          >
+            <div class="d-flex justify-content-between align-items-start">
+              <h3 class="project-card--title p-0">{{ project.title }}</h3>
+              <span class="badge badge-secondary contribution-badge" style="display: none;">
+                {{ project.issue_pr_table|length if project.issue_pr_table else 0 }} contributions
+              </span>
+            </div>
+            <p class="v3-text-secondary">{{ project.short_description | truncate(150, true) }}</p>
+            <span class="v3-text-secondary project-card--team">{{ project.team_name }}</span>
           </div>
         {% endfor %}
+      </div>
+      <div class="text-center mt-4 no-project" style="display: none;">
+        <h6>No project or team found</h6>
       </div>
     </div>
   </div>
 
   <script>
+    // Search functionality
     document.getElementById('searchInput').addEventListener('input', (e) => {
       const searchTerm = e.target.value.toLowerCase()
       let projectSearch = false
@@ -91,25 +111,65 @@
         }
       })
 
-      // Add empty state in project search
-
-      const searchInputBox = document.querySelector('.search-box')
-      let emptyState = document.querySelector('.no-project')
-      if (!projectSearch) {
-        if (!emptyState) {
-          emptyState = document.createElement('h6')
-          emptyState.classList.add('no-project')
-          emptyState.appendChild(document.createTextNode('No project or team found'))
-
-          // Styles for emptyState element
-          emptyState.style.marginTop = '1rem'
-          emptyState.style.paddingLeft = '0.5rem'
-          searchInputBox.insertAdjacentElement('afterend', emptyState)
-        }
+      // Show/hide empty state
+      const emptyState = document.querySelector('.no-project')
+      if (!projectSearch && searchTerm.length > 0) {
+        emptyState.style.display = 'block'
       } else {
-        if (emptyState) {
-          emptyState.remove()
+        emptyState.style.display = 'none'
+      }
+    })
+
+    // Sort
+    document.getElementById('sort').addEventListener('change', (e) => {
+      const sortBy = e.target.value
+      const projectsGrid = document.querySelector('.projects-grid')
+      const cards = Array.from(document.querySelectorAll('.project-card'))
+      const contributionBadges = document.querySelectorAll('.contribution-badge')
+
+      // Show/hide contribution badges
+      if (sortBy === 'contributions') {
+        contributionBadges.forEach((badge) => (badge.style.display = 'block'))
+      } else {
+        contributionBadges.forEach((badge) => (badge.style.display = 'none'))
+      }
+
+      cards.sort((a, b) => {
+        switch (sortBy) {
+          case 'alpha':
+            const titleA = a.dataset.title.toLowerCase()
+            const titleB = b.dataset.title.toLowerCase()
+            return titleA.localeCompare(titleB)
+
+          case 'newest':
+            return new Date(b.dataset.created) - new Date(a.dataset.created)
+
+          case 'oldest':
+            return new Date(a.dataset.created) - new Date(b.dataset.created)
+
+          case 'updated':
+            return new Date(b.dataset.modified) - new Date(a.dataset.modified)
+
+          case 'contributions':
+            return parseInt(b.dataset.contributions) - parseInt(a.dataset.contributions)
+
+          default:
+            return 0
         }
+      })
+
+      // Clear and re-append sorted cards
+      projectsGrid.innerHTML = ''
+      cards.forEach((card) => projectsGrid.appendChild(card))
+    })
+
+    // surprise me to show random project
+    document.getElementById('surprise').addEventListener('click', () => {
+      const cards = Array.from(document.querySelectorAll('.project-card'))
+      const visibleCards = cards.filter((card) => card.style.display !== 'none')
+      if (visibleCards.length > 0) {
+        const randomCard = visibleCards[Math.floor(Math.random() * visibleCards.length)]
+        randomCard.click()
       }
     })
   </script>

--- a/fossunited/www/hackathon/projects.html
+++ b/fossunited/www/hackathon/projects.html
@@ -1,56 +1,77 @@
 {% extends "templates/foss_base.html" %}
+{% from "fossunited/templates/macros/breadcrumb.html" import theme_toggle, breadcrumb %}
+
 {% block page_content %}
-  <div class="container">
-    <div class="backlink d-flex align-items-end mt-5">
-      <a href="/{{ hackathon.route }}" class="fw-bolder"> {{ hackathon.hackathon_name }} </a>
-      <span class="mx-2">></span>
-      <span style="font-weight: var(--fw-normal)">All Projects</span>
-    </div>
-    <div class="header--title-cta-parent mt-6 p-0">
-      <div>
-        {% if hackathon.chapter and not hackathon.hackathon_logo %}
-          {%
-            from
-            'fossunited/templates/macros/chapter_branding_block.html' import chapter_branding_block
-          %}
-          {{ chapter_branding_block(hackathon.chapter) }}
-        {% endif %}
-        <div class="hackathon-name--header align-items-end my-2">
-          {% if hackathon.hackathon_logo %}
-            <img
-              src="{{ hackathon.hackathon_logo }}"
-              alt="Hackathon Logo"
-              style="height: 4rem; width: auto"
-              class="mr-4"
-            />
+  <div class="v3-page">
+    <div class="v3-container">
+      <div class="d-flex justify-content-between align-items-center my-2">
+        {{
+          breadcrumb(items=[{"route": (hackathon.external_website_url or '/' + hackathon.route), "label": hackathon.hackathon_name},
+          {"route": "", "label": "All Projects"}])
+        }}
+        {{ theme_toggle() }}
+      </div>
+
+      <div class="v3-text-primary mt-6 p-0">
+        <div>
+          {% if hackathon.chapter and not hackathon.hackathon_logo %}
+            {%
+              from
+              'fossunited/templates/macros/chapter_branding_block.html' import chapter_branding_block
+            %}
+            {{ chapter_branding_block(hackathon.chapter) }}
           {% endif %}
-          <h1 class="header--event-title pt-2">{{ hackathon.hackathon_name }}</h1>
-        </div>
-      </div>
-    </div>
-    <h5 class="mt-6">All Projects</h5>
-
-    <div class="search-box">
-      <div class="flex items-center p-2 rounded border border-gray-200 bg-white min-w-[50%]">
-        <input type="text" id="searchInput" placeholder="Search by project or team name" />
-      </div>
-    </div>
-
-    {% if not projects %}
-      <div class="text-center mt-5">
-        <h3>No projects found</h3>
-      </div>
-    {% endif %}
-    <div class="projects-grid">
-      {% for project in projects %}
-        <div class="project-card" onClick="window.location.href='/{{ project.route }}'">
-          <div class="project-card--title">{{ project.title }}</div>
-          <div class="project-card--short-bio">
-            {{ project.short_description | truncate(150, true) }}
+          <div class="hackathon-name--header align-items-end my-2">
+            {% if hackathon.hackathon_logo %}
+              <img
+                src="{{ hackathon.hackathon_logo }}"
+                alt="Hackathon Logo"
+                style="height: 4rem; width: auto"
+                class="mr-4"
+              />
+            {% endif %}
           </div>
-          <div class="project-card--team">{{ project.team_name }}</div>
+          <h1 class="my-4">{{ hackathon.hackathon_name }} - Project Submissions</h1>
         </div>
-      {% endfor %}
+      </div>
+
+      <div class="v3-controls">
+        <div class="v3-controls-left flex-wrap">
+          <div class="v3-search-input">
+            <input type="text" placeholder="Search by project or team name" id="searchInput" />
+            <i class="ti ti-search"></i>
+          </div>
+          <div class="d-flex align-items-center">
+            <button class="v3-btn v3-btn-dark mr-2" id="surprise">Surprise Me</button>
+          </div>
+        </div>
+
+        <div class="v3-controls-right">
+          <span style="color: var(--v3-text-color3); font-size: 14px;">Sort by:</span>
+          <select class="v3-select" id="sort">
+            <option value="alpha">Alphabetical</option>
+            <option value="chapter">Chapter</option>
+            <option value="city">City</option>
+          </select>
+        </div>
+      </div>
+
+      {% if not projects %}
+        <div class="text-center mt-5">
+          <h3>No projects found</h3>
+        </div>
+      {% endif %}
+      <div class="projects-grid">
+        {% for project in projects %}
+          <div class="v3-card project-card v3-text-primary" onClick="window.location.href='/{{ project.route }}'">
+            <h3>{{ project.title }}</h3>
+            <p class="v3-text-secondary">
+              {{ project.short_description | truncate(150, true) }}
+            </p>
+            <span class="v3-text-secondary">{{ project.team_name }}</span>
+          </div>
+        {% endfor %}
+      </div>
     </div>
   </div>
 

--- a/fossunited/www/hackathon/projects.html
+++ b/fossunited/www/hackathon/projects.html
@@ -62,6 +62,8 @@
         </div>
       </div>
 
+      <small class="mt-2 v3-text-secondary" id="projectCount" style="display: none;"></small>
+
       {% if not projects %}
         <div class="text-center mt-5">
           <h3>No projects found</h3>
@@ -117,6 +119,19 @@
         emptyState.style.display = 'block'
       } else {
         emptyState.style.display = 'none'
+      }
+      // Update project count
+      // Update project count
+      const projectCountEl = document.getElementById('projectCount')
+      if (searchTerm.length > 0) {
+        const visibleCount = document.querySelectorAll(
+          '.project-card[style*="display: flex"], .project-card:not([style*="display: none"])',
+        ).length
+        const totalCount = document.querySelectorAll('.project-card').length
+        projectCountEl.textContent = `Showing ${visibleCount} projects out of ${totalCount}`
+        projectCountEl.style.display = 'block'
+      } else {
+        projectCountEl.style.display = 'none'
       }
     })
 

--- a/fossunited/www/hackathon/projects.html
+++ b/fossunited/www/hackathon/projects.html
@@ -23,13 +23,13 @@
           {% endif %}
           <div class="hackathon-name--header align-items-end">
             {% if hackathon.hackathon_logo %}
-              <div class="d-inline-block p-2 bg-white rounded">
+              <a href="/{{hackathon.route}}" class="d-inline-block p-2 bg-white rounded">
                 <img
                   src="{{ hackathon.hackathon_logo }}"
                   alt="Hackathon Logo"
                   style="width: 150px"
                 />
-              </div>
+              </a>
             {% endif %}
           </div>
           <h1 class="my-4">

--- a/fossunited/www/hackathon/projects.py
+++ b/fossunited/www/hackathon/projects.py
@@ -4,10 +4,11 @@ from fossunited.doctype_ids import HACKATHON, HACKATHON_PROJECT
 
 
 def get_context(context):
+    context.no_cache = 1
     context.hackathon = frappe.get_doc(HACKATHON, {"permalink": frappe.form_dict.permalink})
     context.projects = frappe.get_all(
         HACKATHON_PROJECT,
-        {"hackathon": context.hackathon.name},
+        {"hackathon": context.hackathon.name, "is_published": 1},
         ["*"],
         page_length=9999,
     )


### PR DESCRIPTION
<img width="1320" height="976" alt="image" src="https://github.com/user-attachments/assets/8005a928-45bb-41c9-8f40-7e47ea0ad9c2" />

- adds sorting function
- show project count
- add dark theme toggle
- show only published projects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project sorting (title, newest, oldest, updated) and "Surprise Me" random project action
  * Real-time search filtering by project title or team name; dynamic visible/total project count
  * Breadcrumb navigation and theme toggle in the page header

* **Style**
  * Redesigned project page to v3 layout with wider project cards (2-column grid) and updated header/branding display
  * Added no-project empty state

* **Bug Fixes / Changes**
  * Only published projects are shown; default light theme applied when toggle is absent
<!-- end of auto-generated comment: release notes by coderabbit.ai -->