### PR TITLE
feat(localhost): add checkin for localhost particpants

### DIFF
--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -21,6 +21,8 @@ declare module 'vue' {
     ChapterHeader: typeof import('./src/components/ChapterHeader.vue')['default']
     CheckinConfirmationDialog: typeof import('./src/components/event/CheckinConfirmationDialog.vue')['default']
     CheckinManageDialog: typeof import('./src/components/event/CheckinManageDialog.vue')['default']
+    CheckInsButton: typeof import('./src/components/ui/CheckInsButton.vue')['default']
+    CheckInsTable: typeof import('./src/components/ui/CheckInsTable.vue')['default']
     ChevronDown: typeof import('./src/components/icons/ChevronDown.vue')['default']
     CityBadge: typeof import('./src/components/CityBadge.vue')['default']
     CityCommunityBranding: typeof import('./src/components/CityCommunityBranding.vue')['default']

--- a/dashboard/src/components/localhost/AttendeeRequestList.vue
+++ b/dashboard/src/components/localhost/AttendeeRequestList.vue
@@ -8,97 +8,177 @@
     @reject-request="rejectRequest($event)"
   />
 
-  <div class="prose mb-4">
-    <h4>Requests</h4>
+  <div class="flex items-center justify-between mb-4">
+    <div class="text-base font-medium">
+      {{ currentView === 'checkins' ? 'Check-ins' : 'Requests' }}
+      <span v-if="currentView === 'checkins'" class="ml-2 text-sm font-normal text-ink-gray-5">
+        ({{ checkins.data?.length || 0 }} checked-in out of {{ totalAccepted }} accepted
+        participants)
+      </span>
+    </div>
+
+    <div class="flex items-center gap-2">
+      <div class="flex items-center gap-1 bg-surface-gray-2 rounded-lg p-1">
+        <button
+          class="px-3 py-1.5 text-sm rounded-md transition-colors"
+          :class="
+            currentView === 'requests'
+              ? 'bg-surface-white text-ink-gray-9 font-medium shadow-sm'
+              : 'text-ink-gray-5 hover:text-ink-gray-9'
+          "
+          @click="currentView = 'requests'"
+        >
+          Requests
+        </button>
+        <button
+          class="px-3 py-1.5 text-sm rounded-md transition-colors"
+          :class="
+            currentView === 'checkins'
+              ? 'bg-surface-white text-ink-gray-9 font-medium shadow-sm'
+              : 'text-ink-gray-5 hover:text-ink-gray-9'
+          "
+          @click="currentView = 'checkins'"
+        >
+          Check-ins
+        </button>
+      </div>
+
+      <Button
+        v-if="currentView === 'checkins'"
+        size="md"
+        icon-left="refresh-cw"
+        @click="refreshCheckins"
+      >
+        Refresh
+      </Button>
+    </div>
   </div>
 
-  <div v-if="requests.loading && !groupedRequests.length" class="w-full p-8 flex justify-center">
-    <LoadingIndicator class="w-6" />
-  </div>
+  <!-- Check-Ins View -->
+  <CheckInsTable
+    v-if="currentView === 'checkins'"
+    :checkins="checkins.data || []"
+    name-field="full_name"
+    docs-message="You can check-in participant during hackathon days"
+    docs-url="https://docs.fossunited.org/localhost/#manage-attendees"
+    :export-filename="`localhost-checkins-${props.localhost.data.name}`"
+    :additional-columns="[
+      { key: 'organization', label: 'Organization', width: '200px' },
+      { key: 'project_route', label: 'Project', width: '200px' },
+    ]"
+  />
 
-  <SearchListView
-    v-else-if="groupedRequests.length > 0"
-    :columns="columns"
-    :rows="groupedRequests"
-    row-key="name"
-    :options="{
-      onRowClick: (row) => {
-        selectedRequest = row
-        showDialog = true
-      },
-    }"
-    search-placeholder="Search requests..."
-    :search-fields="['full_name', 'team_name', 'organization', 'project_title', 'status']"
-    export-filename="localhost_requests"
-    item-label="participant requests"
-    :export-columns="exportColumns"
-    filter-field="localhost_request_status"
-    :filter-options="['All', 'Pending', 'Pending Confirmation', 'Accepted', 'Rejected']"
-  >
-    <template #cell="{ item, row, column }">
-      <div v-if="column.key === 'localhost_request_status'">
-        <Badge
-          :theme="getStatusTheme(row.localhost_request_status)"
-          :label="row.localhost_request_status"
-          size="sm"
-        />
-      </div>
+  <div v-else>
+    <div v-if="requests.loading && !groupedRequests.length" class="w-full p-8 flex justify-center">
+      <LoadingIndicator class="w-6" />
+    </div>
 
