### PR TITLE
feat: partner project template page

### DIFF
--- a/fossunited/doctype_ids.py
+++ b/fossunited/doctype_ids.py
@@ -13,6 +13,7 @@ HACKATHON_PARTNER_PROJECT = "FOSS Hackathon Partner Project"
 HACKATHON_PROJECT = "FOSS Hackathon Project"
 HACKATHON_TEAM = "FOSS Hackathon Team"
 HACKATHON_TEAM_MEMBER = "FOSS Hackathon Team Member"
+HACKATHON_ISSUE_PR = "Hackathon Project Issue PR"
 
 # Chapter-related identifiers
 CHAPTER = "FOSS Chapter"

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/foss_hackathon_partner_project.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/foss_hackathon_partner_project.json
@@ -14,7 +14,11 @@
     "about",
     "column_break_qabl",
     "poc_email",
-    "repo_link"
+    "repo_link",
+    "section_break_tdld",
+    "description",
+    "section_break_ncvl",
+    "project_thread"
   ],
   "fields": [
     {
@@ -63,6 +67,27 @@
       "fieldname": "about",
       "fieldtype": "Small Text",
       "label": "About"
+    },
+    {
+      "fieldname": "section_break_tdld",
+      "fieldtype": "Section Break",
+      "label": "Project Guide"
+    },
+    {
+      "fieldname": "description",
+      "fieldtype": "Markdown Editor",
+      "label": "Description"
+    },
+    {
+      "fieldname": "section_break_ncvl",
+      "fieldtype": "Section Break",
+      "label": "Project Issue/Discussions"
+    },
+    {
+      "fieldname": "project_thread",
+      "fieldtype": "Table",
+      "label": "project_thread",
+      "options": "Hackathon Project Issue PR"
     }
   ],
   "links": [
@@ -71,7 +96,7 @@
       "link_fieldname": "partner_project"
     }
   ],
-  "modified": "2024-06-25 13:12:47.128606",
+  "modified": "2026-03-02 14:12:11.573468",
   "modified_by": "Administrator",
   "module": "FOSS Hackathon",
   "name": "FOSS Hackathon Partner Project",
@@ -113,6 +138,7 @@
       "write": 1
     }
   ],
+  "row_format": "Dynamic",
   "search_fields": "repo_link",
   "show_title_field_in_link": 1,
   "sort_field": "modified",

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/foss_hackathon_partner_project.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/foss_hackathon_partner_project.json
@@ -1,5 +1,6 @@
 {
   "actions": [],
+  "allow_guest_to_view": 1,
   "allow_rename": 1,
   "autoname": "hash",
   "creation": "2024-05-22 16:34:29.481357",
@@ -7,7 +8,9 @@
   "engine": "InnoDB",
   "field_order": [
     "meta_info_section",
+    "is_published",
     "hackathon",
+    "route",
     "project_details_section",
     "logo",
     "project_name",
@@ -88,15 +91,28 @@
       "fieldtype": "Table",
       "label": "project_thread",
       "options": "Hackathon Project Issue PR"
+    },
+    {
+      "default": "0",
+      "fieldname": "is_published",
+      "fieldtype": "Check",
+      "label": "Published?"
+    },
+    {
+      "fieldname": "route",
+      "fieldtype": "Data",
+      "label": "Route"
     }
   ],
+  "has_web_view": 1,
+  "is_published_field": "is_published",
   "links": [
     {
       "link_doctype": "FOSS Hackathon Team",
       "link_fieldname": "partner_project"
     }
   ],
-  "modified": "2026-03-02 14:12:11.573468",
+  "modified": "2026-03-02 14:16:09.606263",
   "modified_by": "Administrator",
   "module": "FOSS Hackathon",
   "name": "FOSS Hackathon Partner Project",

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/foss_hackathon_partner_project.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/foss_hackathon_partner_project.json
@@ -18,6 +18,7 @@
     "column_break_qabl",
     "poc_email",
     "repo_link",
+    "social_group",
     "section_break_tdld",
     "description",
     "section_break_ncvl",
