### PR TITLE
feat(fh26): add carousel cards for contribution to projects

### DIFF
--- a/fossunited/www/fosshack/2026/index.css
+++ b/fossunited/www/fosshack/2026/index.css
@@ -431,20 +431,26 @@ a:hover,
   height: 90px;
 }
 
-/* SIDE DECORATION */
-.side-deco {
-  display: none;
-  align-items: center;
-  justify-content: center;
+.carousel-control-prev-icon,
+.carousel-control-next-icon {
+  filter: invert(0.4);
+}
+.carousel-indicators li {
+  background-color: var(--v3-text-light);
+}
+.carousel-indicators .active {
+  background-color: var(--v3-text);
+}
+/* create space for indicators */
+#infoCarousel {
+  padding-bottom: 40px;
+}
+#infoCarousel .carousel-indicators {
+  bottom: -10px;
 }
 
 .container svg {
   color: inherit;
-}
-
-.side-deco img {
-  width: 100%;
-  max-width: 354px;
 }
 
 footer {
@@ -490,11 +496,6 @@ footer a:hover {
   }
 }
 
-@media (min-width: 992px) {
-  .side-deco {
-    display: flex;
-  }
-}
 
 @media (max-width: 768px) {
   .container {

--- a/fossunited/www/fosshack/2026/index.html
+++ b/fossunited/www/fosshack/2026/index.html
@@ -1,5 +1,6 @@
 {% extends "templates/foss_base.html" %}
 {% from "fossunited/templates/macros/meta_block.html" import meta_tags %}
+{% from "fossunited/templates/macros/breadcrumb.html" import theme_toggle %}
 
 {% block title %}{{ hackathon.name }} - FOSS United{% endblock %}
 {% block meta_block %}
@@ -122,17 +123,7 @@
         </svg>
       </a>
 
-      <button class="theme-toggle rounded" onclick="toggleTheme()">
-        <svg id="theme-icon" width="20" height="20" viewBox="0 0 20 20" fill="none">
-          <path
-            d="M11 10H16M11 13H15M11 16H12M11 7H15M11 4H12M1 10C1 11.1819 1.23279 12.3522 1.68508 13.4442 2.13738 14.5361 2.80031 15.5282 3.63604 16.364 4.47177 17.1997 5.46392 17.8626 6.55585 18.3149 7.64778 18.7672 8.8181 19 10 19 11.1819 19 12.3522 18.7672 13.4442 18.3149 14.5361 17.8626 15.5282 17.1997 16.364 16.364 17.1997 15.5282 17.8626 14.5361 18.3149 13.4442 18.7672 12.3522 19 11.1819 19 10 19 8.8181 18.7672 7.64778 18.3149 6.55585 17.8626 5.46392 17.1997 4.47177 16.364 3.63604 15.5282 2.80031 14.5361 2.13738 13.4442 1.68508 12.3522 1.23279 11.1819 1 10 1 8.8181 1 7.64778 1.23279 6.55585 1.68508 5.46392 2.13738 4.47177 2.80031 3.63604 3.63604 2.80031 4.47177 2.13738 5.46392 1.68508 6.55585 1.23279 7.64778 1 8.8181 1 10Z"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          />
-        </svg>
-      </button>
+      {{ theme_toggle() }}
     </nav>
 
     {# hero section #}
@@ -276,8 +267,8 @@
     {# timeline & editions #}
     <div class="grid-2col mb-4">
       <div>
-        <div class="v3-card p-4">
-          <h2 class="h3 font-weight-semibold v3-text mb-4">Timeline</h2>
+        <div class="v3-card p-4 h-100">
+          <h2 class="h3 font-weight-bold v3-text mb-4">Timeline</h2>
           {% for item in timeline %}
             <div class="timeline-item">
               <div
@@ -316,8 +307,8 @@
         <!-- </div> -->
 
         <div class="v3-bg-dark p-4">
-          <h3 class="h5 mb-3" style="color: var(--v3-main-bg)">Partner Projects Programme</h3>
-          <p class="mb-4" style="font-size: 0.875rem; opacity: 0.9;">
+          <h3 class="h5 mb-3 font-weight-bold" style="color: var(--v3-main-bg)">Partner Projects Programme</h3>
+          <p class="mb-4 small">
             An effort to provide FOSS Hack participants with time and mentorship to be able to contribute to curated open-source projects.
           </p>
 
@@ -343,7 +334,7 @@
             href="/fosshack/2026/partner-projects"
             class="btn v3-bg-muted v3-text text-uppercase font-weight-semibold rounded-0 small d-inline-flex align-items-center justify-content-center"
           >
-            <span class="mr-1">View All</span>
+            <span class="mr-1 small">View All</span>
             <i class="ti ti-chevron-right"></i>
           </a>
         </div>

--- a/fossunited/www/fosshack/2026/index.html
+++ b/fossunited/www/fosshack/2026/index.html
@@ -290,7 +290,7 @@
                 >
                 <div class="d-flex align-items-center">
                   <span class="v3-text-muted" style="font-size: 0.875rem;">{{ item.event }}</span>
-                  <i class="ti ti-chevron-down timeline-icon" style="margin-left: 10px;"></i>
+                  <i class="ti ti-chevron-down timeline-icon rotate" style="margin-left: 10px;"></i>
                 </div>
               </div>
               <div class="timeline-content show">
@@ -369,7 +369,7 @@
             <div class="carousel-inner">
               {% for item in carousel_items %}
               <div class="carousel-item {% if loop.first %}active{% endif %}">
-                <img src="{{ item.image }}" class="mb-4">
+                <img src="{{ item.image }}" alt="{{ item.title }}" class="mb-4">
                 <h4 class="font-weight-bold mb-4">{{ item.title }}</h4>
                 <p class="text-muted mx-4">
                   {{ item.desc }}
@@ -527,21 +527,6 @@
       content.classList.toggle('show')
       icon.classList.toggle('rotate')
     }
-
-$('.carousel').on('touchstart', function(event){
-  const xClick = event.originalEvent.touches[0].pageX;
-  $(this).one('touchmove', function(event){
-    const xMove = event.originalEvent.touches[0].pageX;
-    if(Math.floor(xClick - xMove) > 5){
-      $(this).carousel('next');
-    } else if(Math.floor(xClick - xMove) < -5){
-      $(this).carousel('prev');
-    }
-  });
-  $('.carousel').on('touchend', function(){
-    $(this).off('touchmove');
-  });
-});
 
     // Load saved theme
     document.addEventListener('DOMContentLoaded', function () {

--- a/fossunited/www/fosshack/2026/index.html
+++ b/fossunited/www/fosshack/2026/index.html
@@ -356,7 +356,7 @@
         <section class="text-center v3-text-primary p-4">
           <h3 class="font-weight-bold h3 my-6">It’s not just code...</h3>
 
-          <div id="infoCarousel" class="carousel slide" data-ride="carousel" data-interval="3500">
+          <div id="infoCarousel" class="carousel slide" data-ride="carousel" data-interval="2000">
             <!-- indicators -->
             <ol class="carousel-indicators">
               {% for item in carousel_items %}

--- a/fossunited/www/fosshack/2026/index.html
+++ b/fossunited/www/fosshack/2026/index.html
@@ -352,13 +352,46 @@
 
     {# why participate & rules #}
     <div class="grid-2col grid-sidebar mb-4">
-      <div class="side-deco v3-card v3-fh-card">
-        <img src="/assets/fossunited/images/fosshack/fh-26-sideblock.svg" alt="" />
+      <div class="v3-card v3-fh-card">
+        <section class="text-center v3-text-primary p-4">
+          <h3 class="font-weight-bold h3 my-6">It’s not just code...</h3>
+
+          <div id="infoCarousel" class="carousel slide" data-ride="carousel" data-interval="3500">
+            <!-- indicators -->
+            <ol class="carousel-indicators">
+              {% for item in carousel_items %}
+              <li data-target="#infoCarousel" data-slide-to="{{ loop.index0 }}"
+                class="{% if loop.first %}active{% endif %}"></li>
+              {% endfor %}
+            </ol>
+
+            <!-- slides -->
+            <div class="carousel-inner">
+              {% for item in carousel_items %}
+              <div class="carousel-item {% if loop.first %}active{% endif %}">
+                <img src="{{ item.image }}" class="mb-4">
+                <h4 class="font-weight-bold mb-4">{{ item.title }}</h4>
+                <p class="text-muted mx-4">
+                  {{ item.desc }}
+                </p>
+              </div>
+              {% endfor %}
+            </div>
+
+            <!-- arrows -->
+            <a class="carousel-control-prev" href="#infoCarousel" role="button" data-slide="prev">
+              <span class="carousel-control-prev-icon"></span>
+            </a>
+            <a class="carousel-control-next" href="#infoCarousel" role="button" data-slide="next">
+              <span class="carousel-control-next-icon"></span>
+            </a>
+          </div>
+        </section>
       </div>
 
       <div class="v3-card v3-fh-card h-100 d-flex flex-column">
         <div class="p-5 v3-border border">
-          <h2 class="h3 font-weight-semibold v3-text mb-4">Why Participate?</h2>
+          <h2 class="h3 font-weight-bold v3-text mb-4">Why Participate?</h2>
           <ul class="v3-text-muted pl-4">
             {% for reason in why_participate %}
               <li class="mb-2">{{ reason }}</li>
@@ -470,19 +503,6 @@
       </div>
     {% endif %}
 
-    {% if partner_projects %}
-      <div class="mb-5">
-        <a href="/fosshack/2026/partner-projects" target="_blank">
-          <h1 class="h1 font-weight-bold v3-text mb-5">
-            Partner Projects
-            <i class="ti ti-arrow-up-right small"></i>
-          </h1>
-        </a>
-        <div class="tier-content">
-          {{ logo_grid(partner_projects, 'fh-sponsor-grid-5', 'fh-logo-partner', 8) }}
-        </div>
-      </div>
-    {% endif %}
   </div>
 
   <!-- TODO: Add previous foss hack winners -->
@@ -507,6 +527,21 @@
       content.classList.toggle('show')
       icon.classList.toggle('rotate')
     }
+
+$('.carousel').on('touchstart', function(event){
+  const xClick = event.originalEvent.touches[0].pageX;
+  $(this).one('touchmove', function(event){
+    const xMove = event.originalEvent.touches[0].pageX;
+    if(Math.floor(xClick - xMove) > 5){
+      $(this).carousel('next');
+    } else if(Math.floor(xClick - xMove) < -5){
+      $(this).carousel('prev');
+    }
+  });
+  $('.carousel').on('touchend', function(){
+    $(this).off('touchmove');
+  });
+});
 
     // Load saved theme
     document.addEventListener('DOMContentLoaded', function () {

--- a/fossunited/www/fosshack/2026/index.html
+++ b/fossunited/www/fosshack/2026/index.html
@@ -290,10 +290,10 @@
                 >
                 <div class="d-flex align-items-center">
                   <span class="v3-text-muted" style="font-size: 0.875rem;">{{ item.event }}</span>
-                  <i class="ti ti-chevron-down timeline-icon" style="margin-left: 0px;"></i>
+                  <i class="ti ti-chevron-down timeline-icon" style="margin-left: 10px;"></i>
                 </div>
               </div>
-              <div class="timeline-content">
+              <div class="timeline-content show">
                 <p class="v3-text-muted mb-0" style="font-size: 0.8rem;">{{ item.desc }}</p>
               </div>
             </div>
@@ -302,32 +302,49 @@
       </div>
 
       <div>
-        <div class="grid-3col mb-3">
-          {% for edition in previous_editions %}
-            <a
-              href="{{ edition.route }}"
-              class="v3-card p-3 text-center d-block"
-              style="text-decoration: none;"
-            >
-              <p class="v3-text-muted mb-1 text-xs text-nowrap">FOSS Hack</p>
-              <h3 class="v3-text h6 mb-0">{{ edition.year }}</h3>
-            </a>
-          {% endfor %}
-        </div>
+        <!-- <div class="grid-3col mb-3"> -->
+        <!--   {% for edition in previous_editions %} -->
+        <!--     <a -->
+        <!--       href="{{ edition.route }}" -->
+        <!--       class="v3-card p-3 text-center d-block" -->
+        <!--       style="text-decoration: none;" -->
+        <!--     > -->
+        <!--       <p class="v3-text-muted mb-1 text-xs text-nowrap">FOSS Hack</p> -->
+        <!--       <h3 class="v3-text h6 mb-0">{{ edition.year }}</h3> -->
+        <!--     </a> -->
+        <!--   {% endfor %} -->
+        <!-- </div> -->
 
         <div class="v3-bg-dark p-4">
           <h3 class="h5 mb-3" style="color: var(--v3-main-bg)">Partner Projects Programme</h3>
           <p class="mb-4" style="font-size: 0.875rem; opacity: 0.9;">
-            Contribute to existing Free & Open Source Software projects from India - design, code,
-            document, test, and more - as part of FOSS Hack 2026 and begin your journey into the
-            FOSS ecosystem!
+            An effort to provide FOSS Hack participants with time and mentorship to be able to contribute to curated open-source projects.
           </p>
+
+          <div class="mt-3">
+            {% for project in partner_projects %}
+            <a href="{{ project.link }}" target="_blank"
+              class="d-flex align-items-center text-decoration-none py-2">
+
+              <img src="{{ project.image or '/assets/fossunited/images/fosshack/partner-project-logo.png' }}"
+                alt="{{ project.sponsor_name }}"
+                class="mr-2"
+                style="width:40px;height:40px;object-fit:contain;">
+
+              <span class="font-weight-bold">
+                {{ project.sponsor_name }}
+              </span>
+
+            </a>
+            {% endfor %}
+          </div>
+
           <a
             href="/fosshack/2026/partner-projects"
-            class="btn v3-bg-muted v3-text text-uppercase font-weight-semibold rounded-0"
-            style="font-size: 0.875rem; padding: 8px 12px;"
+            class="btn v3-bg-muted v3-text text-uppercase font-weight-semibold rounded-0 small d-inline-flex align-items-center justify-content-center"
           >
-            Know More →
+            <span class="mr-1">View All</span>
+            <i class="ti ti-chevron-right"></i>
           </a>
         </div>
       </div>
@@ -350,7 +367,7 @@
         </div>
 
         <div class="p-5 v3-border border flex-grow-1 v3-text-primary">
-          <h2 class="h3 rules font-weight-semibold v3-text mb-4">Rules in a nutshell</h2>
+          <h2 class="h3 rules font-weight-bold v3-text mb-4">Rules in a nutshell</h2>
           {{ rules }}
         </div>
       </div>

--- a/fossunited/www/fosshack/2026/index.py
+++ b/fossunited/www/fosshack/2026/index.py
@@ -205,28 +205,25 @@ def get_context(context):
         {
             "image": "/assets/fossunited/images/fosshack/doc-img.svg",
             "title": "Documentation",
-            "desc": """Evaluation will be done on basis of code commit during the course of the
-            event.You cannot use external APIs as the core feature. Your project must have a valid
-            FOSS license""",
+            "desc": """Help improve documentation for open-source projects — write guides,
+            tutorials, READMEs, or API references.""",
         },
         {
             "image": "/assets/fossunited/images/fosshack/data-img.svg",
             "title": "Data",
-            "desc": """Evaluation will be done on basis of code commit during the course of the
-            event.You cannot use external APIs as the core feature. Your project must have a valid
-            FOSS license""",
+            "desc": """Contribute datasets (OSMaps), data pipelines, or data analysis
+            to open-source projects.""",
         },
         {
             "image": "/assets/fossunited/images/fosshack/design-img.svg",
             "title": "Design",
-            "desc": """Evaluation will be done on basis of code commit during the course of the
-            event.You cannot use external APIs as the core feature. Your project must have a valid
-            FOSS license""",
+            "desc": """Improve the user experience and visual design of open-source projects —
+            create logos, UI/UX improvements, or design systems.""",
         },
         {
             "image": "/assets/fossunited/images/fosshack/code-img.svg",
             "title": "Code",
-            "desc": "We value unique ideas and creative problem solving.",
+            "desc": """Solve issues and make PRs contribution to OSS repositories.""",
         },
     ]
 

--- a/fossunited/www/fosshack/2026/index.py
+++ b/fossunited/www/fosshack/2026/index.py
@@ -167,6 +167,7 @@ def get_context(context):
         HACKATHON_PARTNER_PROJECT,
         {"hackathon": hackathon_id},
         ["repo_link as link", "project_name as sponsor_name", "logo as image"],
+        limit_page_length=7,
     )
 
     # Volunteers

--- a/fossunited/www/fosshack/2026/index.py
+++ b/fossunited/www/fosshack/2026/index.py
@@ -201,6 +201,35 @@ def get_context(context):
 
     context.rules = hackathon.hackathon_rules
 
+    context.carousel_items = [
+        {
+            "image": "/assets/fossunited/images/fosshack/doc-img.svg",
+            "title": "Documentation",
+            "desc": """Evaluation will be done on basis of code commit during the course of the
+            event.You cannot use external APIs as the core feature. Your project must have a valid
+            FOSS license""",
+        },
+        {
+            "image": "/assets/fossunited/images/fosshack/data-img.svg",
+            "title": "Data",
+            "desc": """Evaluation will be done on basis of code commit during the course of the
+            event.You cannot use external APIs as the core feature. Your project must have a valid
+            FOSS license""",
+        },
+        {
+            "image": "/assets/fossunited/images/fosshack/design-img.svg",
+            "title": "Design",
+            "desc": """Evaluation will be done on basis of code commit during the course of the
+            event.You cannot use external APIs as the core feature. Your project must have a valid
+            FOSS license""",
+        },
+        {
+            "image": "/assets/fossunited/images/fosshack/code-img.svg",
+            "title": "Code",
+            "desc": "We value unique ideas and creative problem solving.",
+        },
+    ]
+
     context.hide_nav = True
     context.hide_footer = True
     context.no_cache = 1


### PR DESCRIPTION
- Not just code, they can do docs, data and design as well
- Update partner projects to limit show 7
- Expand timeline content by default (to cover space :) )


https://github.com/user-attachments/assets/1db91468-30de-4ea8-9b12-10f04524d04c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive carousels with touch swipe navigation for browsing content.
  * Introduced carousel slides highlighting key categories: Documentation, Data, Design, and Code.
  * Redesigned Partner Projects section with streamlined layout and visual branding.

* **Style**
  * Removed decorative side elements from larger viewports.
  * Enhanced typography styling for section headings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->