### PR TITLE
feat(rss): add rss feed for upcoming published events

### DIFF
--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -2,6 +2,7 @@ import json
 from zoneinfo import ZoneInfo
 
 import frappe
+from frappe import _
 from frappe.rate_limiter import rate_limit
 from frappe.utils import add_days, now_datetime
 from ics import Calendar, Event

--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -91,7 +91,8 @@ def check_if_chapter_or_event_core_member(event: str) -> bool:
     )
     return is_team
 
-
+# Only published event data is returned. No sensitive fields exposed.
+# nosemgrep: guest-whitelisted-method
 @frappe.whitelist(allow_guest=True)
 @rate_limit(limit=5, seconds=60 * 60 * 6)
 def generate_ics(event_ids: str | list, chapter: str | None = None):

--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -94,12 +94,13 @@ def check_if_chapter_or_event_core_member(event: str) -> bool:
 
 @frappe.whitelist(allow_guest=True)
 @rate_limit(limit=5, seconds=60 * 60 * 6)
-def generate_ics(event_ids):
+def generate_ics(event_ids, chapter=None):
     """
     Return ICS event for the event ids provided
 
     Args:
         event_ids (list): list of event ids (doc.name)
+        chapter (str, optional): chapter docname to restrict events to
 
     Returns:
         str: ICS data
@@ -125,9 +126,15 @@ def generate_ics(event_ids):
 
     c = Calendar()
 
+    filters = [["name", "IN", ids], ["status", "=", "Live"], ["is_published", "=", 1]]
+    if chapter:
+        if not isinstance(chapter, str) or len(chapter) > 140:
+            frappe.throw("Invalid chapter", frappe.ValidationError)
+        filters.append(["chapter", "=", chapter])
+
     events = frappe.db.get_all(
         EVENT,
-        filters=[["name", "IN", ids]],
+        filters=filters,
         fields=[
             "event_name",
             "event_location",

--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -94,7 +94,7 @@ def check_if_chapter_or_event_core_member(event: str) -> bool:
 
 @frappe.whitelist(allow_guest=True)
 @rate_limit(limit=5, seconds=60 * 60 * 6)
-def generate_ics(event_ids, chapter=None):
+def generate_ics(event_ids: str | list, chapter: str | None = None):
     """
     Return ICS event for the event ids provided
 
@@ -129,7 +129,7 @@ def generate_ics(event_ids, chapter=None):
     filters = [["name", "IN", ids], ["status", "=", "Live"], ["is_published", "=", 1]]
     if chapter:
         if not isinstance(chapter, str) or len(chapter) > 140:
-            frappe.throw("Invalid chapter", frappe.ValidationError)
+            frappe.throw(_("Invalid chapter"), frappe.ValidationError)
         filters.append(["chapter", "=", chapter])
 
     events = frappe.db.get_all(

--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -91,6 +91,7 @@ def check_if_chapter_or_event_core_member(event: str) -> bool:
     )
     return is_team
 
+
 # Only published event data is returned. No sensitive fields exposed.
 # nosemgrep: guest-whitelisted-method
 @frappe.whitelist(allow_guest=True)

--- a/fossunited/chapters/doctype/foss_chapter/templates/foss_chapter.html
+++ b/fossunited/chapters/doctype/foss_chapter/templates/foss_chapter.html
@@ -85,7 +85,28 @@
     'fossunited/templates/macros/event_card.html' import event_card
   %}
   <div class="container my-5">
-    <h3 class="subtitle">Upcoming Events</h3>
+    <div class="d-flex align-items-center justify-content-between flex-wrap gap-2 mb-3">
+      <h3 class="subtitle mb-0">Upcoming Events</h3>
+      <div class="d-flex gap-2">
+        <a
+          href="/c/{{ doc.slug }}/rss.xml"
+          class="btn btn-sm btn-secondary"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="RSS feed for upcoming events"
+        >
+          <i class="ti ti-rss" aria-hidden="true"></i> RSS Feed
+        </a>
+        <button
+          id="download-ics-btn"
+          class="btn btn-sm btn-secondary"
+          data-event-ids="{{ upcoming_events | map(attribute='name') | list | tojson | e }}"
+          aria-label="Download upcoming events as ICS calendar file"
+        >
+          <i class="ti ti-calendar-down" aria-hidden="true"></i> Download ICS
+        </button>
+      </div>
+    </div>
     <div class="events-grid-4">
       {% for event in upcoming_events %}{{ event_card(event) }}{% endfor %}
     </div>
