### PR TITLE
feat(timeline): add accepted event grants as upcoming events for timeline + rss

### DIFF
--- a/fossunited/www/events/timeline/index.py
+++ b/fossunited/www/events/timeline/index.py
@@ -3,36 +3,28 @@ from datetime import datetime
 import frappe
 from frappe.utils import get_datetime, now_datetime
 
-from fossunited.doctype_ids import CHAPTER, EVENT, HACKATHON
+from fossunited.doctype_ids import EVENT, EVENT_GRANTS, HACKATHON
 
 
 def get_context(context, page_type="upcoming"):
     context.no_cache = 1
-
     context.page_type = page_type
 
     now = get_datetime(now_datetime())
 
-    if page_type == "upcoming":
-        context.title = "Upcoming Events - FOSS United"
-        event_filters = {
-            "event_end_date": [">=", now],
-            "status": "Live",
-        }
-        hackathon_filters = {
-            "is_published": 1,
-            "end_date": [">=", now],
-        }
-    else:
-        context.title = "Past Events - FOSS United"
-        event_filters = {
-            "event_end_date": ["<", now],
-            "status": "Concluded",
-        }
-        hackathon_filters = {
-            "is_published": 1,
-            "end_date": ["<", now],
-        }
+    is_upcoming = page_type == "upcoming"
+
+    context.title = "Upcoming Events - FOSS United" if is_upcoming else "Past Events - FOSS United"
+
+    event_filters = {
+        "event_end_date": [">=" if is_upcoming else "<", now],
+        "status": "Live" if is_upcoming else "Concluded",
+    }
+
+    hackathon_filters = {
+        "is_published": 1,
+        "end_date": [">=" if is_upcoming else "<", now],
+    }
 
     events = frappe.get_all(
         EVENT,
@@ -53,6 +45,8 @@ def get_context(context, page_type="upcoming"):
             "banner_image",
             "chapter",
             "must_attend",
+            "chapter.chapter_type as _chapter_type",
+            "chapter.city as _chapter_city",
         ],
     )
 
@@ -68,42 +62,85 @@ def get_context(context, page_type="upcoming"):
             "hackathon_banner as banner_image",
             "hackathon_type as event_location",
             "chapter",
+            "chapter.chapter_type as _chapter_type",
+            "chapter.city as _chapter_city",
+        ],
+    )
+
+    grants = frappe.get_all(
+        EVENT_GRANTS,
+        filters={
+            "grant_status": "Approved",
+            "event_end_date": [">=" if is_upcoming else "<", now],
+        },
+        fields=[
+            "name",
+            "event_name",
+            "event_start_date",
+            "event_end_date",
+            "event_location",
+            "event_website",
+            "grant_amount",
         ],
     )
 
     for h in hackathons:
-        h["must_attend"] = 1
         h["_kind"] = "hackathon"
+        h["must_attend"] = 1  # by default
 
     for e in events:
         e["_kind"] = "event"
 
-    chapter_data = frappe.get_all(CHAPTER, fields=["name", "chapter_type", "city"])
+    GRANTS_CHAPTER_BASE = frappe._dict(
+        {
+            "doctype": "FOSS Chapter",
+            "chapter_name": "FOSS Event Grants",
+            "chapter_type": "City Community",
+        }
+    )
 
-    chapter_type_map = {c.name: c.chapter_type for c in chapter_data}
-    chapter_city_map = {c.name: c.city for c in chapter_data}
+    for g in grants:
+        website = g.get("event_website") or "/grants/events"
+        location = (g.get("event_location") or "").strip().title()
+        city = location.split(",")[0].strip() if location else None
 
-    # Get unique cities for filter dropdown
-    context.all_cities = sorted(list(set(c.city for c in chapter_data if c.city)))
+        g.update(
+            {
+                "route": website,
+                "external_event_url": website,
+                "is_external_event": 1,
+                "banner_image": None,
+                "chapter": frappe._dict({**GRANTS_CHAPTER_BASE, "city": city}),
+                "must_attend": (g.get("grant_amount") or 0) > 10000,
+                "_kind": "grant",
+                "_chapter_city": city,
+                "event_location": location,
+            }
+        )
+
+    # Collect cities directly from fetched data
+    context.all_cities = sorted(
+        {e.get("_chapter_city") for e in events + hackathons + grants if e.get("_chapter_city")}
+    )
 
     timeline = []
 
-    for item in events + hackathons:
+    for item in events + hackathons + grants:
         start_dt = get_datetime(item.get("event_start_date"))
         end_dt = get_datetime(item.get("event_end_date"))
 
-        row = {
-            **{k: (v.isoformat() if isinstance(v, datetime) else v) for k, v in item.items()},
-            "_start": start_dt.isoformat(),
-            "_end": end_dt.isoformat(),
-            "_is_past": end_dt < now,
-            "_chapter_type": chapter_type_map.get(item.get("chapter")),
-            "_chapter_city": chapter_city_map.get(item.get("chapter")),
-        }
+        timeline.append(
+            {
+                **{k: (v.isoformat() if isinstance(v, datetime) else v) for k, v in item.items()},
+                "_start": start_dt.isoformat(),
+                "_end": end_dt.isoformat(),
+                "_is_past": end_dt < now,
+            }
+        )
 