@@ -102,6 +103,11 @@
       "fieldtype": "Table",
       "label": "Issue PR Table",
       "options": "Hackathon Project Issue PR"
+    },
+    {
+      "fieldname": "social_group",
+      "fieldtype": "Data",
+      "label": "Social Group"
     }
   ],
   "has_web_view": 1,
@@ -112,7 +118,7 @@
       "link_fieldname": "partner_project"
     }
   ],
-  "modified": "2026-03-02 16:34:32.769179",
+  "modified": "2026-03-02 16:55:06.446018",
   "modified_by": "Administrator",
   "module": "FOSS Hackathon",
   "name": "FOSS Hackathon Partner Project",

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/foss_hackathon_partner_project.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/foss_hackathon_partner_project.json
@@ -93,7 +93,7 @@
       "options": "Hackathon Project Issue PR"
     },
     {
-      "default": "0",
+      "default": "1",
       "fieldname": "is_published",
       "fieldtype": "Check",
       "label": "Published?"
@@ -112,7 +112,7 @@
       "link_fieldname": "partner_project"
     }
   ],
-  "modified": "2026-03-02 14:16:09.606263",
+  "modified": "2026-03-02 14:26:55.766336",
   "modified_by": "Administrator",
   "module": "FOSS Hackathon",
   "name": "FOSS Hackathon Partner Project",

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/foss_hackathon_partner_project.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/foss_hackathon_partner_project.json
@@ -21,7 +21,7 @@
     "section_break_tdld",
     "description",
     "section_break_ncvl",
-    "project_thread"
+    "issue_pr_table"
   ],
   "fields": [
     {
@@ -87,12 +87,6 @@
       "label": "Project Issue/Discussions"
     },
     {
-      "fieldname": "project_thread",
-      "fieldtype": "Table",
-      "label": "project_thread",
-      "options": "Hackathon Project Issue PR"
-    },
-    {
       "default": "1",
       "fieldname": "is_published",
       "fieldtype": "Check",
@@ -102,6 +96,12 @@
       "fieldname": "route",
       "fieldtype": "Data",
       "label": "Route"
+    },
+    {
+      "fieldname": "issue_pr_table",
+      "fieldtype": "Table",
+      "label": "Issue PR Table",
+      "options": "Hackathon Project Issue PR"
     }
   ],
   "has_web_view": 1,
@@ -112,7 +112,7 @@
       "link_fieldname": "partner_project"
     }
   ],
-  "modified": "2026-03-02 14:26:55.766336",
+  "modified": "2026-03-02 16:34:32.769179",
   "modified_by": "Administrator",
   "module": "FOSS Hackathon",
   "name": "FOSS Hackathon Partner Project",

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/foss_hackathon_partner_project.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/foss_hackathon_partner_project.py
@@ -1,7 +1,15 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
+import frappe
 from frappe.website.website_generator import WebsiteGenerator
+
+from fossunited.doctype_ids import (
+    HACKATHON,
+    HACKATHON_ISSUE_PR,
+    HACKATHON_PROJECT,
+    HACKATHON_TEAM_MEMBER,
+)
 
 
 class FOSSHackathonPartnerProject(WebsiteGenerator):
@@ -28,4 +36,45 @@ class FOSSHackathonPartnerProject(WebsiteGenerator):
         repo_link: DF.Data | None
         route: DF.Data | None
     # end: auto-generated types
