### PR TITLE
fix(tests): allow hackathon test to allow registrations

### DIFF
--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -47,7 +47,7 @@ class FOSSHackathonParticipant(Document):
         if not hackathon:
             frappe.throw("Invalid Hackathon selected")
 
-        today = frappe.utils.nowdate()
+        today = frappe.utils.now_datetime()
 
         # Registration closed manually
         if not hackathon.is_registration_live:

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_project/templates/foss_hackathon_project.html
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_project/templates/foss_hackathon_project.html
@@ -1,13 +1,15 @@
 {% extends "templates/foss_base.html" %}
+{% from "fossunited/templates/macros/breadcrumb.html" import breadcrumb, theme_toggle %}
+
 {% block page_content %}
   <div class="v3-page">
     <div class="v3-container">
-      <div class="v3-breadcrumb">
-        <a href="/{{ hackathon.route }}">{{ hackathon.hackathon_name }}</a>
-        <span class="mx-2">></span>
-        <a href="/{{ hackathon.route }}/projects/all">{{ _("All Projects") }}</a>
-        <span class="mx-2">></span>
-        <span>{{ doc.title }}</span>
+      <div class="d-flex justify-content-between align-items-center">
+        {{
+          breadcrumb(items=[{"route": ('/' + hackathon.route), "label": hackathon.hackathon_name},
+          {"route": ('/' + hackathon.route + '/projects/all'), "label": "All Projects"}, {"label": doc.title}])
+        }}
+        {{ theme_toggle() }}
       </div>
 
       <div class="v3-card mb-4">

--- a/fossunited/templates/macros/breadcrumb.html
+++ b/fossunited/templates/macros/breadcrumb.html
@@ -4,9 +4,9 @@
       {# Use provided items #}
       {% for item in items %}
         {% if loop.last %}
-          <span>{{ item.label }}</span>
+          <span>{{ _(item.label) }}</span>
         {% else %}
-          <a class="hover:cursor-pointer" href="{{ item.route }}">{{ item.label }}</a>
+          <a class="hover:cursor-pointer" href="{{ item.route }}">{{ _(item.label) }}</a>
           {% if not loop.last %}<span class="px-1">></span>{% endif %}
         {% endif %}
       {% endfor %}
@@ -33,7 +33,7 @@
         <span class="px-1">></span>
 
         {# Determine display label - check rename_map first, then format #}
-        {% set display_label = rename_map.get(part, part.replace('-', ' ').replace('_', ' ').title()) %}
+        {% set display_label = _(rename_map.get(part, part.replace('-', ' ').replace('_', ' ').title())) %}
 
         {% if loop.last %}
           <span>{{ display_label }}</span>

--- a/fossunited/tests/utils.py
+++ b/fossunited/tests/utils.py
@@ -574,6 +574,7 @@ def insert_test_hackathon(chapter: str, **kwargs):
         "start_date": kwargs.get("start_date", datetime.today() + timedelta(days=1)),
         "end_date": kwargs.get("end_date", datetime.today() + timedelta(days=2)),
         "hackathon_description": kwargs.get("hackathon_description", "Test Hackathon"),
+        "is_registration_live": kwargs.get("is_registration_live", 1),
     }
 
     for key, value in kwargs.items():


### PR DESCRIPTION
- Inserting hackathon doctype for test does not handle registration_live status, so enable it by default for all test to pass

- This is akin to recent commit made to not allow registration via api if event has ended or registration is closed.

- Add theme toggle for projects page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamic breadcrumb navigation system with integrated theme toggle on project pages for improved navigation experience.
  * Translation support for breadcrumb labels enabling multi-language display.

* **Improvements**
  * Enhanced timestamp precision in validation checks for more accurate date-time comparisons.

* **Tests**
  * Updated test utilities with registration status field for comprehensive testing coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->