### PR TITLE
feat(performance): load fonts non-blocking and remove legacy font-face formats

### DIFF
--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -13,8 +13,6 @@
 :root {
   /* font-families */
   --ff-san-serif: 'Inter', sans-serif;
-  --ff-mono: 'Source Code Pro', monospace;
-  --ff-pixel: 'Press Start 2P', cursive;
 
   /* font-sizes */
   --text-xs: 0.75rem;

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -1,22 +1,12 @@
-/* Importing Fonts */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Press+Start+2P&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Source+Code+Pro:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap');
-
 /* FFF Forward Font */
 @font-face {
   font-family: 'FFF Forward';
-  src: url('/assets/fossunited/fonts/fff_font/fff-forward.regular-webfont.eot');
   src:
-    url('/assets/fossunited/fonts/fff_font/fff-forward.regular-webfont.eot?#iefix')
-      format('embedded-opentype'),
     url('/assets/fossunited/fonts/fff_font/fff-forward.regular-webfont.woff2') format('woff2'),
-    url('/assets/fossunited/fonts/fff_font/fff-forward.regular-webfont.woff') format('woff'),
-    url('/assets/fossunited/fonts/fff_font/fff-forward.regular-webfont.ttf') format('truetype'),
-    url('/assets/fossunited/fonts/fff_font/fff-forward.regular-webfont.svg#fff_forwardregular')
-      format('svg');
+    url('/assets/fossunited/fonts/fff_font/fff-forward.regular-webfont.woff') format('woff');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 /* ----- */
 
@@ -24,7 +14,6 @@
   /* font-families */
   --ff-san-serif: 'Inter', sans-serif;
   --ff-mono: 'Source Code Pro', monospace;
-  --ff-serif: 'Source Serif Pro', serif;
   --ff-pixel: 'Press Start 2P', cursive;
 
   /* font-sizes */

--- a/fossunited/templates/foss_base.html
+++ b/fossunited/templates/foss_base.html
@@ -7,15 +7,6 @@
     document.documentElement.setAttribute('data-theme', savedTheme);
   })();
 </script>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preload" as="style"
-  href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Source+Code+Pro:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&family=Press+Start+2P&display=swap"
-  onload="this.rel='stylesheet'">
-<noscript>
-  <link rel="stylesheet"
-    href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Source+Code+Pro:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&family=Press+Start+2P&display=swap">
-</noscript>
 <link
   rel="stylesheet"
   href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/tabler-icons.min.css"

--- a/fossunited/templates/foss_base.html
+++ b/fossunited/templates/foss_base.html
@@ -7,6 +7,15 @@
     document.documentElement.setAttribute('data-theme', savedTheme);
   })();
 </script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="preload" as="style"
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Source+Code+Pro:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&family=Press+Start+2P&display=swap"
+  onload="this.rel='stylesheet'">
+<noscript>
+  <link rel="stylesheet"
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Source+Code+Pro:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&family=Press+Start+2P&display=swap">
+</noscript>
 <link
   rel="stylesheet"
   href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/tabler-icons.min.css"


### PR DESCRIPTION
- Replaced 3 render-blocking `@import` font calls in custom.css in with a single non-blocking `<link rel="preload">`  in foss_base.html

- Merged duplicate Inter imports into one consolidated Google Fonts URL

- Dropped legacy @font-face formats (.eot, .ttf, .svg) from FFF Forward; kept woff2 + woff only

- Added font-display: swap to `@font-face`

- Removed unused --ff-serif CSS variable (Source Serif Pro was never loaded)

Render-blocking `@import` statements inside CSS files force the browser to pause page rendering until all font stylesheets are downloaded. This was causing an estimated ~1,200ms render-blocking delay on every page load. Additionally, the missing `font-display: swap `was causing an extra ~140ms penalty.

Related issue: #730 


