### PR TITLE
fix(agenda): make agenda compact + add icons

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/foss_chapter.py
@@ -191,8 +191,8 @@ class FOSSChapter(WebsiteGenerator):
             context.default_chapter_logo = f"/files/{safe_type}_profile.svg"
             context.default_banner = f"/files/{safe_type}_banner.png"
 
-        context.upcoming_events = self.get_upcoming_events()
-        context.past_events = self.get_past_events()
+        context.upcoming_events = self.get_upcoming_events() + self.get_upcoming_hackathons()
+        context.past_events = self.get_past_events() + self.get_past_hackathons()
         context.members = self.get_members()
         context.social_links = self.get_social_links()
 
@@ -212,7 +212,10 @@ class FOSSChapter(WebsiteGenerator):
             fields=["*"],
             order_by="event_start_date asc",
             page_length=6,
-        ) + frappe.get_all(
+        )
+
+    def get_upcoming_hackathons(self):
+        return frappe.get_all(
             HACKATHON,
             filters={
                 "chapter": self.name,
@@ -231,8 +234,10 @@ class FOSSChapter(WebsiteGenerator):
             },
             fields=["*"],
             order_by="event_end_date desc",
-            page_length=999,
-        ) + frappe.get_all(
+        )
+
+    def get_past_hackathons(self):
+        return frappe.get_all(
             HACKATHON,
             filters={
                 "chapter": self.name,

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -2785,7 +2785,7 @@ body:has(.v3-page) {
 .v3-schedule-list {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1.5rem;
 }
 
 .v3-schedule-date-group {
@@ -2797,10 +2797,6 @@ body:has(.v3-page) {
   font-size: 1.125rem;
   font-weight: 600;
   margin-bottom: 1rem;
-}
-
-.v3-schedule-hall-group {
-  margin-bottom: 1.5rem;
 }
 
 .v3-schedule-hall-title {

--- a/fossunited/templates/macros/agenda_card.html
+++ b/fossunited/templates/macros/agenda_card.html
@@ -27,48 +27,89 @@
               {% endif %}
               {% for item in items %}
                 {% if item_count.value < show_limit %}
-                  <div
-                    class="v3-clickable"
-                    {% if item.cfp_route %}
-                      data-route="{{ item.cfp_route }}"
-                      onclick="window.location.href='/{{ item.cfp_route }}'"
+                  {# Determine link strategy #}
+                  {% set has_cfp = item.cfp_route %}
+                  {% set has_video = item.talk_video %}
+                  {% set has_both = has_cfp and has_video %}
+                  {% set wrap_whole_card = (has_cfp or has_video) and not has_both %}
+
+                  {# Icon mapping with video detection #}
+                  {% set icon_map = {
+                    "Talk": "microphone",
+                    "Lightning Talk": "bolt",
+                    "Workshop": "settings",
+                    "Panel Discussion": "users-group",
+                    "Opening Note": "presentation",
+                    "Break": "coffee",
+                    "Other": "calendar-event"
+                  } %}
+
+                  {# Determine if this is an online meeting #}
+                  {% set is_online = (not item.hall and item.other_category and
+                                      item.other_category|lower in ["meeting", "online"]) or has_video %}
+                  {% set icon = "video" if is_online else icon_map.get(item.category, "calendar-event") %}
+
+                  <div class="mb-2">
+                    {# Wrap entire card if only one link type exists #}
+                    {% if wrap_whole_card %}
+                    {% set single_link = ("/" ~ item.cfp_route) if has_cfp else item.talk_video %}
+                      <a class="v3-clickable" href="{{ single_link }}">
                     {% endif %}
-                  >
-                    <div class="v3-schedule-item">
-                      <div class="v3-schedule-header">
-                        <div class="v3-schedule-time">{{ item.start_time_display }}</div>
-                        <div
-                          style="flex: 1; height: 1px; background: var(--v3-text-color); margin: 0 0.5rem;"
-                        ></div>
-                        <div class="v3-schedule-badge">{{ item.category }}</div>
-                      </div>
-                      <div class="v3-schedule-content">
-                        {% if item.cfp_speakers %}
-                          <div
-                            class="v3-speaker-imgs cols-{{ [item.cfp_speakers|length, 4]|min }}"
-                          >
-                            {% for speaker in item.cfp_speakers[:4] %}
-                              <img
-                                src="{{ speaker.photo or '/assets/fossunited/images/defaults/user_profile_image.png' }}"
-                                alt="{{ speaker.full_name }}"
-                                class="v3-speaker-img"
-                              />
-                            {% endfor %}
-                          </div>
-                        {% endif %}
-                        <div class="v3-schedule-details">
-                          <div class="v3-schedule-title">{{ item.title }}</div>
-                          {% if item.cfp_speakers %}
-                            <div class="v3-speaker-names">
-                              {% for speaker in item.cfp_speakers %}
-                                <div class="v3-speaker-name">{{ speaker.full_name }}</div>
-                              {% endfor %}
+                      <div class="v3-schedule-item">
+                        <div class="v3-schedule-header">
+                          <div class="v3-schedule-time">{{ item.start_time_display }}</div>
+                          <div style="flex: 1; height: 1px; background: var(--v3-text-color); margin: 0 0.5rem;"></div>
+                          <div class="v3-schedule-badge">{{ item.category }}</div>
+                        </div>
+
+                        <div class="v3-schedule-content">
+                          {# Image/Icon section - links to video if both links exist #}
+                          {% if has_both %}
+                          <a href="{{ item.talk_video }}" class="v3-clickable">
+                          {% endif %}
+                            {% if item.cfp_speakers %}
+                              <div class="v3-speaker-imgs cols-{{ [item.cfp_speakers|length, 4]|min }}">
+                                {% for speaker in item.cfp_speakers[:4] %}
+                                <img
+                                  src="{{ speaker.photo or '/assets/fossunited/images/defaults/user_profile_image.png' }}"
+                                  alt="{{ speaker.full_name }}"
+                                  class="v3-speaker-img"
+                                />
+                                {% endfor %}
+                              </div>
+                            {% else %}
+                              <div class="rounded align-items-center justify-content-center text-black bg-white p-2">
+                                <i class="ti ti-{{ icon }}" style="font-size: 1.5rem;"></i>
+                              </div>
+                            {% endif %}
+                          {% if has_both %}
+                          </a>
+                          {% endif %}
+
+                          {# Content section - links to CFP if both links exist #}
+                          {% if has_both %}
+                          <a href="/{{ item.cfp_route }}" class="v3-clickable" style="flex: 1;">
+                          {% endif %}
+                            <div class="v3-schedule-details">
+                              <div class="v3-schedule-title">{{ item.title }}</div>
+                              {% if item.cfp_speakers %}
+                                <div class="v3-speaker-names">
+                                  {% for speaker in item.cfp_speakers %}
+                                    <div class="v3-speaker-name">{{ speaker.full_name }}</div>
+                                  {% endfor %}
+                                </div>
+                              {% endif %}
                             </div>
+                          {% if has_both %}
+                          </a>
                           {% endif %}
                         </div>
                       </div>
-                    </div>
+                    {% if wrap_whole_card %}
+                    </a>
+                    {% endif %}
                   </div>
+
                   {% set item_count.value = item_count.value + 1 %}
                 {% endif %}
               {% endfor %}
@@ -78,6 +119,7 @@
       {% endfor %}
     </div>
 
+    {# Show "View Full Schedule" button if there are more items #}
     {% set total_items = namespace(value=0) %}
     {% for date_str, halls in schedule_data.items() %}
       {% for hall, items in halls.items() %}
@@ -86,12 +128,11 @@
     {% endfor %}
 
     {% if total_items.value > show_limit %}
-      <a
+
         href="/{{ route }}/schedule"
         class="v3-btn v3-btn-secondary"
         style="margin-top: 1rem; width: auto;"
-        >View Full Schedule</a
-      >
+      >View Full Schedule</a>
     {% endif %}
   </div>
 {% endmacro %}

--- a/fossunited/templates/macros/agenda_card.html
+++ b/fossunited/templates/macros/agenda_card.html
@@ -127,8 +127,8 @@
       {% endfor %}
     {% endfor %}
 
-    {% if total_items.value > show_limit %}
-
+    {% if total_items.value > show_limit and route %}
+      <a
         href="/{{ route }}/schedule"
         class="v3-btn v3-btn-secondary"
         style="margin-top: 1rem; width: auto;"


### PR DESCRIPTION
- add icons based on category so its easy to visualize
- make agenda compact for halls/dates (useful for hackathon page)
- use talk_video to wrap for online meeting if no linked_cfp or hall is given


<img width="684" height="1261" alt="image" src="https://github.com/user-attachments/assets/710895b9-114c-4c55-b8f4-0ccdf27f9908" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reduced vertical spacing in the schedule list for a tighter layout

* **New Features**
  * Smarter agenda cards with contextual linking for talks and videos
  * Separate anchors for image/icon and content when multiple link types exist
  * Conditional "View Full Schedule" button when more items are available
  * Improved speaker avatar and online/video indicators in agenda cards
  * Upcoming and past hackathons are now surfaced alongside events
<!-- end of auto-generated comment: release notes by coderabbit.ai -->