-        timeline.append(row)
-
-    # Sort: upcoming = chronological, past = reverse chronological
-    timeline.sort(key=lambda x: x["_start"], reverse=(page_type == "completed"))
+    timeline.sort(
+        key=lambda x: x["_start"],
+        reverse=not is_upcoming,
+    )
 
     context.timeline_events = timeline

--- a/fossunited/www/events/timeline/index.py
+++ b/fossunited/www/events/timeline/index.py
@@ -111,6 +111,7 @@ def get_context(context, page_type="upcoming"):
                 "is_external_event": 1,
                 "banner_image": None,
                 "chapter": frappe._dict({**GRANTS_CHAPTER_BASE, "city": city}),
+                "_chapter_type": "City Community",
                 "must_attend": (g.get("grant_amount") or 0) > 10000,
                 "_kind": "grant",
                 "_chapter_city": city,

--- a/fossunited/www/events/timeline/rss.py
+++ b/fossunited/www/events/timeline/rss.py
@@ -64,13 +64,44 @@ def get_context(context):
         order_by="start_date asc",
         limit=10,
     )
+    grants = frappe.get_all(
+        "FOSS Event Grant",
+        fields=[
+            "name",
+            "event_name",
+            "event_description",
+            "event_start_date",
+            "event_end_date",
+            "event_location",
+            "event_type",
+            "event_website as route",
+            "'FOSS Event Grants' as chapter",
+            "grant_amount",
+            "modified",
+        ],
+        filters={
+            "grant_status": "Approved",
+            "event_end_date": (">=", now),
+        },
+        order_by="event_start_date asc",
+        limit=20,
+    )
+
+    for g in grants:
+        g.route = g.route or "/grants/events"
+        g.must_attend = (g.grant_amount or 0) > 10000
+        g.event_start_date = frappe.utils.get_datetime(g.event_start_date)
+        g.event_end_date = frappe.utils.get_datetime(g.event_end_date)
 
     # Combine and process events
-    all_events = events + hackathons
+    all_events = events + hackathons + grants
     all_events.sort(key=lambda x: x.event_start_date)
 
     for event in all_events:
-        event.link = urljoin(host, event.route)
+        if event.route and event.route.startswith("http"):
+            event.link = event.route
+        else:
+            event.link = urljoin(host, event.route or "")
         event.title = escape_html(event.event_name or "")
         event.chapter_name = escape_html(event.chapter or "")
         event.location = escape_html(event.event_location or "")

--- a/fossunited/www/events/timeline/rss.py
+++ b/fossunited/www/events/timeline/rss.py
@@ -75,7 +75,6 @@ def get_context(context):
             "event_location",
             "event_type",
             "event_website as route",
-            "'FOSS Event Grants' as chapter",
             "grant_amount",
             "modified",
         ],
@@ -89,9 +88,13 @@ def get_context(context):
 
     for g in grants:
         g.route = g.route or "/grants/events"
+        g.chapter = "FOSS Event Grants"
         g.must_attend = (g.grant_amount or 0) > 10000
         g.event_start_date = frappe.utils.get_datetime(g.event_start_date)
         g.event_end_date = frappe.utils.get_datetime(g.event_end_date)
+
+    for h in hackathons:
+        h["must_attend"] = 1
 
     # Combine and process events
     all_events = events + hackathons + grants

--- a/fossunited/www/events/timeline/rss.py
+++ b/fossunited/www/events/timeline/rss.py
@@ -90,15 +90,13 @@ def get_context(context):
         g.route = g.route or "/grants/events"
         g.chapter = "FOSS Event Grants"
         g.must_attend = (g.grant_amount or 0) > 10000
-        g.event_start_date = frappe.utils.get_datetime(g.event_start_date)
-        g.event_end_date = frappe.utils.get_datetime(g.event_end_date)
 
     for h in hackathons:
         h["must_attend"] = 1
 
     # Combine and process events
     all_events = events + hackathons + grants
-    all_events.sort(key=lambda x: x.event_start_date)
+    all_events.sort(key=lambda x: frappe.utils.get_datetime(x.event_start_date))
 
     for event in all_events:
         if event.route and event.route.startswith("http"):


### PR DESCRIPTION
- as we approve event grants, we can show them in timeline for community to see and engage
- workaround way to append data as event to show up as event_card
- link to external if website is given, if not go to grants page

- also remove chapter mapping, and directly fetch from linked chapter field via orm method only

- extend rss timeline to get event grants info as events too

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Grants now appear in the events timeline alongside events and hackathons.
  * Grants included in RSS event feeds with full details, metadata, and direct links.
  * Grant listings show chapter, derived city/location, banner images, and must-attend badge.

* **Improvements**
  * Unified upcoming vs past handling and single-rule sorting across events, hackathons, and grants.
  * Timeline and city listings built from combined event sources for consistent display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->