### PR TITLE
feat(hackathon): redesign default hackathon page similar to event page

### DIFF
--- a/fossunited/api/schedule.py
+++ b/fossunited/api/schedule.py
@@ -47,6 +47,8 @@ def safe_speaker_name(sp):
     return str(sp or "").strip()
 
 
+# nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
+# Only published event data is returned. No sensitive fields exposed.
 @frappe.whitelist(allow_guest=True)
 def get_event_schedule(event_id: str, doctype: str = EVENT) -> dict:
     """

--- a/fossunited/api/schedule.py
+++ b/fossunited/api/schedule.py
@@ -48,7 +48,7 @@ def safe_speaker_name(sp):
 
 
 @frappe.whitelist(allow_guest=True)
-def get_event_schedule(event_id: str) -> dict:
+def get_event_schedule(event_id: str, doctype: str = EVENT) -> dict:
     """
     Get the schedule for the event, grouped by date and hall.
     For each schedule item with a linked_cfp, also fetch the proposal route and speakers.
@@ -61,7 +61,7 @@ def get_event_schedule(event_id: str) -> dict:
     """
     schedule = frappe.db.get_all(
         EVENT_SCHEDULE,
-        {"parent": event_id, "parenttype": EVENT},
+        {"parent": event_id, "parenttype": doctype},
         ["*"],
         order_by="scheduled_date asc, start_time asc",
     )

--- a/fossunited/api/schedule.py
+++ b/fossunited/api/schedule.py
@@ -47,8 +47,8 @@ def safe_speaker_name(sp):
     return str(sp or "").strip()
 
 
-# nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
 # Only published event data is returned. No sensitive fields exposed.
+# nosemgrep: guest-whitelisted-method
 @frappe.whitelist(allow_guest=True)
 def get_event_schedule(event_id: str, doctype: str = EVENT) -> dict:
     """

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -463,7 +463,8 @@ class FOSSChapterEvent(WebsiteGenerator):
 
         return stats
 
-    def format_schedule_for_template(self, schedule_dict):
+    @staticmethod
+    def format_schedule_for_template(schedule_dict):
         """Format schedule dict with time display for template rendering.
         Returns nested structure: {date: {hall: [items]}} with start_time_display added.
         """

--- a/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
@@ -6,6 +6,10 @@ import frappe
 from frappe.website.website_generator import WebsiteGenerator
 
 from fossunited.api.emailing import create_email_group
+from fossunited.api.schedule import get_event_schedule
+from fossunited.chapters.doctype.foss_chapter_event.foss_chapter_event import (
+    FOSSChapterEvent,
+)
 from fossunited.doctype_ids import (
     CHAPTER,
     HACKATHON,
@@ -107,6 +111,9 @@ class FOSSHackathon(WebsiteGenerator):
             filters={"hackathon": self.name},
             fields=["*"],
         )
+
+        schedule_dict = get_event_schedule(self.name, self.doctype)
+        context.schedule_data = FOSSChapterEvent.format_schedule_for_template(self, schedule_dict)
 
         context.volunteers = self.get_volunteers()
         context.no_cache = 1

--- a/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
@@ -13,8 +13,9 @@ from fossunited.chapters.doctype.foss_chapter_event.foss_chapter_event import (
 from fossunited.doctype_ids import (
     CHAPTER,
     HACKATHON,
-    HACKATHON_PROJECT,
-    PROPOSAL,
+    HACKATHON_LOCALHOST,
+    HACKATHON_PARTICIPANT,
+    HACKATHON_PARTNER_PROJECT,
     USER_PROFILE,
 )
 from fossunited.fossunited.utils import get_event_sponsors
@@ -97,49 +98,30 @@ class FOSSHackathon(WebsiteGenerator):
         if self.chapter:
             context.chapter = frappe.get_doc(CHAPTER, self.chapter)
 
-        context.nav_items = self.get_nav_items()
         context.sponsors_dict = get_event_sponsors(self.sponsor_list)
-        context.tag_icon = {
-            "Remote": "world",
-            "In-person": "building",
-            "Hybrid": "world",
-        }
-
-        context.schedule_dict = self.get_schedule_dict()
-        context.recent_projects = frappe.get_all(
-            HACKATHON_PROJECT,
-            filters={"hackathon": self.name},
-            fields=["*"],
-        )
 
         schedule_dict = get_event_schedule(self.name, self.doctype)
         context.schedule_data = FOSSChapterEvent.format_schedule_for_template(self, schedule_dict)
 
+        context.event_stats = frappe.db.count(HACKATHON_PARTICIPANT, {"hackathon": self.name})
+
+        cities_dict = self.get_localhosts()
+        context.localhosts_by_city = [
+            {"city": city, "localhosts": hosts} for city, hosts in sorted(cities_dict.items())
+        ]
+
         context.volunteers = self.get_volunteers()
+        context.partner_projects = frappe.get_all(
+            HACKATHON_PARTNER_PROJECT,
+            {"hackathon": self.name},
+            ["repo_link as link", "project_name as sponsor_name", "logo as image"],
+        )
+        context.status_live = self.end_date > frappe.utils.now_datetime()
+        context.registration_status = frappe.db.exists(
+            HACKATHON_PARTICIPANT, {"user": frappe.session.user}
+        )
+        context.event_year = str(self.start_date.year)
         context.no_cache = 1
-
-    def get_nav_items(self):
-        nav_items = ["information", "submissions"]
-        if self.show_schedule_tab:
-            nav_items.append("schedule")
-
-        return nav_items
-
-    def get_schedule_dict(self):
-        schedule_dict = {}
-        for schedule in self.schedule:
-            date = schedule.scheduled_date.strftime("%-d %B")
-            if date not in schedule_dict:
-                schedule_dict[date] = []
-            self.get_speakers(schedule)
-            if schedule.start_time:
-                schedule.start_time = BASE_DATE + schedule.start_time
-            if schedule.end_time:
-                schedule.end_time = BASE_DATE + schedule.end_time
-            schedule_dict[date].append(schedule)
-
-        schedule_dict["days"] = list(schedule_dict.keys())
-        return schedule_dict
 
     def get_volunteers(self):
         members = []
@@ -165,22 +147,6 @@ class FOSSHackathon(WebsiteGenerator):
                 }
             )
         return members
-
-    def get_speakers(self, schedule):
-        if not schedule.linked_cfp:
-            schedule.no_speaker = True
-            return
-
-        cfp = frappe.get_doc(PROPOSAL, schedule.linked_cfp)
-        user = frappe.get_doc(USER_PROFILE, {"email": cfp.submitted_by})
-        schedule.cfp_route = cfp.route
-        schedule.speaker_route = user.route
-        schedule.speaker_full_name = user.full_name
-        schedule.speaker_designation_company = (
-            f"{cfp.designation} at {cfp.organization}"
-            if cfp.designation and cfp.organization
-            else (cfp.designation or cfp.organization or "")
-        )
 
     def get_meta(self):
         import re
@@ -220,3 +186,55 @@ class FOSSHackathon(WebsiteGenerator):
         )
 
         return pagetitle, description, image