-    pass
+
+    def before_save(self):
+        self.set_route()
+
+    def set_route(self):
+        """route as /fosshack/year/partner-project/project_name"""
+        start_date = frappe.db.get_value(HACKATHON, self.hackathon, "start_date")
+        event_year = str(start_date.year)
+        self.route = f"fosshack/{event_year}/partner-projects/{frappe.scrub(self.project_name)}"
+
+    def get_context(self, context):
+        """Enhance the web page context with additional data"""
+        context.no_cache = 1
+
+        hackathon = frappe.get_doc(HACKATHON, self.hackathon)
+        context.hackathon = hackathon
+
+        # Get all participant projects linked to this partner project
+        participant_projects = frappe.get_all(
+            HACKATHON_PROJECT,
+            filters={
+                "hackathon": self.hackathon,
+                "partner_project": self.name,
+                "is_published": 1,
+            },
+            fields=["name", "title", "short_description", "route", "team"],
+            order_by="creation desc",
+        )
+
+        # Enrich participant projects with team size and likes
+        for project in participant_projects:
+            # Get team size
+            project.team_size = frappe.db.count(
+                HACKATHON_TEAM_MEMBER, filters={"parent": project.team}
+            )
+            project.contributions = frappe.db.count(
+                HACKATHON_ISSUE_PR, filters={"parent": project.name}
+            )
+
+        context.participant_projects = participant_projects
+
+        return context

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/foss_hackathon_partner_project.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/foss_hackathon_partner_project.py
@@ -35,6 +35,7 @@ class FOSSHackathonPartnerProject(WebsiteGenerator):
         project_name: DF.Data | None
         repo_link: DF.Data | None
         route: DF.Data | None
+        social_group: DF.Data | None
     # end: auto-generated types
 
     def before_save(self):
@@ -61,7 +62,7 @@ class FOSSHackathonPartnerProject(WebsiteGenerator):
                 "partner_project": self.name,
                 "is_published": 1,
             },
-            fields=["name", "title", "short_description", "route", "team"],
+            fields=["name", "title", "short_description", "route", "team", "team_name"],
             order_by="creation desc",
         )
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/foss_hackathon_partner_project.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/foss_hackathon_partner_project.py
@@ -1,10 +1,10 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
-from frappe.model.document import Document
+from frappe.website.website_generator import WebsiteGenerator
 
 
-class FOSSHackathonPartnerProject(Document):
+class FOSSHackathonPartnerProject(WebsiteGenerator):
     # begin: auto-generated types
     # This code is auto-generated. Do not modify anything in this block.
 
@@ -20,10 +20,12 @@ class FOSSHackathonPartnerProject(Document):
         about: DF.SmallText | None
         description: DF.MarkdownEditor | None
         hackathon: DF.Link | None
+        is_published: DF.Check
         logo: DF.AttachImage | None
         poc_email: DF.Data | None
         project_name: DF.Data | None
         project_thread: DF.Table[HackathonProjectIssuePR]
         repo_link: DF.Data | None
+        route: DF.Data | None
     # end: auto-generated types
     pass

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/foss_hackathon_partner_project.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/foss_hackathon_partner_project.py
@@ -29,10 +29,10 @@ class FOSSHackathonPartnerProject(WebsiteGenerator):
         description: DF.MarkdownEditor | None
         hackathon: DF.Link | None
         is_published: DF.Check
+        issue_pr_table: DF.Table[HackathonProjectIssuePR]
         logo: DF.AttachImage | None
         poc_email: DF.Data | None
         project_name: DF.Data | None
-        project_thread: DF.Table[HackathonProjectIssuePR]
         repo_link: DF.Data | None
         route: DF.Data | None
     # end: auto-generated types

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/foss_hackathon_partner_project.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/foss_hackathon_partner_project.py
@@ -13,11 +13,17 @@ class FOSSHackathonPartnerProject(Document):
     if TYPE_CHECKING:
         from frappe.types import DF
 
+        from fossunited.foss_hackathon.doctype.hackathon_project_issue_pr.hackathon_project_issue_pr import (  # noqa: E501
+            HackathonProjectIssuePR,
+        )
+
         about: DF.SmallText | None
+        description: DF.MarkdownEditor | None
         hackathon: DF.Link | None
         logo: DF.AttachImage | None
         poc_email: DF.Data | None
         project_name: DF.Data | None
+        project_thread: DF.Table[HackathonProjectIssuePR]
         repo_link: DF.Data | None
     # end: auto-generated types
     pass

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/templates/foss_hackathon_partner_project.html
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/templates/foss_hackathon_partner_project.html
@@ -35,15 +35,15 @@
 
             <div class="d-flex flex-wrap gap-2 align-items-center">
               {% if doc.repo_link %}
