### PR TITLE
feat: add generic error handler to inform users

### DIFF
--- a/dashboard/src/components/hackathon/HackathonAttendanceMode.vue
+++ b/dashboard/src/components/hackathon/HackathonAttendanceMode.vue
@@ -234,7 +234,7 @@ const updateParticipantLocalhost = (localhost) => {
       toast.success('Attendance mode updated successfully!')
     },
     onError(err) {
-      toast.error('Failed to update attendance mode.' + err.message)
+      showError(err, `Failed to update attendance mode.`)
     },
   })
 }
@@ -257,7 +257,7 @@ const makeParticipantRemote = () => {
       toast.success('Attendance mode updated successfully!')
     },
     onError(err) {
-      toast.error('Failed to update attendance mode.' + err.message)
+      showError(err, `Failed to update attendance mode.`)
     },
   })
 }

--- a/dashboard/src/components/hackathon/HackathonProjectDetails.vue
+++ b/dashboard/src/components/hackathon/HackathonProjectDetails.vue
@@ -83,7 +83,10 @@ const updateProjectErrors = () => {
     errors.push('Repository link cannot be empty')
   }
   if (projectDoc.doc.repo_link && !projectDoc.doc.repo_link.startsWith('https://')) {
-    errors.push('Enter a valid repo link')
+    errors.push('Enter a valid repo link starting with https://')
+  }
+  if (projectDoc.doc.demo_link && !projectDoc.doc.demo_link.startsWith('https://')) {
+    errors.push('Enter a valid demo link starting with https://')
   }
 
   return errors
@@ -102,8 +105,7 @@ const handleProjectUpdate = () => {
       toast.success('Project updated successfully')
     })
     .catch((err) => {
-      const message = err?.messages?.[0] || err?.message || 'Project update failed'
-      toast.error(message)
+      showError(err, 'Failed to save project')
     })
 }
 </script>

--- a/dashboard/src/components/hackathon/HackathonProjectIssue.vue
+++ b/dashboard/src/components/hackathon/HackathonProjectIssue.vue
@@ -256,6 +256,7 @@ const handleAddIssuePr = async () => {
     showAddDialog.value = false
   } catch (err) {
     addIssueErrors.value = err.messages || [err.message]
+    showError(err, `Failed to add item.`)
   }
 }
 
@@ -291,6 +292,6 @@ const deleteIssuePr = (row) => {
   projectDoc.save
     .submit()
     .then(() => toast.success(`Deleted the ${row.type}`))
-    .catch((err) => toast.error(err.message))
+    .catch((err) => showError(err, `Failed to delete item.`))
 }
 </script>

--- a/dashboard/src/components/hackathon/HackathonTeamMember.vue
+++ b/dashboard/src/components/hackathon/HackathonTeamMember.vue
@@ -172,7 +172,7 @@ const createJoinRequest = () => {
       toast.success('Invite sent successfully')
     },
     onError(error) {
-      toast.error('Failed to send invite' + error)
+      showError(error, `Failed to send invite.`)
     },
   })
   invite.fetch()
@@ -200,7 +200,7 @@ const removeTeamMember = (member) => {
       toast.success('Member removed successfully')
     },
     onError(error) {
-      toast.error('Failed to remove member' + error)
+      showError(error, `Failed to remove member.`)
     },
   })
   team.fetch()

--- a/dashboard/src/components/hackathon/JoinTeam.vue
+++ b/dashboard/src/components/hackathon/JoinTeam.vue
@@ -142,7 +142,7 @@ const acceptInvite = (inviteId) => {
       window.location.reload()
     },
     onError(error) {
-      showError(error, `Error accepting team invite. Please use ID directly: ${teamCode.value}`)
+      showError(error, `Error accepting team invite. Please use Team Code directly to join`)
     },
   })
 }

--- a/dashboard/src/components/hackathon/JoinTeam.vue
+++ b/dashboard/src/components/hackathon/JoinTeam.vue
@@ -113,7 +113,7 @@ const joinThroughCode = createResource({
     window.location.reload()
   },
   onError(error) {
-    toast.error('Invalid Team Code.' + error.message)
+    showError(error, `Invalid Team Code '${teamCode.value}'`)
   },
 })
 
@@ -142,7 +142,7 @@ const acceptInvite = (inviteId) => {
       window.location.reload()
     },
     onError(error) {
-      toast.error('An error occurred: ' + error.message)
+      showError(error, `Error accepting team invite. Please use ID directly: ${teamCode.value}`)
     },
   })
 }
@@ -161,7 +161,7 @@ const rejectInvite = (inviteId) => {
       props.invitations.fetch()
     },
     onError(error) {
-      toast.error('An error occurred: ' + error.message)
+      showError(error, `Error rejecting team invite.`)
     },
   })
 }

--- a/dashboard/src/components/localhost/AttendeeRequestList.vue
+++ b/dashboard/src/components/localhost/AttendeeRequestList.vue
@@ -349,7 +349,7 @@ const checkInParticipant = async (row) => {
     requests.fetch()
     checkins.reload()
   } catch (err) {
-    toast.error(err.messages?.[0] || err.message)
+    showError(err, `Failed to checkin ${row.full_name}`)
   }
 }
 
