### PR TITLE
fix(hackathon): disable button when api fetch is loading

### DIFF
--- a/dashboard/src/components/hackathon/JoinTeam.vue
+++ b/dashboard/src/components/hackathon/JoinTeam.vue
@@ -10,7 +10,13 @@
           class="grow"
           description="Enter the team code shared by your team leader."
         />
-        <Button variant="solid" label="Join" @click="joinThroughCode" />
+        <Button
+          variant="solid"
+          label="Join"
+          :loading="joinThroughCode.loading"
+          :disabled="joinThroughCode.loading"
+          @click="joinThroughCode"
+        />
       </div>
     </div>
     <div v-if="invitations.data.length > 0">

--- a/dashboard/src/components/hackathon/JoinTeam.vue
+++ b/dashboard/src/components/hackathon/JoinTeam.vue
@@ -15,7 +15,7 @@
           label="Join"
           :loading="joinThroughCode.loading"
           :disabled="joinThroughCode.loading"
-          @click="joinThroughCode"
+          @click="handleJoinThroughCode"
         />
       </div>
     </div>
@@ -107,21 +107,25 @@ onMounted(() => {
   }
 })
 
-const joinThroughCode = () => {
-  createResource({
-    url: 'fossunited.api.hackathon.join_team_via_code',
+const joinThroughCode = createResource({
+  url: 'fossunited.api.hackathon.join_team_via_code',
+  onSuccess(data) {
+    window.location.reload()
+  },
+  onError(error) {
+    toast.error('Invalid Team Code.' + error.message)
+  },
+})
+
+const handleJoinThroughCode = () => {
+  if (joinThroughCode.loading) return
+  joinThroughCode.update({
     params: {
       team_code: teamCode.value,
       hackathon: props.hackathon.data.name,
     },
-    auto: true,
-    onSuccess(data) {
-      window.location.reload()
-    },
-    onError(error) {
-      toast.error('Invalid Team Code.' + error.message)
-    },
   })
+  joinThroughCode.fetch()
 }
 
 const acceptInvite = (inviteId) => {

--- a/dashboard/src/pages/hackathon/CreateProject.vue
+++ b/dashboard/src/pages/hackathon/CreateProject.vue
@@ -263,6 +263,7 @@
             class="w-full md:w-2/5"
             size="md"
             :loading="createProject.loading"
+            :disabled="createProject.loading"
             @click="handleCreateProject"
           />
         </div>
@@ -397,6 +398,7 @@ const createProject = createResource({
 })
 
 const handleCreateProject = () => {
+  if (createProject.loading) return
   const errors = validateCreateProject()
   if (errors.length) {
     errorMessage.value = errors.join(', ')

--- a/dashboard/src/pages/hackathon/CreateTeam.vue
+++ b/dashboard/src/pages/hackathon/CreateTeam.vue
@@ -59,6 +59,7 @@
           label="Create"
           class="font-semibold"
           :loading="createTeam.loading"
+          :disabled="createTeam.loading"
           @click="handleTeamCreation"
         />
       </div>
@@ -138,6 +139,7 @@ const createTeam = createResource({
 })
 
 const handleTeamCreation = () => {
+  if (createTeam.loading) return
   if (validateFields().length > 0) {
     errorMessage.value = validateFields().join(', ')
     return

--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -122,7 +122,7 @@ def get_participant(hackathon: str) -> dict:
 
 @frappe.whitelist()
 @require_hackathon_participant(hackathon_id="hackathon")
-@rate_limit(limit=3, seconds=60 * 60)
+@rate_limit(limit=5, seconds=60 * 60)
 def create_team(hackathon: str, team: dict) -> dict:
     """
     Create a team document
@@ -213,7 +213,7 @@ def get_team_from_participant_id(hackathon: str, id: str) -> dict:
 
 @frappe.whitelist()
 @require_hackathon_team(team_id="team", hackathon_id="hackathon")
-@rate_limit(limit=3, seconds=60 * 60 * 12)
+@rate_limit(limit=5, seconds=60 * 60)
 def create_project(hackathon: str, team: str, project: dict) -> dict:
     """
     Create a project document


### PR DESCRIPTION
- since we added rate limit to functions, we need to make web page behave properly to enable single req per click



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Join Team, Create Project, and Create Team actions now disable and show loading while in progress, preventing duplicate submissions and concurrent requests.

* **Improvements**
  * Increased rate limits: team creation from 3→5 requests/hour; project creation from 3 per 12 hours→5 requests/hour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->