-                <a class="v3-btn v3-btn-primary" href="{{ doc.repo_link }}" target="_blank">
+                <a class="v3-btn v3-btn-primary" href="{{ doc.repo_link }}" target="_blank" rel="noopener noreferrer">
                   <i class="ti ti-brand-github"></i>
                   <span>View Repository</span>
                 </a>
               {% endif %}
-              {% if doc.poc_email %}
-                <a class="v3-btn v3-btn-secondary" href="mailto:{{ doc.poc_email }}">
-                  <i class="ti ti-mail"></i>
-                  <span>Contact</span>
+              {% if doc.social_group %}
+                <a class="v3-btn v3-btn-secondary" href="{{ doc.social_group }}">
+                  <i class="ti ti-message"></i>
+                  <span>Chat</span>
                 </a>
               {% endif %}
             </div>
@@ -97,14 +97,18 @@
               </div>
             {% endif %}
             <div class="d-flex align-items-center gap-2 mt-2 text-sm">
-              <div class="v3-text-tertiary">
+              <span class="v3-text-tertiary">
+                <i class="ti ti-users-group"></i>
+                {{ project.team_name }}
+              </span>
+              <span class="v3-text-tertiary">
                 <i class="ti ti-users"></i>
                 {{ project.team_size }} member{{ 's' if project.team_size != 1 else '' }}
-              </div>
-              <div class="v3-text-tertiary">
+              </span>
+              <span class="v3-text-tertiary">
                 <i class="ti ti-git-pull-request"></i>
                 {{ project.contributions }} Issue/PR