@@ -374,7 +374,7 @@ const undoCheckIn = async (row) => {
     requests.fetch()
     checkins.reload()
   } catch (err) {
-    toast.error(err.messages?.[0] || err.message)
+    showError(err, `Failed to undo checkin ${row.full_name}`)
   }
 }
 </script>

--- a/dashboard/src/components/mailing/CreateCampaignDrawer.vue
+++ b/dashboard/src/components/mailing/CreateCampaignDrawer.vue
@@ -68,7 +68,7 @@ const newsletter = createResource({
     open.value = false
   },
   onError(err) {
-    toast.error('Error while creating campaign! ' + err.messages)
+    showError(err, `Error while creating campaign!`)
   },
 })
 

--- a/dashboard/src/components/mailing/ManageCampaignDrawer.vue
+++ b/dashboard/src/components/mailing/ManageCampaignDrawer.vue
@@ -158,8 +158,7 @@ const updateCampaign = createResource({
     emit('update-campaigns')
   },
   onError(err) {
-    errorMessages.value = err.messages
-    toast.error(`Error: ${err.messages}`)
+    showError(err, `Failed to update campaign.`)
   },
 })
 
@@ -185,7 +184,7 @@ const sendCampaign = createResource({
     campaign.fetch()
   },
   onError(err) {
-    toast.error(`Error: ${err.messages}`)
+    showError(err, `Failed to send campaign.`)
   },
 })
 

--- a/dashboard/src/components/mailing/ManageCampaignDrawer.vue
+++ b/dashboard/src/components/mailing/ManageCampaignDrawer.vue
@@ -158,6 +158,7 @@ const updateCampaign = createResource({
     emit('update-campaigns')
   },
   onError(err) {
+    errorMessages.value = ''
     showError(err, `Failed to update campaign.`)
   },
 })
@@ -184,6 +185,7 @@ const sendCampaign = createResource({
     campaign.fetch()
   },
   onError(err) {
+    errorMessages.value = ''
     showError(err, `Failed to send campaign.`)
   },
 })

--- a/dashboard/src/components/mailing/SendTestDialog.vue
+++ b/dashboard/src/components/mailing/SendTestDialog.vue
@@ -106,7 +106,7 @@ const sendTest = createResource({
     inSuccess.value = true
   },
   onError(err) {
-    toast.error(err.messages)
+    showError(err, `Failed to send test mail.`)
   },
 })
 

