### PR TITLE
feat(profile): add projects section to user profile

### DIFF
--- a/dashboard/src/pages/MyProfile.vue
+++ b/dashboard/src/pages/MyProfile.vue
@@ -620,6 +620,7 @@ const validateProject = (p) => {
 
 const openAddProject = () => {
   Object.assign(newProject, emptyProject())
+  editingProject.value = null
   projectErrors.value = ''
   showAddProject.value = true
 }
@@ -643,6 +644,7 @@ const handleAddProject = () => {
 }
 
 const startEditProject = (project) => {
+  showAddProject.value = false
   editingProject.value = { ...project }
   projectErrors.value = ''
 }

--- a/dashboard/src/pages/MyProfile.vue
+++ b/dashboard/src/pages/MyProfile.vue
@@ -187,22 +187,17 @@
             <FormControl v-model="profileDoc.doc.medium" type="url" label="Medium" />
             <FormControl v-model="profileDoc.doc.mastodon" type="url" label="Mastodon" />
             <FormControl v-model="profileDoc.doc.bluesky" type="url" label="Bluesky" />
-            <ErrorMessage class="col-span-2" :message="updateErrors" />
-            <div class="hidden md:block"></div>
-            <div class="flex justify-end">
-              <Button
-                :variant="'solid'"
-                :size="'md'"
-                :theme="'green'"
-                label="Save"
-                class="w-full md:w-2/3"
-                @click="handleUpdateProfile()"
-              />
-            </div>
-
             <!-- Projects -->
-            <div class="col-span-2 py-1 border-b mt-2">
+            <div class="col-span-2 py-1 border-b mt-2 flex items-center justify-between">
               <h4 class="text-md font-medium uppercase">Projects</h4>
+              <Button
+                v-if="!showAddProject"
+                variant="outline"
+                size="sm"
+                icon="plus"
+                label="Add Project"
+                @click="openAddProject()"
+              />
             </div>
             <div class="col-span-2 text-sm text-ink-gray-5">
               Add your open-source or personal projects to showcase on your profile.
@@ -327,14 +322,15 @@
               <ErrorMessage :message="projectErrors" />
             </div>
 
-            <div class="col-span-2">
+            <ErrorMessage class="col-span-2" :message="updateErrors" />
+            <div class="col-span-2 flex justify-end">
               <Button
-                v-if="!showAddProject"
-                variant="outline"
-                size="sm"
-                icon="plus"
-                label="Add Project"
-                @click="openAddProject()"
+                :variant="'solid'"
+                :size="'md'"
+                :theme="'green'"
+                label="Save"
+                class="w-full md:w-1/3"
+                @click="handleUpdateProfile()"
               />
             </div>
           </div>

--- a/dashboard/src/pages/MyProfile.vue
+++ b/dashboard/src/pages/MyProfile.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex">
     <div class="w-full">
-      <div v-if="profile.data" class="w-full">
+      <div v-if="profileDoc?.doc" class="w-full">
         <div class="prose p-4 pb-0">
           <h2 class="mb-1">My Profile</h2>
           <p class="text-sm mb-4">Edit your profile details</p>
@@ -11,7 +11,7 @@
             <img
               class="w-full aspect-[4.96/1]"
               :src="
-                profile.data.cover_image ||
+                profileDoc.doc.cover_image ||
                 '/assets/fossunited/images/defaults/user_profile_banner.png'
               "
               alt="Banner Image"
@@ -35,7 +35,7 @@
                 </template>
               </FileUploader>
               <Button
-                v-if="profile.data.cover_image"
+                v-if="profileDoc.doc.cover_image"
                 icon="trash"
                 variant="solid"
                 theme="red"
@@ -50,7 +50,7 @@
             <img
               class="aspect-square border-4 border-white rounded w-28"
               :src="
-                profile.data.profile_photo ||
+                profileDoc.doc.profile_photo ||
                 '/assets/fossunited/images/defaults/user_profile_image.png'
               "
               alt="Profile Photo"
@@ -76,7 +76,7 @@
           </div>
           <div class="flex flex-col md:grid md:grid-cols-2 gap-4 my-2 p-6">
             <Switch
-              v-model="profile.data.is_private"
+              v-model="profileDoc.doc.is_private"
               size="sm"
               label="Make Profile Private"
               description="Enabling this will make your profile unavailable to others. You will still be able to do the tasks that require profile creation."
@@ -85,7 +85,7 @@
               @click="toggleProfilePrivacy()"
             />
             <Switch
-              v-model="profile.data.show_activity"
+              v-model="profileDoc.doc.show_activity"
               size="sm"
               label="Show Community Activity"
               description="Enabling this will allow others to view which FOSS United events you have attended till date."
@@ -97,19 +97,19 @@
               <h4 class="text-md font-medium uppercase">Basic Details</h4>
             </div>
             <FormControl
-              v-model="profile_dict.full_name"
+              v-model="profileDoc.doc.full_name"
               label="Full Name &ast;"
               placeholder="Enter your full name"
             />
             <FormControl
-              v-model="profile_dict.user"
+              v-model="profileDoc.doc.user"
               label="Email &ast;"
               placeholder="Enter your email"
               disabled
             />
             <div>
               <FormControl
-                v-model="profile_dict.username"
+              v-model="profileDoc.doc.username"
                 label="Username &ast;"
                 placeholder="Enter your username"
               />
@@ -122,9 +122,9 @@
                 </div>
                 <div
                   v-else-if="
-                    profile_dict.username &&
+                    profileDoc.doc.username &&
                     !usernameValidateErrors &&
-                    profile_dict.username !== initialUsername
+                    profileDoc.doc.username !== initialUsername
                   "
                   class="flex"
                 >
@@ -137,7 +137,7 @@
               <ErrorMessage :message="usernameValidateErrors" class="mt-2" />
             </div>
             <FormControl
-              v-model="profile_dict.cfp_visibility"
+              v-model="profileDoc.doc.cfp_visibility"
               type="select"
               :options="[
                 {
@@ -157,17 +157,17 @@
               description="Chose who all can see the CFP Proposals you have made till date"
             />
             <FormControl
-              v-model="profile_dict.bio"
+              v-model="profileDoc.doc.bio"
               label="Short Tagline"
               description="A short tagline about yourself"
             />
-            <FormControl v-model="profile_dict.current_city" label="Current City" />
+            <FormControl v-model="profileDoc.doc.current_city" label="Current City" />
             <TextEditor
               label="About"
               class="col-span-2"
               placeholder="Tell more about yourself here."
-              :model-value="profile_dict.about"
-              @update:model-value="profile_dict.about = $event"
+              :model-value="profileDoc.doc.about"
+              @update:model-value="profileDoc.doc.about = $event"
             />
             <div class="col-span-2 py-1 border-b">
               <h4 class="text-md font-medium uppercase">SOCIAL Links</h4>
@@ -176,17 +176,17 @@
               Enter the complete links to your social, including
               <code>http(s)://</code>
             </div>
-            <FormControl v-model="profile_dict.website" type="url" label="Website" />
-            <FormControl v-model="profile_dict.x" type="url" label="Twitter / X" />
-            <FormControl v-model="profile_dict.linkedin" type="url" label="LinkedIn" />
-            <FormControl v-model="profile_dict.github" type="url" label="GitHub" />
-            <FormControl v-model="profile_dict.gitlab" type="url" label="GitLab" />
-            <FormControl v-model="profile_dict.instagram" type="url" label="Instagram" />
-            <FormControl v-model="profile_dict.youtube" type="url" label="YouTube" />
-            <FormControl v-model="profile_dict.devto" type="url" label="Dev.to" />
-            <FormControl v-model="profile_dict.medium" type="url" label="Medium" />
-            <FormControl v-model="profile_dict.mastodon" type="url" label="Mastodon" />
-            <FormControl v-model="profile_dict.bluesky" type="url" label="Bluesky" />
+            <FormControl v-model="profileDoc.doc.website" type="url" label="Website" />
+            <FormControl v-model="profileDoc.doc.x" type="url" label="Twitter / X" />
+            <FormControl v-model="profileDoc.doc.linkedin" type="url" label="LinkedIn" />
+            <FormControl v-model="profileDoc.doc.github" type="url" label="GitHub" />
+            <FormControl v-model="profileDoc.doc.gitlab" type="url" label="GitLab" />
+            <FormControl v-model="profileDoc.doc.instagram" type="url" label="Instagram" />
+            <FormControl v-model="profileDoc.doc.youtube" type="url" label="YouTube" />
+            <FormControl v-model="profileDoc.doc.devto" type="url" label="Dev.to" />
+            <FormControl v-model="profileDoc.doc.medium" type="url" label="Medium" />
+            <FormControl v-model="profileDoc.doc.mastodon" type="url" label="Mastodon" />
+            <FormControl v-model="profileDoc.doc.bluesky" type="url" label="Bluesky" />
             <ErrorMessage class="col-span-2" :message="updateErrors" />
             <div class="hidden md:block"></div>
             <div class="flex justify-end">
@@ -264,6 +264,12 @@
                     placeholder="A short description"
                     class="md:col-span-2"
                   />
+                  <FormControl
+                    v-model="editingProject.cover_image"
+                    label="Cover Image URL (optional)"
+                    placeholder="https://..."
+                    class="md:col-span-2"
+                  />
                 </div>
                 <div class="flex gap-2 justify-end">
                   <Button variant="outline" size="sm" label="Cancel" @click="cancelEditProject()" />
@@ -298,6 +304,12 @@
                   v-model="newProject.tagline"
                   label="Tagline *"
                   placeholder="A short description"
+                  class="md:col-span-2"
+                />
+                <FormControl
+                  v-model="newProject.cover_image"
+                  label="Cover Image URL (optional)"
+                  placeholder="https://..."
                   class="md:col-span-2"
                 />
               </div>
@@ -339,36 +351,12 @@ import { isValidUrl } from '@/helpers/utils'
 
 import { reactive, ref, watch, computed } from 'vue'
 import { toast } from 'vue-sonner'
-const profile_dict = reactive({
-  full_name: '',
-  user: '',
-  username: '',
-  bio: '',
-  cfp_visibility: '',
-  current_city: '',
-  about: '',
-  website: '',
-  x: '',
-  linkedin: '',
-  github: '',
-  gitlab: '',
-  instagram: '',
-  youtube: '',
-  devto: '',
-  medium: '',
-  mastodon: '',
-  bluesky: '',
-})
-
 const profileDoc = ref(null)
 
 const profile = createResource({
   url: 'fossunited.api.dashboard.get_session_user_profile',
   auto: true,
   onSuccess(data) {
-    Object.keys(profile_dict).forEach((key) => {
-      profile_dict[key] = data[key]
-    })
     profileDoc.value = createDocumentResource({
       doctype: 'FOSS User Profile',
       name: data.name,
@@ -402,7 +390,7 @@ const setBannerImage = (_file) => {
       } else {
         toast.success('Banner Image Removed')
       }
-      profile.fetch()
+      profileDoc.value.get.submit()
     },
   })
 }
@@ -417,7 +405,7 @@ const setProfileImage = (_file) => {
     },
     auto: true,
     onSuccess() {
-      profile.fetch()
+      profileDoc.value.get.submit()
       toast.success('Profile Image Updated')
     },
     onError(err) {
@@ -428,14 +416,12 @@ const setProfileImage = (_file) => {
 
 const toggleProfilePrivacy = () => {
   profileDoc.value.setValue.submit({ is_private: !profileDoc.value.doc.is_private }).then(() => {
-    profile.fetch()
     toast.info(profileDoc.value.doc.is_private ? 'Profile is now private' : 'Profile is now public')
   })
 }
 
 const toggleShowActivity = () => {
   profileDoc.value.setValue.submit({ show_activity: !profileDoc.value.doc.show_activity }).then(() => {
-    profile.fetch()
     toast.info(
       profileDoc.value.doc.show_activity
         ? 'Community Activity will be shown on your profile page now'
@@ -448,25 +434,15 @@ const updateErrors = ref('')
 
 const updateProfileErrors = () => {
   const errors = []
-  if (!profile_dict.full_name.trim()) errors.push('\nFull Name is required')
-  if (!profile_dict.username.trim()) errors.push('\nUsername is required')
-  if (!profile_dict.user.trim()) errors.push('\nEmail is required')
+  const doc = profileDoc.value?.doc
+  if (!doc) return errors
+  if (!doc.full_name?.trim()) errors.push('\nFull Name is required')
+  if (!doc.username?.trim()) errors.push('\nUsername is required')
+  if (!doc.user?.trim()) errors.push('\nEmail is required')
 
-  const socials = {
-    website: profile_dict.website,
-    x: profile_dict.x,
-    linkedin: profile_dict.linkedin,
-    github: profile_dict.github,
-    gitlab: profile_dict.gitlab,
-    instagram: profile_dict.instagram,
-    youtube: profile_dict.youtube,
-    devto: profile_dict.devto,
-    medium: profile_dict.medium,
-    mastodon: profile_dict.mastodon,
-    bluesky: profile_dict.bluesky,
-  }
-  Object.keys(socials).forEach((key) => {
-    const url = socials[key]
+  const socials = ['website', 'x', 'linkedin', 'github', 'gitlab', 'instagram', 'youtube', 'devto', 'medium', 'mastodon', 'bluesky']
+  socials.forEach((key) => {
+    const url = doc[key]
     if (url && !isValidUrl(url)) {
       errors.push(`\n${key} is not a valid url`)
     }
@@ -474,7 +450,7 @@ const updateProfileErrors = () => {
   return errors
 }
 
-const initialUsername = computed(() => profile.data?.username ?? '')
+const initialUsername = computed(() => profileDoc.value?.doc?.username ?? '')
 const usernameValidateErrors = ref('')
 
 const getUsernameErrors = () => {
@@ -484,17 +460,18 @@ const getUsernameErrors = () => {
     'Username can only contain letters, numbers, underscores and dots.',
     'Username cannot end with extensions like .txt, .html, etc.',
   ]
-  if (!profile_dict.username) {
+  const username = profileDoc.value?.doc?.username
+  if (!username) {
     _errors.push('Username is required')
     return _errors
   }
-  if (profile_dict.username.length < 3 || profile_dict.username.length > 30) {
+  if (username.length < 3 || username.length > 30) {
     _errors.push(messages[0])
   }
-  if (!/^[a-zA-Z0-9_\.]+$/.test(profile_dict.username)) {
+  if (!/^[a-zA-Z0-9_\.]+$/.test(username)) {
     _errors.push(messages[1])
   }
-  if (/\.(txt|html|php|js|json|xml|css|htm)$/i.test(profile_dict.username)) {
+  if (/\.(txt|html|php|js|json|xml|css|htm)$/i.test(username)) {
     _errors.push(messages[2])
   }
   return _errors
@@ -505,7 +482,7 @@ const validateUsername = async () => {
 
   if (errors.length !== 0) {
     usernameValidateErrors.value = errors.join(', ')
-  } else if (profile_dict.username !== initialUsername.value) {
+  } else if (profileDoc.value?.doc?.username !== initialUsername.value) {
     usernameValidateErrors.value = ''
     try {
       await isValidUsername.fetch()
@@ -524,10 +501,10 @@ const validateUsername = async () => {
 }
 
 watch(
-  () => profile_dict.username,
+  () => profileDoc.value?.doc?.username,
   (newValue) => {
     usernameValidateErrors.value = ''
-    if (newValue.trim() !== '') {
+    if (newValue?.trim()) {
       validateUsername()
     }
   },
@@ -537,25 +514,9 @@ const isValidUsername = createResource({
   url: 'fossunited.api.profile.is_valid_username',
   makeParams() {
     return {
-      username: profile_dict.username,
-      id: profile.data.name,
+      username: profileDoc.value?.doc?.username,
+      id: profileDoc.value?.doc?.name,
     }
-  },
-})
-
-const updateProfile = createResource({
-  url: 'fossunited.api.profile.update_profile',
-  makeParams() {
-    return {
-      fields_dict: profile_dict,
-    }
-  },
-  onSuccess() {
-    toast.success('Profile Updated Successfully')
-    profile.fetch()
-  },
-  onError(err) {
-    toast.error('Error updating profile: ' + err.messages)
   },
 })
 
@@ -569,7 +530,10 @@ const handleUpdateProfile = () => {
   if (usernameValidateErrors.value) {
     return
   }
-  updateProfile.fetch()
+  profileDoc.value.save
+    .submit()
+    .then(() => toast.success('Profile Updated Successfully'))
+    .catch((err) => toast.error('Error updating profile: ' + (err?.message || '')))
 }
 
 

--- a/dashboard/src/pages/MyProfile.vue
+++ b/dashboard/src/pages/MyProfile.vue
@@ -187,6 +187,19 @@
             <FormControl v-model="profileDoc.doc.medium" type="url" label="Medium" />
             <FormControl v-model="profileDoc.doc.mastodon" type="url" label="Mastodon" />
             <FormControl v-model="profileDoc.doc.bluesky" type="url" label="Bluesky" />
+            <ErrorMessage class="col-span-2" :message="updateErrors" />
+            <div class="hidden md:block"></div>
+            <div class="flex justify-end">
+              <Button
+                :variant="'solid'"
+                :size="'md'"
+                :theme="'green'"
+                label="Save"
+                class="w-full md:w-2/3"
+                @click="handleUpdateProfile()"
+              />
+            </div>
+
             <!-- Projects -->
             <div class="col-span-2 py-1 border-b mt-2 flex items-center justify-between">
               <h4 class="text-md font-medium uppercase">Projects</h4>
@@ -266,6 +279,7 @@
                     class="md:col-span-2"
                   />
                 </div>
+                <ErrorMessage :message="projectErrors" />
                 <div class="flex gap-2 justify-end">
                   <Button variant="outline" size="sm" label="Cancel" @click="cancelEditProject()" />
                   <Button
@@ -277,7 +291,6 @@
                     @click="saveEditProject()"
                   />
                 </div>
-                <ErrorMessage :message="projectErrors" />
               </div>
             </div>
 
@@ -308,6 +321,7 @@
                   class="md:col-span-2"
                 />
               </div>
+              <ErrorMessage :message="projectErrors" />
               <div class="flex gap-2 justify-end">
                 <Button variant="outline" size="sm" label="Cancel" @click="showAddProject = false" />
                 <Button
@@ -319,20 +333,9 @@
                   @click="handleAddProject()"
                 />
               </div>
-              <ErrorMessage :message="projectErrors" />
             </div>
 
-            <ErrorMessage class="col-span-2" :message="updateErrors" />
-            <div class="col-span-2 flex justify-end">
-              <Button
-                :variant="'solid'"
-                :size="'md'"
-                :theme="'green'"
-                label="Save"
-                class="w-full md:w-1/3"
-                @click="handleUpdateProfile()"
-              />
-            </div>
+            <!-- bottom of form: no lonely Add Project button needed here -->
           </div>
         </div>
       </div>

--- a/dashboard/src/pages/MyProfile.vue
+++ b/dashboard/src/pages/MyProfile.vue
@@ -335,6 +335,7 @@
 import TextEditor from '@/components/ui/TextEditor.vue'
 import { IconCheck } from '@tabler/icons-vue'
 import { createResource, createDocumentResource, FileUploader, Switch, FormControl, ErrorMessage } from 'frappe-ui'
+import { isValidUrl } from '@/helpers/utils'
 
 import { reactive, ref, watch, computed } from 'vue'
 import { toast } from 'vue-sonner'
@@ -426,55 +427,24 @@ const setProfileImage = (_file) => {
 }
 
 const toggleProfilePrivacy = () => {
-  createResource({
-    url: 'fossunited.api.profile.toggle_profile_privacy',
-    makeParams() {
-      return {
-        value: profile.data.is_private,
-      }
-    },
-    auto: true,
-    onSuccess() {
-      if (profile.data.is_private) {
-        toast.info('Profile is now private')
-      } else {
-        toast.info('Profile is now public')
-      }
-      profile.fetch()
-    },
+  profileDoc.value.setValue.submit({ is_private: !profileDoc.value.doc.is_private }).then(() => {
+    profile.fetch()
+    toast.info(profileDoc.value.doc.is_private ? 'Profile is now private' : 'Profile is now public')
   })
 }
 
 const toggleShowActivity = () => {
-  createResource({
-    url: 'fossunited.api.profile.toggle_show_activity',
-    makeParams() {
-      return {
-        value: profile.data.show_activity,
-      }
-    },
-    auto: true,
-    onSuccess() {
-      if (profile.data.show_activity) {
-        toast.info('Community Activity will be shown on your profile page now')
-      } else {
-        toast.info("Community Activity won't be shown on your profile page now")
-      }
-      profile.fetch()
-    },
+  profileDoc.value.setValue.submit({ show_activity: !profileDoc.value.doc.show_activity }).then(() => {
+    profile.fetch()
+    toast.info(
+      profileDoc.value.doc.show_activity
+        ? 'Community Activity will be shown on your profile page now'
+        : "Community Activity won't be shown on your profile page now",
+    )
   })
 }
 
 const updateErrors = ref('')
-
-const isValidUrl = (url) => {
-  try {
-    const parsed = new URL(url)
-    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
-  } catch (_) {
-    return false
-  }
-}
 
 const updateProfileErrors = () => {
   const errors = []

--- a/dashboard/src/pages/MyProfile.vue
+++ b/dashboard/src/pages/MyProfile.vue
@@ -626,6 +626,7 @@ const openAddProject = () => {
 }
 
 const handleAddProject = () => {
+  if (!profileDoc.value?.doc) return
   const err = validateProject(newProject)
   if (err) { projectErrors.value = err; return }
   projectErrors.value = ''
@@ -655,6 +656,7 @@ const cancelEditProject = () => {
 }
 
 const saveEditProject = () => {
+  if (!profileDoc.value?.doc) return
   const err = validateProject(editingProject.value)
   if (err) { projectErrors.value = err; return }
   projectErrors.value = ''
@@ -673,6 +675,7 @@ const saveEditProject = () => {
 }
 
 const deleteProject = (rowName) => {
+  if (!profileDoc.value?.doc) return
   if (!confirm('Delete this project?')) return
   profileDoc.value.doc.projects = profileDoc.value.doc.projects.filter((p) => p.name !== rowName)
   profileDoc.value.save

--- a/dashboard/src/pages/MyProfile.vue
+++ b/dashboard/src/pages/MyProfile.vue
@@ -199,6 +199,132 @@
                 @click="handleUpdateProfile()"
               />
             </div>
+
+            <!-- Projects -->
+            <div class="col-span-2 py-1 border-b mt-2">
+              <h4 class="text-md font-medium uppercase">Projects</h4>
+            </div>
+            <div class="col-span-2 text-sm text-ink-gray-5">
+              Add your open-source or personal projects to showcase on your profile.
+            </div>
+
+            <!-- existing project cards -->
+            <div
+              v-for="project in projects"
+              :key="project.name"
+              class="col-span-2 border rounded-lg p-4 flex flex-col gap-3"
+            >
+              <div v-if="editingProject?.name !== project.name" class="flex justify-between items-start gap-2">
+                <div class="flex-1 min-w-0">
+                  <p class="font-medium truncate">{{ project.project_name }}</p>
+                  <p class="text-sm text-ink-gray-5 truncate">{{ project.tagline }}</p>
+                  <a
+                    :href="project.project_link"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-sm text-ink-blue-3 hover:underline break-all"
+                  >{{ project.project_link }}</a>
+                </div>
+                <div class="flex gap-1 shrink-0">
+                  <Button
+                    icon="edit-3"
+                    variant="ghost"
+                    size="sm"
+                    :title="`Edit ${project.project_name}`"
+                    @click="startEditProject(project)"
+                  />
+                  <Button
+                    icon="trash"
+                    variant="ghost"
+                    size="sm"
+                    theme="red"
+                    :title="`Delete ${project.project_name}`"
+                    @click="deleteProject(project.name)"
+                  />
+                </div>
+              </div>
+
+              <!-- inline edit form -->
+              <div v-else class="flex flex-col gap-3">
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+                  <FormControl
+                    v-model="editingProject.project_name"
+                    label="Project Name *"
+                    placeholder="My Awesome Project"
+                  />
+                  <FormControl
+                    v-model="editingProject.project_link"
+                    label="Project Link *"
+                    type="url"
+                    placeholder="https://github.com/..."
+                  />
+                  <FormControl
+                    v-model="editingProject.tagline"
+                    label="Tagline *"
+                    placeholder="A short description"
+                    class="md:col-span-2"
+                  />
+                </div>
+                <div class="flex gap-2 justify-end">
+                  <Button variant="outline" size="sm" label="Cancel" @click="cancelEditProject()" />
+                  <Button
+                    variant="solid"
+                    size="sm"
+                    theme="green"
+                    label="Save"
+                    :loading="isSavingProject"
+                    @click="saveEditProject()"
+                  />
+                </div>
+                <ErrorMessage :message="projectErrors" />
+              </div>
+            </div>
+
+            <!-- add new project form -->
+            <div v-if="showAddProject" class="col-span-2 border rounded-lg p-4 flex flex-col gap-3">
+              <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+                <FormControl
+                  v-model="newProject.project_name"
+                  label="Project Name *"
+                  placeholder="My Awesome Project"
+                />
+                <FormControl
+                  v-model="newProject.project_link"
+                  label="Project Link *"
+                  type="url"
+                  placeholder="https://github.com/..."
+                />
+                <FormControl
+                  v-model="newProject.tagline"
+                  label="Tagline *"
+                  placeholder="A short description"
+                  class="md:col-span-2"
+                />
+              </div>
+              <div class="flex gap-2 justify-end">
+                <Button variant="outline" size="sm" label="Cancel" @click="showAddProject = false" />
+                <Button
+                  variant="solid"
+                  size="sm"
+                  theme="green"
+                  label="Add Project"
+                  :loading="isSavingProject"
+                  @click="handleAddProject()"
+                />
+              </div>
+              <ErrorMessage :message="projectErrors" />
+            </div>
+
+            <div class="col-span-2">
+              <Button
+                v-if="!showAddProject"
+                variant="outline"
+                size="sm"
+                icon="plus"
+                label="Add Project"
+                @click="openAddProject()"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -212,7 +338,6 @@ import { createResource, FileUploader, Switch, FormControl, ErrorMessage } from 
 
 import { reactive, ref, watch, computed } from 'vue'
 import { toast } from 'vue-sonner'
-
 const profile_dict = reactive({
   full_name: '',
   user: '',
@@ -467,5 +592,134 @@ const handleUpdateProfile = () => {
     return
   }
   updateProfile.fetch()
+}
+
+
+const projects = ref([])
+const showAddProject = ref(false)
+const isSavingProject = ref(false)
+const projectErrors = ref('')
+
+const emptyProject = () => ({ project_name: '', project_link: '', tagline: '', cover_image: '' })
+const newProject = reactive(emptyProject())
+const editingProject = ref(null)
+
+const projectsResource = createResource({
+  url: 'fossunited.api.profile.get_profile_projects',
+  auto: true,
+  onSuccess(data) {
+    projects.value = data
+  },
+})
+
+const validateProject = (p) => {
+  if (!p.project_name?.trim()) return 'Project Name is required'
+  if (!p.project_link?.trim()) return 'Project Link is required'
+  if (!p.tagline?.trim()) return 'Tagline is required'
+  try {
+    const u = new URL(p.project_link)
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') throw new Error()
+  } catch {
+    return 'Project Link must be a valid URL'
+  }
+  return ''
+}
+
+const openAddProject = () => {
+  Object.assign(newProject, emptyProject())
+  projectErrors.value = ''
+  showAddProject.value = true
+}
+
+const handleAddProject = async () => {
+  const err = validateProject(newProject)
+  if (err) { projectErrors.value = err; return }
+  projectErrors.value = ''
+  isSavingProject.value = true
+  try {
+    await createResource({
+      url: 'fossunited.api.profile.add_profile_project',
+      makeParams() {
+        return {
+          project_name: newProject.project_name,
+          project_link: newProject.project_link,
+          tagline: newProject.tagline,
+          cover_image: newProject.cover_image,
+        }
+      },
+      auto: true,
+      onSuccess(data) {
+        projects.value.push(data)
+        showAddProject.value = false
+        toast.success('Project added')
+      },
+      onError(e) {
+        projectErrors.value = e?.messages?.[0] || 'Failed to add project'
+      },
+    })
+  } finally {
+    isSavingProject.value = false
+  }
+}
+
+const startEditProject = (project) => {
+  editingProject.value = { ...project }
+  projectErrors.value = ''
+}
+
+const cancelEditProject = () => {
+  editingProject.value = null
+  projectErrors.value = ''
+}
+
+const saveEditProject = async () => {
+  const err = validateProject(editingProject.value)
+  if (err) { projectErrors.value = err; return }
+  projectErrors.value = ''
+  isSavingProject.value = true
+  try {
+    await createResource({
+      url: 'fossunited.api.profile.update_profile_project',
+      makeParams() {
+        return {
+          row_name: editingProject.value.name,
+          project_name: editingProject.value.project_name,
+          project_link: editingProject.value.project_link,
+          tagline: editingProject.value.tagline,
+          cover_image: editingProject.value.cover_image,
+        }
+      },
+      auto: true,
+      onSuccess() {
+        const idx = projects.value.findIndex((p) => p.name === editingProject.value.name)
+        if (idx !== -1) projects.value[idx] = { ...editingProject.value }
+        editingProject.value = null
+        toast.success('Project updated')
+      },
+      onError(e) {
+        projectErrors.value = e?.messages?.[0] || 'Failed to update project'
+      },
+    })
+  } finally {
+    isSavingProject.value = false
+  }
+}
+
+const deleteProject = async (rowName) => {
+  if (!confirm('Delete this project?')) return
+  try {
+    await createResource({
+      url: 'fossunited.api.profile.delete_profile_project',
+      makeParams() { return { row_name: rowName } },
+      auto: true,
+      onSuccess() {
+        projects.value = projects.value.filter((p) => p.name !== rowName)
+        toast.success('Project deleted')
+      },
+      onError(e) {
+        toast.error(e?.messages?.[0] || 'Failed to delete project')
+      },
+    })
+  } catch (_) { /* handled in onError */ }
 }
 </script>

--- a/dashboard/src/pages/MyProfile.vue
+++ b/dashboard/src/pages/MyProfile.vue
@@ -210,7 +210,7 @@
 
             <!-- existing project cards -->
             <div
-              v-for="project in projects"
+              v-for="project in (profileDoc?.doc?.projects ?? [])"
               :key="project.name"
               class="col-span-2 border rounded-lg p-4 flex flex-col gap-3"
             >
@@ -272,7 +272,7 @@
                     size="sm"
                     theme="green"
                     label="Save"
-                    :loading="isSavingProject"
+                    :loading="profileDoc?.save?.loading"
                     @click="saveEditProject()"
                   />
                 </div>
@@ -308,7 +308,7 @@
                   size="sm"
                   theme="green"
                   label="Add Project"
-                  :loading="isSavingProject"
+                  :loading="profileDoc?.save?.loading"
                   @click="handleAddProject()"
                 />
               </div>
@@ -334,7 +334,7 @@
 <script setup>
 import TextEditor from '@/components/ui/TextEditor.vue'
 import { IconCheck } from '@tabler/icons-vue'
-import { createResource, FileUploader, Switch, FormControl, ErrorMessage } from 'frappe-ui'
+import { createResource, createDocumentResource, FileUploader, Switch, FormControl, ErrorMessage } from 'frappe-ui'
 
 import { reactive, ref, watch, computed } from 'vue'
 import { toast } from 'vue-sonner'
@@ -359,12 +359,20 @@ const profile_dict = reactive({
   bluesky: '',
 })
 
+const profileDoc = ref(null)
+
 const profile = createResource({
   url: 'fossunited.api.dashboard.get_session_user_profile',
   auto: true,
   onSuccess(data) {
     Object.keys(profile_dict).forEach((key) => {
       profile_dict[key] = data[key]
+    })
+    profileDoc.value = createDocumentResource({
+      doctype: 'FOSS User Profile',
+      name: data.name,
+      fields: ['*'],
+      auto: true,
     })
   },
 })
@@ -595,33 +603,17 @@ const handleUpdateProfile = () => {
 }
 
 
-const projects = ref([])
 const showAddProject = ref(false)
-const isSavingProject = ref(false)
 const projectErrors = ref('')
 
 const emptyProject = () => ({ project_name: '', project_link: '', tagline: '', cover_image: '' })
 const newProject = reactive(emptyProject())
 const editingProject = ref(null)
 
-const projectsResource = createResource({
-  url: 'fossunited.api.profile.get_profile_projects',
-  auto: true,
-  onSuccess(data) {
-    projects.value = data
-  },
-})
-
 const validateProject = (p) => {
   if (!p.project_name?.trim()) return 'Project Name is required'
   if (!p.project_link?.trim()) return 'Project Link is required'
   if (!p.tagline?.trim()) return 'Tagline is required'
-  try {
-    const u = new URL(p.project_link)
-    if (u.protocol !== 'http:' && u.protocol !== 'https:') throw new Error()
-  } catch {
-    return 'Project Link must be a valid URL'
-  }
   return ''
 }
 
@@ -635,27 +627,18 @@ const handleAddProject = () => {
   const err = validateProject(newProject)
   if (err) { projectErrors.value = err; return }
   projectErrors.value = ''
-  isSavingProject.value = true
-  createResource({
-    url: 'fossunited.api.profile.add_profile_project',
-    params: {
-      project_name: newProject.project_name,
-      project_link: newProject.project_link,
-      tagline: newProject.tagline,
-      cover_image: newProject.cover_image,
-    },
-    auto: true,
-    onSuccess(data) {
-      projects.value.push(data)
+  profileDoc.value.doc.projects.push({ ...newProject })
+  profileDoc.value.save
+    .submit()
+    .then(() => {
       showAddProject.value = false
-      isSavingProject.value = false
+      Object.assign(newProject, emptyProject())
       toast.success('Project added')
-    },
-    onError(e) {
-      projectErrors.value = e?.messages?.[0] || 'Failed to add project'
-      isSavingProject.value = false
-    },
-  })
+    })
+    .catch((e) => {
+      profileDoc.value.get.submit()
+      projectErrors.value = e?.message || 'Failed to add project'
+    })
 }
 
 const startEditProject = (project) => {
@@ -672,44 +655,31 @@ const saveEditProject = () => {
   const err = validateProject(editingProject.value)
   if (err) { projectErrors.value = err; return }
   projectErrors.value = ''
-  isSavingProject.value = true
-  createResource({
-    url: 'fossunited.api.profile.update_profile_project',
-    params: {
-      row_name: editingProject.value.name,
-      project_name: editingProject.value.project_name,
-      project_link: editingProject.value.project_link,
-      tagline: editingProject.value.tagline,
-      cover_image: editingProject.value.cover_image,
-    },
-    auto: true,
-    onSuccess() {
-      const idx = projects.value.findIndex((p) => p.name === editingProject.value.name)
-      if (idx !== -1) projects.value[idx] = { ...editingProject.value }
+  const idx = profileDoc.value.doc.projects.findIndex((p) => p.name === editingProject.value.name)
+  if (idx !== -1) Object.assign(profileDoc.value.doc.projects[idx], editingProject.value)
+  profileDoc.value.save
+    .submit()
+    .then(() => {
       editingProject.value = null
-      isSavingProject.value = false
       toast.success('Project updated')
-    },
-    onError(e) {
-      projectErrors.value = e?.messages?.[0] || 'Failed to update project'
-      isSavingProject.value = false
-    },
-  })
+    })
+    .catch((e) => {
+      profileDoc.value.get.submit()
+      projectErrors.value = e?.message || 'Failed to update project'
+    })
 }
 
 const deleteProject = (rowName) => {
   if (!confirm('Delete this project?')) return
-  createResource({
-    url: 'fossunited.api.profile.delete_profile_project',
-    params: { row_name: rowName },
-    auto: true,
-    onSuccess() {
-      projects.value = projects.value.filter((p) => p.name !== rowName)
+  profileDoc.value.doc.projects = profileDoc.value.doc.projects.filter((p) => p.name !== rowName)
+  profileDoc.value.save
+    .submit()
+    .then(() => {
       toast.success('Project deleted')
-    },
-    onError(e) {
-      toast.error(e?.messages?.[0] || 'Failed to delete project')
-    },
-  })
+    })
+    .catch((e) => {
+      profileDoc.value.get.submit()
+      toast.error(e?.message || 'Failed to delete project')
+    })
 }
 </script>

--- a/dashboard/src/pages/MyProfile.vue
+++ b/dashboard/src/pages/MyProfile.vue
@@ -631,35 +631,31 @@ const openAddProject = () => {
   showAddProject.value = true
 }
 
-const handleAddProject = async () => {
+const handleAddProject = () => {
   const err = validateProject(newProject)
   if (err) { projectErrors.value = err; return }
   projectErrors.value = ''
   isSavingProject.value = true
-  try {
-    await createResource({
-      url: 'fossunited.api.profile.add_profile_project',
-      makeParams() {
-        return {
-          project_name: newProject.project_name,
-          project_link: newProject.project_link,
-          tagline: newProject.tagline,
-          cover_image: newProject.cover_image,
-        }
-      },
-      auto: true,
-      onSuccess(data) {
-        projects.value.push(data)
-        showAddProject.value = false
-        toast.success('Project added')
-      },
-      onError(e) {
-        projectErrors.value = e?.messages?.[0] || 'Failed to add project'
-      },
-    })
-  } finally {
-    isSavingProject.value = false
-  }
+  createResource({
+    url: 'fossunited.api.profile.add_profile_project',
+    params: {
+      project_name: newProject.project_name,
+      project_link: newProject.project_link,
+      tagline: newProject.tagline,
+      cover_image: newProject.cover_image,
+    },
+    auto: true,
+    onSuccess(data) {
+      projects.value.push(data)
+      showAddProject.value = false
+      isSavingProject.value = false
+      toast.success('Project added')
+    },
+    onError(e) {
+      projectErrors.value = e?.messages?.[0] || 'Failed to add project'
+      isSavingProject.value = false
+    },
+  })
 }
 
 const startEditProject = (project) => {
@@ -672,54 +668,48 @@ const cancelEditProject = () => {
   projectErrors.value = ''
 }
 
-const saveEditProject = async () => {
+const saveEditProject = () => {
   const err = validateProject(editingProject.value)
   if (err) { projectErrors.value = err; return }
   projectErrors.value = ''
   isSavingProject.value = true
-  try {
-    await createResource({
-      url: 'fossunited.api.profile.update_profile_project',
-      makeParams() {
-        return {
-          row_name: editingProject.value.name,
-          project_name: editingProject.value.project_name,
-          project_link: editingProject.value.project_link,
-          tagline: editingProject.value.tagline,
-          cover_image: editingProject.value.cover_image,
-        }
-      },
-      auto: true,
-      onSuccess() {
-        const idx = projects.value.findIndex((p) => p.name === editingProject.value.name)
-        if (idx !== -1) projects.value[idx] = { ...editingProject.value }
-        editingProject.value = null
-        toast.success('Project updated')
-      },
-      onError(e) {
-        projectErrors.value = e?.messages?.[0] || 'Failed to update project'
-      },
-    })
-  } finally {
-    isSavingProject.value = false
-  }
+  createResource({
+    url: 'fossunited.api.profile.update_profile_project',
+    params: {
+      row_name: editingProject.value.name,
+      project_name: editingProject.value.project_name,
+      project_link: editingProject.value.project_link,
+      tagline: editingProject.value.tagline,
+      cover_image: editingProject.value.cover_image,
+    },
+    auto: true,
+    onSuccess() {
+      const idx = projects.value.findIndex((p) => p.name === editingProject.value.name)
+      if (idx !== -1) projects.value[idx] = { ...editingProject.value }
+      editingProject.value = null
+      isSavingProject.value = false
+      toast.success('Project updated')
+    },
+    onError(e) {
+      projectErrors.value = e?.messages?.[0] || 'Failed to update project'
+      isSavingProject.value = false
+    },
+  })
 }
 
-const deleteProject = async (rowName) => {
+const deleteProject = (rowName) => {
   if (!confirm('Delete this project?')) return
-  try {
-    await createResource({
-      url: 'fossunited.api.profile.delete_profile_project',
-      makeParams() { return { row_name: rowName } },
-      auto: true,
-      onSuccess() {
-        projects.value = projects.value.filter((p) => p.name !== rowName)
-        toast.success('Project deleted')
-      },
-      onError(e) {
-        toast.error(e?.messages?.[0] || 'Failed to delete project')
-      },
-    })
-  } catch (_) { /* handled in onError */ }
+  createResource({
+    url: 'fossunited.api.profile.delete_profile_project',
+    params: { row_name: rowName },
+    auto: true,
+    onSuccess() {
+      projects.value = projects.value.filter((p) => p.name !== rowName)
+      toast.success('Project deleted')
+    },
+    onError(e) {
+      toast.error(e?.messages?.[0] || 'Failed to delete project')
+    },
+  })
 }
 </script>

--- a/dashboard/src/pages/MyProfile.vue
+++ b/dashboard/src/pages/MyProfile.vue
@@ -613,6 +613,7 @@ const editingProject = ref(null)
 const validateProject = (p) => {
   if (!p.project_name?.trim()) return 'Project Name is required'
   if (!p.project_link?.trim()) return 'Project Link is required'
+  if (!isValidUrl(p.project_link)) return 'Project Link must be a valid HTTP(S) URL'
   if (!p.tagline?.trim()) return 'Tagline is required'
   return ''
 }

--- a/dashboard/src/pages/MyProfile.vue
+++ b/dashboard/src/pages/MyProfile.vue
@@ -82,7 +82,7 @@
               description="Enabling this will make your profile unavailable to others. You will still be able to do the tasks that require profile creation."
               aria-label="Make Profile Private"
               title="Make Profile Private"
-              @click="toggleProfilePrivacy()"
+              @update:model-value="toggleProfilePrivacy"
             />
             <Switch
               v-model="profileDoc.doc.show_activity"
@@ -91,7 +91,7 @@
               description="Enabling this will allow others to view which FOSS United events you have attended till date."
               aria-label="Show Community Activity"
               title="Show Community Activity"
-              @click="toggleShowActivity()"
+              @update:model-value="toggleShowActivity"
             />
             <div class="col-span-2 py-1 border-b">
               <h4 class="text-md font-medium uppercase">Basic Details</h4>
@@ -414,16 +414,16 @@ const setProfileImage = (_file) => {
   })
 }
 
-const toggleProfilePrivacy = () => {
-  profileDoc.value.setValue.submit({ is_private: !profileDoc.value.doc.is_private }).then(() => {
-    toast.info(profileDoc.value.doc.is_private ? 'Profile is now private' : 'Profile is now public')
+const toggleProfilePrivacy = (value) => {
+  profileDoc.value.setValue.submit({ is_private: value }).then(() => {
+    toast.info(value ? 'Profile is now private' : 'Profile is now public')
   })
 }
 
-const toggleShowActivity = () => {
-  profileDoc.value.setValue.submit({ show_activity: !profileDoc.value.doc.show_activity }).then(() => {
+const toggleShowActivity = (value) => {
+  profileDoc.value.setValue.submit({ show_activity: value }).then(() => {
     toast.info(
-      profileDoc.value.doc.show_activity
+      value
         ? 'Community Activity will be shown on your profile page now'
         : "Community Activity won't be shown on your profile page now",
     )

--- a/dashboard/src/pages/MyProfile.vue
+++ b/dashboard/src/pages/MyProfile.vue
@@ -413,20 +413,32 @@ const setProfileImage = (_file) => {
   })
 }
 
-const toggleProfilePrivacy = (value) => {
-  profileDoc.value.setValue.submit({ is_private: value }).then(() => {
+const toggleProfilePrivacy = async (value) => {
+  const previous = !value
+  try {
+    await profileDoc.value.setValue.submit({ is_private: value })
     toast.info(value ? 'Profile is now private' : 'Profile is now public')
-  })
+  } catch (err) {
+    profileDoc.value.doc.is_private = previous
+    toast.error('Failed to update privacy setting')
+    console.error(err)
+  }
 }
 
-const toggleShowActivity = (value) => {
-  profileDoc.value.setValue.submit({ show_activity: value }).then(() => {
+const toggleShowActivity = async (value) => {
+  const previous = !value
+  try {
+    await profileDoc.value.setValue.submit({ show_activity: value })
     toast.info(
       value
         ? 'Community Activity will be shown on your profile page now'
         : "Community Activity won't be shown on your profile page now",
     )
-  })
+  } catch (err) {
+    profileDoc.value.doc.show_activity = previous
+    toast.error('Failed to update activity setting')
+    console.error(err)
+  }
 }
 
 const updateErrors = ref('')

--- a/fossunited/api/profile.py
+++ b/fossunited/api/profile.py
@@ -1,7 +1,6 @@
 import io
 
 import frappe
-from frappe import _
 from frappe.utils.file_manager import save_file
 from PIL import Image
 
@@ -169,80 +168,6 @@ def update_profile(fields_dict):
     except Exception as e:
         frappe.log_error(("Error updating profile: {0}").format(str(e)))
         frappe.throw(("An error occurred while updating the profile. Please try again."))
-
-
-@frappe.whitelist()
-def get_profile_projects() -> list:
-    """Return the projects child table for the logged-in user's profile."""
-    user_doc = get_session_user_profile()
-    profile = frappe.get_doc(USER_PROFILE, user_doc.name)
-    return [
-        {
-            "name": row.name,
-            "project_name": row.project_name,
-            "project_link": row.project_link,
-            "tagline": row.tagline,
-            "cover_image": row.cover_image,
-        }
-        for row in profile.get("projects", [])
-    ]
-
-
-@frappe.whitelist()
-def add_profile_project(
-    project_name: str, project_link: str, tagline: str, cover_image: str = ""
-) -> dict:
-    """Add a new project to the logged-in user's profile."""
-    user_doc = get_session_user_profile()
-    profile = frappe.get_doc(USER_PROFILE, user_doc.name)
-    row = profile.append(
-        "projects",
-        {
-            "project_name": project_name,
-            "project_link": project_link,
-            "tagline": tagline,
-            "cover_image": cover_image,
-        },
-    )
-    profile.save()
-    return {
-        "name": row.name,
-        "project_name": row.project_name,
-        "project_link": row.project_link,
-        "tagline": row.tagline,
-        "cover_image": row.cover_image,
-    }
-
-
-@frappe.whitelist()
-def update_profile_project(
-    row_name: str, project_name: str, project_link: str, tagline: str, cover_image: str = ""
-) -> bool:
-    """Update an existing project row for the logged-in user's profile."""
-    user_doc = get_session_user_profile()
-    profile = frappe.get_doc(USER_PROFILE, user_doc.name)
-    for row in profile.get("projects", []):
-        if row.name == row_name:
-            row.project_name = project_name
-            row.project_link = project_link
-            row.tagline = tagline
-            row.cover_image = cover_image
-            profile.save()
-            return True
-    frappe.throw(_("Project not found"))
-
-
-@frappe.whitelist()
-def delete_profile_project(row_name: str) -> bool:
-    """Delete a project row from the logged-in user's profile."""
-    user_doc = get_session_user_profile()
-    profile = frappe.get_doc(USER_PROFILE, user_doc.name)
-    for row in profile.get("projects", []):
-        if row.name == row_name:
-            profile.remove(row)
-            profile.save()
-            return True
-    frappe.throw(_("Project not found"))
 
 
 @frappe.whitelist()

--- a/fossunited/api/profile.py
+++ b/fossunited/api/profile.py
@@ -6,7 +6,6 @@ from PIL import Image
 
 from fossunited.api.dashboard import get_session_user_profile
 from fossunited.doctype_ids import CHAPTER, RESTRICTED_USERNAME, USER_PROFILE
-from fossunited.fossunited.utils import sanitize_text_content
 
 
 def convert_image_to_webp(image_content: bytes) -> bytes:
@@ -86,68 +85,6 @@ def set_cover_image(file_url: str) -> bool:
 
     except Exception as e:
         frappe.throw(str(e))
-
-
-@frappe.whitelist()
-def update_profile(fields_dict):
-    """
-    Updates User Profile data.
-    Combined with Full Name and Username updates in User doctype,
-    whenever these fields are updated.
-    """
-    user_doc = get_session_user_profile()
-    try:
-        updated_fields = {
-            "full_name": fields_dict.get("full_name"),
-            "username": fields_dict.get("username"),
-            "bio": fields_dict.get("bio"),
-            "cfp_visibility": fields_dict.get("cfp_visibility"),
-            "current_city": fields_dict.get("current_city"),
-            "about": sanitize_text_content(fields_dict.get("about")),
-            "website": fields_dict.get("website"),
-            "x": fields_dict.get("x"),
-            "linkedin": fields_dict.get("linkedin"),
-            "github": fields_dict.get("github"),
-            "gitlab": fields_dict.get("gitlab"),
-            "instagram": fields_dict.get("instagram"),
-            "youtube": fields_dict.get("youtube"),
-            "devto": fields_dict.get("devto"),
-            "medium": fields_dict.get("medium"),
-            "mastodon": fields_dict.get("mastodon"),
-            "bluesky": fields_dict.get("bluesky"),
-        }
-
-        profile = frappe.get_doc(USER_PROFILE, user_doc.name)
-        for field, value in updated_fields.items():
-            if hasattr(profile, field):
-                setattr(profile, field, value)
-        profile.save()
-
-        user_updates = {}
-        if fields_dict.get("full_name") != user_doc.full_name:
-            name_parts = fields_dict.get("full_name").split()
-            if len(name_parts) > 1:
-                user_updates["first_name"] = name_parts[0]
-                user_updates["last_name"] = "".join(name_parts[1:])
-            else:
-                user_updates["first_name"] = name_parts[0]
-                user_updates["last_name"] = ""
-
-        if fields_dict.get("username") != user_doc.username:
-            user_updates["username"] = fields_dict.get("username")
-
-        if user_updates:
-            user = frappe.get_doc("User", user_doc.user)
-            for field, value in user_updates.items():
-                setattr(user, field, value)
-
-            user.save()
-
-        return True
-
-    except Exception as e:
-        frappe.log_error(("Error updating profile: {0}").format(str(e)))
-        frappe.throw(("An error occurred while updating the profile. Please try again."))
 
 
 @frappe.whitelist()

--- a/fossunited/api/profile.py
+++ b/fossunited/api/profile.py
@@ -188,7 +188,9 @@ def get_profile_projects() -> list:
 
 
 @frappe.whitelist()
-def add_profile_project(project_name: str, project_link: str, tagline: str, cover_image: str = "") -> dict:
+def add_profile_project(
+    project_name: str, project_link: str, tagline: str, cover_image: str = ""
+) -> dict:
     """Add a new project to the logged-in user's profile."""
     user_doc = get_session_user_profile()
     profile = frappe.get_doc(USER_PROFILE, user_doc.name)
@@ -213,7 +215,9 @@ def add_profile_project(project_name: str, project_link: str, tagline: str, cove
 
 
 @frappe.whitelist()
-def update_profile_project(row_name: str, project_name: str, project_link: str, tagline: str, cover_image: str = "") -> bool:
+def update_profile_project(
+    row_name: str, project_name: str, project_link: str, tagline: str, cover_image: str = ""
+) -> bool:
     """Update an existing project row for the logged-in user's profile."""
     user_doc = get_session_user_profile()
     profile = frappe.get_doc(USER_PROFILE, user_doc.name)

--- a/fossunited/api/profile.py
+++ b/fossunited/api/profile.py
@@ -171,6 +171,79 @@ def update_profile(fields_dict):
 
 
 @frappe.whitelist()
+def get_profile_projects() -> list:
+    """Return the projects child table for the logged-in user's profile."""
+    user_doc = get_session_user_profile()
+    profile = frappe.get_doc(USER_PROFILE, user_doc.name)
+    return [
+        {
+            "name": row.name,
+            "project_name": row.project_name,
+            "project_link": row.project_link,
+            "tagline": row.tagline,
+            "cover_image": row.cover_image,
+        }
+        for row in profile.get("projects", [])
+    ]
+
+
+@frappe.whitelist()
+def add_profile_project(project_name: str, project_link: str, tagline: str, cover_image: str = "") -> dict:
+    """Add a new project to the logged-in user's profile."""
+    user_doc = get_session_user_profile()
+    profile = frappe.get_doc(USER_PROFILE, user_doc.name)
+    row = profile.append(
+        "projects",
+        {
+            "project_name": project_name,
+            "project_link": project_link,
+            "tagline": tagline,
+            "cover_image": cover_image,
+        },
+    )
+    profile.save()
+    frappe.db.commit()
+    return {
+        "name": row.name,
+        "project_name": row.project_name,
+        "project_link": row.project_link,
+        "tagline": row.tagline,
+        "cover_image": row.cover_image,
+    }
+
+
+@frappe.whitelist()
+def update_profile_project(row_name: str, project_name: str, project_link: str, tagline: str, cover_image: str = "") -> bool:
+    """Update an existing project row for the logged-in user's profile."""
+    user_doc = get_session_user_profile()
+    profile = frappe.get_doc(USER_PROFILE, user_doc.name)
+    for row in profile.get("projects", []):
+        if row.name == row_name:
+            row.project_name = project_name
+            row.project_link = project_link
+            row.tagline = tagline
+            row.cover_image = cover_image
+            profile.save()
+            frappe.db.commit()
+            return True
+    frappe.throw("Project not found")
+
+
+@frappe.whitelist()
+def delete_profile_project(row_name: str) -> bool:
+    """Delete a project row from the logged-in user's profile."""
+    user_doc = get_session_user_profile()
+    profile = frappe.get_doc(USER_PROFILE, user_doc.name)
+    for row in profile.get("projects", []):
+        if row.name == row_name:
+            profile.remove(row)
+            profile.save()
+            frappe.db.commit()
+            return True
+    frappe.throw("Project not found")
+
+
+@frappe.whitelist()
 def is_valid_username(username: str, id: str) -> bool:
     """
     Check if the username is unique and not in restricted list

--- a/fossunited/api/profile.py
+++ b/fossunited/api/profile.py
@@ -89,26 +89,6 @@ def set_cover_image(file_url: str) -> bool:
 
 
 @frappe.whitelist()
-def toggle_profile_privacy(value):
-    user_doc = get_session_user_profile()
-    try:
-        frappe.db.set_value(USER_PROFILE, user_doc.name, "is_private", value)
-        return True
-    except Exception as e:
-        frappe.throw(str(e))
-
-
-@frappe.whitelist()
-def toggle_show_activity(value):
-    user_doc = get_session_user_profile()
-    try:
-        frappe.db.set_value(USER_PROFILE, user_doc.name, "show_activity", value)
-        return True
-    except Exception as e:
-        frappe.throw(str(e))
-
-
-@frappe.whitelist()
 def update_profile(fields_dict):
     """
     Updates User Profile data.

--- a/fossunited/api/profile.py
+++ b/fossunited/api/profile.py
@@ -204,7 +204,6 @@ def add_profile_project(
         },
     )
     profile.save()
-    frappe.db.commit()
     return {
         "name": row.name,
         "project_name": row.project_name,
@@ -228,9 +227,8 @@ def update_profile_project(
             row.tagline = tagline
             row.cover_image = cover_image
             profile.save()
-            frappe.db.commit()
             return True
-    frappe.throw("Project not found")
+    frappe.throw(_("Project not found"))
 
 
 @frappe.whitelist()
@@ -242,9 +240,8 @@ def delete_profile_project(row_name: str) -> bool:
         if row.name == row_name:
             profile.remove(row)
             profile.save()
-            frappe.db.commit()
             return True
-    frappe.throw("Project not found")
+    frappe.throw(_("Project not found"))
 
 
 @frappe.whitelist()

--- a/fossunited/api/profile.py
+++ b/fossunited/api/profile.py
@@ -1,6 +1,7 @@
 import io
 
 import frappe
+from frappe import _
 from frappe.utils.file_manager import save_file
 from PIL import Image
 

--- a/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.py
@@ -360,22 +360,27 @@ class FOSSUserProfile(WebsiteGenerator):
             desc_short=desc_short,
         )
 
-        og_url = frappe.db.get_single_value("Ograph Settings", "ograph_url")
+        og_url = None
+        if frappe.db.exists("DocType", "Ograph Settings"):
+            og_url = frappe.db.get_single_value("Ograph Settings", "ograph_url")
 
-        image = (
-            "{og_url}/gen/profile?"
-            "username={username}&"
-            "full_name={full_name}&"
-            "designation={designation}&"
-            "image={image}"
-        ).format(
-            og_url=og_url,
-            username=self.username,
-            full_name=self.full_name,
-            designation=self.bio or "FOSS United User",
-            image=self.profile_photo
-            or "/assets/fossunited/images/defaults/user_profile_image.png",
-        )
+        if og_url:
+            image = (
+                "{og_url}/gen/profile?"
+                "username={username}&"
+                "full_name={full_name}&"
+                "designation={designation}&"
+                "image={image}"
+            ).format(
+                og_url=og_url,
+                username=self.username,
+                full_name=self.full_name,
+                designation=self.bio or "FOSS United User",
+                image=self.profile_photo
+                or "/assets/fossunited/images/defaults/user_profile_image.png",
+            )
+        else:
+            image = self.profile_photo or "/assets/fossunited/images/defaults/user_profile_image.png"
 
         return pagetitle, description, image
 

--- a/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.py
@@ -380,7 +380,9 @@ class FOSSUserProfile(WebsiteGenerator):
                 or "/assets/fossunited/images/defaults/user_profile_image.png",
             )
         else:
-            image = self.profile_photo or "/assets/fossunited/images/defaults/user_profile_image.png"
+            image = (
+                self.profile_photo or "/assets/fossunited/images/defaults/user_profile_image.png"
+            )
 
         return pagetitle, description, image
 

--- a/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
@@ -15,7 +15,7 @@
         <div class="horizontal-navbar px-8 pt-2" role="tablist" aria-label="Profile sections">
           {%- set _has_resume = (doc.experience | length > 0) or (doc.education | length > 0) -%}
           {%- set _has_projects = doc.projects | length > 0 -%}
-          {%- set nav_items = ['about'] + (['resume'] if _has_resume else []) + (['projects'] if _has_projects else []) -%}
+          {%- set nav_items = ['about'] + (['resume'] if _has_resume else []) + (['projects'] if (_has_projects or doc.user == frappe.session.user) else []) -%}
           {% for item in nav_items %}
             <div
               class="horizontal-navbar--item"
@@ -41,7 +41,7 @@
           {{ render_experience() }} {{ render_education() }}
         </div>
         {% endif %}
-        {% if _has_projects %}
+        {% if _has_projects or doc.user == frappe.session.user %}
         <div class="content-div" id="projects" role="tabpanel" tabindex="0" aria-labelledby="projects-nav-item">{{ render_projects() }}</div>
         {% endif %}
       </div>
@@ -92,7 +92,7 @@
               <i class="ti ti-folder-code"></i>
             </div>
             <div class="project-title">{{ project.project_name }}</div>
-            <div class="project-description">{{ project.tagline or "" | truncate(120) }}</div>
+            <div class="project-description">{{ (project.tagline or "") | truncate(120) }}</div>
             <span class="project-link-text">
               View Project <i class="ti ti-arrow-right"></i>
             </span>

--- a/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
@@ -36,12 +36,12 @@
             <div class="about v3-text-primary">{{ doc.about or "Nothing in about." }}</div>
           </div>
         </div>
-        {% if has_resume %}
+        {% if _has_resume %}
         <div class="content-div" id="resume" role="tabpanel" tabindex="0" aria-labelledby="resume-nav-item">
           {{ render_experience() }} {{ render_education() }}
         </div>
         {% endif %}
-        {% if has_projects %}
+        {% if _has_projects %}
         <div class="content-div" id="projects" role="tabpanel" tabindex="0" aria-labelledby="projects-nav-item">{{ render_projects() }}</div>
         {% endif %}
       </div>

--- a/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
@@ -71,23 +71,22 @@
     {% if doc.projects | len > 0 %}
       <div class="projects-grid">
         {% for project in doc.projects %}
-          <div class="project-container" data-docname="{{ project.name }}">
-            <div class="project-card-body">
-              <div class="project-card-info">
-                <div class="project-title">{{ project.project_name }}</div>
-                <div class="project-description">{{ project.tagline or "" | truncate(120) }}</div>
-              </div>
-              <a
-                rel="nofollow noopener"
-                href="{{ project.project_link }}"
-                class="project-link-icon"
-                target="_blank"
-                title="View {{ project.project_name }}"
-              >
-                <i class="ti ti-external-link"></i>
-              </a>
+          <a
+            class="project-container"
+            href="{{ project.project_link }}"
+            target="_blank"
+            rel="nofollow noopener"
+            data-docname="{{ project.name }}"
+          >
+            <div class="project-card-icon-wrap">
+              <i class="ti ti-folder-code"></i>
             </div>
-          </div>
+            <div class="project-title">{{ project.project_name }}</div>
+            <div class="project-description">{{ project.tagline or "" | truncate(120) }}</div>
+            <span class="project-link-text">
+              View Project <i class="ti ti-arrow-right"></i>
+            </span>
+          </a>
         {% endfor %}
       </div>
     {% else %}

--- a/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
@@ -12,7 +12,7 @@
 
     <div class="container">
       <div class="profile-content-section">
-        <div class="horizontal-navbar px-8 pt-2">
+        <div class="horizontal-navbar px-8 pt-2" role="tablist" aria-label="Profile sections">
           {%- set _has_resume = (doc.experience | length > 0) or (doc.education | length > 0) -%}
           {%- set _has_projects = doc.projects | length > 0 -%}
           {%- set nav_items = ['about'] + (['resume'] if _has_resume else []) + (['projects'] if _has_projects else []) -%}

--- a/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
@@ -13,7 +13,9 @@
     <div class="container">
       <div class="profile-content-section">
         <div class="horizontal-navbar px-8 pt-2">
-          {% set nav_items = ['about'] %}
+          {%- set _has_resume = (doc.experience | length > 0) or (doc.education | length > 0) -%}
+          {%- set _has_projects = doc.projects | length > 0 -%}
+          {%- set nav_items = ['about'] + (['resume'] if _has_resume else []) + (['projects'] if _has_projects else []) -%}
           {% for item in nav_items %}
             <div
               class="horizontal-navbar--item"

--- a/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
@@ -89,7 +89,11 @@
             data-docname="{{ project.name }}"
           >
             <div class="project-card-icon-wrap">
-              <i class="ti ti-folder-code"></i>
+              {% if project.cover_image %}
+                <img src="{{ project.cover_image }}" alt="{{ project.project_name }}" class="project-cover-icon" />
+              {% else %}
+                <i class="ti ti-folder-code"></i>
+              {% endif %}
             </div>
             <div class="project-title">{{ project.project_name }}</div>
             <div class="project-description">{{ (project.tagline or "") | truncate(120) }}</div>

--- a/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
@@ -71,21 +71,19 @@
     {% if doc.projects | len > 0 %}
       <div class="projects-grid">
         {% for project in doc.projects %}
-          <div class="project-container edit-hover" data-docname="{{ project.name }}">
-            <div class="project-title">{{ project.project_name }}</div>
-            <div class="project-description">{{ project.tagline or "" | truncate(100) }}</div>
-            <div class="d-flex align-items-bottom justify-content-between mb-3 p-0">
-              <div class="collaborators-list">
-                <div class="collaborators-container"></div>
+          <div class="project-container" data-docname="{{ project.name }}">
+            <div class="project-card-body">
+              <div class="project-card-info">
+                <div class="project-title">{{ project.project_name }}</div>
+                <div class="project-description">{{ project.tagline or "" | truncate(120) }}</div>
               </div>
               <a
-                rel="nofollow"
+                rel="nofollow noopener"
                 href="{{ project.project_link }}"
-                style="color: hsl(var(--clr-foss-mint-500))"
-                class="project-link"
+                class="project-link-icon"
                 target="_blank"
+                title="View {{ project.project_name }}"
               >
-                View Project
                 <i class="ti ti-external-link"></i>
               </a>
             </div>

--- a/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
@@ -515,8 +515,11 @@
       //for each header-with-button, find the section from its parent
       $('.header-with-button').each((index, element) => {
         let section = $(element).parent().attr('id').split('-')[0]
+        let onClickHandler = section === 'projects'
+          ? `window.location.href='/dashboard/me'`
+          : `addModal(this)`
         $(element).append(`
-                <button class="add-modal-button" name="add-${section}" onClick="addModal(this)">
+                <button class="add-modal-button" name="add-${section}" onClick="${onClickHandler}">
                     <i class="ti ti-plus"></i>
                     Add ${section}
                 </button>

--- a/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
@@ -72,19 +72,6 @@
       <div class="projects-grid">
         {% for project in doc.projects %}
           <div class="project-container edit-hover" data-docname="{{ project.name }}">
-            <img
-              src="{{ project.cover_image }}"
-              alt="{{ project.project_name }}"
-              class="project-banner"
-            />
-            <button
-              class="hide edit-modal-button project-edit-button"
-              style="align-self: flex-end"
-              data-docname="{{ project.name }}"
-              data-doctype="{{ project.doctype }}"
-            >
-              <i class="ti ti-pencil"></i>
-            </button>
             <div class="project-title">{{ project.project_name }}</div>
             <div class="project-description">{{ project.tagline or "" | truncate(100) }}</div>
             <div class="d-flex align-items-bottom justify-content-between mb-3 p-0">

--- a/fossunited/foss_profiles/doctype/foss_user_projects/foss_user_projects.py
+++ b/fossunited/foss_profiles/doctype/foss_user_projects/foss_user_projects.py
@@ -1,8 +1,16 @@
 # Copyright (c) 2024, Frappe x FOSSUnited and contributors
 # For license information, please see license.txt
 
+from urllib.parse import urlparse
+
+import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
 class FOSSUserProjects(Document):
-    pass
+    def validate(self):
+        if self.project_link:
+            parsed = urlparse(self.project_link)
+            if parsed.scheme not in ("http", "https") or not parsed.netloc:
+                frappe.throw(_("Project Link must be a valid HTTP(S) URL"))

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -926,6 +926,10 @@ h6 {
   padding: 0 1rem;
 }
 
+.project-container *:first-child {
+  padding: 0.75rem 1rem 0;
+}
+
 .project-edit-button {
   z-index: 10;
   padding: 6px;

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -957,6 +957,13 @@ h6 {
   flex-shrink: 0;
 }
 
+.project-cover-icon {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 0.375rem;
+}
+
 .project-edit-button {
   z-index: 10;
   padding: 6px;

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -912,33 +912,49 @@ h6 {
 }
 
 .project-container {
+  position: relative;
   display: flex;
   flex-direction: column;
+  gap: 0.4rem;
+  padding: 1rem 1.25rem 1rem 1.5rem;
   border-radius: 0.5rem;
-  border: 1.5px solid hsl(var(--clr-code-night-100));
-  background: hsl(var(--clr-gray-100));
+  border: 1.5px solid hsl(var(--clr-gray-200));
+  background: white;
+  text-decoration: none;
+  color: inherit;
+  overflow: hidden;
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
+.project-container::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: hsl(var(--clr-foss-mint-500));
+}
+
 .project-container:hover {
-  border-color: hsl(var(--clr-foss-mint-500));
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.07);
+  border-color: hsl(var(--clr-foss-mint-400));
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  text-decoration: none;
+  color: inherit;
 }
 
-.project-card-body {
+.project-card-icon-wrap {
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 1rem;
-}
-
-.project-card-info {
-  display: flex;
-  flex-direction: column;
-  gap: 0.3rem;
-  flex: 1;
-  min-width: 0;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.375rem;
+  background: hsl(var(--clr-foss-mint-50));
+  color: hsl(var(--clr-foss-mint-600));
+  font-size: 1rem;
+  margin-bottom: 0.15rem;
+  flex-shrink: 0;
 }
 
 .project-edit-button {
@@ -965,42 +981,33 @@ h6 {
 }
 
 .project-title {
-  color: var(--clr-code-night-800);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
   font-size: var(--text-base);
   font-weight: var(--fw-bold);
+  color: hsl(var(--clr-gray-800));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .project-description {
-  font-size: var(--text-xs);
+  font-size: var(--text-sm);
   line-height: 1.5;
   color: hsl(var(--clr-gray-500));
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  flex: 1;
 }
 
-.project-link-icon {
-  display: flex;
+.project-link-text {
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  width: 2rem;
-  height: 2rem;
-  border-radius: 0.375rem;
-  border: 1.5px solid hsl(var(--clr-code-night-100));
-  color: hsl(var(--clr-gray-500));
-  text-decoration: none;
-  transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
-}
-
-.project-link-icon:hover {
-  border-color: hsl(var(--clr-foss-mint-500));
-  color: hsl(var(--clr-foss-mint-500));
-  background: hsl(var(--clr-foss-mint-50) / 0.15);
+  gap: 0.25rem;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: hsl(var(--clr-foss-mint-600));
+  margin-top: 0.25rem;
 }
 
 .cover-image {

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -914,20 +914,31 @@ h6 {
 .project-container {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  font-size: var(--text-sm);
   border-radius: 0.5rem;
-  /* box-shadow: 0px 0px 0px 1.5px hsl(var(--clr-code-night-100)); */
   border: 1.5px solid hsl(var(--clr-code-night-100));
   background: hsl(var(--clr-gray-100));
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
-.project-container * + * {
-  padding: 0 1rem;
+.project-container:hover {
+  border-color: hsl(var(--clr-foss-mint-500));
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.07);
 }
 
-.project-container *:first-child {
-  padding: 0.75rem 1rem 0;
+.project-card-body {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.project-card-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  flex: 1;
+  min-width: 0;
 }
 
 .project-edit-button {
@@ -954,19 +965,42 @@ h6 {
 }
 
 .project-title {
-  margin-top: 4px;
   color: var(--clr-code-night-800);
   text-overflow: ellipsis;
   white-space: nowrap;
+  overflow: hidden;
   font-size: var(--text-base);
   font-weight: var(--fw-bold);
 }
 
 .project-description {
-  min-height: 4.375rem;
   font-size: var(--text-xs);
-  overflow: hidden;
+  line-height: 1.5;
   color: hsl(var(--clr-gray-500));
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.project-link-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.375rem;
+  border: 1.5px solid hsl(var(--clr-code-night-100));
+  color: hsl(var(--clr-gray-500));
+  text-decoration: none;
+  transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
+}
+
+.project-link-icon:hover {
+  border-color: hsl(var(--clr-foss-mint-500));
+  color: hsl(var(--clr-foss-mint-500));
+  background: hsl(var(--clr-foss-mint-50) / 0.15);
 }
 
 .cover-image {


### PR DESCRIPTION
## Status

- [x] Ready for review

## Related Issue

Closes / Addresses: #1278

## Progress (All must be checked to merge)

- [x] Tested locally

## Changelog

- Added a Projects section with full CRUD: view all projects, inline edit form per project, add new project form, delete with confirmation

- Initially added 4 whitelisted API endpoints (get_profile_projects, add_profile_project, update_profile_project, delete_profile_project), then removed them all in a subsequent refactor since createDocumentResource handles persistence directly via frappe.client.save

### Screenshots

<img width="1448" height="801" alt="image" src="https://github.com/user-attachments/assets/bc769456-3ab8-44df-8c40-669485df6a1a" />

<img width="1448" height="801" alt="image" src="https://github.com/user-attachments/assets/b131508e-5e7b-48b2-a0bb-d97ee3606711" />