-              </div>
+              </span>
             </div>
           </a>
         {% endfor %}

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/templates/foss_hackathon_partner_project.html
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/templates/foss_hackathon_partner_project.html
@@ -1,0 +1,114 @@
+{% extends "templates/foss_base.html" %}
+{% from "fossunited/templates/macros/breadcrumb.html" import breadcrumb, theme_toggle %}
+{% from "fossunited/templates/macros/issue_pr_table.html" import issue_pr_table %}
+
+{% block page_content %}
+  <div class="v3-page">
+    <div class="v3-container">
+      <div class="d-flex justify-content-between align-items-center">
+        {{
+          breadcrumb(items=[{"route": (hackathon.external_website_url), "label": hackathon.hackathon_name},
+          {"route": (hackathon.external_website_url + '/partner-projects'), "label": "Partner Projects"}, {"label": doc.project_name}])
+        }}
+        {{ theme_toggle() }}
+      </div>
+
+      <!-- Project Header -->
+      <div class="v3-card mb-4">
+        <div class="d-flex flex-column flex-lg-row gap-4">
+          {% if doc.logo %}
+            <div class="flex-shrink-0">
+              <img
+                src="{{ doc.logo }}"
+                alt="{{ doc.project_name }}"
+                style="width:120px;height:120px;border-radius:0.75rem;border:1px solid var(--v3-button-border);object-fit:cover;"
+              />
+            </div>
+          {% endif %}
+
+          <div class="flex-fill">
+            <h1 class="v3-text-primary mb-3 h3">{{ doc.project_name }}</h1>
+
+            {% if doc.about %}
+              <p class="v3-text-secondary mb-3">{{ doc.about }}</p>
+            {% endif %}
+
+            <div class="d-flex flex-wrap gap-2 align-items-center">
+              {% if doc.repo_link %}
+                <a class="v3-btn v3-btn-primary" href="{{ doc.repo_link }}" target="_blank">
+                  <i class="ti ti-brand-github"></i>
+                  <span>View Repository</span>
+                </a>
+              {% endif %}
+              {% if doc.poc_email %}
+                <a class="v3-btn v3-btn-secondary" href="mailto:{{ doc.poc_email }}">
+                  <i class="ti ti-mail"></i>
+                  <span>Contact</span>
+                </a>
+              {% endif %}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {{ render_description() }}
+      {{ issue_pr_table(doc.issue_pr_table, "No issues or pull requests linked yet. Check the repository discussion thread for contribution opportunities.") }}
+      {{ render_participant_projects() }}
+    </div>
+  </div>
+{% endblock %}
+
+{% macro render_description() %}
+  {% if doc.description %}
+    <div class="v3-card mb-4">
+      <div class="v3-section-title">
+        <i class="ti ti-book"></i>
+        <span>Description & Contribution Guidelines</span>
+      </div>
+      <div class="v3-text-secondary" style="line-height:1.75;">
+        {{ frappe.utils.md_to_html(doc.description) }}
+      </div>
+    </div>
+  {% endif %}
+{% endmacro %}
+
+{% macro render_participant_projects() %}
+  {% if participant_projects and participant_projects | len > 0 %}
+    <div class="v3-card mb-4">
+      <div class="v3-section-title">
+        <i class="ti ti-code"></i>
+        <span>Participant Contributions</span>
+      </div>
+      <div class="v3-text-secondary mb-3">
+        Projects created by hackathon participants contributing to {{ doc.project_name }}
+      </div>
+
+      <div class="d-flex flex-column gap-2">
+        {% for project in participant_projects %}
+          <a
+            href="/{{ project.route }}"
+            class="v3-clickable d-flex flex-column p-3"
+            style="border:1px solid var(--v3-button-border);border-radius:0.5rem;"
+          >
+            <div class="v3-text-primary mb-1 text-xl">{{ project.title }}</div>
+            {% if project.short_description %}
+              <div class="v3-text-secondary">
+                {{ project.short_description | truncate(100, true) }}
+              </div>
+            {% endif %}
+            <div class="d-flex align-items-center gap-2 mt-2 text-sm">
+              <div class="v3-text-tertiary">
+                <i class="ti ti-users"></i>
+                {{ project.team_size }} member{{ 's' if project.team_size != 1 else '' }}
+              </div>
+              <div class="v3-text-tertiary">
+                <i class="ti ti-git-pull-request"></i>
+                {{ project.contributions }} Issue/PR
+              </div>
+            </div>
+          </a>
+        {% endfor %}
+      </div>
+    </div>
+  {% endif %}
+{% endmacro %}

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/templates/foss_hackathon_partner_project_row.html
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/templates/foss_hackathon_partner_project_row.html
@@ -1,0 +1,4 @@
+<div>
+	<a href="{{ doc.route }}">{{ doc.title or doc.name }}</a>
+</div>
+<!-- this is a sample default list template -->

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_project/templates/foss_hackathon_project.html
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_project/templates/foss_hackathon_project.html
@@ -1,5 +1,6 @@
 {% extends "templates/foss_base.html" %}
 {% from "fossunited/templates/macros/breadcrumb.html" import breadcrumb, theme_toggle %}
+{% from "fossunited/templates/macros/issue_pr_table.html" import issue_pr_table %}
 
 {% block page_content %}
   <div class="v3-page">
@@ -74,7 +75,7 @@
 
       {{ render_team() }}
       {{ render_description() }}
-      {{ render_issue_pr() }}
+      {{ issue_pr_table(doc.issue_pr_table, "No issues or pull requests added.") }}
     </div>
   </div>
 {% endblock %}
@@ -117,49 +118,6 @@
       <span>Description</span>
     </div>
     <div class="v3-text-secondary">{{ doc.description or 'No description added.' }}</div>