+
+    def get_localhosts(self):
+        localhosts = frappe.db.get_all(
+            HACKATHON_LOCALHOST,
+            filters={"parent_hackathon": self.name},
+            fields=["name", "localhost_name", "route", "city", "state", "location"],
+            order_by="city, localhost_name",
+            page_length=99,
+        )
+
+        # Bulk Fetch Counts
+        attending_counts = frappe.db.get_all(
+            HACKATHON_PARTICIPANT,
+            filters={"localhost_request_status": "Accepted", "hackathon": self.name},
+            fields=["localhost", "count(name) as count"],
+            group_by="localhost",
+        )
+        applied_counts = frappe.db.get_all(
+            HACKATHON_PARTICIPANT,
+            filters={"hackathon": self.name},
+            fields=["localhost", "count(name) as count"],
+            group_by="localhost",
+        )
+        likes_counts = frappe.db.get_all(
+            "Comment",
+            filters={
+                "comment_type": "Like",
+                "reference_doctype": HACKATHON_LOCALHOST,
+            },
+            fields=["reference_name as localhost", "count(name) as count"],
+            group_by="reference_name",
+        )
+
+        # Convert to dicts
+        attending_dict = {item["localhost"]: item["count"] for item in attending_counts}
+        applied_dict = {item["localhost"]: item["count"] for item in applied_counts}
+        likes_dict = {item["localhost"]: item["count"] for item in likes_counts}
+
+        # Process LocalHosts and group by city
+        cities_dict = {}
+        for host in localhosts:
+            host["route"] = f"/{host.route}"
+            host["attending"] = attending_dict.get(host.name, 0)
+            host["interested"] = applied_dict.get(host.name, 0) + likes_dict.get(host.name, 0)
+
+            city = host.get("city", "Other")
+            if city not in cities_dict:
+                cities_dict[city] = []
+
+            cities_dict[city].append(host)
+
+        return cities_dict

--- a/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
@@ -101,7 +101,7 @@ class FOSSHackathon(WebsiteGenerator):
         context.sponsors_dict = get_event_sponsors(self.sponsor_list)
 
         schedule_dict = get_event_schedule(self.name, self.doctype)
-        context.schedule_data = FOSSChapterEvent.format_schedule_for_template(self, schedule_dict)
+        context.schedule_data = FOSSChapterEvent.format_schedule_for_template(schedule_dict)
 
         context.event_stats = frappe.db.count(HACKATHON_PARTICIPANT, {"hackathon": self.name})
 
@@ -119,9 +119,10 @@ class FOSSHackathon(WebsiteGenerator):
         )
         context.status_live = self.end_date > frappe.utils.now_datetime()
         context.registration_status = frappe.db.exists(
-            HACKATHON_PARTICIPANT, {"user": frappe.session.user}
+            HACKATHON_PARTICIPANT, {"user": frappe.session.user, "hackathon": self.name}
         )
         context.event_year = str(self.start_date.year)
+        context.pagetitle, context.description, context.image = self.get_meta()
         context.no_cache = 1
 
     def get_volunteers(self):
@@ -210,11 +211,13 @@ class FOSSHackathon(WebsiteGenerator):
             fields=["localhost", "count(name) as count"],
             group_by="localhost",
         )
+        localhost_names = [h["name"] for h in localhosts]
         likes_counts = frappe.db.get_all(
             "Comment",
             filters={
                 "comment_type": "Like",
                 "reference_doctype": HACKATHON_LOCALHOST,
+                "reference_name": ("in", localhost_names),
             },
             fields=["reference_name as localhost", "count(name) as count"],
             group_by="reference_name",

--- a/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
@@ -111,6 +111,7 @@ class FOSSHackathon(WebsiteGenerator):
         ]
 
         context.volunteers = self.get_volunteers()
+        context.mentors = self.get_mentors()
         context.partner_projects = frappe.get_all(
             HACKATHON_PARTNER_PROJECT,
             {"hackathon": self.name},
@@ -238,3 +239,22 @@ class FOSSHackathon(WebsiteGenerator):
             cities_dict[city].append(host)
 
         return cities_dict
+
+    def get_mentors(self):
+        mentors = frappe.get_all(
+            "FOSS Hackathon Mentor",
+            filters={"hackathon": self.name},
+            fields=[
+                "name",
+                "mentor",
+                "full_name",
+                "mentor.user_image as profile_picture",
+                "mentor.username as username",
+            ],
+        )
+
+        for m in mentors:
+            if m.get("username"):
+                m["route"] = f"u/{m['username']}"
+
+        return mentors

--- a/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
@@ -197,7 +197,6 @@ class FOSSHackathon(WebsiteGenerator):
             filters={"parent_hackathon": self.name},
             fields=["name", "localhost_name", "route", "city", "state", "location"],
             order_by="city, localhost_name",
-            page_length=99,
         )
 
         # Bulk Fetch Counts

--- a/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/foss_hackathon.py
@@ -16,6 +16,8 @@ from fossunited.doctype_ids import (
     HACKATHON_LOCALHOST,
     HACKATHON_PARTICIPANT,
     HACKATHON_PARTNER_PROJECT,
+    HACKATHON_PROJECT,
+    HACKATHON_TEAM,
     USER_PROFILE,
 )
 from fossunited.fossunited.utils import get_event_sponsors
@@ -103,7 +105,7 @@ class FOSSHackathon(WebsiteGenerator):
         schedule_dict = get_event_schedule(self.name, self.doctype)
         context.schedule_data = FOSSChapterEvent.format_schedule_for_template(schedule_dict)
 
