### PR TITLE
fix(attendeeList): group requests by teamID and fix search filters

### DIFF
--- a/dashboard/src/components/localhost/AttendeeRequestList.vue
+++ b/dashboard/src/components/localhost/AttendeeRequestList.vue
@@ -54,6 +54,10 @@
     </div>
   </div>
 
+  <span v-if="currentView === 'requests'" class="ml-2 text-sm font-normal text-ink-gray-5">
+    Note: Grouped by teamID (more than one team can share same name)
+  </span>
+
   <!-- Check-Ins View -->
   <CheckInsTable
     v-if="currentView === 'checkins'"
@@ -259,7 +263,7 @@ const totalAccepted = computed(() => {
 })
 
 watchEffect(() => {
-  if (!requests.data) {
+  if (!requests.data || !Array.isArray(requests.data)) {
     groupedRequests.value = []
     return
   }
@@ -275,32 +279,31 @@ watchEffect(() => {
     }
   })
 
-  // Flatten requests and add check-in status
-  const allRequests = []
-  Object.entries(requests.data).forEach(([teamId, teamRequests]) => {
-    teamRequests.forEach((request) => {
-      allRequests.push({
-        ...request,
-        has_checked_in_today: checkedInToday.has(request.name),
-        team_name: request.team?.team_name || 'Unknown Team',
-      })
-    })
-  })
+  // Add check-in status to each request
+  const enrichedRequests = requests.data.map((request) => ({
+    ...request,
+    has_checked_in_today: checkedInToday.has(request.name),
+  }))
 
-  // Group by team name
-  const teamGroups = {}
-  allRequests.forEach((request) => {
-    const teamName = request.team_name
-    if (!teamGroups[teamName]) {
-      teamGroups[teamName] = []
+  // Group by team ID
+  const teamGroups = enrichedRequests.reduce((groups, request) => {
+    const teamId = request.team_id
+    if (!groups[teamId]) {
+      groups[teamId] = []
     }
-    teamGroups[teamName].push(request)
-  })
+    groups[teamId].push(request)
+    return groups
+  }, {})
 
-  // Convert to array of groups
+  // Convert to sorted array of groups
   groupedRequests.value = Object.entries(teamGroups)
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([teamName, rows]) => {
+    .sort(([, aRows], [, bRows]) => {
+      const aName = aRows[0]?.team_name || ''
+      const bName = bRows[0]?.team_name || ''
+      return aName.localeCompare(bName)
+    })
+    .map(([teamId, rows]) => {
+      const teamName = rows[0]?.team_name || 'Unknown Team'
       const hasPending = rows.some((r) => r.localhost_request_status === 'Pending')
       const hasPendingConfirmation = rows.some(
         (r) => r.localhost_request_status === 'Pending Confirmation',

--- a/dashboard/src/components/localhost/RequestDetailDialog.vue
+++ b/dashboard/src/components/localhost/RequestDetailDialog.vue
@@ -51,7 +51,7 @@
         </div>
         <div class="flex flex-col gap-1">
           <div class="text-base font-medium">Team</div>
-          <div>{{ participant.team.team_name }}</div>
+          <div>{{ participant.team_name }}</div>
         </div>
         <div class="flex flex-col gap-1">
           <div class="font-medium">Project</div>

--- a/dashboard/src/components/ui/SearchListView.vue
+++ b/dashboard/src/components/ui/SearchListView.vue
@@ -137,24 +137,31 @@ const getSearchText = (row) => {
 }
 
 const originalGroupRows = new WeakMap()
+
 const filteredRows = computed(() => {
   const term = search.value ? search.value.toLowerCase().trim() : ''
   const hasSearch = !!term
   const hasFilter = props.filterField && selectedFilter.value && selectedFilter.value !== 'All'
 
-  // No filters applied, return original rows
-  if (!hasSearch && !hasFilter) {
-    return props.rows
-  }
-
   if (isGrouped.value) {
-    return props.rows.reduce((acc, group) => {
-      // store original rows once
+    // First pass: cache original rows for all groups
+    props.rows.forEach((group) => {
       if (!originalGroupRows.has(group)) {
-        originalGroupRows.set(group, group.rows)
+        originalGroupRows.set(group, [...group.rows])
       }
-      const sourceRows = originalGroupRows.get(group)
+    })
 
+    // No filters applied - restore all original rows
+    if (!hasSearch && !hasFilter) {
+      props.rows.forEach((group) => {
+        group.rows = originalGroupRows.get(group)
+      })
+      return props.rows
+    }
+
+    // Apply filters
+    return props.rows.reduce((acc, group) => {
+      const sourceRows = originalGroupRows.get(group)
       const filtered = sourceRows.filter((row) => {
         if (hasSearch && !getSearchText(row).includes(term)) return false
         if (hasFilter && row[props.filterField] !== selectedFilter.value) return false
@@ -170,15 +177,10 @@ const filteredRows = computed(() => {
     }, [])
   }
 
+  // Non-grouped filtering
   return props.rows.filter((row) => {
-    // Apply search filter
-    if (hasSearch && !getSearchText(row).includes(term)) {
-      return false
-    }
-    // Apply status filter
-    if (hasFilter && row[props.filterField] !== selectedFilter.value) {
-      return false
-    }
+    if (hasSearch && !getSearchText(row).includes(term)) return false
+    if (hasFilter && row[props.filterField] !== selectedFilter.value) return false
     return true
   })
 })

--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -299,17 +299,9 @@ def get_localhost_requests_by_team(
     ],
 ):
     """
-    Get requests for a particular localhost grouped by team.
-
-    params:
-        hackathon(str): hackathon name
-        localhost(str): localhost name
-        status(list): status of the request
-
-    return:
-        dict: requests grouped by team
+    Get requests for a particular localhost with team and project info.
+    Returns a flat list.
     """
-
     requests = frappe.get_all(
         doctype=HACKATHON_PARTICIPANT,
         filters={
@@ -334,38 +326,51 @@ def get_localhost_requests_by_team(
         order_by="creation",
     )
 
+    # Enrich each request with profile, team, and project data
     for request in requests:
-        request["profile_route"] = frappe.db.get_value(USER_PROFILE, request.user_profile, "route")
-        profile_photo = frappe.db.get_value(USER_PROFILE, request.user_profile, "profile_photo")
-        request["profile_photo"] = (
-            profile_photo
-            if profile_photo
-            else "/assets/fossunited/images/defaults/user_profile_image.png"
-        )
-        request["profile_username"] = frappe.db.get_value(
-            USER_PROFILE, request.user_profile, "username"
-        )
+        # Profile data
+        if request.user_profile:
+            profile = (
+                frappe.db.get_value(
+                    USER_PROFILE,
+                    request.user_profile,
+                    ["route", "profile_photo", "username"],
+                    as_dict=True,
+                )
+                or {}
+            )
+            request["profile_route"] = profile.get("route")
+            request["profile_photo"] = (
+                profile.get("profile_photo")
+                or "/assets/fossunited/images/defaults/user_profile_image.png"
+            )
+            request["profile_username"] = profile.get("username")
+        else:
+            request["profile_route"] = None
+            request["profile_photo"] = "/assets/fossunited/images/defaults/user_profile_image.png"
+            request["profile_username"] = None
 
-    requests_by_team = {}
-
-    for request in requests:
+        # Team data
         team = get_team_from_participant_id(hackathon, request.get("name"))
         if team:
+            request["team_id"] = team.name
+            request["team_name"] = team.team_name
+
+            # Project data
             project = get_project_by_team(hackathon, team.name)
             if project:
                 request["project_title"] = project.title
                 request["project_route"] = project.route
-            if team.name not in requests_by_team:
-                requests_by_team[team.name] = []
-            request["team"] = team
-            requests_by_team[team.name].append(request)
+            else:
+                request["project_title"] = None
+                request["project_route"] = None
         else:
-            request["team"] = {"team_name": "Individual Participants"}
-            if "Individual Participants" not in requests_by_team:
-                requests_by_team["Individual Participants"] = []
-            requests_by_team["Individual Participants"].append(request)
+            request["team_id"] = "individual"
+            request["team_name"] = "Individual Participants"
+            request["project_title"] = None
+            request["project_route"] = None
 
-    return requests_by_team or None
+    return requests
 
 
 @frappe.whitelist()


### PR DESCRIPTION
- many team can share same name, so its better to group by team ID to show uniqueness

- FYI, each team can have only one project so Project == Team

But still since we group by team, we can group by ID for distinguishing