-  </div>
-{% endmacro %}
-
-{% macro render_issue_pr() %}
-  <div class="v3-card mb-4">
-    <div class="v3-section-title">
-      <i class="ti ti-git-pull-request"></i>
-      <span>Issues & PRs Linked</span>
-    </div>
-
-    {% if doc.issue_pr_table | len > 0 %}
-      <div class="d-flex flex-column gap-2">
-        {% for item in doc.issue_pr_table %}
-          <a
-            href="{{ item.link }}"
-            target="_blank"
-            class="v3-clickable d-flex flex-column p-3"
-            style="border:1px solid var(--v3-button-border);border-radius:0.5rem;"
-          >
-            <div
-              class="d-flex align-items-center gap-1 mb-2"
-              style="font-size:0.75rem;text-transform:uppercase;font-weight:600;"
-            >
-              {% if item.type == 'Pull Request' %}
-                <i class="ti ti-git-pull-request v3-text-secondary"></i>
-                <span class="v3-text-secondary">Pull Request</span>
-              {% elif item.type == 'Issue' %}
-                <i class="ti ti-circle-dot v3-text-secondary"></i>
-                <span class="v3-text-secondary">Issue</span>
-              {% else %}
-                <i class="ti ti-messages v3-text-secondary"></i>
-                <span class="v3-text-secondary">Discussion</span>
-              {% endif %}
-            </div>
-            <div class="v3-text-primary" style="font-family:'Courier New',Courier,monospace;">
-              {{ item.title }}
-            </div>
-          </a>
-        {% endfor %}
-      </div>
-    {% else %}
-      <div class="v3-text-tertiary text-center py-5">No Issues, PRs or Discussions added.</div>
-    {% endif %}
   </div>
 {% endmacro %}
 

--- a/fossunited/templates/macros/issue_pr_table.html
+++ b/fossunited/templates/macros/issue_pr_table.html
@@ -11,6 +11,7 @@
           <a
             href="{{ item.link }}"
             target="_blank"
+            rel="noopener noreferrer"
             class="v3-clickable d-flex flex-column p-3"
             style="border:1px solid var(--v3-button-border);border-radius:0.5rem;"
           >

--- a/fossunited/templates/macros/issue_pr_table.html
+++ b/fossunited/templates/macros/issue_pr_table.html
@@ -1,0 +1,44 @@
+{% macro issue_pr_table(docfield, empty_message) %}
+  <div class="v3-card mb-4">
+    <div class="v3-section-title">
+      <i class="ti ti-git-pull-request"></i>
+      <span>Issues & Pull Requests Thread</span>
+    </div>
+
+    {% if docfield | len > 0 %}
+      <div class="d-flex flex-column gap-2">
+        {% for item in docfield %}
+          <a
+            href="{{ item.link }}"
+            target="_blank"
+            class="v3-clickable d-flex flex-column p-3"
+            style="border:1px solid var(--v3-button-border);border-radius:0.5rem;"
+          >
+            <div
+              class="d-flex align-items-center gap-1 mb-2"
+              style="font-size:0.75rem;text-transform:uppercase;font-weight:600;"
+            >
+              {% if item.type == 'Pull Request' %}
+                <i class="ti ti-git-pull-request v3-text-secondary"></i>
+                <span class="v3-text-secondary">Pull Request</span>
+              {% elif item.type == 'Issue' %}
+                <i class="ti ti-circle-dot v3-text-secondary"></i>
+                <span class="v3-text-secondary">Issue</span>
+              {% else %}
+                <i class="ti ti-messages v3-text-secondary"></i>
+                <span class="v3-text-secondary">Discussion</span>
+              {% endif %}
+            </div>
+            <div class="v3-text-primary" style="font-family:'Courier New',Courier,monospace;">
+              {{ item.title }}
+            </div>
+          </a>
+        {% endfor %}
+      </div>
+    {% else %}
+      <div class="v3-text-tertiary text-center py-5">
+        {{ empty_message or "No issues or pull requests linked yet." }}
+      </div>
+    {% endif %}
+  </div>
+{% endmacro %}


### PR DESCRIPTION
- Add description (markdown) field for text information
- add PR table for linking some issue/PR (easy to grasp)
  or better link to single Discussion thread to take over.

- Make macro for common issue pr table in page

- Show list of projects contributing to this partner project as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Partner project pages are now web-publishable with auto-generated routes and a published toggle.
  * Added project description, social link, and issue/PR tracking table fields.
  * Unified issue/PR display component available for projects.
  * Partner project detail pages render participant projects, team sizes, and contribution summaries.
* **Templates**
  * New detail and list templates for partner projects with markdown rendering and issue/PR listing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->