### PR TITLE
fix(website): replace unsupported font-weight-600 with font-weight-bold

### DIFF
--- a/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/templates/foss_hackathon_partner_project.html
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/templates/foss_hackathon_partner_project.html
@@ -91,13 +91,13 @@
             class="v3-clickable d-flex flex-column p-3"
             style="border:1px solid var(--v3-button-border);border-radius:0.5rem;"
           >
-            <div class="v3-text-primary mb-1 text-lg">{{ project.title }}</div>
+            <div class="v3-text-primary mb-1 text-sm font-weight-600">{{ project.title }}</div>
             {% if project.short_description %}
-              <div class="v3-text-secondary text-base">
+              <div class="v3-text-secondary text-sm">
                 {{ project.short_description | truncate(100, true) }}
               </div>
             {% endif %}
-            <div class="d-flex align-items-center gap-2 mt-2 text-base">
+            <div class="d-flex align-items-center gap-2 mt-2 text-sm">
               <span class="v3-text-tertiary">
                 <i class="ti ti-users-group"></i>
                 {{ project.team_name }}

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/templates/foss_hackathon_partner_project.html
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_partner_project/templates/foss_hackathon_partner_project.html
@@ -91,7 +91,7 @@
             class="v3-clickable d-flex flex-column p-3"
             style="border:1px solid var(--v3-button-border);border-radius:0.5rem;"
           >
-            <div class="v3-text-primary mb-1 text-sm font-weight-600">{{ project.title }}</div>
+            <div class="v3-text-primary mb-1 text-sm font-weight-bold">{{ project.title }}</div>
             {% if project.short_description %}
               <div class="v3-text-secondary text-sm">
                 {{ project.short_description | truncate(100, true) }}

--- a/fossunited/templates/macros/issue_pr_table.html
+++ b/fossunited/templates/macros/issue_pr_table.html
@@ -29,7 +29,7 @@
                 <span class="v3-text-secondary">Discussion</span>
               {% endif %}
             </div>
-            <div class="v3-text-primary text-base">
+            <div class="v3-text-primary text-sm">
               {{ item.title }}
             </div>
           </a>


### PR DESCRIPTION
This PR improves the typography hierarchy on the FOSS Hack partner project pages.

Changes:
- Reduced font size in participant contribution cards
- Adjusted issue/PR section typography
- Ensured section headings remain visually dominant

Fixes #1460

Contribution made as part of FOSS Hack 2026.