### PR TITLE
doctype(fh-participant): sync localhost email group based on status

### DIFF
--- a/dashboard/src/components/mailing/EmailFormTemplate.vue
+++ b/dashboard/src/components/mailing/EmailFormTemplate.vue
@@ -124,19 +124,11 @@ const emailGroups = createResource({
     data.forEach((item) => {
       let label = item.group_type
 
-      // For localhost groups with custom titles, extract status from title
-      if (
-        props.document_type === 'FOSS Hackathon LocalHost' &&
-        item.group_type === 'Event Participants'
-      ) {
-        // Title format: "Pending-abc123-Localhost" or "Accepted-abc123-Localhost"
-        const titleParts = item.name.split('-')
-        if (titleParts.length >= 3 && titleParts[titleParts.length - 1] === 'Localhost') {
-          const status = titleParts[0] // "Pending", "Accepted", etc.
-          label = `${status} Participants`
-        }
+      // For localhost groups, extract status from title
+      if (item.name && item.name.endsWith('-Localhost')) {
+        const status = item.name.split('-')[0]
+        label = `${status} Participants`
       }
-
       d.push({
         label: label,
         value: item.name,

--- a/dashboard/src/components/mailing/EmailFormTemplate.vue
+++ b/dashboard/src/components/mailing/EmailFormTemplate.vue
@@ -122,8 +122,23 @@ const emailGroups = createResource({
   transform(data) {
     let d = []
     data.forEach((item) => {
+      let label = item.group_type
+
+      // For localhost groups with custom titles, extract status from title
+      if (
+        props.document_type === 'FOSS Hackathon LocalHost' &&
+        item.group_type === 'Event Participants'
+      ) {
+        // Title format: "Pending-abc123-Localhost" or "Accepted-abc123-Localhost"
+        const titleParts = item.name.split('-')
+        if (titleParts.length >= 3 && titleParts[titleParts.length - 1] === 'Localhost') {
+          const status = titleParts[0] // "Pending", "Accepted", etc.
+          label = `${status} Participants`
+        }
+      }
+
       d.push({
-        label: item.group_type,
+        label: label,
         value: item.name,
         description: `${item.total_subscribers} subscribers`,
       })

--- a/dashboard/src/components/mailing/ManageCampaignDrawer.vue
+++ b/dashboard/src/components/mailing/ManageCampaignDrawer.vue
@@ -84,6 +84,21 @@ const campaign = createResource({
   },
   onSuccess(data) {
     data.status = getStatus
+    // Transform email group labels for localhost
+    if (data.email_group) {
+      data.email_group = data.email_group.map((group) => {
+        let label = group.label
+        // For localhost groups, extract status from value (group name)
+        if (group.value && group.value.endsWith('-Localhost')) {
+          const status = group.value.split('-')[0]
+          label = `${status} Participants`
+        }
+        return {
+          ...group,
+          label: label,
+        }
+      })
+    }
     campaignData.value = cloneDeep(data)
     return data
   },

--- a/fossunited/api/emailing.py
+++ b/fossunited/api/emailing.py
@@ -60,19 +60,6 @@ def create_email_group(
         )
         return None
 
-    filters = {
-        "reference_document": reference_document,
-        "document_type": document_type,
-        "group_type": type,
-    }
-    if chapter:
-        filters["chapter"] = chapter
-
-    existing_group = frappe.get_value(EMAIL_GROUP, filters, "name")
-
-    if existing_group:
-        return frappe.get_doc(EMAIL_GROUP, existing_group)
-
     suffix = EMAIL_GROUP_SUFFIX_BY_DOCTYPE.get(document_type)
     if suffix is None:
         frappe.throw(
@@ -81,6 +68,20 @@ def create_email_group(
         )
 
     group_title = custom_title if custom_title else f"{type}-{reference_document}{suffix}"
+
+    filters = {
+        "reference_document": reference_document,
+        "document_type": document_type,
+        "group_type": type,
+        "title": group_title,
+    }
+    if chapter:
+        filters["chapter"] = chapter
+
+    existing_group = frappe.get_value(EMAIL_GROUP, filters, "name")
+
+    if existing_group:
+        return frappe.get_doc(EMAIL_GROUP, existing_group)
 
     group = frappe.get_doc(
         {

--- a/fossunited/api/emailing.py
+++ b/fossunited/api/emailing.py
@@ -38,6 +38,7 @@ def create_email_group(
     reference_document: str,
     document_type: str = EVENT,
     chapter: Optional[str] = None,
+    custom_title: Optional[str] = None,
 ):
     """
     Ensure an email group exists for the given document.
@@ -47,6 +48,7 @@ def create_email_group(
         type: type of email group
         reference_document: id of the reference document of type document_type
         document_type: type of reference document (default: "FOSS Chapter Event")
+        custom_title: custom title to create email group
     """
     try:
         _doc = frappe.get_doc(document_type, reference_document)
@@ -78,7 +80,7 @@ def create_email_group(
             frappe.ValidationError,
         )
 
-    group_title = f"{type}-{reference_document}{suffix}"
+    group_title = custom_title if custom_title else f"{type}-{reference_document}{suffix}"
 
     group = frappe.get_doc(
         {
@@ -107,7 +109,7 @@ def add_to_email_group(email_group: str, email: str):
         email_group: id of email group
         email: email to be added to the group
     """
-    logger = frappe.logger("email_group")  # Logs to logs/email_group.log
+    logger = frappe.logger("email_group")
 
     if not frappe.db.exists(EMAIL_GROUP, email_group):
         frappe.throw("This email group does not exist", frappe.DoesNotExistError)
@@ -149,17 +151,16 @@ def handle_email_group_subscription(
     subscribe_to_event: bool = True,
     document_type_event: Optional[str] = None,
     document_type_chapter: str = CHAPTER,
+    custom_group_title: Optional[str] = None,
 ):
     """
     Sync email(s) to event and/or chapter email groups.
-
-    Always adds to event group. Chapter group is conditional.
 
     Args:
         emails (list): List of email addresses to process.
         chapter (str): Chapter name.
         event (str, optional): Event reference.
-        event_type (str): Event group type.
+        event_type (str): Event group type (e.g., "Accepted Participants").
         chapter_type (str): Chapter group type.
         subscribe_to_chapter (bool): Whether to add/remove from chapter group.
         subscribe_to_event (bool): Whether to add/remove from event group.
@@ -171,7 +172,7 @@ def handle_email_group_subscription(
         return
 
     try:
-        # Always create chapter group
+        # Create/get chapter group
         chapter_group = create_email_group(
             type=chapter_type,
             reference_document=chapter,
@@ -180,7 +181,7 @@ def handle_email_group_subscription(
         )
 
         if not chapter_group:
-            return  # skip silently
+            return
 
         event_group = None
         if event and document_type_event:
@@ -189,6 +190,7 @@ def handle_email_group_subscription(
                 reference_document=event,
                 document_type=document_type_event,
                 chapter=chapter,
+                custom_title=custom_group_title,
             )
 
         for email in emails:
@@ -196,20 +198,24 @@ def handle_email_group_subscription(
                 continue
 
             try:
-                if subscribe_to_event:
-                    add_to_email_group(event_group.name, email)
-                else:
-                    remove_from_email_group(event_group.name, email)
+                # Handle event group subscription
+                if event_group:
+                    if subscribe_to_event:
+                        add_to_email_group(event_group.name, email)
+                    else:
+                        remove_from_email_group(event_group.name, email)
 
+                # Handle chapter group subscription
                 if subscribe_to_chapter:
                     add_to_email_group(chapter_group.name, email)
                 else:
                     remove_from_email_group(chapter_group.name, email)
+
             except frappe.DuplicateEntryError:
                 continue
 
     except Exception:
-        frappe.log_error(frappe.get_traceback(), "sync_email_group_subscription failed")
+        frappe.log_error(frappe.get_traceback(), "handle_email_group_subscription failed")
 
 
 @frappe.whitelist()

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -60,12 +60,16 @@ class FOSSHackathonParticipant(Document):
         if self.has_value_changed("subscribe_chapter_mailing"):
             self.handle_add_to_email_group()
 
-        if self.has_value_changed("localhost_request_status") and self.localhost:
-            self.sync_localhost_status_groups(old_status=self._get_old_status())
-
-        # Add to new localhost group after localhost change
-        if self.has_value_changed("localhost") and self.localhost:
+        if self.has_value_changed("localhost") and self.localhost and self.wants_to_attend_locally:
+            # Localhost changed — just add to new group
             self.sync_localhost_status_groups()
+        elif (
+            self.has_value_changed("localhost_request_status")
+            and self.localhost
+            and self.wants_to_attend_locally
+        ):
+            # Only status changed within the same localhost
+            self.sync_localhost_status_groups(old_status=self._get_old_status())
 
     def validate(self):
         if self.wants_to_attend_locally and not self.localhost:

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -116,14 +116,13 @@ class FOSSHackathonParticipant(Document):
             )
 
         # ADD to current status group
-        subscribe_chapter = self.subscribe_chapter_mailing
         handle_email_group_subscription(
             emails=[self.email],
             chapter=event_doc.chapter,
             event=self.localhost,
             event_type="Event Participants",
             custom_group_title=f"{current_status}-{self.localhost}-Localhost",
-            subscribe_to_chapter=subscribe_chapter,
+            subscribe_to_chapter=self.subscribe_chapter_mailing,
             subscribe_to_event=True,
             document_type_event=HACKATHON_LOCALHOST,
         )
@@ -145,7 +144,7 @@ class FOSSHackathonParticipant(Document):
                     chapter=event_doc.chapter,
                     event=self.localhost,
                     event_type="Event Participants",
-                    custom_event_title=f"{status}-{self.localhost}-Localhost",
+                    custom_group_title=f"{status}-{self.localhost}-Localhost",
                     subscribe_to_chapter=False,
                     subscribe_to_event=False,
                     document_type_event=HACKATHON_LOCALHOST,

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -38,21 +38,25 @@ class FOSSHackathonParticipant(Document):
 
     def after_insert(self):
         self.handle_add_to_email_group()
+        # Add to status-based localhost group if applicable
+        if self.wants_to_attend_locally and self.localhost:
+            self.sync_localhost_status_groups()
 
     def before_save(self):
         if self.has_value_changed("wants_to_attend_locally"):
             self.handle_localhost_request()
+
         self.handle_localhost_rejection()
+
         if self.has_value_changed("localhost"):
             self.update_request_status()
+
         if self.has_value_changed("subscribe_chapter_mailing"):
             self.handle_add_to_email_group()
-        if (
-            self.has_value_changed("localhost_request_status")
-            and self.localhost_request_status == "Accepted"
-            and self.localhost
-        ):
-            self.subscribe_to_localhost_email_group()
+
+        # Handle status-based email group changes
+        if self.has_value_changed("localhost_request_status") and self.localhost:
+            self.sync_localhost_status_groups(old_status=self._get_old_status())
 
     def validate(self):
         if self.wants_to_attend_locally and not self.localhost:
@@ -60,9 +64,13 @@ class FOSSHackathonParticipant(Document):
 
     def on_trash(self):
         try:
-            # remove from mailing group as well
+            # Remove from all email groups
             self.subscribe_chapter_mailing = 0
             self.handle_add_to_email_group()
+
+            # Remove from status-based localhost groups
+            if self.localhost:
+                self.remove_from_all_localhost_groups()
         except Exception:
             frappe.log_error(
                 frappe.get_traceback(),
@@ -70,7 +78,7 @@ class FOSSHackathonParticipant(Document):
             )
 
     def handle_add_to_email_group(self):
-        # Check if user should be subscribed
+        """Handle chapter and hackathon event subscription"""
         event_doc = frappe.get_doc(HACKATHON, self.hackathon)
 
         handle_email_group_subscription(
@@ -82,22 +90,79 @@ class FOSSHackathonParticipant(Document):
             document_type_event=HACKATHON,
         )
 
-    def subscribe_to_localhost_email_group(self):
-        event_doc = frappe.get_doc(HACKATHON, self.hackathon)
+    def sync_localhost_status_groups(self, old_status=None):
+        """
+        Add/remove participant from localhost email groups based on status.
+        Args:
+            old_status: Previous status to remove from that group
+        """
+        if not self.localhost:
+            return
 
+        event_doc = frappe.get_doc(HACKATHON, self.hackathon)
+        current_status = self.localhost_request_status
+
+        # REMOVE from old status group first
+        if old_status and old_status != current_status:
+            handle_email_group_subscription(
+                emails=[self.email],
+                chapter=event_doc.chapter,
+                event=self.localhost,
+                event_type="Event Participants",
+                custom_group_title=f"{old_status}-{self.localhost}-Localhost",
+                subscribe_to_chapter=False,
+                subscribe_to_event=False,  # Remove
+                document_type_event=HACKATHON_LOCALHOST,
+            )
+
+        # ADD to current status group
+        subscribe_chapter = self.subscribe_chapter_mailing
         handle_email_group_subscription(
             emails=[self.email],
             chapter=event_doc.chapter,
             event=self.localhost,
-            subscribe_to_chapter=self.subscribe_chapter_mailing,
+            event_type="Event Participants",
+            custom_group_title=f"{current_status}-{self.localhost}-Localhost",
+            subscribe_to_chapter=subscribe_chapter,
             subscribe_to_event=True,
             document_type_event=HACKATHON_LOCALHOST,
         )
 
+    def remove_from_all_localhost_groups(self):
+        """Remove participant from all localhost status groups"""
+        if not self.localhost:
+            return
+
+        event_doc = frappe.get_doc(HACKATHON, self.hackathon)
+
+        # All possible statuses
+        all_statuses = ["Pending", "Pending Confirmation", "Accepted", "Rejected"]
+
+        for status in all_statuses:
+            try:
+                handle_email_group_subscription(
+                    emails=[self.email],
+                    chapter=event_doc.chapter,
+                    event=self.localhost,
+                    event_type="Event Participants",
+                    custom_event_title=f"{status}-{self.localhost}-Localhost",
+                    subscribe_to_chapter=False,
+                    subscribe_to_event=False,
+                    document_type_event=HACKATHON_LOCALHOST,
+                )
+            except Exception:
+                # Continue removing from other groups even if one fails
+                frappe.log_error(
+                    frappe.get_traceback(),
+                    f"Error removing from {status} group",
+                )
+
     def update_request_status(self):
+        """Reset status to Pending when localhost changes"""
         self.localhost_request_status = "Pending"
 
     def handle_localhost_rejection(self):
+        """Handle rejection by adding comment and resetting wants_to_attend_locally"""
         if not self.has_value_changed("localhost") and self.localhost_request_status == "Rejected":
             localhost_name = frappe.db.get_value(
                 HACKATHON_LOCALHOST, self.localhost, "localhost_name"
@@ -109,6 +174,7 @@ class FOSSHackathonParticipant(Document):
             self.wants_to_attend_locally = False
 
     def handle_localhost_request(self):
+        """Validate localhost request changes"""
         prev_doc = self.get_doc_before_save()
         if not prev_doc:
             return
@@ -127,9 +193,13 @@ class FOSSHackathonParticipant(Document):
 
         self.localhost_request_status = "Pending"
 
+    def _get_old_status(self):
+        """Get previous status value"""
+        prev_doc = self.get_doc_before_save()
+        return prev_doc.localhost_request_status if prev_doc else None
+
     def has_permission(self, ptype="read", user=None):
         """Participants can only edit their own record"""
-        # note: we already set "if owner" perm, but safer side to have this.
         user = user or frappe.session.user
 
         if user == "Administrator":

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -49,14 +49,23 @@ class FOSSHackathonParticipant(Document):
         self.handle_localhost_rejection()
 
         if self.has_value_changed("localhost"):
+            # Remove from old localhost groups before changing
+            old_localhost = (
+                self.get_doc_before_save().localhost if self.get_doc_before_save() else None
+            )
+            if old_localhost:
+                self.remove_from_all_localhost_groups(old_localhost)
             self.update_request_status()
 
         if self.has_value_changed("subscribe_chapter_mailing"):
             self.handle_add_to_email_group()
 
-        # Handle status-based email group changes
         if self.has_value_changed("localhost_request_status") and self.localhost:
             self.sync_localhost_status_groups(old_status=self._get_old_status())
+
+        # Add to new localhost group after localhost change
+        if self.has_value_changed("localhost") and self.localhost:
+            self.sync_localhost_status_groups()
 
     def validate(self):
         if self.wants_to_attend_locally and not self.localhost:
@@ -127,14 +136,18 @@ class FOSSHackathonParticipant(Document):
             document_type_event=HACKATHON_LOCALHOST,
         )
 
-    def remove_from_all_localhost_groups(self):
-        """Remove participant from all localhost status groups"""
-        if not self.localhost:
+    def remove_from_all_localhost_groups(self, localhost_id=None):
+        """Remove participant from all localhost status groups
+
+        Args:
+            localhost_id: Specific localhost to remove from. If None, uses self.localhost
+        """
+        target_localhost = localhost_id or self.localhost
+
+        if not target_localhost:
             return
 
         event_doc = frappe.get_doc(HACKATHON, self.hackathon)
-
-        # All possible statuses
         all_statuses = ["Pending", "Pending Confirmation", "Accepted", "Rejected"]
 
         for status in all_statuses:
@@ -142,18 +155,17 @@ class FOSSHackathonParticipant(Document):
                 handle_email_group_subscription(
                     emails=[self.email],
                     chapter=event_doc.chapter,
-                    event=self.localhost,
+                    event=target_localhost,
                     event_type="Event Participants",
-                    custom_group_title=f"{status}-{self.localhost}-Localhost",
+                    custom_group_title=f"{status}-{target_localhost}-Localhost",
                     subscribe_to_chapter=False,
                     subscribe_to_event=False,
                     document_type_event=HACKATHON_LOCALHOST,
                 )
             except Exception:
-                # Continue removing from other groups even if one fails
                 frappe.log_error(
                     frappe.get_traceback(),
-                    f"Error removing from {status} group",
+                    f"Error removing from {status} group of localhost {target_localhost}",
                 )
 
     def update_request_status(self):

--- a/fossunited/patches.txt
+++ b/fossunited/patches.txt
@@ -10,3 +10,4 @@ fossunited.patches.v1_0.migrate_old_cfps_to_new_schema
 fossunited.patches.v1_0.convert_lead_to_core_team_chapters
 fossunited.patches.v1_0.convert_event_type_new_option
 fossunited.patches.v1_0.set_jobs_route
+fossunited.patches.v1_0.sync_localhost_email_group

--- a/fossunited/patches/v1_0/sync_localhost_email_group.py
+++ b/fossunited/patches/v1_0/sync_localhost_email_group.py
@@ -14,7 +14,7 @@ def execute():
             "wants_to_attend_locally",
         ],
         filters={
-            "hackathon": "1hdcnkbtmk",
+            "hackathon": "1hdcnkbtmk",  # FOSS Hack 2026
             "localhost": ["is", "set"],
         },
     )
@@ -37,6 +37,9 @@ def execute():
             doc.handle_add_to_email_group()
 
             success_count += 1
+            if success_count % 100 == 0:
+                frappe.db.commit()
+                print(f"Progress: {success_count}/{total}")
 
         except Exception as e:
             error_count += 1

--- a/fossunited/patches/v1_0/sync_localhost_email_group.py
+++ b/fossunited/patches/v1_0/sync_localhost_email_group.py
@@ -1,0 +1,51 @@
+import frappe
+
+
+def execute():
+    """Migrate existing participants to status-based groups"""
+
+    # Get ALL participants to ensure proper email group sync
+    participants = frappe.get_all(
+        "FOSS Hackathon Participant",
+        fields=[
+            "name",
+            "localhost",
+            "localhost_request_status",
+            "wants_to_attend_locally",
+        ],
+        filters={
+            "hackathon": "1hdcnkbtmk",
+            "localhost": ["is", "set"],
+        },
+    )
+
+    total = len(participants)
+    print(f"Starting migration for {total} participants")
+
+    success_count = 0
+    error_count = 0
+
+    for p in participants:
+        try:
+            doc = frappe.get_doc("FOSS Hackathon Participant", p.name)
+
+            # Sync localhost groups only if applicable
+            if p.wants_to_attend_locally and p.localhost:
+                doc.sync_localhost_status_groups()
+
+            # Always sync chapter/hackathon groups
+            doc.handle_add_to_email_group()
+
+            success_count += 1
+
+        except Exception as e:
+            error_count += 1
+            print(f"Error migrating participant {p.name}: {str(e)}")
+            frappe.logger().error(f"Error migrating participant {p.name}: {str(e)}")
+            continue
+
+    # Single commit at the end
+    frappe.db.commit()
+
+    print(f"Migration complete! Success: {success_count}, Errors: {error_count}")
+    frappe.logger().info(f"Migration complete! Success: {success_count}, Errors: {error_count}")

--- a/fossunited/www/fosshack/2026/index.py
+++ b/fossunited/www/fosshack/2026/index.py
@@ -36,7 +36,7 @@ def get_context(context):
         "prize_pool": "₹5,00,000",
         "register_url": f"/dashboard/register-for-hackathon?id={hackathon_id}",
         "event_page_url": f"/{hackathon.route}",
-        "projects_idea_url": "https://forum.fossunited.org/t/hackathon-ideas/159",
+        "projects_idea_url": "https://forum.fossunited.org/t/problem-statements-and-ideas-fosshack-2026/7186",
         "status": "Registrations Open"
         if hackathon.is_registration_live
         else "Opening on Jan 2026",


### PR DESCRIPTION
- Sync email group based on status change and as well as localhost change

- Now localhost will have 4 email group for all status (easy for organizers to communicate to them)
- The doctype title will be : `Accepted-04uusbegi3-Localhost`


- The dashboard email form shows the status + participants for localhost

- Added migration which will run sync for email for all participants for FH26 who is in localhost

- Will add unit tests in next PR to make everything works as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Localhost email groups now display status-based labels (e.g., "Accepted Participants").
  * Email groups can use a custom title; UI selection values now reflect group titles.
  * Migration added to backfill and sync localhost/status group memberships.

* **Improvements**
  * Participant group memberships auto-update on status or localhost changes and are cleaned on deletion.
  * Event/chapter group creation and membership handling now more conditional to avoid unused groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->