### PR TITLE
feat: add checkin email group for localhost attendees

### DIFF
--- a/dashboard/src/components/mailing/EmailFormTemplate.vue
+++ b/dashboard/src/components/mailing/EmailFormTemplate.vue
@@ -126,8 +126,8 @@ const emailGroups = createResource({
 
       // For localhost groups, extract status from title
       if (item.name && item.name.endsWith('-Localhost')) {
-        const status = item.name.split('-')[0]
-        label = `${status} Participants`
+        const name = item.name.replace(/-[^-]+-Localhost$/, '')
+        label = `${name} Participants`
       }
       d.push({
         label: label,

--- a/dashboard/src/components/mailing/ManageCampaignDrawer.vue
+++ b/dashboard/src/components/mailing/ManageCampaignDrawer.vue
@@ -90,8 +90,8 @@ const campaign = createResource({
         let label = group.label
         // For localhost groups, extract status from value (group name)
         if (group.value && group.value.endsWith('-Localhost')) {
-          const status = group.value.split('-')[0]
-          label = `${status} Participants`
+          const name = group.value.replace(/-[^-]+-Localhost$/, '')
+          label = `${name} Participants`
         }
         return {
           ...group,

--- a/dashboard/src/helpers/utils.js
+++ b/dashboard/src/helpers/utils.js
@@ -55,7 +55,7 @@ export function showError(error, fallback = 'An error occurred') {
   const isRateLimited = error?.response?.status === 429 || error?.status === 429
   const apiMessage = typeof error === 'string' ? error : error?.messages?.[0] || error?.message
   const message = isRateLimited
-    ? 'Too many requests/attempts. Please try again after 10 minutes.'
+    ? 'Too many requests/attempts. Take rest & Please try again after an hour.'
     : apiMessage || fallback
   const displayMessage = message === fallback ? fallback : `${fallback}: ${message}`
 

--- a/dashboard/src/pages/hackathon/CreateTeam.vue
+++ b/dashboard/src/pages/hackathon/CreateTeam.vue
@@ -94,7 +94,7 @@ const userParticipantInfo = createResource({
     })
   },
   onError(error) {
-    toast.error('Error fetching user info' + error)
+    showError(error, `Error fetching user info`)
   },
 })
 
@@ -134,7 +134,7 @@ const createTeam = createResource({
     })
   },
   onError(error) {
-    toast.error('Error creating team' + error)
+    showError(error, `Error creating team`)
   },
 })
 

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -266,22 +266,18 @@ class FOSSHackathonParticipant(Document):
 
     @frappe.whitelist()
     def add_check_in(self):
-        # Add to email group BEFORE saving
+        # Add to email group and checkin
+        result = add_checkin(self)
         if self.localhost:
             checkin_date = frappe.utils.nowdate()
             self.sync_localhost_status_groups(new_status=f"Checkin-{checkin_date}")
-
-        # Then add the check-in
-        result = add_checkin(self)
         return result
 
     @frappe.whitelist()
     def remove_today_check_in(self):
-        # Remove from email group BEFORE saving
+        # Remove from email group
+        result = remove_today_checkin(self)
         if self.localhost:
             checkin_date = frappe.utils.nowdate()
             self.sync_localhost_status_groups(old_status=f"Checkin-{checkin_date}")
-
-        # Then remove the check-in
-        result = remove_today_checkin(self)
         return result

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -76,7 +76,7 @@ class FOSSHackathonParticipant(Document):
         self.handle_add_to_email_group()
         # Add to status-based localhost group if applicable
         if self.wants_to_attend_locally and self.localhost:
-            self.sync_localhost_status_groups()
+            self.sync_localhost_status_groups(new_status=self.localhost_request_status)
 
     def before_save(self):
         if self.has_value_changed("wants_to_attend_locally"):
@@ -98,10 +98,13 @@ class FOSSHackathonParticipant(Document):
 
         if self.has_value_changed("localhost") and self.localhost:
             # Localhost changed — just add to new group
-            self.sync_localhost_status_groups()
+            self.sync_localhost_status_groups(new_status=self.localhost_request_status)
         elif self.has_value_changed("localhost_request_status") and self.localhost:
             # Only status changed within the same localhost
-            self.sync_localhost_status_groups(old_status=self._get_old_status())
+            self.sync_localhost_status_groups(
+                new_status=self.localhost_request_status,
+                old_status=self._get_old_status(),
+            )
 
     def validate(self):
         if self.wants_to_attend_locally and not self.localhost:
@@ -135,42 +138,38 @@ class FOSSHackathonParticipant(Document):
             document_type_event=HACKATHON,
         )
 
-    def sync_localhost_status_groups(self, old_status=None):
-        """
-        Add/remove participant from localhost email groups based on status.
-        Args:
-            old_status: Previous status to remove from that group
-        """
+    def sync_localhost_status_groups(self, old_status=None, new_status=None):
         if not self.localhost:
             return
 
         event_doc = frappe.get_doc(HACKATHON, self.hackathon)
-        current_status = self.localhost_request_status
 
-        # REMOVE from old status group first
-        if old_status and old_status != current_status:
+        # REMOVE from old group
+        if old_status:
+            # frappe.throw("for old")
             handle_email_group_subscription(
                 emails=[self.email],
                 chapter=event_doc.chapter,
                 event=self.localhost,
                 event_type="Event Participants",
                 custom_group_title=f"{old_status}-{self.localhost}-Localhost",
-                subscribe_to_chapter=False,
-                subscribe_to_event=False,  # Remove
+                subscribe_to_chapter=self.subscribe_chapter_mailing,
+                subscribe_to_event=False,
                 document_type_event=HACKATHON_LOCALHOST,
             )
 
-        # ADD to current status group
-        handle_email_group_subscription(
-            emails=[self.email],
-            chapter=event_doc.chapter,
-            event=self.localhost,
-            event_type="Event Participants",
-            custom_group_title=f"{current_status}-{self.localhost}-Localhost",
-            subscribe_to_chapter=self.subscribe_chapter_mailing,
-            subscribe_to_event=True,
-            document_type_event=HACKATHON_LOCALHOST,
-        )
+        # ADD to new group
+        if new_status:
+            handle_email_group_subscription(
+                emails=[self.email],
+                chapter=event_doc.chapter,
+                event=self.localhost,
+                event_type="Event Participants",
+                custom_group_title=f"{new_status}-{self.localhost}-Localhost",
+                subscribe_to_chapter=self.subscribe_chapter_mailing,
+                subscribe_to_event=True,
+                document_type_event=HACKATHON_LOCALHOST,
+            )
 
     def remove_from_all_localhost_groups(self, localhost_id=None):
         """Remove participant from all localhost status groups
@@ -194,7 +193,7 @@ class FOSSHackathonParticipant(Document):
                     event=target_localhost,
                     event_type="Event Participants",
                     custom_group_title=f"{status}-{target_localhost}-Localhost",
-                    subscribe_to_chapter=False,
+                    subscribe_to_chapter=self.subscribe_chapter_mailing,
                     subscribe_to_event=False,
                     document_type_event=HACKATHON_LOCALHOST,
                 )
@@ -267,8 +266,22 @@ class FOSSHackathonParticipant(Document):
 
     @frappe.whitelist()
     def add_check_in(self):
-        return add_checkin(self)
+        # Add to email group BEFORE saving
+        if self.localhost:
+            checkin_date = frappe.utils.nowdate()
+            self.sync_localhost_status_groups(new_status=f"Checkin-{checkin_date}")
+
+        # Then add the check-in
+        result = add_checkin(self)
+        return result
 
     @frappe.whitelist()
     def remove_today_check_in(self):
-        return remove_today_checkin(self)
+        # Remove from email group BEFORE saving
+        if self.localhost:
+            checkin_date = frappe.utils.nowdate()
+            self.sync_localhost_status_groups(old_status=f"Checkin-{checkin_date}")
+
+        # Then remove the check-in
+        result = remove_today_checkin(self)
+        return result

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/test_foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/test_foss_hackathon_participant.py
@@ -97,7 +97,17 @@ class TestFOSSHackathonParticipant(FrappeTestCase):
             ["Pending Confirmation", "Accepted", "Rejected"], participant.email
         )
 
-        # Test 6: Delete participant - should remove from all groups
+        # Test 6a: Checkin group for the day
+        participant.add_check_in()
+        participant.save()
+        self._assert_in_group(f"Checkin-{frappe.utils.nowdate()}", participant.email)
+
+        # Test 6b: Checkin removed for the day
+        participant.remove_today_check_in()
+        participant.save()
+        self._assert_not_in_groups([f"Checkin-{frappe.utils.nowdate()}"], participant.email)
+
+        # Test 7: Delete participant - should remove from all groups
         participant.delete()
         self._assert_not_in_groups(
             ["Pending", "Pending Confirmation", "Accepted", "Rejected"],

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/templates/foss_hackathon_partner_project.html
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/templates/foss_hackathon_partner_project.html
@@ -22,7 +22,7 @@
                 class="bg-white"
                 src="{{ doc.logo }}"
                 alt="{{ doc.project_name }}"
-                style="width:120px;height:120px;border-radius:0.75rem;border:1px solid var(--v3-button-border);object-fit:cover;"
+                style="width:120px;height:120px;border-radius:0.75rem;border:1px solid var(--v3-button-border);object-fit:contain;"
               />
             </div>
           {% endif %}


### PR DESCRIPTION
- We've function that can add or remove, so we can reuse that and plug it to checkin function so user is added to the date's checkin group

- test to make sure it works as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated rate-limit message to advise a one-hour retry window.
  * Improved error surfacing for team creation and user info failures.
  * Fixed localhost email group labeling so group names display more intuitively.

* **New Features**
  * Better participant status sync that tracks daily check-ins and updates email group membership accordingly.

* **Style**
  * Project logo now scales to fit its box without clipping.

* **Tests**
  * Added intermediate checks for daily check-in group membership in participant tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->