### PR TITLE
Fix : Invitation Acceptance Error

### DIFF
--- a/dashboard/src/components/hackathon/JoinTeam.vue
+++ b/dashboard/src/components/hackathon/JoinTeam.vue
@@ -130,15 +130,13 @@ const handleJoinThroughCode = () => {
 
 const acceptInvite = (inviteId) => {
   createResource({
-    url: 'frappe.client.set_value',
+    url: 'fossunited.api.hackathon.respond_to_join_team_request',
     params: {
-      doctype: 'FOSS Hackathon Join Team Request',
-      name: inviteId,
-      fieldname: 'status',
-      value: 'Accepted',
+      request_id: inviteId,
+      status: 'Accepted',
     },
     auto: true,
-    onSuccess: (data) => {
+    onSuccess: () => {
       window.location.reload()
     },
     onError(error) {
@@ -149,15 +147,13 @@ const acceptInvite = (inviteId) => {
 
 const rejectInvite = (inviteId) => {
   createResource({
-    url: 'frappe.client.set_value',
+    url: 'fossunited.api.hackathon.respond_to_join_team_request',
     params: {
-      doctype: 'FOSS Hackathon Join Team Request',
-      name: inviteId,
-      fieldname: 'status',
-      value: 'Rejected',
+      request_id: inviteId,
+      status: 'Rejected',
     },
     auto: true,
-    onSuccess: (data) => {
+    onSuccess: () => {
       props.invitations.fetch()
     },
     onError(error) {

--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -613,6 +613,79 @@ def get_issue_pr_title(url: str) -> dict:
 
 
 @frappe.whitelist()
+def respond_to_join_team_request(request_id: str, status: str) -> dict:
+    """
+    Accept or reject a join-team invitation.
+
+    This is the backend-safe alternative to calling ``frappe.client.set_value``
+    directly from the frontend.  ``frappe.client.set_value`` passes through
+    normal Frappe permission checks and may be rejected when the session user
+    (the invite *recipient*) does not hold a write-permission role on the
+    ``FOSS Hackathon Join Team Request`` DocType.  The ``before_save`` hook
+    also triggers side-effects (adding the member to the team, rejecting other
+    pending requests) that require elevated database access.
+
+    This method:
+
+    1. Ensures the caller is a logged-in user (not Guest).
+    2. Validates that ``status`` is one of the allowed transition values.
+    3. Fetches the request document and verifies that the session user is the
+       intended recipient.
+    4. Checks that the request is still in ``Pending`` state so that an already
+       resolved request cannot be changed again.
+    5. Updates the status with ``ignore_permissions=True`` so that the
+       controller's ``before_save`` side-effects can run without a permission
+       error, then commits the transaction.
+    6. Returns a success dict on completion.
+
+    Args:
+        request_id (str): Name (primary key) of the
+            ``FOSS Hackathon Join Team Request`` document.
+        status (str): New status – must be ``"Accepted"`` or ``"Rejected"``.
+
+    Returns:
+        dict: ``{"success": True, "status": <new status>}``
+
+    Raises:
+        frappe.AuthenticationError: If the caller is a guest.
+        frappe.ValidationError: If ``status`` is not a valid transition value,
+            if the session user is not the request recipient, or if the request
+            is no longer pending.
+        frappe.DoesNotExistError: If ``request_id`` does not exist.
+    """
+    current_user = frappe.session.user
+    if current_user == "Guest":
+        frappe.throw("Authentication required", frappe.AuthenticationError)
+
+    allowed_statuses = ("Accepted", "Rejected")
+    if status not in allowed_statuses:
+        frappe.throw(
+            f"Invalid status '{status}'. Allowed values: {', '.join(allowed_statuses)}",
+            frappe.ValidationError,
+        )
+
+    request_doc = frappe.get_doc(JOIN_TEAM_REQUEST, request_id)
+
+    if request_doc.reciever_email != current_user:
+        frappe.throw(
+            "You are not authorized to respond to this invitation",
+            frappe.PermissionError,
+        )
+
+    if request_doc.status != "Pending":
+        frappe.throw(
+            f"This invitation has already been {request_doc.status.lower()} and cannot be changed",
+            frappe.ValidationError,
+        )
+
+    request_doc.status = status
+    request_doc.save(ignore_permissions=True)
+    frappe.db.commit()
+
+    return {"success": True, "status": request_doc.status}
+
+
+@frappe.whitelist()
 def get_count_team_members_and_max_count(hackathon: str, team: str):
     """
     Get count of team members and maximum count of team members allowed

--- a/fossunited/tests/test_hackathon_api.py
+++ b/fossunited/tests/test_hackathon_api.py
@@ -12,6 +12,7 @@ from fossunited.api.hackathon import (
     delete_project,
     get_participant,
     join_team_via_code,
+    respond_to_join_team_request,
 )
 from fossunited.doctype_ids import (
     CHAPTER,
@@ -19,12 +20,15 @@ from fossunited.doctype_ids import (
     HACKATHON_PARTICIPANT,
     HACKATHON_PROJECT,
     HACKATHON_TEAM,
+    HACKATHON_TEAM_MEMBER,
     USER_PROFILE,
 )
 from fossunited.tests.utils import (
     insert_test_chapter,
     insert_test_hackathon,
+    insert_test_hackathon_join_request,
     insert_test_hackathon_participant,
+    insert_test_hackathon_team,
     insert_user_profile,
 )
 
@@ -417,3 +421,101 @@ class TestHackathonAPI(FrappeTestCase):
 
         with self.assertRaises(frappe.PermissionError):
             delete_project(hackathon=self.hackathon.name, team=team.name)
+
+
+class TestRespondToJoinTeamRequest(FrappeTestCase):
+    """Tests for the respond_to_join_team_request API endpoint."""
+
+    def setUp(self):
+        frappe.set_user("Administrator")
+        self.sender = "invite_sender@example.com"
+        self.recipient = "invite_recipient@example.com"
+        self.outsider = "invite_outsider@example.com"
+
+        for email in [self.sender, self.recipient, self.outsider]:
+            insert_user_profile(email)
+
+        self.chapter = insert_test_chapter(chapter_name="Invite Test Chapter")
+        self.hackathon = insert_test_hackathon(
+            chapter=self.chapter.name,
+            hackathon_name="Invite Test Hackathon",
+        )
+
+        self.sender_participant = insert_test_hackathon_participant(
+            hackathon_id=self.hackathon.name,
+            user=self.sender,
+            email=self.sender,
+        )
+        self.recipient_participant = insert_test_hackathon_participant(
+            hackathon_id=self.hackathon.name,
+            user=self.recipient,
+            email=self.recipient,
+        )
+
+        self.team = insert_test_hackathon_team(hackathon=self.hackathon)
+        self.team.append(
+            "members",
+            {
+                "member": self.sender_participant.name,
+                "full_name": self.sender_participant.full_name,
+                "email": self.sender_participant.email,
+            },
+        )
+        self.team.save()
+
+        frappe.set_user(self.sender)
+        self.request = insert_test_hackathon_join_request(
+            hackathon_id=self.hackathon.name,
+            team_id=self.team.name,
+            requested_by=self.sender,
+            reciever_email=self.recipient,
+        )
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+        self.chapter.delete(force=True)
+        self.hackathon.delete(force=True)
+        self.team.delete(force=True)
+
+    def test_recipient_can_accept_invite(self):
+        frappe.set_user(self.recipient)
+        result = respond_to_join_team_request(self.request.name, "Accepted")
+        self.assertTrue(result["success"])
+        self.assertEqual(result["status"], "Accepted")
+        self.request.reload()
+        self.assertEqual(self.request.status, "Accepted")
+        self.assertTrue(
+            frappe.db.exists(
+                HACKATHON_TEAM_MEMBER,
+                {"parent": self.team.name, "member": self.recipient_participant.name},
+            )
+        )
+
+    def test_recipient_can_reject_invite(self):
+        frappe.set_user(self.recipient)
+        result = respond_to_join_team_request(self.request.name, "Rejected")
+        self.assertTrue(result["success"])
+        self.assertEqual(result["status"], "Rejected")
+        self.request.reload()
+        self.assertEqual(self.request.status, "Rejected")
+
+    def test_non_recipient_cannot_respond(self):
+        frappe.set_user(self.outsider)
+        with self.assertRaises(frappe.PermissionError):
+            respond_to_join_team_request(self.request.name, "Accepted")
+
+    def test_guest_cannot_respond(self):
+        frappe.set_user("Guest")
+        with self.assertRaises(frappe.AuthenticationError):
+            respond_to_join_team_request(self.request.name, "Accepted")
+
+    def test_invalid_status_raises_validation_error(self):
+        frappe.set_user(self.recipient)
+        with self.assertRaises(frappe.ValidationError):
+            respond_to_join_team_request(self.request.name, "Pending")
+
+    def test_already_resolved_request_cannot_be_changed(self):
+        frappe.set_user(self.recipient)
+        respond_to_join_team_request(self.request.name, "Rejected")
+        with self.assertRaises(frappe.ValidationError):
+            respond_to_join_team_request(self.request.name, "Accepted")


### PR DESCRIPTION
This pull request introduces a secure backend API for handling join team invitations in hackathons, replacing direct client-side document updates with a permission-aware method. It updates the frontend to use this new API and adds comprehensive backend tests to ensure correct behavior and access control.

**Backend API & Security Improvements:**

* Added a new backend method `respond_to_join_team_request` in `hackathon.py` to securely handle accepting or rejecting join team invitations, ensuring only the intended recipient can respond and that all necessary permission and state checks are enforced.
* Updated the frontend logic in `JoinTeam.vue` to use the new API endpoint instead of directly updating the document via `frappe.client.set_value`, improving security and reliability. [[1]](diffhunk://#diff-e9b493403430ab4d778c8e3a8d993efeb6c09391d8fe3027bf5a320da44a2221L133-R139) [[2]](diffhunk://#diff-e9b493403430ab4d778c8e3a8d993efeb6c09391d8fe3027bf5a320da44a2221L152-R156)

**Testing Enhancements:**

* Added a new test class `TestRespondToJoinTeamRequest` in `test_hackathon_api.py` to cover all major scenarios for the new API, including recipient acceptance/rejection, permission errors for non-recipients and guests, invalid status handling, and prevention of changes to already resolved requests.
* Updated test imports to include new helper methods and constants required for join team request testing.## Status



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened validation when responding to hackathon team join invitations with enhanced permission checks, ensuring only intended recipients can accept or reject requests and preventing duplicate responses.

* **Tests**
  * Added comprehensive test coverage for team invitation response functionality, including permission validation and edge case handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->