@@ -121,6 +142,34 @@
       if (window.innerWidth < 425 && '{{ doc.chapter_type }}' == 'City Community') {
         $('.header--banner').css('object-position', 'right')
       }
+
+      $('#download-ics-btn').on('click', function () {
+        var btn = $(this)
+        var eventIds = JSON.parse(btn.data('event-ids') || '[]')
+        if (!eventIds.length) return
+
+        btn.prop('disabled', true).text('Downloading…')
+        frappe.call({
+          method: 'fossunited.api.chapter.generate_ics',
+          args: { event_ids: JSON.stringify(eventIds) },
+          callback: function (r) {
+            if (r.message) {
+              var blob = new Blob([r.message], { type: 'text/calendar;charset=utf-8' })
+              var url = URL.createObjectURL(blob)
+              var a = document.createElement('a')
+              a.href = url
+              a.download = '{{ doc.slug }}-upcoming-events.ics'
+              document.body.appendChild(a)
+              a.click()
+              document.body.removeChild(a)
+              URL.revokeObjectURL(url)
+            }
+          },
+          always: function () {
+            btn.prop('disabled', false).html('<i class="ti ti-calendar-down" aria-hidden="true"></i> Download ICS')
+          },
+        })
+      })
     })
   </script>
 {% endblock %}

--- a/fossunited/chapters/doctype/foss_chapter/templates/foss_chapter.html
+++ b/fossunited/chapters/doctype/foss_chapter/templates/foss_chapter.html
@@ -70,6 +70,15 @@
           </a>
         {% endif %}
       {% endfor %}
+      <a
+        href="/c/{{ doc.slug }}/rss.xml"
+        aria-label="RSS feed for {{ doc.chapter_name }} upcoming events"
+        target="_blank"
+        rel="noopener noreferrer"
+        title="RSS Feed"
+      >
+        <i class="ti ti-rss" style="font-size: 1.5rem;" aria-hidden="true"></i>
+      </a>
     </div>
   </div>
 {% endmacro %}

