### PR TITLE
fix(dashboard): sanitize HTML in cleanedHTML helper using DOMPurify

### DIFF
--- a/dashboard/src/components/reviewers/ReviewSection.vue
+++ b/dashboard/src/components/reviewers/ReviewSection.vue
@@ -39,7 +39,7 @@
             <div
               v-if="review.remarks"
               class="prose prose-sm max-w-full"
-              v-html="review.remarks"
+              v-html="cleanedHTML(review.remarks)"
             ></div>
             <span v-else class="text-sm text-ink-gray-5">No Remarks</span>
             <div class="flex items-center gap-2">

--- a/dashboard/src/helpers/utils.js
+++ b/dashboard/src/helpers/utils.js
@@ -1,5 +1,6 @@
 import { computed } from 'vue'
 import { toast } from 'vue-sonner'
+import DOMPurify from 'dompurify'
 
 export const truncateStr = (title, len) => {
   return title.length > len ? title.substring(0, len) + '...' : title
@@ -21,7 +22,7 @@ export const copyToClipboard = (text) => {
 export const cleanedHTML = (htmlData) => {
   const html = htmlData || ''
   const tempDiv = document.createElement('div')
-  tempDiv.innerHTML = html
+  tempDiv.innerHTML = DOMPurify.sanitize(html)
 
   // Process each <p> tag
   tempDiv.querySelectorAll('p').forEach((p) => {


### PR DESCRIPTION

This PR adds HTML sanitization to prevent potential XSS issues when rendering dynamic content.

The  cleanedHTML() helper in utils.js now uses DOMPurify.sanitize() before parsing HTML with  tempDiv.innerHTML . This ensures that any unsafe tags or scripts are removed before the content is processed.

## Changes Made
- Added DOMPurify.sanitize() in the cleanedHTML() helper
- Ensured sanitized HTML is used when rendering `review.remarks`
- Prevented raw unsanitized HTML from being rendered via v-html in ReviewSection.vue

## Why this change?
Previously, HTML content was inserted using `tempDiv.innerHTML` without sanitization, which could potentially allow unsafe HTML to be rendered. Using DOMPurify ensures the content is cleaned before rendering.

## Issue
Closes #1165