-      <div v-else-if="column.key === 'is_student'" class="ml-4">
-        <span class="text-sm text-ink-gray-5">{{ row.is_student ? 'Yes' : 'No' }}</span>
-      </div>
-
-      <div v-else-if="column.key === 'git_profile'">
-        <a
-          v-if="row.git_profile"
-          :href="row.git_profile"
-          target="_blank"
-          class="text-sm flex items-center font-semibold hover:underline"
-        >
-          <span>Open</span>
-          <IconArrowUpRight class="w-4 h-4" />
-        </a>
-        <span v-else class="text-sm text-ink-gray-4">—</span>
-      </div>
-
-      <div v-else-if="column.key === 'project_title'">
-        <a
-          v-if="row.project_route"
-          class="text-sm flex items-center font-semibold hover:underline cursor-pointer"
-          @click="redirectRoute(row.project_route)"
-        >
-          <span class="truncate">{{ row.project_title }}</span>
-          <IconArrowUpRight class="w-4 h-4" />
-        </a>
-        <span v-else class="text-sm text-ink-gray-4">—</span>
-      </div>
-
-      <div v-else-if="column.key === 'actions'">
-        <div v-if="row.localhost_request_status === 'Pending'" class="flex gap-2">
-          <Button icon="check" label="Accept" theme="green" @click.stop="acceptRequest(row)" />
-          <Button icon="x" label="Reject" theme="red" @click.stop="rejectRequest(row)" />
+    <SearchListView
+      v-else-if="groupedRequests.length > 0"
+      :columns="columns"
+      :rows="groupedRequests"
+      row-key="name"
+      :options="{
+        onRowClick: (row) => {
+          selectedRequest = row
+          showDialog = true
+        },
+      }"
+      search-placeholder="Search requests..."
+      :search-fields="['full_name', 'team_name', 'organization', 'project_title', 'status']"
+      export-filename="localhost_requests"
+      item-label="participant requests"
+      :export-columns="exportColumns"
+      filter-field="localhost_request_status"
+      :filter-options="['All', 'Pending', 'Pending Confirmation', 'Accepted', 'Rejected']"
+    >
+      <template #cell="{ item, row, column }">
+        <div v-if="column.key === 'localhost_request_status'">
+          <Badge
+            :theme="getStatusTheme(row.localhost_request_status)"
+            :label="row.localhost_request_status"
+            size="sm"
+          />
         </div>
-      </div>
 
-      <div v-else class="text-sm truncate text-wrap" :title="item || '—'">
-        {{ item || '—' }}
-      </div>
-    </template>
-  </SearchListView>
+        <div v-else-if="column.key === 'is_student'" class="ml-4">
+          <span class="text-sm text-ink-gray-5">{{ row.is_student ? 'Yes' : 'No' }}</span>
+        </div>
 
-  <div v-else class="text-center py-12 text-ink-gray-4">
-    <p class="text-lg font-medium">No Requests</p>
-    <p class="text-sm mt-1">There are no localhost requests yet.</p>
+        <div v-else-if="column.key === 'git_profile'">
+          <a
+            v-if="row.git_profile"
+            :href="row.git_profile"
+            target="_blank"
+            class="text-sm flex items-center font-semibold hover:underline"
+          >
+            <span>Open</span>
+            <IconArrowUpRight class="w-4 h-4" />
+          </a>
+          <span v-else class="text-sm text-ink-gray-4">—</span>
+        </div>
+
+        <div
+          v-else-if="column.key === 'checkin' && row.localhost_request_status === 'Accepted'"
+          class="flex gap-2"
+        >
+          <Button
+            v-if="!row.has_checked_in_today"
+            size="sm"
+            label="Check-in"
+            @click.stop="checkInParticipant(row)"
+          />
+          <Button
+            v-else
+            size="sm"
+            label="Checked in"
+            theme="green"
+            variant="outline"
+            @click.stop="confirmUndoCheckIn(row)"
+          />
+        </div>
+
+        <div v-else-if="column.key === 'project_title'">
+          <a
+            v-if="row.project_route"
+            class="text-sm flex items-center font-semibold hover:underline cursor-pointer"
+            @click="redirectRoute(row.project_route)"
+          >
+            <span class="truncate">{{ row.project_title }}</span>
+            <IconArrowUpRight class="w-4 h-4" />
+          </a>
+          <span v-else class="text-sm text-ink-gray-4">—</span>
+        </div>
+
+        <div v-else-if="column.key === 'actions'">
+          <div v-if="row.localhost_request_status === 'Pending'" class="flex gap-2">
+            <Button icon="check" label="Accept" theme="green" @click.stop="acceptRequest(row)" />
+            <Button icon="x" label="Reject" theme="red" @click.stop="rejectRequest(row)" />
+          </div>
+        </div>
+
+        <div v-else class="text-sm truncate text-wrap" :title="item || '—'">
+          {{ item || '—' }}
+        </div>
+      </template>
+    </SearchListView>
+
+    <div v-else class="text-center py-12 text-ink-gray-4">
+      <p class="text-lg font-medium">No Requests</p>
+      <p class="text-sm mt-1">There are no localhost requests yet.</p>
+    </div>
   </div>
 </template>
 
 <script setup>
 import { ref, computed, watchEffect } from 'vue'