-        context.event_stats = frappe.db.count(HACKATHON_PARTICIPANT, {"hackathon": self.name})
+        context.hackathon_stats = self.get_hackathon_stats()
 
         cities_dict = self.get_localhosts()
         context.localhosts_by_city = [
@@ -261,3 +263,31 @@ class FOSSHackathon(WebsiteGenerator):
                 m["route"] = f"u/{m['username']}"
 
         return mentors
+
+    def get_hackathon_stats(self):
+        member_count = frappe.db.count(
+            HACKATHON_PARTICIPANT,
+            {
+                "hackathon": self.name,
+            },
+        )
+
+        teams_count = frappe.db.count(
+            HACKATHON_TEAM,
+            {
+                "hackathon": self.name,
+            },
+        )
+
+        projects_count = frappe.db.count(
+            HACKATHON_PROJECT,
+            {
+                "hackathon": self.name,
+                "is_published": 1,
+            },
+        )
+        return {
+            "members": member_count,
+            "teams": teams_count,
+            "projects": projects_count,
+        }

--- a/fossunited/foss_hackathon/doctype/foss_hackathon/templates/foss_hackathon.html
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/templates/foss_hackathon.html
@@ -1,4 +1,6 @@
 {% extends "templates/foss_base.html" %}
+{% from "fossunited/templates/macros/agenda_card.html" import agenda_card %}
+
 {% block page_content %}
   <div class="container header-section-parent">
     <div class="header-section event-header">
@@ -144,77 +146,9 @@
 {% endmacro %}
 {% macro render_schedule() %}
   <div class="container event-content-div content-div" id="schedule">
-    <div class="schedule-section my-3">
-      <h5>Schedule</h5>
-      <div class="my-3">
-        <div class="buttons-group">
-          {% for day in schedule_dict.days %}
-            <button
-              class="button {% if loop.first %}dark-button active{% endif %}"
-              data-day="{{ day }}"
-              onclick="showScheduleByDate()"
-            >
-              {{ day }}
-            </button>
-          {% endfor %}
-        </div>
-      </div>
-      <div class="my-3">
-        {% for k,schedule_list in schedule_dict.items() %}{% if k != 'days' %}
-          <div class="schedule-grid" data-date="{{ k }}">
-            {% for schedule in schedule_list %}
-              <div
-                class="schedule-card {% if not schedule.linked_cfp %}no-hover{% endif %}"
-                {%
-                  if
-                  schedule.cfp_route
-                %}
-                  onclick="window.location.href='/{{ schedule.cfp_route }}'"
-                {% endif %}
-              >
-                <div class="schedule--title-time-section">
-                  <div class="schedule--title">{{ schedule.talk_title }}</div>
-                  {% if schedule.end_time == None %}
-                    <div class="schedule--time">
-                      Starts at {{ schedule.start_time.strftime('%I:%M %p') }}
-                    </div>
-                  {% endif %}
-                  {% if schedule.start_time == None %}
-                    <div class="schedule--time">
-                      Ends at {{ schedule.end_time.strftime('%I:%M %p') }}
-                    </div>
-                  {% endif %}
-                  {% if schedule.start_time and schedule.end_time %}
-                    <div class="schedule--time">
-                      {{ schedule.start_time.strftime('%I:%M %p') }} -
-                      {{
-                        schedule.end_time.strftime('%I:%M
-                        %p')
-                      }}
-                    </div>
-                  {% endif %}
-                </div>
-                {% if not schedule.no_speaker %}
-                  <div class="schedule--speakers-section">
-                    <a
-                      target="_blank"
-                      href="/{{ schedule.speaker_route }}"
-                      class="schedule--speaker-container"
-                      onclick="event.stopPropagation();"
-                    >
-                      <div class="schedule--speaker-name">{{ schedule.speaker_full_name }}</div>
-                      <div class="speaker-designation-company">
-                        {{ schedule.speaker_designation_company }}
-                      </div>
-                    </a>
-                  </div>
-                {% endif %}
-              </div>
-            {% endfor %}
-          </div>
-        {% endif %}{% endfor %}
-      </div>
-    </div>
+    <section class="ev-agenda-section" aria-labelledby="schedule-heading">
+      {{ agenda_card(schedule_data, show_limit=30) }}
+    </section>
   </div>
 {% endmacro %}
 {% macro render_submissions() %}

--- a/fossunited/foss_hackathon/doctype/foss_hackathon/templates/foss_hackathon.html
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/templates/foss_hackathon.html
@@ -221,7 +221,11 @@
                 <div class="ev-detail-text">
                   <div class="ev-detail-primary">
                     {% if doc.start_date.strftime("%Y-%m-%d") != doc.end_date.strftime("%Y-%m-%d") %}
-                      {{ doc.start_date.strftime("%-d - ") }}{{ doc.end_date.strftime("%-d %B %Y") }}
+                      {% if doc.start_date.strftime("%B") != doc.end_date.strftime("%B") %}
+                        {{ doc.start_date.strftime("%-d %B") }} - {{ doc.end_date.strftime("%-d %B %Y") }}
+                      {% else %}
+                        {{ doc.start_date.strftime("%-d") }} - {{ doc.end_date.strftime("%-d %B %Y") }}
+                      {% endif %}
                     {% else %}
                       {{ doc.end_date.strftime("%-d %B %Y") }}
                     {% endif %}
@@ -327,7 +331,7 @@
                 <div class="col-12 mb-4">
                   <div class="v3-card p-4">
                     <!-- City Heading -->
-                    <h5 class="localhost-header font-weight-bold mb-3">
+                    <h5 class="localhost-header no-font-inherit font-weight-bold mb-3">
                       localhost:{{ city_group.city|lower }}
                     </h5>
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon/templates/foss_hackathon.html
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/templates/foss_hackathon.html
@@ -1,187 +1,410 @@
-{% extends "templates/foss_base.html" %}
+{% extends 'templates/foss_base.html' %}
+{% from "fossunited/templates/macros/meta_block.html" import meta_tags %}
+{% from "fossunited/templates/macros/volunteers_card.html" import people_card %}
 {% from "fossunited/templates/macros/agenda_card.html" import agenda_card %}
+{% from "fossunited/templates/macros/sponsor_card.html" import sponsor_card %}
+{% from "fossunited/templates/macros/projects_card.html" import projects_card %}
+{% from "fossunited/templates/macros/breadcrumb.html" import breadcrumb, theme_toggle %}
+{% from "fossunited/templates/macros/chapter_branding_block.html" import chapter_branding_block %}
+{% from "fossunited/templates/macros/event_card.html" import event_must_attend_tag, event_category_tag %}
 
-{% block page_content %}
-  <div class="container header-section-parent">
-    <div class="header-section event-header">
-      <img
-        src="{{ doc.hackathon_banner or '/assets/fossunited/images/defaults/event_banner.png' }}"
-        alt="Cover Image"
-        class="foss-banner-image header--banner"
-      />
-      <div class="header--title-cta-parent">
-        <div>
-          {% if doc.chapter %}
-            {%
-              from
-              'fossunited/templates/macros/chapter_branding_block.html' import chapter_branding_block
-            %}
-            <a href="/{{ chapter.route }}"> {{ chapter_branding_block(doc.chapter) }} </a>
-          {% endif %}
-          <h1 class="header--event-title">{{ doc.hackathon_name }}</h1>
-        </div>
-        {% if doc.is_registration_live %}
-          <button
-            class="primary-button ticket-button"
-            onClick="window.location.href='/dashboard/register-for-hackathon?id={{ doc.name }}'"
-          >
-            <span>Register</span>
-          </button>
+{% macro event_cover() %}
+  <div class="v3-banner-wrap">
+    <img
+      src="{{ doc.hackathon_banner or '/assets/fossunited/images/defaults/event_logo.png' }}"
+      alt="{{ doc.hackathon_name }} banner"
+      class="v3-banner bg-white"
+    />
+
+    {% if event_stats %}
+      <div class="ev-stats" role="region" aria-label="Event statistics">
+        {% if event_stats > 0 %}
+          <span>{{ event_stats }} Attend{{ "ing" if status_live else "ed" }}</span>
         {% endif %}
       </div>
-      <div class="header--tags">
-        {% from 'fossunited/templates/macros/foss_tags.html' import tag %}
-        {{
-          tag(doc.hackathon_type,
-          icon=tag_icon[doc.hackathon_type])
-        }}
-      </div>
-    </div>
-  </div>
-  <div class="container">
-    <div class="time-location-parent">
-      <div class="event-date-parent time-location--child-container">
-        <i
-          class="ti ti-calendar-event"
-          style="font-size: var(--text-2xl); font-weight: var(--fw-semibold)"
-        ></i>
-        <div class="d-flex flex-column">
-          <div class="event-start-date child-container--heading">
-            {{ doc.start_date.strftime("%A, %-d %B %Y") }}
-          </div>
-          <div class="event-end-date child-container--subtext">
-            {{ doc.end_date.strftime("%A, %-d %B %Y") }}
-          </div>
-        </div>
-      </div>
-      <div class="event-time-parent time-location--child-container">
-        <i
-          class="ti ti-clock"
-          style="font-size: var(--text-2xl); font-weight: var(--fw-semibold)"
-        ></i>
-        <div class="d-flex flex-column">
-          <div class="event-start-time child-container--heading">
-            Starts at {{ doc.start_date.strftime("%-I:%M %p") }}
-          </div>
-          <div class="event-end-time child-container--subtext">
-            Ends at {{ doc.end_date.strftime("%-I:%M %p") }}
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  {% from 'fossunited/templates/macros/horizontal_navbar.html' import horizontal_navbar %}
-  <div class="horizontal-navbar-parent">
-    <div class="container">{{ horizontal_navbar(nav_items) }}</div>
-  </div>
-  <div>{{ render_information() }} {{ render_schedule() }} {{ render_submissions() }}</div>
-{% endblock %}
-{% macro render_information() %}
-  <div class="container event-content-div content-div" id="information">
-    <div class="description-section my-3">
-      <h5>Description</h5>
-      <div class="event--description-block mt-2">
-        {{ doc.hackathon_description or 'No Description Available for this event' }}
-      </div>
-    </div>
-
-    {% if doc.hackathon_rules %}
-      <div class="description-section my-3">
-        <h5>Hackathon Rules</h5>
-        <div class="event--description-block mt-2">{{ doc.hackathon_rules }}</div>
-      </div>
     {% endif %}
-    {% if doc.sponsor_list %}
-      <div class="sponsors-section my-3">
-        <h5 class="mt-3 mb-1">Sponsors</h5>
-        {% for k,v in sponsors_dict.items() %}
-          <div class="sponsor--tier-block">
-            <div class="sponsor--tier-heading">{{ k }}</div>
-            <div class="sponsor--flex">
-              {% for sponsor in v %}
-                <a href="{{ sponsor.link }}" target="_blank" class="sponsor--block">
-                  <img
-                    src="{{ sponsor.image }}"
-                    alt="{{ sponsor.sponsor_name }}"
-                    class="sponsor--image"
-                  />
+
+    {% if registration_status %}
+      <div class="v3-status v3-status--success" role="status" aria-live="polite">
+        <i class="ti ti-discount-check-filled" aria-hidden="true"></i>
+        You've registered for this event
+      </div>
+
+      {% if status_live and not doc.is_registration_live %}
+        <div class="v3-status v3-status--warning" role="status" aria-live="polite">
+          <i class="ti ti-ban" aria-hidden="true"></i>
+          Registration is closed for the event
+        </div>
+      {% endif %}
+    {% endif %}
+  </div>
+{% endmacro %}
+{% macro hackathon_resources() %}
+  <div class="v3-card p-5">
+    <a href="/{{ doc.route }}/projects/all" class="v3-btn v3-btn-secondary w-100 mb-4"
+      >View Submissions</a
+    >
+    <a
+      href="/fosshack/{{ event_year }}/partner-projects"
+      class="v3-btn v3-btn-secondary w-100 mb-4"
+      target="_blank"
+      rel="noopener noreferrer"
+      >Partner Projects</a
+    >
+    <a
+      href="https://forum.fossunited.org/t/hackathon-ideas/159"
+      class="v3-btn v3-btn-secondary w-100"
+      target="_blank"
+      rel="noopener noreferrer"
+      >Projects Ideas</a
+    >
+  </div>
+{% endmacro %}
+{% block meta_block %}
+  {{ meta_tags(pagetitle, description, image) }}
+{% endblock %}
+
+{% block content %}
+  <style>
+    body {
+      background: var(--v3-main-bg);
+    }
+
+    .ev-main-card {
+      width: 100%;
+      max-width: 840px;
+      margin-bottom: 2rem;
+    }
+
+    .ev-title {
+      color: var(--v3-text-color);
+      font-size: 1.75rem;
+      font-weight: 600;
+      line-height: 2.1rem;
+      margin: 0.5rem 0;
+    }
+
+    .ev-detail-row {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin-bottom: 0.5rem;
+    }
+    .ql-editor > ol {
+      padding: 0;
+    }
+
+    .ev-icon {
+      width: 2.875rem;
+      height: 2.875rem;
+      background: var(--v3-main-bg);
+      border-radius: 0.5rem;
+      border: 1px solid var(--v3-button-border);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+
+    .ev-icon:hover {
+      opacity: 0.9;
+    }
+
+    .ev-icon i {
+      font-size: 1.5rem;
+      color: var(--v3-text-color3);
+    }
+
+    .ev-detail-primary {
+      color: var(--v3-text-color3);
+      font-size: 1rem;
+      line-height: 1.5rem;
+    }
+
+    .ev-detail-secondary {
+      color: var(--v3-text-color2);
+      font-size: 0.875rem;
+    }
+
+    .ev-stats {
+      padding: 0.25rem 0.5rem;
+      background: var(--v3-main-bg);
+      border-radius: 0.5rem;
+      display: flex;
+      gap: 0.375rem;
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: var(--v3-text-color3);
+    }
+
+    .ev-contact {
+      padding: 1.5rem;
+      align-items: center;
+      gap: 0.375rem;
+    }
+
+    .ev-contact i {
+      font-size: 1rem;
+      color: var(--v3-text-color);
+    }
+
+    .ev-contact-email {
+      color: var(--v3-text-color);
+      font-size: 1rem;
+      padding-left: 0.5rem;
+    }
+
+    /* Visibility helpers */
+    .show-mobile-only {
+      display: block;
+    }
+
+    .show-desktop-only {
+      display: none;
+    }
+
+    @media (min-width: 48rem) {
+      .ev-title {
+        font-size: 2rem;
+        line-height: 2.4rem;
+      }
+
+      /* Visibility helpers */
+      .show-mobile-only {
+        display: none;
+      }
+
+      .show-desktop-only {
+        display: block;
+      }
+    }
+  </style>
+
+  <div class="v3-page ev-page">
+    <div class="v3-container">
+      <div class="d-flex justify-content-between align-items-center">
+        {{ breadcrumb(breadcrumbs) }}
+        {{ theme_toggle() }}
+      </div>
+
+      <!-- Main Event Card - Fixed 840px -->
+      <div class="v3-card ev-main-card">
+        <div class="v3-header">
+          <div class="show-mobile-only">{{ event_cover() }}</div>
+          <div
+            style="flex: 1; display: flex; flex-direction: column; gap: 1.2rem; justify-content: space-between;"
+          >
+            <!-- Header Info -->
+            <div style="display: flex; flex-direction: column;">
+              <div style="display: flex; flex-direction: column;">
+                {{ chapter_branding_block(chapter) }}
+
+                <h1 class="ev-title">{{ doc.hackathon_name }}</h1>
+                <div class="v3-event-tags" aria-label="Event tags">
+                  {{ event_must_attend_tag() }}
+                  {{ event_category_tag(doc.hackathon_type) }}
+                </div>
+              </div>
+            </div>
+
+            <!-- Date/Time/Location -->
+            <div style="margin-top: 3px;">
+              <div class="ev-detail-row">
+                <div
+                  class="ev-icon"
+                  type="button"
+                  aria-label="Add event to calendar"
+                  title="Download to calendar"
+                >
+                  <i class="ti ti-calendar-plus" aria-hidden="true"></i>
+                </div>
+                <div class="ev-detail-text">
+                  <div class="ev-detail-primary">
+                    {% if doc.start_date.strftime("%Y-%m-%d") != doc.end_date.strftime("%Y-%m-%d") %}
+                      {{ doc.start_date.strftime("%-d - ") }}{{ doc.end_date.strftime("%-d %B %Y") }}
+                    {% else %}
+                      {{ doc.end_date.strftime("%-d %B %Y") }}
+                    {% endif %}
+                  </div>
+                  <div class="ev-detail-secondary">
+                    <time datetime="{{ doc.start_date.isoformat() }}">
+                      {{ doc.start_date.strftime("%-I:%M %p") }}
+                    </time>
+                    -
+                    <time datetime="{{ doc.end_date.isoformat() }}">
+                      {{ doc.end_date.strftime("%-I:%M %p") }}
+                    </time>
+                  </div>
+                </div>
+              </div>
+
+              <div class="ev-detail-row">
+                <div class="ev-icon" aria-hidden="true"><i class="ti ti-map-pin"></i></div>
+                <div class="ev-detail-secondary">{{ doc.hackathon_type }}</div>
+              </div>
+            </div>
+
+            <div>
+              <div class="v3-btn-group" role="group" aria-label="Event actions">
+                {% if doc.is_registration_live %}
+                  <a
+                    href="/dashboard/register-for-hackathon?id={{ doc.name }}"
+                    class="v3-btn v3-btn-primary"
+                    aria-label="Register for {{ doc.hackathon_name }}"
+                  >
+                    Register
+                  </a>
+                {% endif %}
+                <a
+                  href="/fosshack/{{ event_year }}"
+                  class="v3-btn v3-btn-secondary"
+                  aria-label="Goto Event Landing Page"
+                >
+                  Event Page
+                  <i class="ti ti-arrow-up-right" aria-hidden="true"></i>
                 </a>
-              {% endfor %}
+
+                {% if registration_status %}
+                  <a
+                    href="/dashboard/my-hackathons"
+                    class="v3-btn v3-btn-secondary v3-btn-icon-only"
+                    aria-label="Goto hackathon dashboard"
+                  >
+                    <i class="ti ti-edit" aria-hidden="true"></i>
+                  </a>
+                {% endif %}
+              </div>
             </div>
           </div>
-        {% endfor %}
-      </div>
-    {% endif %}
-    {% if doc.community_partners %}
-      <div class="community-partners-sections my-3">
-        <div class="sponsor--tier-block">
-          <h5>Community Partners</h5>
-          <div class="sponsor--flex">
-            {% for partner in doc.community_partners %}
-              <a href="{{ partner.link }}" target="_blank" class="sponsor--block">
-                <img
-                  src="{{ partner.logo }}"
-                  alt="{{ partner.org_name }}"
-                  class="sponsor--image"
-                />
-              </a>
-            {% endfor %}
-          </div>
+
+          <!-- Banner -->
+          <div class="show-desktop-only">{{ event_cover() }}</div>
         </div>
       </div>
-    {% endif %}
-    {% if doc.volunteers %}
-      <div class="event-members-section my-3">
-        <h5>Event Members</h5>
-        <div class="event--members-block">
-          {% from 'fossunited/templates/macros/member_card.html' import member_card %}
-          <div class="members-grid-6">
-            {% for volunteer in volunteers %}{{ member_card(volunteer) }}{% endfor %}
-          </div>
+
+      <!-- Content Grid -->
+      <div class="v3-grid">
+        <!-- Main Column -->
+        <main class="v3-content-main">
+          <!-- About -->
+          {% if doc.hackathon_description %}
+            <section class="v3-card ev-about-section" aria-labelledby="about-heading">
+              <h2 class="v3-section-title" id="about-heading">
+                <i class="ti ti-info-square" aria-hidden="true"></i>
+                <span>About</span>
+              </h2>
+
+              <div class="v3-text-primary prose" style="font-size: 1rem; line-height: 1.5rem;">
+                {{ doc.hackathon_description }}
+
+                <div class="font-weight-bold my-4">Hackathon Rules</div>
+                {{ doc.hackathon_rules }}
+              </div>
+            </section>
+          {% endif %}
+
+          <div class="show-mobile-only">{{ hackathon_resources() }}</div>
+
+          <!-- Schedule -->
+          {% if schedule_data %}
+            <section class="ev-agenda-section" aria-labelledby="schedule-heading">
+              <h2 id="schedule-heading" class="sr-only">Event Schedule</h2>
+              {{ agenda_card(schedule_data, show_limit=30) }}
+            </section>
+          {% endif %}
+
+          <!-- Sponsors -->
+          {% if sponsors_dict %}
+            <section class="ev-sponsors-section" aria-labelledby="sponsors-heading">
+              <h2 id="sponsors-heading" class="sr-only">Event Sponsors</h2>
+              {{ sponsor_card(sponsors_dict, doc.deck_link) }}
+            </section>
+          {% endif %}
+
+          {% if localhosts_by_city %}
+            <div class="row">
+              {% for city_group in localhosts_by_city %}
+                <div class="col-12 mb-4">
+                  <div class="v3-card p-4">
+                    <!-- City Heading -->
+                    <h5 class="localhost-header font-weight-bold mb-3">
+                      localhost:{{ city_group.city|lower }}
+                    </h5>
+
+                    <!-- Localhosts -->
+                    {% for localhost in city_group.localhosts %}
+                      <a href="{{ localhost.route }}" class="d-block py-2 text-decoration-none">
+                        <div class="font-weight-600 v3-text-primary mb-1">
+                          {{ localhost.localhost_name }}
+                        </div>
+
+                        <small>
+                          <span class="v3-text-success"> {{ localhost.attending or 0 }} </span>
+                          <span class="v3-text-secondary"> attending </span>
+                          |
+                          <span class="v3-text-success"> {{ localhost.interested or 0 }} </span>
+                          <span class="v3-text-secondary"> interested </span>
+                        </small>
+                      </a>
+                    {% endfor %}
+                  </div>
+                </div>
+              {% endfor %}
+            </div>
+          {% endif %}
+
+          {% if doc.has_partner_projects and partner_projects %}
+            <section aria-labelledby="projects-heading">
+              <h2 id="projects-heading" class="sr-only">Partner Projects</h2>
+              {{ projects_card(partner_projects, "Partner Projects", "ti-code") }}
+            </section>
+          {% endif %}
+
+          {% if doc.community_partners %}
+            <section aria-labelledby="partners-heading">
+              <h2 id="partners-heading" class="sr-only">Community Partners</h2>
+              {{ projects_card(doc.community_partners, "Community Partners", "ti-users") }}
+            </section>
+          {% endif %}
+        </main>
+
+        <!-- Sidebar -->
+        <div class="v3-content-sidebar" aria-label="Event information sidebar">
+          <!-- (Desktop) -->
+          <div class="show-desktop-only">{{ hackathon_resources() }}</div>
+
+          <!-- mentors -->
+          {% if mentors %}
+            <section class="ev-speakers-section" aria-labelledby="speakers-heading">
+              <h2 id="speakers-heading" class="sr-only">Mentors</h2>
+              {{ people_card(mentors, 'speakers', submissions) }}
+            </section>
+          {% endif %}
+
+          <!-- Volunteers -->
+          {% if volunteers %}
+            <section class="ev-volunteers-section" aria-labelledby="volunteers-heading">
+              <h2 id="volunteers-heading" class="sr-only">Volunteers</h2>
+              {{ people_card(volunteers, 'volunteers') }}
+            </section>
+          {% endif %}
+
+          <!-- Contact -->
+          <section class="v3-card ev-contact" aria-labelledby="contact-heading">
+            <h2 id="contact-heading" class="sr-only">Contact Information</h2>
+            {% if chapter.email %}
+              <div class="d-flex align-items-center pb-2">
+                <i class="ti ti-mail" aria-hidden="true"></i>
+                <div class="ev-contact-email">
+                  <a href="mailto:{{ chapter.email }}" aria-label="Email {{ chapter.email }}">
+                    {{ chapter.email }}
+                  </a>
+                </div>
+              </div>
+            {% endif %}
+          </section>
         </div>
-      </div>
-    {% endif %}
-  </div>
-{% endmacro %}
-{% macro render_schedule() %}
-  <div class="container event-content-div content-div" id="schedule">
-    <section class="ev-agenda-section" aria-labelledby="schedule-heading">
-      {{ agenda_card(schedule_data, show_limit=30) }}
-    </section>
-  </div>
-{% endmacro %}
-{% macro render_submissions() %}
-  <div class="container event-content-div content-div" id="submissions">
-    <div class="submissions-section my-3">
-      <div class="d-flex align-items-center justify-content-between">
-        <h5>Recent Submissions</h5>
-        <a href="/{{ doc.route }}/projects/all">View All</a>
-      </div>
-      <div class="projects-grid">
-        {% for project in recent_projects %}
-          <div class="project-card" onClick="window.location.href='/{{ project.route }}'">
-            <div class="project-card--title">{{ project.title }}</div>
-            <div class="project-card--short-bio">{{ project.short_description }}</div>
-            <div class="project-card--team">{{ project.team_name }}</div>
-          </div>
-        {% endfor %}
       </div>
     </div>
   </div>
-{% endmacro %}
-{% block page_script %}
-  <script>
-    $(document).ready(function () {
-      $('.schedule-grid').hide()
-      $('.schedule-grid[data-date="{{schedule_dict.days[0]}}"]').show()
-    })
-
-    function showScheduleByDate() {
-      $('.buttons-group button').removeClass('dark-button active')
-      $(event.target).addClass('dark-button active')
-      $('.schedule-grid').hide()
-      $('.schedule-grid[data-date="' + $(event.target).data('day') + '"]').show()
-    }
-  </script>
 {% endblock %}

--- a/fossunited/foss_hackathon/doctype/foss_hackathon/templates/foss_hackathon.html
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/templates/foss_hackathon.html
@@ -343,7 +343,7 @@
           {% if sponsors_dict %}
             <section class="ev-sponsors-section" aria-labelledby="sponsors-heading">
               <h2 id="sponsors-heading" class="sr-only">Event Sponsors</h2>
-              {{ sponsor_card(sponsors_dict, doc.deck_link) }}
+              {{ sponsor_card(sponsors_dict, None) }}
             </section>
           {% endif %}
 
@@ -403,7 +403,7 @@
           {% if mentors %}
             <section class="ev-speakers-section" aria-labelledby="speakers-heading">
               <h2 id="speakers-heading" class="sr-only">Mentors</h2>
-              {{ people_card(mentors, 'Mentors') }}
+              {{ people_card(mentors, 'Mentors', icon="school") }}
             </section>
           {% endif %}
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon/templates/foss_hackathon.html
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/templates/foss_hackathon.html
@@ -306,7 +306,7 @@
           <div class="show-mobile-only">{{ hackathon_resources() }}</div>
 
           <!-- Schedule -->
-          {% if schedule_data %}
+          {% if doc.show_schedule_tab and schedule_data %}
             <section class="ev-agenda-section" aria-labelledby="schedule-heading">
               <h2 id="schedule-heading" class="sr-only">Event Schedule</h2>
               {{ agenda_card(schedule_data, show_limit=30) }}
@@ -377,7 +377,7 @@
           {% if mentors %}
             <section class="ev-speakers-section" aria-labelledby="speakers-heading">
               <h2 id="speakers-heading" class="sr-only">Mentors</h2>
-              {{ people_card(mentors, 'speakers', submissions) }}
+              {{ people_card(mentors, 'Mentors') }}
             </section>
           {% endif %}
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon/templates/foss_hackathon.html
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon/templates/foss_hackathon.html
@@ -16,10 +16,29 @@
       class="v3-banner bg-white"
     />
 
-    {% if event_stats %}
-      <div class="ev-stats" role="region" aria-label="Event statistics">
-        {% if event_stats > 0 %}
-          <span>{{ event_stats }} Attend{{ "ing" if status_live else "ed" }}</span>
+    {% if hackathon_stats %}
+      <div class="ev-stats" role="region" aria-label="Hackathon statistics">
+        {% if hackathon_stats.members > 0 %}
+          <span> {{ hackathon_stats.members }} Attend{{ "ing" if status_live else "ed" }} </span>
+        {% endif %}
+
+        {% if hackathon_stats.members > 0 and hackathon_stats.teams > 0 %}
+          <span aria-hidden="true">•</span>
+        {% endif %}
+
+        {% if hackathon_stats.teams > 0 %}
+          <span> {{ hackathon_stats.teams }} Teams </span>
+        {% endif %}
+
+        {%
+          if (hackathon_stats.members > 0 or hackathon_stats.teams > 0)
+          and hackathon_stats.projects > 0
+        %}
+          <span aria-hidden="true">•</span>
+        {% endif %}
+
+        {% if hackathon_stats.projects > 0 %}
+          <span> {{ hackathon_stats.projects }} Projects </span>
         {% endif %}
       </div>
     {% endif %}
@@ -27,13 +46,14 @@
     {% if registration_status %}
       <div class="v3-status v3-status--success" role="status" aria-live="polite">
         <i class="ti ti-discount-check-filled" aria-hidden="true"></i>
-        You've registered for this event
+        {% if status_live %} You've registered for this hackathon
+        {% else %} You had attended this hackathon {% endif %}
       </div>
 
       {% if status_live and not doc.is_registration_live %}
         <div class="v3-status v3-status--warning" role="status" aria-live="polite">
           <i class="ti ti-ban" aria-hidden="true"></i>
-          Registration is closed for the event
+          Registration is closed for the hackathon
         </div>
       {% endif %}
     {% endif %}
@@ -222,9 +242,11 @@
                   <div class="ev-detail-primary">
                     {% if doc.start_date.strftime("%Y-%m-%d") != doc.end_date.strftime("%Y-%m-%d") %}
                       {% if doc.start_date.strftime("%B") != doc.end_date.strftime("%B") %}
-                        {{ doc.start_date.strftime("%-d %B") }} - {{ doc.end_date.strftime("%-d %B %Y") }}
+                        {{ doc.start_date.strftime("%-d %B") }}
+                        - {{ doc.end_date.strftime("%-d %B %Y") }}
                       {% else %}
-                        {{ doc.start_date.strftime("%-d") }} - {{ doc.end_date.strftime("%-d %B %Y") }}
+                        {{ doc.start_date.strftime("%-d") }}
+                        - {{ doc.end_date.strftime("%-d %B %Y") }}
                       {% endif %}
                     {% else %}
                       {{ doc.end_date.strftime("%-d %B %Y") }}
@@ -250,7 +272,7 @@
 
             <div>
               <div class="v3-btn-group" role="group" aria-label="Event actions">
-                {% if doc.is_registration_live %}
+                {% if doc.is_registration_live and status_live %}
                   <a
                     href="/dashboard/register-for-hackathon?id={{ doc.name }}"
                     class="v3-btn v3-btn-primary"

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -1733,6 +1733,16 @@ h6 {
   display: flex;
 }
 
+.localhost-header {
+  background: var(--v3-text-color);
+  color: var(--v3-card-bg);
+  padding: 0.5rem 1rem;
+  font-family: 'Space Mono', monospace;
+  font-size: 0.875rem;
+  font-weight: 700;
+  width: fit-content;
+}
+
 .search-box {
   padding-top: 1rem;
   margin-bottom: 0;

--- a/fossunited/templates/macros/agenda_card.html
+++ b/fossunited/templates/macros/agenda_card.html
@@ -7,7 +7,12 @@
         <path fill-rule="evenodd" clip-rule="evenodd" d="M3.36823 8.21051C3.36823 7.74543 3.74525 7.36841 4.21033 7.36841H11.7893C12.2544 7.36841 12.6314 7.74543 12.6314 8.21051C12.6314 8.6756 12.2544 9.05262 11.7893 9.05262H4.21033C3.74525 9.05262 3.36823 8.6756 3.36823 8.21051Z" fill="currentColor"/>
         <path fill-rule="evenodd" clip-rule="evenodd" d="M3.36823 11.5789C3.36823 11.1138 3.74525 10.7368 4.21033 10.7368H8.42086C8.88594 10.7368 9.26296 11.1138 9.26296 11.5789C9.26296 12.044 8.88594 12.421 8.42086 12.421H4.21033C3.74525 12.421 3.36823 12.044 3.36823 11.5789Z" fill="currentColor"/>
       </svg>
-      <a href="/{{ route }}/schedule">Agenda</a><i class="ti ti-arrow-up-right" style="font-size: 0.9rem;" aria-hidden="true"></i>
+      {% if route %}
+      <a href="/{{ route }}/schedule">Agenda</a>
+      <i class="ti ti-arrow-up-right" style="font-size: 0.9rem;" aria-hidden="true"></i>
+      {% else %}
+      <span>Agenda</span>
+      {% endif %}
     </div>
 
     <div class="v3-schedule-list">

--- a/fossunited/templates/macros/volunteers_card.html
+++ b/fossunited/templates/macros/volunteers_card.html
@@ -6,7 +6,7 @@
   <div class="v3-card {% if show_view_all %}has-view-all{% endif %}">
     <div class="v3-section-title">
       <i class="ti ti-{{ 'empathize' if type == 'volunteers' else 'microphone' }}"></i>
-      <span>{{ 'Volunteers' if type == 'volunteers' else type.upper() }}</span>
+      <span>{{ 'Volunteers' if type == 'volunteers' else type.capitalize() }}</span>
     </div>
 
     <div class="v3-people-container" id="container_{{ unique_id }}" data-expanded="false">

--- a/fossunited/templates/macros/volunteers_card.html
+++ b/fossunited/templates/macros/volunteers_card.html
@@ -1,11 +1,11 @@
-{% macro people_card(items, type, submissions=None) %}
+{% macro people_card(items, type, submissions=None, icon="empathize") %}
   {# type can be 'volunteers' or 'speakers' #}
   {% set show_view_all = items|length >= 4 %}
   {% set unique_id = type + '_' + range(1000, 9999) | random | string %}
 
   <div class="v3-card {% if show_view_all %}has-view-all{% endif %}">
     <div class="v3-section-title">
-      <i class="ti ti-{{ 'empathize' if type == 'volunteers' else 'microphone' }}"></i>
+      <i class="ti ti-{{ 'empathize' if type == 'volunteers' else 'microphone' if type == 'speakers' else icon }}"></i>
       <span>{{ 'Volunteers' if type == 'volunteers' else type.capitalize() }}</span>
     </div>
 

--- a/fossunited/templates/macros/volunteers_card.html
+++ b/fossunited/templates/macros/volunteers_card.html
@@ -1,60 +1,66 @@
 {% macro people_card(items, type, submissions=None) %}
-{# type can be 'volunteers' or 'speakers' #}
-{% set show_view_all = items|length >= 4 %}
-{% set unique_id = type + '_' + range(1000, 9999) | random | string %}
+  {# type can be 'volunteers' or 'speakers' #}
+  {% set show_view_all = items|length >= 4 %}
+  {% set unique_id = type + '_' + range(1000, 9999) | random | string %}
 
-<div class="v3-card {% if show_view_all %}has-view-all{% endif %}">
-  <div class="v3-section-title">
-    <i class="ti ti-{{ 'empathize' if type == 'volunteers' else 'microphone' }}"></i>
-    <span>{{ 'Volunteers' if type == 'volunteers' else 'Speakers' }}</span>
-  </div>
-
-  <div class="v3-people-container" id="container_{{ unique_id }}" data-expanded="false">
-    <div class="v3-people-list">
-      {% if type == 'volunteers' %}
-        {% for volunteer in items %}
-        <div class="v3-clickable v3-people-item" onclick="window.location.href='/{{ volunteer.route }}'">
-          <img src="{{ volunteer.profile_picture or '/assets/fossunited/images/defaults/user_profile_image.png' }}"
-               alt="{{ volunteer.full_name }}"
-               class="v3-people-avatar">
-          <div class="v3-people-name">{{ volunteer.full_name }}</div>
-        </div>
-        {% endfor %}
-      {% else %}
-        {% for speaker in items %}
-        {% for submission in submissions %}
-        {% if submission.name == speaker.parent %}
-        <div class="v3-clickable v3-people-item" onclick="window.location.href='/{{ submission.route }}'">
-        <img src="{{ speaker.photo or '/assets/fossunited/images/defaults/user_profile_image.png' }}" alt="{{ speaker.full_name }}" class="v3-people-avatar">
-          <div class="v3-people-name">{{ speaker.full_name }}</div>
-        </div>
-        {% endif %}
-        {% endfor %}
-        {% endfor %}
-      {% endif %}
+  <div class="v3-card {% if show_view_all %}has-view-all{% endif %}">
+    <div class="v3-section-title">
+      <i class="ti ti-{{ 'empathize' if type == 'volunteers' else 'microphone' }}"></i>
+      <span>{{ 'Volunteers' if type == 'volunteers' else type.upper() }}</span>
     </div>
+
+    <div class="v3-people-container" id="container_{{ unique_id }}" data-expanded="false">
+      <div class="v3-people-list">
+        {% if type != 'speakers' %}
+          {% for volunteer in items %}
+            <a class="v3-clickable v3-people-item" href="/{{ volunteer.route }}">
+              <img
+                src="{{ volunteer.profile_picture or '/assets/fossunited/images/defaults/user_profile_image.png' }}"
+                alt="{{ volunteer.full_name }}"
+                class="v3-people-avatar"
+              />
+              <div class="v3-people-name">{{ volunteer.full_name }}</div>
+            </a>
+          {% endfor %}
+        {% else %}
+          {% for speaker in items %}
+            {% for submission in submissions %}
+              {% if submission.name == speaker.parent %}
+                <a class="v3-clickable v3-people-item" href="/{{ submission.route }}">
+                  <img
+                    src="{{ speaker.photo or '/assets/fossunited/images/defaults/user_profile_image.png' }}"
+                    alt="{{ speaker.full_name }}"
+                    class="v3-people-avatar"
+                  />
+                  <div class="v3-people-name">{{ speaker.full_name }}</div>
+                </a>
+              {% endif %}
+            {% endfor %}
+          {% endfor %}
+        {% endif %}
+      </div>
+    </div>
+
+    {% if show_view_all %}
+      <div class="v3-view-all-link" onclick="togglePeopleView('{{ unique_id }}')">
+        <span id="btn_text_{{ unique_id }}">View All</span>
+      </div>
+    {% endif %}
   </div>
 
-  {% if show_view_all %}
-  <div class="v3-view-all-link" onclick="togglePeopleView('{{ unique_id }}')">
-    <span id="btn_text_{{ unique_id }}">View All</span>
-  </div>
-  {% endif %}
-</div>
+  <script>
+    function togglePeopleView(uniqueId) {
+      const container = document.getElementById('container_' + uniqueId)
+      const btnText = document.getElementById('btn_text_' + uniqueId)
+      const isExpanded = container.getAttribute('data-expanded') === 'true'
 
-<script>
-function togglePeopleView(uniqueId) {
-  const container = document.getElementById('container_' + uniqueId);
-  const btnText = document.getElementById('btn_text_' + uniqueId);
-  const isExpanded = container.getAttribute('data-expanded') === 'true';
-
-  if (isExpanded) {
-    container.setAttribute('data-expanded', 'false');
-    btnText.textContent = 'View All';
-  } else {
-    container.setAttribute('data-expanded', 'true');
-    btnText.textContent = 'Show Less';
-  }
-}
-</script>
+      if (isExpanded) {
+        container.setAttribute('data-expanded', 'false')
+        btnText.textContent = 'View All'
+      } else {
+        container.setAttribute('data-expanded', 'true')
+        btnText.textContent = 'Show Less'
+      }
+    }
+  </script>
 {% endmacro %}

--- a/fossunited/www/fosshack/2026/index.py
+++ b/fossunited/www/fosshack/2026/index.py
@@ -2,11 +2,7 @@ import frappe
 
 from fossunited.doctype_ids import (
     HACKATHON,
-    HACKATHON_LOCALHOST,
-    HACKATHON_PARTICIPANT,
     HACKATHON_PARTNER_PROJECT,
-    HACKATHON_PROJECT,
-    HACKATHON_TEAM,
 )
 from fossunited.fossunited.utils import get_event_sponsors
 
@@ -21,6 +17,8 @@ def get_context(context):
 
     # Fetch hackathon details
     hackathon = frappe.get_doc(HACKATHON, hackathon_id)
+    cities_dict = hackathon.get_localhosts()
+    hackathon_stats = hackathon.get_hackathon_stats()
 
     context.doc = hackathon
     context.pagetitle, context.description, context.image = hackathon.get_meta()
@@ -78,78 +76,6 @@ def get_context(context):
         },
     ]
 
-    member_count = frappe.db.count(
-        HACKATHON_PARTICIPANT,
-        {
-            "hackathon": hackathon_id,
-        },
-    )
-
-    teams_count = frappe.db.count(
-        HACKATHON_TEAM,
-        {
-            "hackathon": hackathon_id,
-        },
-    )
-
-    projects_count = frappe.db.count(
-        HACKATHON_PROJECT,
-        {
-            "hackathon": hackathon_id,
-            "is_published": 1,
-        },
-    )
-
-    # Get all LocalHosts
-    localhosts = frappe.db.get_all(
-        HACKATHON_LOCALHOST,
-        filters={"parent_hackathon": hackathon_id},
-        fields=["name", "localhost_name", "route", "city", "state", "location"],
-        order_by="city, localhost_name",
-        page_length=99,
-    )
-
-    # Bulk Fetch Counts
-    attending_counts = frappe.db.get_all(
-        HACKATHON_PARTICIPANT,
-        filters={"localhost_request_status": "Accepted", "hackathon": hackathon_id},
-        fields=["localhost", "count(name) as count"],
-        group_by="localhost",
-    )
-    applied_counts = frappe.db.get_all(
-        HACKATHON_PARTICIPANT,
-        filters={"hackathon": hackathon_id},
-        fields=["localhost", "count(name) as count"],
-        group_by="localhost",
-    )
-    likes_counts = frappe.db.get_all(
-        "Comment",
-        filters={
-            "comment_type": "Like",
-            "reference_doctype": HACKATHON_LOCALHOST,
-        },
-        fields=["reference_name as localhost", "count(name) as count"],
-        group_by="reference_name",
-    )
-
-    # Convert to dicts
-    attending_dict = {item["localhost"]: item["count"] for item in attending_counts}
-    applied_dict = {item["localhost"]: item["count"] for item in applied_counts}
-    likes_dict = {item["localhost"]: item["count"] for item in likes_counts}
-
-    # Process LocalHosts and group by city
-    cities_dict = {}
-    for host in localhosts:
-        host["route"] = f"/{host.route}"
-        host["attending"] = attending_dict.get(host.name, 0)
-        host["interested"] = applied_dict.get(host.name, 0) + likes_dict.get(host.name, 0)
-
-        city = host.get("city", "Other")
-        if city not in cities_dict:
-            cities_dict[city] = []
-
-        cities_dict[city].append(host)
-
     context.localhosts_by_city = [
         {"city": city, "localhosts": hosts} for city, hosts in sorted(cities_dict.items())
     ]
@@ -176,10 +102,10 @@ def get_context(context):
     # Stats
     context.stats = {
         "prize_pool": "₹ 5,00,000",
-        "local_hosts": len(localhosts),
-        "participants": member_count,
-        "teams": teams_count,
-        "projects": projects_count,
+        "local_hosts": sum(len(hosts) for hosts in cities_dict.values()),
+        "participants": hackathon_stats["members"],
+        "teams": hackathon_stats["teams"],
+        "projects": hackathon_stats["projects"],
         "projects_url": f"/{hackathon.route}/projects/all",
     }
 


### PR DESCRIPTION
- Using event page functions we format and show data similar to default event page, but has hackathon context and its counter parts applicable.

<img width="843" height="968" alt="image" src="https://github.com/user-attachments/assets/d2790468-17e1-4f5a-b383-5c3f612abe23" />

- Header card

<img width="297" height="1027" alt="image" src="https://github.com/user-attachments/assets/e9a5bfa8-5a3b-4d54-ac57-839c2cf8a2c3" />

- Localhost list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modernized hackathon event page with event cover, stats banner, modular content cards, and new resources (submissions, partner projects, project ideas).
  * Added localhosts grouped by city, mentors listing, and aggregated hackathon stats.

* **Improvements**
  * Responsive two-column layout and enhanced sidebar for sponsors, volunteers, and contact.
  * Agenda link now degrades gracefully when unavailable; registration and event status surfaced.
  * Volunteers and speakers now use standard links for improved accessibility.

* **Style**
  * New CSS for a local-development header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->