--- a/fossunited/chapters/doctype/foss_chapter/templates/foss_chapter.html
+++ b/fossunited/chapters/doctype/foss_chapter/templates/foss_chapter.html
@@ -160,7 +160,7 @@
         btn.prop('disabled', true).text('Downloading…')
         frappe.call({
           method: 'fossunited.api.chapter.generate_ics',
-          args: { event_ids: JSON.stringify(eventIds) },
+          args: { event_ids: JSON.stringify(eventIds), chapter: '{{ doc.name }}' },
           callback: function (r) {
             if (r.message) {
               var blob = new Blob([r.message], { type: 'text/calendar;charset=utf-8' })

--- a/fossunited/chapters/doctype/foss_chapter/templates/foss_chapter.html
+++ b/fossunited/chapters/doctype/foss_chapter/templates/foss_chapter.html
@@ -109,7 +109,6 @@
         <button
           id="download-ics-btn"
           class="btn btn-sm btn-secondary"
-          data-event-ids="{{ upcoming_events | map(attribute='name') | list | tojson }}"
           aria-label="Download upcoming events as ICS calendar file"
         >
           <i class="ti ti-calendar-down" aria-hidden="true"></i> Download ICS
@@ -147,6 +146,7 @@
 {% endmacro %}
 {% block page_script %}
   <script>
+    var _upcomingEventIds = {{ upcoming_events | map(attribute='name') | list | tojson }};
     $(document).ready(function () {
       if (window.innerWidth < 425 && '{{ doc.chapter_type }}' == 'City Community') {
         $('.header--banner').css('object-position', 'right')
@@ -154,8 +154,7 @@
 
       $('#download-ics-btn').on('click', function () {
         var btn = $(this)
-        var raw = btn.attr('data-event-ids') || '[]'
-        var eventIds = JSON.parse(raw)
+        var eventIds = _upcomingEventIds
         if (!eventIds.length) return
 
         btn.prop('disabled', true).text('Downloading…')

--- a/fossunited/chapters/doctype/foss_chapter/templates/foss_chapter.html
+++ b/fossunited/chapters/doctype/foss_chapter/templates/foss_chapter.html
@@ -109,7 +109,7 @@
         <button
           id="download-ics-btn"
           class="btn btn-sm btn-secondary"
-          data-event-ids="{{ upcoming_events | map(attribute='name') | list | tojson | e }}"
+          data-event-ids="{{ upcoming_events | map(attribute='name') | list | tojson }}"
           aria-label="Download upcoming events as ICS calendar file"
         >
           <i class="ti ti-calendar-down" aria-hidden="true"></i> Download ICS

--- a/fossunited/chapters/doctype/foss_chapter/templates/foss_chapter.html
+++ b/fossunited/chapters/doctype/foss_chapter/templates/foss_chapter.html
@@ -1,4 +1,8 @@
 {% extends "templates/foss_base.html" %}
+{% block head_include %}
+{{ super() }}
+<link rel="alternate" type="application/rss+xml" title="Upcoming Events \u2013 {{ doc.chapter_name }}" href="/c/{{ doc.slug }}/rss.xml" />
+{% endblock %}
 {% block page_content %}
   {{ header() }}
   {{ render_about() }}

--- a/fossunited/chapters/doctype/foss_chapter/templates/foss_chapter.html
+++ b/fossunited/chapters/doctype/foss_chapter/templates/foss_chapter.html
@@ -154,7 +154,8 @@
 
       $('#download-ics-btn').on('click', function () {
         var btn = $(this)
-        var eventIds = JSON.parse(btn.data('event-ids') || '[]')
+        var raw = btn.attr('data-event-ids') || '[]'
+        var eventIds = JSON.parse(raw)
         if (!eventIds.length) return
 
         btn.prop('disabled', true).text('Downloading…')

--- a/fossunited/chapters/doctype/foss_chapter/templates/foss_chapter.html
+++ b/fossunited/chapters/doctype/foss_chapter/templates/foss_chapter.html
@@ -93,6 +93,10 @@
     from
     'fossunited/templates/macros/event_card.html' import event_card
   %}
+  {%
+    from
+    'fossunited/templates/macros/ics_download.html' import ics_download
+  %}
   <div class="container my-5">
     <div class="d-flex align-items-center justify-content-between flex-wrap gap-2 mb-3">
       <h3 class="subtitle mb-0">Upcoming Events</h3>
@@ -106,13 +110,12 @@
         >
           <i class="ti ti-rss" aria-hidden="true"></i> RSS Feed
         </a>
-        <button
-          id="download-ics-btn"
-          class="btn btn-sm btn-secondary"
-          aria-label="Download upcoming events as ICS calendar file"
-        >
-          <i class="ti ti-calendar-down" aria-hidden="true"></i> Download ICS
-        </button>
+        {{ ics_download(
+          event_ids=upcoming_events | map(attribute='name') | list,
+          filename=doc.slug + '-upcoming-events.ics',
+          chapter=doc.name,
+          btn_id='ics-download-btn',
+        ) }}
       </div>
     </div>
     <div class="events-grid-4">
@@ -146,39 +149,10 @@
 {% endmacro %}
 {% block page_script %}
   <script>
-    var _upcomingEventIds = {{ upcoming_events | map(attribute='name') | list | tojson }};
     $(document).ready(function () {
       if (window.innerWidth < 425 && '{{ doc.chapter_type }}' == 'City Community') {
         $('.header--banner').css('object-position', 'right')
       }
-
-      $('#download-ics-btn').on('click', function () {
-        var btn = $(this)
-        var eventIds = _upcomingEventIds
-        if (!eventIds.length) return
-
-        btn.prop('disabled', true).text('Downloading…')
-        frappe.call({
-          method: 'fossunited.api.chapter.generate_ics',
-          args: { event_ids: JSON.stringify(eventIds), chapter: '{{ doc.name }}' },
-          callback: function (r) {
-            if (r.message) {
-              var blob = new Blob([r.message], { type: 'text/calendar;charset=utf-8' })
-              var url = URL.createObjectURL(blob)
-              var a = document.createElement('a')
-              a.href = url
-              a.download = '{{ doc.slug }}-upcoming-events.ics'
-              document.body.appendChild(a)
-              a.click()
-              document.body.removeChild(a)
-              URL.revokeObjectURL(url)
-            }
-          },
-          always: function () {
-            btn.prop('disabled', false).html('<i class="ti ti-calendar-down" aria-hidden="true"></i> Download ICS')
-          },
-        })
-      })
     })
   </script>
 {% endblock %}

--- a/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
+++ b/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
@@ -612,27 +612,11 @@
       </div>
     </div>
 
-    <script>
-      function downloadEventIcs() {
-        frappe.call({
-          method: 'fossunited.api.chapter.generate_ics',
-          args: {
-            event_ids: ['{{ doc.name }}'],
-          },
-          callback: (r) => {
-            if (r.message) {
-              const blob = new Blob([r.message], { type: 'text/calendar' })
-              const url = URL.createObjectURL(blob)
-              const a = document.createElement('a')
-              a.href = url
-              a.download = `{{ doc.event_name.replace(' ', '_') | replace(' ', '_') }}.ics`
-              a.click()
-              URL.revokeObjectURL(url)
-            }
-          },
-        })
-      }
-
-    </script>
+    {%- from 'fossunited/templates/macros/ics_download.html' import ics_download -%}
+    {{ ics_download(
+      event_ids=[doc.name],
+      filename=doc.event_name.replace(' ', '_') + '.ics',
+      fn_name='downloadEventIcs',
+    ) }}
   </div>
 {% endblock %}

--- a/fossunited/hooks.py
+++ b/fossunited/hooks.py
@@ -33,6 +33,10 @@ website_route_rules = [
         "from_route": "/hack/<permalink>/projects/all",
         "to_route": "/hackathon/projects",
     },
+    {
+        "from_route": "/c/<chapter>/rss.xml",
+        "to_route": "/c/rss.xml",
+    },
 ]
 
 # add methods and filters to jinja environment
@@ -85,7 +89,6 @@ website_redirects = [
     {"source": r"c/(.+)/cfp", "target": r"/dashboard/cfp/apply/\1"},
     {"source": r"c/(.+)/cfp/all", "target": r"/dashboard/cfp/all/\1"},
     {"source": r"c/(.+)/schedule", "target": r"/dashboard/schedule/\1"},
-    {"source": r"c/([^/]+)/rss\.xml", "target": r"/c/rss.xml?chapter=\1"},
     {
         "source": r"c/(.+)/tickets",
         "target": r"/api/method/fossunited.api.pages.buy_tickets_page?route=c/\1",

--- a/fossunited/hooks.py
+++ b/fossunited/hooks.py
@@ -85,6 +85,7 @@ website_redirects = [
     {"source": r"c/(.+)/cfp", "target": r"/dashboard/cfp/apply/\1"},
     {"source": r"c/(.+)/cfp/all", "target": r"/dashboard/cfp/all/\1"},
     {"source": r"c/(.+)/schedule", "target": r"/dashboard/schedule/\1"},
+    {"source": r"c/([^/]+)/rss\.xml", "target": r"/c/rss.xml?chapter=\1"},
     {
         "source": r"c/(.+)/tickets",
         "target": r"/api/method/fossunited.api.pages.buy_tickets_page?route=c/\1",

--- a/fossunited/templates/macros/ics_download.html
+++ b/fossunited/templates/macros/ics_download.html
@@ -1,0 +1,51 @@
+{% macro ics_download(event_ids, filename, chapter='', btn_id=None, btn_class='btn btn-sm btn-secondary', fn_name=None) %}
+{% if btn_id %}
+<button
+  id="{{ btn_id }}"
+  class="{{ btn_class }}"
+  aria-label="Download events as ICS calendar file"
+>
+  <i class="ti ti-calendar-down" aria-hidden="true"></i> Download ICS
+</button>
+{% endif %}
+<script>
+  (function () {
+    function _download(ids, btn) {
+      if (btn) { btn.disabled = true; btn.textContent = 'Downloading\u2026'; }
+      frappe.call({
+        method: 'fossunited.api.chapter.generate_ics',
+        args: {
+          event_ids: JSON.stringify(ids),
+          {% if chapter %}chapter: '{{ chapter }}',{% endif %}
+        },
+        callback: function (r) {
+          if (r.message) {
+            var blob = new Blob([r.message], { type: 'text/calendar;charset=utf-8' });
+            var url = URL.createObjectURL(blob);
+            var a = document.createElement('a');
+            a.href = url;
+            a.download = '{{ filename }}';
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+          }
+        },
+        always: function () {
+          if (btn) {
+            btn.disabled = false;
+            btn.innerHTML = '<i class="ti ti-calendar-down" aria-hidden="true"></i> Download ICS';
+          }
+        },
+      });
+    }
+    {% if btn_id %}
+    var _btn = document.getElementById('{{ btn_id }}');
+    if (_btn) { _btn.addEventListener('click', function () { _download({{ event_ids | tojson }}, _btn); }); }
+    {% endif %}
+    {% if fn_name %}
+    window.{{ fn_name }} = function () { _download({{ event_ids | tojson }}, null); };
+    {% endif %}
+  })();
+</script>
+{% endmacro %}

--- a/fossunited/www/c/rss.py
+++ b/fossunited/www/c/rss.py
@@ -1,0 +1,116 @@
+from datetime import datetime
+from email.utils import format_datetime
+from urllib.parse import urljoin
+
+import frappe
+from frappe.utils import escape_html, get_request_site_address, sanitize_html
+
+from fossunited.doctype_ids import EVENT
+
+no_cache = 1
+base_template_path = "www/c/rss.xml"
+
+
+def _safe_cdata(text):
+    return (text or "").replace("]]>", "]]]]><![CDATA[>")
+
+
+def get_context(context):
+    slug = frappe.form_dict.get("chapter")
+    if not slug:
+        frappe.throw("chapter parameter is required", frappe.InvalidRequestException)
+
+    chapter = frappe.db.get_value(
+        "FOSS Chapter", {"slug": slug}, ["chapter_name", "route", "name", "slug"], as_dict=True
+    ) or frappe.db.get_value(
+        "FOSS Chapter", slug, ["chapter_name", "route", "name", "slug"], as_dict=True
+    )
+    if not chapter:
+        frappe.throw("Chapter not found", frappe.DoesNotExistError)
+
+    host = get_request_site_address()
+
+    events = frappe.get_all(
+        EVENT,
+        filters={
+            "chapter": chapter.name,
+            "event_end_date": (">=", frappe.utils.now()),
+            "status": "Live",
+            "is_published": 1,
+        },
+        fields=[
+            "name",
+            "event_name",
+            "event_description",
+            "event_start_date",
+            "event_end_date",
+            "event_location",
+            "event_type",
+            "route",
+            "modified",
+            "is_external_event",
+            "external_event_url",
+            "must_attend",
+        ],
+        order_by="event_start_date asc",
+        limit=50,
+    )
+
+    items = []
+    for e in events:
+        if e.is_external_event and e.external_event_url:
+            link = e.external_event_url
+        else:
+            link = urljoin(host, e.route) if e.route else host + "/events/timeline"
+
+        location = escape_html(e.event_location or "")
+        event_type = escape_html(e.event_type or "")
+        start = frappe.utils.get_datetime(e.event_start_date)
+        end = frappe.utils.get_datetime(e.event_end_date)
+
+        description = _safe_cdata(sanitize_html(e.event_description or ""))
+        content = (
+            "<![CDATA["
+            f"<p><strong>Type:</strong> {event_type}</p>"
+            f"<p><strong>Location:</strong> {location}</p>"
+            f"<p><strong>Start:</strong> {start.strftime('%d %B %Y, %I:%M %p')}</p>"
+            f"<p><strong>End:</strong> {end.strftime('%d %B %Y, %I:%M %p')}</p>"
+        )
+        if e.must_attend:
+            content += "<p><strong>⭐ Must Attend</strong></p>"
+        if description:
+            content += f"<div>{description}</div>"
+        content += f'<p><a href="{link}">View Event →</a></p>'
+        content += "]]>"
+
+        items.append(
+            {
+                "title": escape_html(
+                    f"{e.event_name} – {location}" if location else (e.event_name or "")
+                ),
+                "link": link,
+                "guid": f"{host}/c/{chapter.slug}/rss.xml#{e.name}",
+                "author": escape_html(chapter.chapter_name),
+                "published_date": format_datetime(start),
+                "modified": e.modified,
+                "category": event_type,
+                "content": content,
+            }
+        )
+
+    if items:
+        modified = format_datetime(max(frappe.utils.get_datetime(i["modified"]) for i in items))
+    else:
+        modified = format_datetime(datetime.now())
+
+    feed_url = f"{host}/c/{chapter.slug}/rss.xml"
+    chapter_url = urljoin(host, chapter.route) if chapter.route else host
+
+    return {
+        "title": f"{chapter.chapter_name} – Upcoming Events",
+        "description": f"Upcoming events from {chapter.chapter_name}",
+        "modified": modified,
+        "items": items,
+        "link": chapter_url,
+        "feed_url": feed_url,
+    }

--- a/fossunited/www/c/rss.py
+++ b/fossunited/www/c/rss.py
@@ -1,3 +1,4 @@
+import html
 from datetime import datetime
 from email.utils import format_datetime
 from urllib.parse import urljoin
@@ -29,7 +30,7 @@ def get_context(context):
         if event.is_external_event and event.external_event_url:
             event.link = event.external_event_url
         else:
-            event.link = urljoin(host, event.route or "") or host + "/events/timeline"
+            event.link = urljoin(host, event.route) if event.route else host + "/events/timeline"
 
         location = escape_html(event.event_location or "")
         event.event_type_display = escape_html(event.event_type or "Event")
@@ -47,9 +48,12 @@ def get_context(context):
         event.end_date_formatted = end_date.strftime("%d %B %Y, %I:%M %p")
         event.published_date = format_datetime(start_date)
 
+        _name = html.escape(event.event_name or "", quote=True)
+        _link = html.escape(event.link, quote=True)
+
         event_details = f"""
         <![CDATA[
-        <h3>{event.event_name}</h3>
+        <h3>{_name}</h3>
         <p><strong>Type:</strong> {event.event_type_display}</p>
         <p><strong>Location:</strong> {location}</p>
         <p><strong>Start:</strong> {event.start_date_formatted}</p>
@@ -60,16 +64,16 @@ def get_context(context):
             event_details += "<p><strong>⭐ Must Attend Event</strong></p>"
 
         if event.banner_image:
-            banner_url = urljoin(host, event.banner_image)
+            banner_url = html.escape(urljoin(host, event.banner_image), quote=True)
             event_details += (
-                f'<p><img src="{banner_url}" alt="{event.event_name}"'
+                f'<p><img src="{banner_url}" alt="{_name}"'
                 ' style="max-width: 600px; height: auto;"/></p>'
             )
 
         if event.event_description:
             event_details += f"<div>{sanitize_html(event.event_description)}</div>"
 
-        event_details += f'<p><a href="{event.link}">View Event Details \u2192</a></p>'
+        event_details += f'<p><a href="{_link}">View Event Details \u2192</a></p>'
         event_details += "]]>"
 
         event.content = event_details

--- a/fossunited/www/c/rss.py
+++ b/fossunited/www/c/rss.py
@@ -1,4 +1,3 @@
-import html
 from datetime import datetime
 from email.utils import format_datetime
 from urllib.parse import urljoin
@@ -7,14 +6,10 @@ import frappe
 from frappe import _
 from frappe.utils import escape_html, get_request_site_address, sanitize_html
 
-from fossunited.doctype_ids import EVENT
+from fossunited.doctype_ids import CHAPTER
 
 no_cache = 1
 base_template_path = "www/c/rss.xml"
-
-
-def _safe_cdata(text):
-    return (text or "").replace("]]>", "]]]]><![CDATA[>")
 
 
 def get_context(context):
@@ -22,97 +17,76 @@ def get_context(context):
     if not slug:
         frappe.throw(_("chapter parameter is required"), frappe.InvalidRequestException)
 
-    chapter = frappe.db.get_value(
-        "FOSS Chapter", {"slug": slug}, ["chapter_name", "route", "name", "slug"], as_dict=True
-    ) or frappe.db.get_value(
-        "FOSS Chapter", slug, ["chapter_name", "route", "name", "slug"], as_dict=True
-    )
-    if not chapter:
+    try:
+        doc = frappe.get_doc(CHAPTER, {"slug": slug})
+    except frappe.DoesNotExistError:
         frappe.throw(_("Chapter not found"), frappe.DoesNotExistError)
 
     host = get_request_site_address()
+    events = [e for e in doc.get_upcoming_events() if e.is_published]
 
-    events = frappe.get_all(
-        EVENT,
-        filters={
-            "chapter": chapter.name,
-            "event_end_date": (">=", frappe.utils.now()),
-            "status": "Live",
-            "is_published": 1,
-        },
-        fields=[
-            "name",
-            "event_name",
-            "event_description",
-            "event_start_date",
-            "event_end_date",
-            "event_location",
-            "event_type",
-            "route",
-            "modified",
-            "is_external_event",
-            "external_event_url",
-            "must_attend",
-        ],
-        order_by="event_start_date asc",
-        limit=50,
-    )
-
-    items = []
-    for e in events:
-        if e.is_external_event and e.external_event_url:
-            link = e.external_event_url
+    for event in events:
+        if event.is_external_event and event.external_event_url:
+            event.link = event.external_event_url
         else:
-            link = urljoin(host, e.route) if e.route else host + "/events/timeline"
+            event.link = urljoin(host, event.route or "") or host + "/events/timeline"
 
-        location = escape_html(e.event_location or "")
-        event_type = escape_html(e.event_type or "")
-        start = frappe.utils.get_datetime(e.event_start_date)
-        end = frappe.utils.get_datetime(e.event_end_date)
-
-        description = _safe_cdata(sanitize_html(e.event_description or ""))
-        content = (
-            "<![CDATA["
-            f"<p><strong>Type:</strong> {event_type}</p>"
-            f"<p><strong>Location:</strong> {location}</p>"
-            f"<p><strong>Start:</strong> {start.strftime('%d %B %Y, %I:%M %p')}</p>"
-            f"<p><strong>End:</strong> {end.strftime('%d %B %Y, %I:%M %p')}</p>"
+        location = escape_html(event.event_location or "")
+        event.event_type_display = escape_html(event.event_type or "Event")
+        location = location or ("Online" if event.event_type == "Online" else "TBA")
+        event.title = escape_html(
+            f"{event.event_name} \u2013 {location}" if event.event_name else ""
         )
-        if e.must_attend:
-            content += "<p><strong>⭐ Must Attend</strong></p>"
-        if description:
-            content += f"<div>{description}</div>"
-        content += f'<p><a href="{html.escape(link, quote=True)}">View Event →</a></p>'
-        content += "]]>"
+        event.author = escape_html(doc.chapter_name)
+        event.category = event.event_type_display
+        event.guid = f"{host}/c/{doc.slug}/rss.xml#{event.name}"
 
-        items.append(
-            {
-                "title": escape_html(
-                    f"{e.event_name} – {location}" if location else (e.event_name or "")
-                ),
-                "link": link,
-                "guid": f"{host}/c/{chapter.slug}/rss.xml#{e.name}",
-                "author": escape_html(chapter.chapter_name),
-                "published_date": format_datetime(start),
-                "modified": e.modified,
-                "category": event_type,
-                "content": content,
-            }
-        )
+        start_date = frappe.utils.get_datetime(event.event_start_date)
+        end_date = frappe.utils.get_datetime(event.event_end_date)
+        event.start_date_formatted = start_date.strftime("%d %B %Y, %I:%M %p")
+        event.end_date_formatted = end_date.strftime("%d %B %Y, %I:%M %p")
+        event.published_date = format_datetime(start_date)
 
-    if items:
-        modified = format_datetime(max(frappe.utils.get_datetime(i["modified"]) for i in items))
+        event_details = f"""
+        <![CDATA[
+        <h3>{event.event_name}</h3>
+        <p><strong>Type:</strong> {event.event_type_display}</p>
+        <p><strong>Location:</strong> {location}</p>
+        <p><strong>Start:</strong> {event.start_date_formatted}</p>
+        <p><strong>End:</strong> {event.end_date_formatted}</p>
+        """
+
+        if event.must_attend:
+            event_details += "<p><strong>⭐ Must Attend Event</strong></p>"
+
+        if event.banner_image:
+            banner_url = urljoin(host, event.banner_image)
+            event_details += (
+                f'<p><img src="{banner_url}" alt="{event.event_name}"'
+                ' style="max-width: 600px; height: auto;"/></p>'
+            )
+
+        if event.event_description:
+            event_details += f"<div>{sanitize_html(event.event_description)}</div>"
+
+        event_details += f'<p><a href="{event.link}">View Event Details \u2192</a></p>'
+        event_details += "]]>"
+
+        event.content = event_details
+
+    if events:
+        modified = format_datetime(max(e.modified for e in events))
     else:
         modified = format_datetime(datetime.now())
 
-    feed_url = f"{host}/c/{chapter.slug}/rss.xml"
-    chapter_url = urljoin(host, chapter.route) if chapter.route else host
+    feed_url = f"{host}/c/{doc.slug}/rss.xml"
+    chapter_url = urljoin(host, doc.route) if doc.route else host
 
     return {
-        "title": f"{chapter.chapter_name} – Upcoming Events",
-        "description": f"Upcoming events from {chapter.chapter_name}",
+        "title": f"{doc.chapter_name} \u2013 Upcoming Events",
+        "description": f"Upcoming events from {doc.chapter_name}",
         "modified": modified,
-        "items": items,
+        "items": events,
         "link": chapter_url,
         "feed_url": feed_url,
     }

--- a/fossunited/www/c/rss.py
+++ b/fossunited/www/c/rss.py
@@ -1,3 +1,4 @@
+import html
 from datetime import datetime
 from email.utils import format_datetime
 from urllib.parse import urljoin
@@ -81,7 +82,7 @@ def get_context(context):
             content += "<p><strong>⭐ Must Attend</strong></p>"
         if description:
             content += f"<div>{description}</div>"
-        content += f'<p><a href="{link}">View Event →</a></p>'
+        content += f'<p><a href="{html.escape(link, quote=True)}">View Event →</a></p>'
         content += "]]>"
 
         items.append(

--- a/fossunited/www/c/rss.py
+++ b/fossunited/www/c/rss.py
@@ -3,6 +3,7 @@ from email.utils import format_datetime
 from urllib.parse import urljoin
 
 import frappe
+from frappe import _
 from frappe.utils import escape_html, get_request_site_address, sanitize_html
 
 from fossunited.doctype_ids import EVENT
@@ -18,7 +19,7 @@ def _safe_cdata(text):
 def get_context(context):
     slug = frappe.form_dict.get("chapter")
     if not slug:
-        frappe.throw("chapter parameter is required", frappe.InvalidRequestException)
+        frappe.throw(_("chapter parameter is required"), frappe.InvalidRequestException)
 
     chapter = frappe.db.get_value(
         "FOSS Chapter", {"slug": slug}, ["chapter_name", "route", "name", "slug"], as_dict=True
@@ -26,7 +27,7 @@ def get_context(context):
         "FOSS Chapter", slug, ["chapter_name", "route", "name", "slug"], as_dict=True
     )
     if not chapter:
-        frappe.throw("Chapter not found", frappe.DoesNotExistError)
+        frappe.throw(_("Chapter not found"), frappe.DoesNotExistError)
 
     host = get_request_site_address()
 

--- a/fossunited/www/c/rss.xml
+++ b/fossunited/www/c/rss.xml
@@ -1,0 +1,1 @@
+{% extends "templates/rss.xml" %}


### PR DESCRIPTION
## Status

- [x] Ready for review


## Related Issue

Closes / Addresses: #1461 


## PR Description

Adds a per-chapter RSS feed at /c/{slug}/rss.xml listing upcoming published events.

- Feed includes event type, location, start/end time, and description; sorted by start date
- Autodiscovery added to each chapter page
- Extends shared templates/rss.xml base template