-import { LoadingIndicator, createResource, Button, Badge } from 'frappe-ui'
+import { LoadingIndicator, createResource, Button, Badge, frappeRequest } from 'frappe-ui'
 import { truncateStr, redirectRoute } from '@/helpers/utils'
 import RequestDetailDialog from '@/components/localhost/RequestDetailDialog.vue'
 import SearchListView from '@/components/ui/SearchListView.vue'
+import CheckInsTable from '@/components/ui/CheckInsTable.vue'
 import { IconArrowUpRight } from '@tabler/icons-vue'
+import { toast } from 'vue-sonner'
 
 const props = defineProps({
   localhost: {
@@ -109,6 +189,7 @@ const props = defineProps({
 
 const emit = defineEmits(['updateRequest'])
 
+const currentView = ref('requests')
 const showDialog = ref(false)
 const selectedRequest = ref({})
 const groupedRequests = ref([])
@@ -121,6 +202,7 @@ const columns = [
   { label: 'Organization', key: 'organization', width: '200px' },
   { label: 'Project', key: 'project_title', width: '220px' },
   { label: 'Git Profile', key: 'git_profile', width: '90px' },
+  { label: 'Check-in', key: 'checkin', width: '140px' },
   { label: 'Actions', key: 'actions', width: '100px' },
 ]
 
@@ -155,18 +237,44 @@ const requests = createResource({
   auto: true,
 })
 
+const checkins = createResource({
+  url: 'fossunited.api.hackathon.get_localhost_checkins',
+  params: { localhost_id: props.localhost.data.name },
+  auto: true,
+})
+
+const totalAccepted = computed(() => {
+  if (!requests.data) return 0
+  // Count all accepted participants across all teams
+  return Object.values(requests.data)
+    .flat()
+    .filter((r) => r.localhost_request_status === 'Accepted').length
+})
+
 watchEffect(() => {
   if (!requests.data) {
     groupedRequests.value = []
     return
   }
 
-  // Flatten the dict structure into a single array with team info
+  // Build set of participants who checked in today (SAME AS RSVP)
+  const checkedInToday = new Set()
+  const today = new Date().toISOString().split('T')[0]
+
+  ;(checkins.data || []).forEach((c) => {
+    const date = new Date(c.check_in_time).toISOString().split('T')[0]
+    if (date === today) {
+      checkedInToday.add(c.parent)
+    }
+  })
+
+  // Flatten requests and add check-in status
   const allRequests = []
   Object.entries(requests.data).forEach(([teamId, teamRequests]) => {
     teamRequests.forEach((request) => {
       allRequests.push({
         ...request,
+        has_checked_in_today: checkedInToday.has(request.name),
         team_name: request.team?.team_name || 'Unknown Team',
       })
     })
@@ -182,11 +290,10 @@ watchEffect(() => {
     teamGroups[teamName].push(request)
   })
 
-  // Convert to array of groups, sorted alphabetically by team name
+  // Convert to array of groups
   groupedRequests.value = Object.entries(teamGroups)
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([teamName, rows]) => {
-      // Count statuses in this team
       const hasPending = rows.some((r) => r.localhost_request_status === 'Pending')
       const hasPendingConfirmation = rows.some(
         (r) => r.localhost_request_status === 'Pending Confirmation',
@@ -194,12 +301,8 @@ watchEffect(() => {
 
       return {
         group: `${teamName} (${rows.length})`,
-        // Collapse groups that have no pending or pending confirmation requests
         collapsed: !hasPending && !hasPendingConfirmation,
-        rows: rows.sort((a, b) => {
-          // Sort by full name within each team
-          return (a.full_name || '').localeCompare(b.full_name || '')
-        }),
+        rows: rows.sort((a, b) => (a.full_name || '').localeCompare(b.full_name || '')),
       }
     })
 })
@@ -226,5 +329,54 @@ const acceptRequest = (member) => {
 
 const rejectRequest = (member) => {
   updateRequestStatus(member.name, 'Rejected').fetch()
+}
+
+const refreshCheckins = () => {
+  checkins.reload()
+}
+
+// Simple check-in function
+const checkInParticipant = async (row) => {
+  try {
+    await frappeRequest({
+      url: 'run_doc_method',
+      params: {
+        dt: 'FOSS Hackathon Participant',
+        dn: row.name,
+        method: 'add_check_in',
+      },
+    })
+
+    toast.success(`Checked in ${row.full_name}`)
+    requests.fetch()
+    checkins.reload()
+  } catch (err) {
+    toast.error(err.messages?.[0] || err.message)
+  }
+}
+
+// Undo check-in
+const confirmUndoCheckIn = (row) => {
+  if (window.confirm(`Remove check-in for ${row.full_name}?`)) {
+    undoCheckIn(row)
+  }
+}
+const undoCheckIn = async (row) => {
+  try {
+    await frappeRequest({
+      url: 'run_doc_method',
+      params: {
+        dt: 'FOSS Hackathon Participant',
+        dn: row.name,
+        method: 'remove_today_check_in',
+      },
+    })
+
+    toast.success('Check-in removed')
+    requests.fetch()
+    checkins.reload()
+  } catch (err) {
+    toast.error(err.messages?.[0] || err.message)
+  }
 }
 </script>

--- a/dashboard/src/components/localhost/AttendeeRequestList.vue
+++ b/dashboard/src/components/localhost/AttendeeRequestList.vue
@@ -62,10 +62,7 @@
     docs-message="You can check-in participant during hackathon days"
     docs-url="https://docs.fossunited.org/localhost/#manage-attendees"
     :export-filename="`localhost-checkins-${props.localhost.data.name}`"
-    :additional-columns="[
-      { key: 'organization', label: 'Organization', width: '200px' },
-      { key: 'project_route', label: 'Project', width: '200px' },
-    ]"
+    :additional-columns="[{ key: 'organization', label: 'Organization', width: '200px' }]"
   />
 
   <div v-else>

--- a/dashboard/src/components/ui/CheckInsTable.vue
+++ b/dashboard/src/components/ui/CheckInsTable.vue
@@ -1,0 +1,89 @@
+<template>
+  <div>
+    <DocsInfo :message="docsMessage" :docs-url="docsUrl" />
+
+    <SearchListView
+      :rows="checkinGroups"
+      :columns="columns"
+      :search-placeholder="searchPlaceholder"
+      :item-label="itemLabel"
+      :export-filename="exportFilename"
+      :export-columns="exportColumns"
+      :options="{
+        selectable: false,
+        showTooltip: true,
+        resizeColumn: true,
+      }"
+    >
+      <template #group-header="{ group }">
+        <span class="text-base font-medium leading-6 text-ink-gray-9">
+          {{ formatFullDate(group.group) }} - {{ group.rows.length }} check-ins
+        </span>
+      </template>
+
+      <template #cell="{ item, column }">
+        <span v-if="column.key === 'check_in_time'" class="text-sm text-ink-gray-6">
+          {{ formatTimeOnly(item) }}
+        </span>
+        <span v-else class="text-base block truncate text-wrap">{{ item }}</span>
+      </template>
+    </SearchListView>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref, watchEffect } from 'vue'
+import SearchListView from '@/components/ui/SearchListView.vue'
+import DocsInfo from '@/components/DocsInfo.vue'
+import { formatFullDate, formatTimeOnly } from '@/helpers/date'
+
+const props = defineProps({
+  checkins: { type: Array, default: () => [] },
+  nameField: { type: String, default: 'name1' },
+  docsMessage: { type: String, default: 'Check-ins is available during event days.' },
+  docsUrl: { type: String, default: '' },
+  searchPlaceholder: { type: String, default: 'Search check-ins...' },
+  itemLabel: { type: String, default: 'check-ins' },
+  exportFilename: { type: String, required: true },
+  additionalColumns: { type: Array, default: () => [] },
+})
+
+const checkinGroups = ref([])
+
+// Base columns
+const columns = computed(() => [
+  { key: props.nameField, label: 'Name', width: '250px' },
+  { key: 'email', label: 'Email', width: '200px' },
+  ...props.additionalColumns,
+  { key: 'check_in_time', label: 'Checked-in Time', width: '1fr' },
+])
+
+const exportColumns = computed(() => [
+  { key: 'date', label: 'Date' },
+  { key: props.nameField, label: 'Name', width: '250px' },
+  { key: 'email', label: 'Email' },
+  ...props.additionalColumns,
+  { key: 'check_in_time', label: 'Check-in Time' },
+])
+
+// Group check-ins by date
+watchEffect(() => {
+  const list = props.checkins || []
+  const byDate = {}
+
+  list.forEach((checkin) => {
+    const date = new Date(checkin.check_in_time).toISOString().split('T')[0]
+    if (!byDate[date]) byDate[date] = []
+    byDate[date].push({ ...checkin, date })
+  })
+
+  const dates = Object.keys(byDate).sort().reverse()
+  const existingStates = Object.fromEntries(checkinGroups.value.map((g) => [g.group, g.collapsed]))
+
+  checkinGroups.value = dates.map((date) => ({
+    group: date,
+    collapsed: existingStates[date] ?? false,
+    rows: byDate[date],
+  }))
+})
+</script>

--- a/dashboard/src/pages/EventRsvpInsights.vue
+++ b/dashboard/src/pages/EventRsvpInsights.vue
@@ -11,8 +11,8 @@
       <div class="font-semibold text-ink-gray-8">
         {{ sectionTitle }}
         <span v-if="currentView === 'checkins'" class="ml-2 text-sm font-normal text-ink-gray-5">
-          ({{ checkins.data?.length || 0 }} / {{ eventStats.data?.total_accepted || 0 }} confirmed
-          attendees)
+          ({{ checkins.data?.length || 0 }} checked-in out of
+          {{ eventStats.data?.total_accepted || 0 }} confirmed attendees)
         </span>
       </div>
 
@@ -59,31 +59,17 @@
       message="You can check-in attendees during the event days."
       docs-url="https://docs.fossunited.org/event-rsvp/#event-check-ins"
     />
-    <!-- Check-Ins View -->
-    <SearchListView
-      v-if="currentView === 'checkins'"
-      class="h-[600px]"
-      :rows="checkinGroups"
-      :columns="checkinColumns"
-      search-placeholder="Search check-in attendees..."
-      item-label="check-ins"
-      :export-filename="`event-checkins-${route.params.id}`"
-      :export-columns="checkinExportColumns"
-      :options="listOptions"
-    >
-      <template #group-header="{ group }">
-        <span class="text-base font-medium leading-6 text-ink-gray-9">
-          {{ formatFullDate(group.group) }} - {{ group.rows.length }} check-ins
-        </span>
-      </template>
 
-      <template #cell="{ item, row, column }">
-        <span v-if="column.key === 'check_in_time'" class="text-sm text-ink-gray-6">
-          {{ formatTimeOnly(item) }}
-        </span>
-        <span v-else class="text-base truncate text-wrap">{{ item }}</span>
-      </template>
-    </SearchListView>
+    <!-- Check-Ins View -->
+    <CheckInsTable
+      v-if="currentView === 'checkins'"
+      :checkins="checkins.data || []"
+      name-field="name1"
+      docs-message="You can check-in attendees during the event days"
+      docs-url="https://docs.fossunited.org/event-rsvp/#event-check-ins"
+      :export-filename="`event-checkins-${route.params.id}`"
+      :additional-columns="[{ key: 'im_a', label: 'Im a', width: '200px' }]"
+    />
 
     <!-- Attendees View -->
     <SearchListView
@@ -95,7 +81,6 @@
       item-label="attendees"
       :export-filename="`rsvp-submissions-${route.params.id}`"
       :export-columns="attendeeExportColumns"
-      :options="listOptions"
     >
       <template #group-header="{ group }">
         <span class="text-base font-medium leading-6 text-ink-gray-9">
@@ -177,6 +162,7 @@ import { useRoute } from 'vue-router'
 import { computed, ref, watchEffect } from 'vue'
 import { createResource, Button, frappeRequest } from 'frappe-ui'
 import SearchListView from '@/components/ui/SearchListView.vue'
+import CheckInsTable from '@/components/ui/CheckInsTable.vue'
 import { toast } from 'vue-sonner'
 import { formatFullDate, formatTimeOnly } from '@/helpers/date'
 import DocsInfo from '@/components/DocsInfo.vue'
@@ -186,7 +172,6 @@ const route = useRoute()
 // Current view toggle
 const currentView = ref('attendees')
 
-const checkinGroups = ref([])
 const attendeeGroups = ref([])
 
 // Resources
@@ -238,47 +223,6 @@ const sectionTitle = computed(() => {
   }
 
   return 'Attendees List'
-})
-
-const listOptions = {
-  selectable: false,
-  showTooltip: true,
-  resizeColumn: true,
-  emptyState: {
-    title: 'No data',
-    description: 'No records found.',
-  },
-}
-
-// Check-in columns
-const checkinColumns = [
-  { key: 'name1', label: 'Name', width: '250px' },
-  { key: 'email', label: 'Email', width: '200px' },
-  { key: 'im_a', label: 'Im a', width: '200px' },
-  { key: 'check_in_time', label: 'Checked-in Time', width: '1fr' },
-]
-
-const checkinExportColumns = [{ key: 'date', label: 'Date' }, ...checkinColumns]
-
-// Group check-ins by date
-watchEffect(() => {
-  const list = checkins.data || []
-  const byDate = {}
-
-  list.forEach((checkin) => {
-    const date = new Date(checkin.check_in_time).toISOString().split('T')[0]
-    if (!byDate[date]) byDate[date] = []
-    byDate[date].push({ ...checkin, date })
-  })
-
-  const dates = Object.keys(byDate).sort().reverse()
-  const existingStates = Object.fromEntries(checkinGroups.value.map((g) => [g.group, g.collapsed]))
-
-  checkinGroups.value = dates.map((date) => ({
-    group: date,
-    collapsed: existingStates[date] ?? false,
-    rows: byDate[date],
-  }))
 })
 
 const attendeeColumns = computed(() => {

--- a/dashboard/src/pages/EventRsvpInsights.vue
+++ b/dashboard/src/pages/EventRsvpInsights.vue
@@ -164,7 +164,6 @@ import { createResource, Button, frappeRequest } from 'frappe-ui'
 import SearchListView from '@/components/ui/SearchListView.vue'
 import CheckInsTable from '@/components/ui/CheckInsTable.vue'
 import { toast } from 'vue-sonner'
-import { formatFullDate, formatTimeOnly } from '@/helpers/date'
 import DocsInfo from '@/components/DocsInfo.vue'
 
 const route = useRoute()

--- a/fossunited/api/checkins.py
+++ b/fossunited/api/checkins.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import frappe
+from frappe.utils import getdate, now_datetime
 
 from fossunited.api.tickets import has_valid_permission
 from fossunited.doctype_ids import EVENT_TICKET
@@ -158,3 +159,32 @@ def assign_tshirt(event_id: str, attendee: dict):
     ticket = frappe.get_doc(EVENT_TICKET, attendee["name"])
     ticket.tshirt_delivered = True
     ticket.save(ignore_permissions=True)
+
+
+# for event checkins
+def has_checked_in_today(doc):
+    """Check if document has a check-in today"""
+    today = getdate()
+    for check_in in doc.check_ins:
+        if getdate(check_in.check_in_time) == today:
+            return True
+    return False
+
+
+def add_checkin(doc):
+    """Add a check-in to document"""
+    if has_checked_in_today(doc):
+        frappe.throw("Already checked in today")
+    doc.append("check_ins", {"check_in_time": now_datetime()})
+    doc.save()
+
+
+def remove_today_checkin(doc):
+    """Remove today's check-in from document"""
+    today = getdate()
+    for check_in in reversed(doc.check_ins):
+        if getdate(check_in.check_in_time) == today:
+            doc.remove(check_in)
+            doc.save()
+            return True
+    frappe.throw("No check-in found for today")

--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -665,10 +665,11 @@ def get_localhost_checkins(localhost_id: str):
 
 
 @frappe.whitelist()
+@require_localhost_organizer(localhost_param="localhost_id")
 def get_localhost_checkin_stats(localhost_id: str):
     """Get localhost statistics"""
     total_accepted = frappe.db.count(
-        "FOSS Hackathon Participant",
+        HACKATHON_PARTICIPANT,
         filters={"localhost": localhost_id, "localhost_request_status": "Accepted"},
     )
 

--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -6,6 +6,7 @@ import frappe
 from frappe.rate_limiter import rate_limit
 
 from fossunited.doctype_ids import (
+    EVENT_CHECKIN,
     HACKATHON,
     HACKATHON_LOCALHOST,
     HACKATHON_PARTICIPANT,
@@ -19,6 +20,7 @@ from fossunited.integrations.github import GithubHelper
 from fossunited.utils.decorators import (
     require_hackathon_participant,
     require_hackathon_team,
+    require_localhost_organizer,
 )
 
 
@@ -285,6 +287,7 @@ def get_project_by_email(hackathon: str):
 
 
 @frappe.whitelist()
+@require_localhost_organizer(localhost_param="localhost")
 def get_localhost_requests_by_team(
     hackathon: str,
     localhost: str,
@@ -628,3 +631,45 @@ def get_count_team_members_and_max_count(hackathon: str, team: str):
     max_team_size = frappe.db.get_value(HACKATHON, hackathon, "max_team_members")
     team_members_count = len(frappe.get_doc(HACKATHON_TEAM, team).members)
     return {"team_members_count": team_members_count, "max_team_size": max_team_size}
+
+
+@frappe.whitelist()
+@require_localhost_organizer(localhost_param="localhost_id")
+def get_localhost_checkins(localhost_id: str):
+    """Get all check-ins for a localhost"""
+    from frappe.query_builder import DocType, Order
+
+    Participant = DocType(HACKATHON_PARTICIPANT)
+    CheckIn = DocType(EVENT_CHECKIN)
+
+    checkins = (
+        frappe.qb.from_(CheckIn)
+        .join(Participant)
+        .on(CheckIn.parent == Participant.name)
+        .select(
+            Participant.full_name,
+            Participant.email,
+            Participant.organization,
+            Participant.is_student,
+            CheckIn.check_in_time,
+            CheckIn.parent,
+        )
+        .where(Participant.localhost == localhost_id)
+        .where(CheckIn.parenttype == HACKATHON_PARTICIPANT)
+        .where(CheckIn.parentfield == "check_ins")
+        .orderby(CheckIn.check_in_time, order=Order.desc)
+        .run(as_dict=True)
+    )
+
+    return checkins
+
+
+@frappe.whitelist()
+def get_localhost_checkin_stats(localhost_id: str):
+    """Get localhost statistics"""
+    total_accepted = frappe.db.count(
+        "FOSS Hackathon Participant",
+        filters={"localhost": localhost_id, "localhost_request_status": "Accepted"},
+    )
+
+    return {"total_accepted": total_accepted}

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/foss_event_rsvp_submission.py
@@ -1,8 +1,13 @@
 import frappe
 from frappe.model.document import Document
-from frappe.utils import getdate, now_datetime, nowdate
+from frappe.utils import getdate, nowdate
 
 from fossunited.api.chapter import check_if_chapter_member
+from fossunited.api.checkins import (
+    add_checkin,
+    has_checked_in_today,
+    remove_today_checkin,
+)
 from fossunited.api.emailing import handle_email_group_subscription
 from fossunited.doctype_ids import CHAPTER, EVENT, EVENT_RSVP, RSVP_RESPONSE
 
@@ -177,6 +182,11 @@ class FOSSEventRSVPSubmission(Document):
             document_type_event=EVENT,
         )
 
+    @frappe.whitelist()
+    def has_checked_in_today(self):
+        return has_checked_in_today(self)
+
+    @frappe.whitelist()
     def add_check_in(self):
         """Add a check-in record for this submission"""
         # Check if event allows check-in (between start and end date)
@@ -186,15 +196,11 @@ class FOSSEventRSVPSubmission(Document):
         if not self.can_check_in(event_start, event_end):
             frappe.throw("Check-in is only available during the event dates")
 
-        # Check if already checked in today
-        if self.has_checked_in_today():
-            frappe.throw("You have already checked in today")
+        return add_checkin(self)
 
-        # Add check-in record
-        self.append("check_ins", {"check_in_time": now_datetime()})
-        self.save()
-
-        return {"success": True, "message": "Checked in successfully"}
+    @frappe.whitelist()
+    def remove_today_check_in(self):
+        return remove_today_checkin(self)
 
     def can_check_in(self, event_start_date, event_end_date):
         """Check if check-in is allowed based on date only (no time)."""
@@ -206,27 +212,6 @@ class FOSSEventRSVPSubmission(Document):
         end_date = getdate(event_end_date)
 
         return start_date <= today <= end_date
-
-    def has_checked_in_today(self):
-        """Check if user has already checked in today"""
-
-        today = getdate()
-        for check_in in self.check_ins:
-            if getdate(check_in.check_in_time) == today:
-                return True
-        return False
-
-    def remove_todays_checkin(self):
-        """Remove today's check-in record for this submission"""
-        today = getdate()
-
-        for i, check_in in enumerate(self.check_ins):
-            if getdate(check_in.check_in_time) == today:
-                self.remove(check_in)
-                self.save()
-                return {"success": True, "message": "Check-in removed successfully"}
-
-        frappe.throw("No check-in found for today")
 
 
 @frappe.whitelist()

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
@@ -330,7 +330,7 @@ class TestFOSSEventRSVPSubmission(FrappeTestCase):
 
         result = submission.add_check_in()
 
-        self.assertTrue(result["success"])
+        self.assertTrue(result)
         self.assertEqual(len(submission.check_ins), 1)
         self.assertTrue(submission.has_checked_in_today())
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -20,7 +20,9 @@ class FOSSHackathonParticipant(Document):
     if TYPE_CHECKING:
         from frappe.types import DF
 
-        from fossunited.fossunited.doctype.event_check_in.event_check_in import EventCheckIn
+        from fossunited.fossunited.doctype.event_check_in.event_check_in import (
+            EventCheckIn,
+        )
 
         check_ins: DF.Table[EventCheckIn]
         email: DF.Data
@@ -80,7 +82,9 @@ class FOSSHackathonParticipant(Document):
         if self.has_value_changed("localhost"):
             # Remove from old localhost groups before changing
             old_localhost = (
-                self.get_doc_before_save().localhost if self.get_doc_before_save() else None
+                self.get_doc_before_save().localhost
+                if self.get_doc_before_save()
+                else None
             )
             if old_localhost:
                 self.remove_from_all_localhost_groups(old_localhost)
@@ -203,7 +207,10 @@ class FOSSHackathonParticipant(Document):
 
     def handle_localhost_rejection(self):
         """Handle rejection by adding comment and resetting wants_to_attend_locally"""
-        if not self.has_value_changed("localhost") and self.localhost_request_status == "Rejected":
+        if (
+            not self.has_value_changed("localhost")
+            and self.localhost_request_status == "Rejected"
+        ):
             localhost_name = frappe.db.get_value(
                 HACKATHON_LOCALHOST, self.localhost, "localhost_name"
             )
@@ -219,13 +226,18 @@ class FOSSHackathonParticipant(Document):
         if not prev_doc:
             return
 
-        if frappe.db.get_value("User", frappe.session.user, "user_type") == "System User":
+        if (
+            frappe.db.get_value("User", frappe.session.user, "user_type")
+            == "System User"
+        ):
             return
 
         if not self.wants_to_attend_locally:
             return
 
-        if (self.localhost == prev_doc.localhost) and self.localhost_request_status == "Rejected":
+        if (
+            self.localhost == prev_doc.localhost
+        ) and self.localhost_request_status == "Rejected":
             frappe.throw(
                 "You have already been rejected from this localhost.",
                 frappe.PermissionError,

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -87,9 +87,7 @@ class FOSSHackathonParticipant(Document):
         if self.has_value_changed("localhost"):
             # Remove from old localhost groups before changing
             old_localhost = (
-                self.get_doc_before_save().localhost
-                if self.get_doc_before_save()
-                else None
+                self.get_doc_before_save().localhost if self.get_doc_before_save() else None
             )
             if old_localhost:
                 self.remove_from_all_localhost_groups(old_localhost)
@@ -212,10 +210,7 @@ class FOSSHackathonParticipant(Document):
 
     def handle_localhost_rejection(self):
         """Handle rejection by adding comment and resetting wants_to_attend_locally"""
-        if (
-            not self.has_value_changed("localhost")
-            and self.localhost_request_status == "Rejected"
-        ):
+        if not self.has_value_changed("localhost") and self.localhost_request_status == "Rejected":
             localhost_name = frappe.db.get_value(
                 HACKATHON_LOCALHOST, self.localhost, "localhost_name"
             )
@@ -231,18 +226,13 @@ class FOSSHackathonParticipant(Document):
         if not prev_doc:
             return
 
-        if (
-            frappe.db.get_value("User", frappe.session.user, "user_type")
-            == "System User"
-        ):
+        if frappe.db.get_value("User", frappe.session.user, "user_type") == "System User":
             return
 
         if not self.wants_to_attend_locally:
             return
 
-        if (
-            self.localhost == prev_doc.localhost
-        ) and self.localhost_request_status == "Rejected":
+        if (self.localhost == prev_doc.localhost) and self.localhost_request_status == "Rejected":
             frappe.throw(
                 "You have already been rejected from this localhost.",
                 frappe.PermissionError,

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -4,6 +4,11 @@
 import frappe
 from frappe.model.document import Document
 
+from fossunited.api.checkins import (
+    add_checkin,
+    has_checked_in_today,
+    remove_today_checkin,
+)
 from fossunited.api.emailing import handle_email_group_subscription
 from fossunited.doctype_ids import (
     HACKATHON,
@@ -265,3 +270,15 @@ class FOSSHackathonParticipant(Document):
         if ptype == "create":
             return True
         return user in {self.user, self.email}
+
+    @frappe.whitelist()
+    def has_checked_in_today(self):
+        return has_checked_in_today(self)
+
+    @frappe.whitelist()
+    def add_check_in(self):
+        return add_checkin(self)
+
+    @frappe.whitelist()
+    def remove_today_check_in(self):
+        return remove_today_checkin(self)

--- a/fossunited/utils/decorators.py
+++ b/fossunited/utils/decorators.py
@@ -14,6 +14,8 @@ from fossunited.api.chapter import (
 from fossunited.doctype_ids import (
     HACKATHON_PARTICIPANT,
     HACKATHON_TEAM,
+    LOCALHOST_ORGANIZER,
+    USER_PROFILE,
 )
 
 
@@ -183,6 +185,57 @@ def require_chapter_or_event_member(event_id="event"):
             if not check_if_chapter_or_event_core_member(event):
                 frappe.throw(
                     "You must be either a chapter member or event member",
+                    frappe.PermissionError,
+                )
+
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def require_localhost_organizer(localhost_param="localhost_id"):
+    """
+    Decorator to check if user is a localhost organizer or system manager.
+
+    Args:
+        localhost_param: name of the parameter containing localhost ID
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            # System Manager bypass
+            if "System Manager" in frappe.get_roles():
+                return func(*args, **kwargs)
+
+            # Get localhost ID from kwargs
+            localhost_id = kwargs.get(localhost_param)
+            if not localhost_id:
+                frappe.throw("Localhost ID not provided", frappe.PermissionError)
+
+            # Get organizer profiles from child table
+            organizer_profiles = frappe.get_all(
+                LOCALHOST_ORGANIZER,
+                filters={"parent": localhost_id},
+                pluck="profile",
+            )
+
+            # Get users from profiles
+            if organizer_profiles:
+                organizer_users = frappe.get_all(
+                    USER_PROFILE,
+                    filters={"name": ["in", organizer_profiles]},
+                    pluck="user",
+                )
+            else:
+                organizer_users = []
+
+            # Check if current user is an organizer
+            if frappe.session.user not in organizer_users:
+                frappe.throw(
+                    "Only localhost organizers can access this resource",
                     frappe.PermissionError,
                 )
 


### PR DESCRIPTION
- Similar to rsvp, add checkin tab for localhost management to checkin and get view for it.

<img width="1555" height="750" alt="image" src="https://github.com/user-attachments/assets/09b35cf0-e584-467a-bfb5-01e31fd76939" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a check-ins table and UI toggle for requests vs check-ins, with date-grouped display, refresh, check-in/undo actions and updated header messaging.
  * New endpoints to retrieve check-ins and check-in statistics for organizers.

* **Refactor**
  * Centralized check-in logic into shared API helpers and updated local wrappers.
  * Strengthened organizer authorization for localhost-scoped operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->