--- a/dashboard/src/helpers/utils.js
+++ b/dashboard/src/helpers/utils.js
@@ -53,9 +53,10 @@ export const isSmallScreen = computed(() => window.innerWidth < 768)
  */
 export function showError(error, fallback = 'An error occurred') {
   const isRateLimited = error?.response?.status === 429 || error?.status === 429
+  const apiMessage = typeof error === 'string' ? error : error?.messages?.[0] || error?.message
   const message = isRateLimited
     ? 'Too many requests/attempts. Please try again after 10 minutes.'
-    : error.messages?.[0] || error.message || fallback
+    : apiMessage || fallback
   const displayMessage = message === fallback ? fallback : `${fallback}: ${message}`
 
   console.error('API Error:', error)

--- a/dashboard/src/helpers/utils.js
+++ b/dashboard/src/helpers/utils.js
@@ -52,11 +52,15 @@ export const isSmallScreen = computed(() => window.innerWidth < 768)
  * @param {string} fallback - Fallback message (optional)
  */
 export function showError(error, fallback = 'An error occurred') {
-  const message = error.messages?.[0] || error.message || fallback
+  const isRateLimited = error?.response?.status === 429 || error?.status === 429
+  const message = isRateLimited
+    ? 'Too many requests/attempts. Please try again after 10 minutes.'
+    : error.messages?.[0] || error.message || fallback
+  const displayMessage = message === fallback ? fallback : `${fallback}: ${message}`
 
   console.error('API Error:', error)
 
-  toast.error(message, {
+  toast.error(displayMessage, {
     duration: 5000,
     action: {
       label: 'Details',

--- a/dashboard/src/helpers/utils.js
+++ b/dashboard/src/helpers/utils.js
@@ -1,4 +1,5 @@
 import { computed } from 'vue'
+import { toast } from 'vue-sonner'
 
 export const truncateStr = (title, len) => {
   return title.length > len ? title.substring(0, len) + '...' : title
@@ -44,3 +45,27 @@ export const isValidUrl = (link) => {
 }
 
 export const isSmallScreen = computed(() => window.innerWidth < 768)
+
+/**
+ * Minimal error handler - shows error message with console hint
+ * @param {Error} error - Error from frappe-ui/api
+ * @param {string} fallback - Fallback message (optional)
+ */
+export function showError(error, fallback = 'An error occurred') {
+  const message = error.messages?.[0] || error.message || fallback
+
+  console.error('API Error:', error)
+
+  toast.error(message, {
+    duration: 5000,
+    action: {
+      label: 'Details',
+      onClick: () => {
+        console.group('🔍 Error Details')
+        console.error(error)
+        console.groupEnd()
+        toast.info('Check console (Press F12)')
+      },
+    },
+  })
+}

--- a/dashboard/src/main.js
+++ b/dashboard/src/main.js
@@ -5,6 +5,7 @@ import router from './router'
 import App from './App.vue'
 import { session } from './data/session'
 import dayjs from 'dayjs'
+import { showError } from '@/helpers/utils'
 
 import {
   Button,
@@ -19,6 +20,7 @@ import {
 const { initializeTheme } = useTheme()
 initializeTheme()
 
+window.showError = showError
 const app = createApp(App)
 
 setConfig('resourceFetcher', frappeRequest)

--- a/dashboard/src/pages/hackathon/CreateProject.vue
+++ b/dashboard/src/pages/hackathon/CreateProject.vue
@@ -361,8 +361,12 @@ const validateCreateProject = () => {
     errors.push('Repository link is required')
   }
   if (project.repo_link && !project.repo_link.startsWith('https://')) {
-    errors.push('Enter a valid repo link')
+    errors.push('Enter a valid repo link starting with https://')
   }
+  if (project.demo_link && !project.demo_link.startsWith('https://')) {
+    errors.push('Enter a valid demo link starting with https://')
+  }
+
   return errors
 }
 
@@ -393,7 +397,7 @@ const createProject = createResource({
     })
   },
   onError(error) {
-    toast.error('Failed to create project')
+    showError(error, `Failed to create project`)
   },
 })
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -114,6 +114,7 @@ export default [
         qz: 'readonly',
         localforage: 'readonly',
         extend_cscript: 'readonly',
+        showError: 'readonly',
       },
       parserOptions: { sourceType: 'module' },
     },

--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
@@ -328,9 +328,8 @@ class TestFOSSEventRSVPSubmission(FrappeTestCase):
 
         submission = insert_rsvp_submission(linked_rsvp=self.rsvp.name)
 
-        result = submission.add_check_in()
+        submission.add_check_in()
 
-        self.assertTrue(result)
         self.assertEqual(len(submission.check_ins), 1)
         self.assertTrue(submission.has_checked_in_today())
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_team/foss_hackathon_team.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_team/foss_hackathon_team.py
@@ -3,7 +3,6 @@
 import frappe
 from frappe.model.document import Document
 
-from fossunited.api.hackathon import get_count_team_members_and_max_count
 from fossunited.doctype_ids import (
     HACKATHON,
     HACKATHON_PARTICIPANT,
@@ -41,18 +40,6 @@ class FOSSHackathonTeam(Document):
         self.validate_no_duplicate_members()
         self.validate_new_members_not_in_other_teams()
 
-    def before_save(self):
-        """Runs on both insert and save"""
-        if not self.is_new() and self.has_value_changed("members"):
-            team_count = get_count_team_members_and_max_count(self.hackathon, self.name)
-            current_members = len(self.members)
-            max_size = team_count["max_team_size"]
-
-            if current_members >= max_size:
-                frappe.throw(
-                    f"Maximum team size of {max_size} members reached. Cannot add more members."
-                )
-
     def on_update(self):
         self.delete_if_empty_team()
 
@@ -61,7 +48,13 @@ class FOSSHackathonTeam(Document):
         max_size = frappe.db.get_value(HACKATHON, self.hackathon, "max_team_members")
         if not max_size:
             return
-        if len(self.members) >= max_size:
+
+        old_doc = self.get_doc_before_save()
+
+        if old_doc and len(self.members) <= len(old_doc.members):
+            return
+
+        if len(self.members) > max_size:
             frappe.throw(f"Team cannot have more than {max_size} members")
 
     def validate_no_duplicate_members(self):

--- a/fossunited/tests/utils.py
+++ b/fossunited/tests/utils.py
@@ -575,6 +575,7 @@ def insert_test_hackathon(chapter: str, **kwargs):
         "end_date": kwargs.get("end_date", datetime.today() + timedelta(days=2)),
         "hackathon_description": kwargs.get("hackathon_description", "Test Hackathon"),
         "is_registration_live": kwargs.get("is_registration_live", 1),
+        "max_team_members": kwargs.get("max_team_members", 4),
     }
 
     for key, value in kwargs.items():


### PR DESCRIPTION
- every toast.error needs to parse err message via 

`    toast.error(err.messages?.[0] || err.message)`

so we can make a generic helper that parses them with condition (eg: rate limit) and informs user to check console log for further info to report to us.

As code grows, lots of validation error might be thrown and frappe errors might look alien to large majority so..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized, globally available error handling for consistent, context-rich error messages.

* **Validation**
  * Repository and demo links now must start with https:// with updated validation messages.

* **Bug Fixes**
  * Clearer error reporting across attendance, project creation/editing, issues, team join/invite flows, check-ins, and mailing/campaign actions.

* **Changes**
  * Team size enforcement logic updated and default max team members set to 4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->