### PR TITLE
fix(emailing): allow only if localhost organizer or chapter member

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "development/frappe-semgrep-rules"]
+	path = development/frappe-semgrep-rules
+	url = https://github.com/frappe/semgrep-rules

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ repos:
     rev: 'v1.153.1'
     hooks:
       - id: semgrep
+        stages: [commit]
         entry: semgrep
         # or see https://semgrep.dev/explore to select a ruleset and copy its URL
         args: ['--config', 'development/frappe-semgrep-rules/rules', '--error', '--skip-unknown-extensions']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,12 @@ repos:
   #     - id: vale
   #       pass_filenames: true
   #       args: [--output=line, --minAlertLevel=error]
+
+  - repo: https://github.com/semgrep/pre-commit
+    rev: 'v1.153.1'
+    hooks:
+      - id: semgrep
+        entry: semgrep
+        # or see https://semgrep.dev/explore to select a ruleset and copy its URL
+        args: ['--config', 'development/frappe-semgrep-rules/rules', '--error', '--skip-unknown-extensions']
+        additional_dependencies: ['attrs']

--- a/fossunited/api/emailing.py
+++ b/fossunited/api/emailing.py
@@ -1,6 +1,7 @@
 from typing import Literal, Optional
 
 import frappe
+from frappe import _
 
 from fossunited.api.chapter import check_if_chapter_member
 from fossunited.doctype_ids import (
@@ -64,7 +65,7 @@ def create_email_group(
     suffix = EMAIL_GROUP_SUFFIX_BY_DOCTYPE.get(document_type)
     if suffix is None:
         frappe.throw(
-            f"Unsupported document type: {document_type}",
+            _(f"Unsupported document type: {document_type}"),
             frappe.ValidationError,
         )
 
@@ -114,7 +115,7 @@ def add_to_email_group(email_group: str, email: str):
     logger = frappe.logger("email_group")
 
     if not frappe.db.exists(EMAIL_GROUP, email_group):
-        frappe.throw("This email group does not exist", frappe.DoesNotExistError)
+        frappe.throw(_("This email group does not exist"), frappe.DoesNotExistError)
 
     if frappe.db.exists(EMAIL_MEMBER, {"email_group": email_group, "email": email}):
         logger.info(f"Email '{email}' already exists in group '{email_group}'")
@@ -132,7 +133,7 @@ def remove_from_email_group(email_group: str, email: str):
     logger = frappe.logger("email_group")
 
     if not frappe.db.exists(EMAIL_GROUP, email_group):
-        frappe.throw("This email group does not exist", frappe.DoesNotExistError)
+        frappe.throw(_("This email group does not exist"), frappe.DoesNotExistError)
 
     member_name = frappe.db.exists(EMAIL_MEMBER, {"email_group": email_group, "email": email})
     if not member_name:
@@ -240,7 +241,7 @@ def create_newsletter_campaign(
     _chapter = chapter
 
     if not _reference_document and not _chapter:
-        frappe.throw("Either reference_document or chapter need to be provided")
+        frappe.throw(_("Either reference_document or chapter need to be provided"))
 
     if not _chapter:
         # Get Chapter ID
@@ -554,6 +555,7 @@ def send_campaign(campaign_id: str):
     args:
         campaign: id of campaign / newsletter doctype
     """
+    campaign = frappe.get_doc(CAMPAIGN, campaign_id)
     campaign.flags.ignore_permissions = 1
     campaign.send_emails()
     campaign.save()
@@ -569,12 +571,13 @@ def send_test_email(campaign_id: str, email: str):
         campaign_id : campaign / newsletter id
         email: email to send test email to
     """
+    campaign = frappe.get_doc(CAMPAIGN, campaign_id)
     campaign.flags.ignore_permissions = 1
     try:
         campaign.send_test_email(email)
         campaign.save()
     except frappe.InvalidEmailAddressError as e:
-        frappe.throw(str(e))
+        frappe.throw(_(str(e)))
 
 
 @frappe.whitelist()
@@ -597,6 +600,7 @@ def get_sending_status(campaign_id: str) -> dict:
         }
         ```
     """
+    campaign = frappe.get_doc(CAMPAIGN, campaign_id)
     campaign.flags.ignore_permissions = 1
 
     stats = campaign.get_sending_status()
@@ -615,10 +619,10 @@ def check_newsletter_permission(document_type, reference_document, chapter):
 
     # Otherwise check chapter membership
     if not chapter:
-        frappe.throw("Cannot determine chapter for permission check", frappe.PermissionError)
+        frappe.throw(_("Cannot determine chapter for permission check"), frappe.PermissionError)
 
     if not check_if_chapter_member(chapter, user):
         frappe.throw(
-            "You are not authorized to create newsletters for this chapter",
+            _("You are not authorized to create newsletters for this chapter"),
             frappe.PermissionError,
         )

--- a/fossunited/api/emailing.py
+++ b/fossunited/api/emailing.py
@@ -14,6 +14,7 @@ from fossunited.doctype_ids import (
     HACKATHON_LOCALHOST,
     STUDENT_CLUB,
 )
+from fossunited.utils.decorators import is_localhost_organizer, require_mailing_access
 
 EMAIL_GROUP_TYPES = Literal[
     "Chapter Event Participants",
@@ -245,6 +246,7 @@ def create_newsletter_campaign(
         # Get Chapter ID
         _chapter = frappe.db.get_value(document_type, _reference_document, ["chapter"])
 
+    check_newsletter_permission(document_type, _reference_document, _chapter)
     chapter_dict = frappe.db.get_value(
         CHAPTER,
         _chapter,
@@ -444,6 +446,7 @@ def get_email_groups(
 
 
 @frappe.whitelist()
+@require_mailing_access(campaign_param="campaign_id")
 def update_campaign(campaign_id: str, data: dict):
     """
     Update an email campaign with new details(data)
@@ -541,6 +544,7 @@ def get_formatted_attachment_list(attachments: list) -> list:
 
 
 @frappe.whitelist()
+@require_mailing_access(campaign_param="campaign_id")
 def send_campaign(campaign_id: str):
     """
     Send the campaigns
@@ -548,21 +552,13 @@ def send_campaign(campaign_id: str):
     args:
         campaign: id of campaign / newsletter doctype
     """
-    campaign = frappe.get_doc(CAMPAIGN, campaign_id)
-
-    if not campaign.chapter:
-        chapter = frappe.db.get_value(EVENT, campaign.event, ["chapter"])
-    else:
-        chapter = campaign.chapter
-
-    ensure_mailing_access(chapter)
-
     campaign.flags.ignore_permissions = 1
     campaign.send_emails()
     campaign.save()
 
 
 @frappe.whitelist()
+@require_mailing_access(campaign_param="campaign_id")
 def send_test_email(campaign_id: str, email: str):
     """
     Send out a test email for a campaign
@@ -571,20 +567,6 @@ def send_test_email(campaign_id: str, email: str):
         campaign_id : campaign / newsletter id
         email: email to send test email to
     """
-
-    campaign = frappe.get_doc(CAMPAIGN, campaign_id)
-
-    if not campaign.chapter:
-        chapter = frappe.db.get_value(
-            campaign.document_type,
-            campaign.reference_document,
-            ["chapter"],
-        )
-    else:
-        chapter = campaign.chapter
-
-    ensure_mailing_access(chapter)
-
     campaign.flags.ignore_permissions = 1
     try:
         campaign.send_test_email(email)
@@ -594,6 +576,7 @@ def send_test_email(campaign_id: str, email: str):
 
 
 @frappe.whitelist()
+@require_mailing_access(campaign_param="campaign_id")
 def get_sending_status(campaign_id: str) -> dict:
     """
     Get sending stats related to a campaign
@@ -612,20 +595,6 @@ def get_sending_status(campaign_id: str) -> dict:
         }
         ```
     """
-
-    campaign = frappe.get_doc(CAMPAIGN, campaign_id)
-
-    if not campaign.chapter:
-        chapter = frappe.db.get_value(
-            campaign.document_type,
-            campaign.reference_document,
-            ["chapter"],
-        )
-    else:
-        chapter = campaign.chapter
-
-    ensure_mailing_access(chapter)
-
     campaign.flags.ignore_permissions = 1
 
     stats = campaign.get_sending_status()
@@ -633,12 +602,21 @@ def get_sending_status(campaign_id: str) -> dict:
     return stats
 
 
-def ensure_mailing_access(chapter):
-    """Make sure user is chapter member or localhost organizer"""
+def check_newsletter_permission(document_type, reference_document, chapter):
+    """Check if user has permission to create newsletter"""
     user = frappe.session.user
 
-    if {"System Manager", "Localhost Organizer"} & set(frappe.get_roles(user)):
-        return
+    # Check if localhost organizer
+    if document_type == HACKATHON_LOCALHOST and reference_document:
+        if is_localhost_organizer(reference_document, user):
+            return
+
+    # Otherwise check chapter membership
+    if not chapter:
+        frappe.throw("Cannot determine chapter for permission check", frappe.PermissionError)
 
     if not check_if_chapter_member(chapter, user):
-        frappe.throw("You are not chapter member to send email", frappe.PermissionError)
+        frappe.throw(
+            "You are not authorized to create newsletters for this chapter",
+            frappe.PermissionError,
+        )

--- a/fossunited/api/emailing.py
+++ b/fossunited/api/emailing.py
@@ -314,6 +314,7 @@ def get_newsletter_campaigns(
         list : of all the email campaigns
     """
 
+    check_newsletter_permission(document_type, reference_document, chapter)
     campaigns = frappe.db.get_all(
         doctype=CAMPAIGN,
         filters={
@@ -351,6 +352,7 @@ def get_newsletter_campaigns(
 
 
 @frappe.whitelist()
+@require_mailing_access(campaign_param="id")
 def get_campaign_detail(id: str) -> dict:
     """
     Get campaign details and return it as dict

--- a/fossunited/tests/test_emailing.py
+++ b/fossunited/tests/test_emailing.py
@@ -39,6 +39,8 @@ class TestEmailing(FrappeTestCase):
             frappe.delete_doc("Email Group", group_name, force=True)
 
     def setup_campaign(self):
+        frappe.set_user(self.core_team_email)
+
         email_group = frappe.get_doc(
             EMAIL_GROUP,
             {

--- a/fossunited/tests/test_emailing.py
+++ b/fossunited/tests/test_emailing.py
@@ -82,12 +82,12 @@ class TestEmailing(FrappeTestCase):
 
         test_email = fake.email()
 
-        send_test_email(self.newsletter.name, test_email)
+        send_test_email(campaign_id=self.newsletter.name, email=test_email)
 
     def test_send_campaign(self):
         frappe.set_user(self.core_team_email)
 
-        send_campaign(self.newsletter.name)
+        send_campaign(campaign_id=self.newsletter.name)
 
     def test_create_email_group_creates_group(self):
         group = create_email_group(

--- a/fossunited/utils/decorators.py
+++ b/fossunited/utils/decorators.py
@@ -195,47 +195,85 @@ def require_chapter_or_event_member(event_id="event"):
     return decorator
 
 
-def require_localhost_organizer(localhost_param="localhost_id"):
-    """
-    Decorator to check if user is a localhost organizer or system manager.
+def is_localhost_organizer(localhost_id, user=None):
+    """Check if user is a localhost organizer"""
+    if not user:
+        user = frappe.session.user
 
-    Args:
-        localhost_param: name of the parameter containing localhost ID
-    """
+    # System Manager bypass
+    if "System Manager" in frappe.get_roles(user):
+        return True
+
+    # Get user's profile
+    profile = frappe.db.get_value(USER_PROFILE, {"user": user}, "name")
+    if not profile:
+        return False
+
+    # Check if profile exists in localhost organizers
+    return frappe.db.exists(
+        LOCALHOST_ORGANIZER,
+        {
+            "parent": localhost_id,
+            "parenttype": HACKATHON_LOCALHOST,
+            "profile": profile,
+            "parentfield": "organizers",
+        },
+    )
+
+
+def require_localhost_organizer(localhost_param="localhost_id"):
+    """Decorator to check if user is a localhost organizer or system manager"""
 
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            # System Manager bypass
-            if "System Manager" in frappe.get_roles():
-                return func(*args, **kwargs)
-
-            # Get localhost ID from kwargs
             localhost_id = kwargs.get(localhost_param)
             if not localhost_id:
                 frappe.throw("Localhost ID not provided", frappe.PermissionError)
 
-            # Get organizer profiles from child table
-            organizer_profiles = frappe.get_all(
-                LOCALHOST_ORGANIZER,
-                filters={"parent": localhost_id},
-                pluck="profile",
-            )
-
-            # Get users from profiles
-            if organizer_profiles:
-                organizer_users = frappe.get_all(
-                    USER_PROFILE,
-                    filters={"name": ["in", organizer_profiles]},
-                    pluck="user",
-                )
-            else:
-                organizer_users = []
-
-            # Check if current user is an organizer
-            if frappe.session.user not in organizer_users:
+            if not is_localhost_organizer(localhost_id):
                 frappe.throw(
                     "Only localhost organizers can access this resource",
+                    frappe.PermissionError,
+                )
+
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def require_mailing_access(campaign_param="campaign_id"):
+    """Decorator to check if user has mailing access (chapter member or localhost organizer)"""
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            campaign_id = kwargs.get(campaign_param)
+            if not campaign_id:
+                frappe.throw("Campaign ID not provided", frappe.PermissionError)
+
+            user = frappe.session.user
+            campaign = frappe.get_doc(CAMPAIGN, campaign_id)
+
+            # Check if localhost organizer
+            if campaign.document_type == HACKATHON_LOCALHOST:
+                if is_localhost_organizer(campaign.reference_document, user):
+                    return func(*args, **kwargs)
+
+            # Otherwise check chapter membership
+            chapter = campaign.chapter
+            if not chapter:
+                chapter = frappe.db.get_value(
+                    campaign.document_type,
+                    campaign.reference_document,
+                    "chapter",
+                )
+
+            if not check_if_chapter_member(chapter, user):
+                frappe.throw(
+                    "You are not authorized organizer to send emails for this campaign",
                     frappe.PermissionError,
                 )
 

--- a/fossunited/utils/decorators.py
+++ b/fossunited/utils/decorators.py
@@ -5,6 +5,7 @@ Permission check decorators for hackathon and chapter operations
 from functools import wraps
 
 import frappe
+from frappe import _
 
 from fossunited.api.chapter import (
     check_if_chapter_member,
@@ -12,6 +13,8 @@ from fossunited.api.chapter import (
     check_if_event_member,
 )
 from fossunited.doctype_ids import (
+    CAMPAIGN,
+    HACKATHON_LOCALHOST,
     HACKATHON_PARTICIPANT,
     HACKATHON_TEAM,
     LOCALHOST_ORGANIZER,
@@ -31,18 +34,18 @@ def require_hackathon_participant(hackathon_id="hackathon"):
         @wraps(func)
         def wrapper(*args, **kwargs):
             if frappe.session.user == "Guest":
-                frappe.throw("Authentication required", frappe.PermissionError)
+                frappe.throw(_("Authentication required"), frappe.PermissionError)
 
             hackathon = kwargs.get(hackathon_id)
             if not hackathon:
-                frappe.throw("Hackathon data is required", frappe.ValidationError)
+                frappe.throw(_("Hackathon data is required"), frappe.ValidationError)
 
             if not frappe.db.exists(
                 HACKATHON_PARTICIPANT,
                 {"hackathon": hackathon, "user": frappe.session.user},
             ):
                 frappe.throw(
-                    "You are not a participant of this hackathon",
+                    _("You are not a participant of this hackathon"),
                     frappe.PermissionError,
                 )
 
@@ -66,19 +69,19 @@ def require_hackathon_team(team_id="team", hackathon_id="hackathon"):
         @wraps(func)
         def wrapper(*args, **kwargs):
             if frappe.session.user == "Guest":
-                frappe.throw("Authentication required", frappe.PermissionError)
+                frappe.throw(_("Authentication required"), frappe.PermissionError)
 
             team = kwargs.get(team_id)
             hackathon = kwargs.get(hackathon_id)
 
             if not team:
-                frappe.throw("Team data is not provided", frappe.ValidationError)
+                frappe.throw(_("Team data is not provided"), frappe.ValidationError)
 
             team_doc = frappe.get_doc(HACKATHON_TEAM, team)
 
             # Check if hackathon matches if provided
             if hackathon and team_doc.hackathon != hackathon:
-                frappe.throw("Team does not belong to this hackathon", frappe.ValidationError)
+                frappe.throw(_("Team does not belong to this hackathon"), frappe.ValidationError)
 
             # Check if user is a member
             is_member = False
@@ -98,7 +101,7 @@ def require_hackathon_team(team_id="team", hackathon_id="hackathon"):
                         break
 
             if not is_member:
-                frappe.throw("You are not a member of this team", frappe.PermissionError)
+                frappe.throw(_("You are not a member of this team"), frappe.PermissionError)
 
             return func(*args, **kwargs)
 
@@ -119,14 +122,14 @@ def require_chapter_member(chapter_id="chapter"):
         @wraps(func)
         def wrapper(*args, **kwargs):
             if frappe.session.user == "Guest":
-                frappe.throw("Authentication required", frappe.PermissionError)
+                frappe.throw(_("Authentication required"), frappe.PermissionError)
 
             chapter = kwargs.get(chapter_id)
             if not chapter:
-                frappe.throw("Chapter data is required", frappe.ValidationError)
+                frappe.throw(_("Chapter data is required"), frappe.ValidationError)
 
             if not check_if_chapter_member(chapter, frappe.session.user):
-                frappe.throw("You are not a member of this chapter", frappe.PermissionError)
+                frappe.throw(_("You are not a member of this chapter"), frappe.PermissionError)
 
             return func(*args, **kwargs)
 
@@ -147,14 +150,14 @@ def require_event_member(event_id="event"):
         @wraps(func)
         def wrapper(*args, **kwargs):
             if frappe.session.user == "Guest":
-                frappe.throw("Authentication required", frappe.PermissionError)
+                frappe.throw(_("Authentication required"), frappe.PermissionError)
 
             event = kwargs.get(event_id)
             if not event:
-                frappe.throw("Event data is required", frappe.ValidationError)
+                frappe.throw(_("Event data is required"), frappe.ValidationError)
 
             if not check_if_event_member(event):
-                frappe.throw("You are not an event volunteer", frappe.PermissionError)
+                frappe.throw(_("You are not an event volunteer"), frappe.PermissionError)
 
             return func(*args, **kwargs)
 
@@ -175,16 +178,16 @@ def require_chapter_or_event_member(event_id="event"):
         @wraps(func)
         def wrapper(*args, **kwargs):
             if frappe.session.user == "Guest":
-                frappe.throw("Authentication required", frappe.PermissionError)
+                frappe.throw(_("Authentication required"), frappe.PermissionError)
 
             event = kwargs.get(event_id)
             if not event:
-                frappe.throw("Event ID is not provided", frappe.ValidationError)
+                frappe.throw(_("Event ID is not provided"), frappe.ValidationError)
 
             # Reuse existing function directly
             if not check_if_chapter_or_event_core_member(event):
                 frappe.throw(
-                    "You must be either a chapter member or event member",
+                    _("You must be either a chapter member or event member"),
                     frappe.PermissionError,
                 )
 
@@ -229,11 +232,11 @@ def require_localhost_organizer(localhost_param="localhost_id"):
         def wrapper(*args, **kwargs):
             localhost_id = kwargs.get(localhost_param)
             if not localhost_id:
-                frappe.throw("Localhost ID not provided", frappe.PermissionError)
+                frappe.throw(_("Localhost ID not provided"), frappe.PermissionError)
 
             if not is_localhost_organizer(localhost_id):
                 frappe.throw(
-                    "Only localhost organizers can access this resource",
+                    _("Only localhost organizers can access this resource"),
                     frappe.PermissionError,
                 )
 
@@ -252,7 +255,7 @@ def require_mailing_access(campaign_param="campaign_id"):
         def wrapper(*args, **kwargs):
             campaign_id = kwargs.get(campaign_param)
             if not campaign_id:
-                frappe.throw("Campaign ID not provided", frappe.PermissionError)
+                frappe.throw(_("Campaign ID not provided"), frappe.PermissionError)
 
             user = frappe.session.user
             campaign = frappe.get_doc(CAMPAIGN, campaign_id)
@@ -273,7 +276,7 @@ def require_mailing_access(campaign_param="campaign_id"):
 
             if not check_if_chapter_member(chapter, user):
                 frappe.throw(
-                    "You are not authorized organizer to send emails for this campaign",
+                    _("You are not authorized organizer to send emails for this campaign"),
                     frappe.PermissionError,
                 )
 

--- a/shell.nix
+++ b/shell.nix
@@ -14,7 +14,7 @@ in
 	  # pypkgs
 	  # ruff black
 	  # ty # basedpyright
-	  uv nodePackages.eslint nodePackages.prettier html-tidy nodePackages.yarn semgrep
+	  uv nodePackages.eslint nodePackages.prettier html-tidy nodePackages.yarn
 	  vale harper
 	];
 


### PR DESCRIPTION
- wrap functions with decorator to check if is organizer to handle campaign detail and send

- @ni5arga for reporting
  
Just makes sure that to the respective content only organizers are allowed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Centralized and tightened permission checks for newsletter/campaign actions, with clearer, localized authorization messages.

* **Tests**
  * Updated tests to set the correct user context and invoke mailing APIs with explicit keyword arguments.

* **Chores**
  * Added Semgrep to pre-commit and a related submodule; adjusted developer/local environment tooling declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->