### PR TITLE
feat(events): show message when event has concluded

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
+++ b/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
@@ -112,6 +112,12 @@
       Registration is closed for the event
     </div>
     {% endif %}
+    {% if status_concluded %}
+    <div class="v3-status v3-status--warning" role="status" aria-live="polite">
+      <i class="ti ti-ban" aria-hidden="true"></i>
+      This event has concluded.
+    </div>
+    {% endif %}
 
 
   </div>
@@ -284,9 +290,6 @@
                 {{ chapter_branding_block(chapter) }}
 
                 <h1 class="ev-title">{{ doc.event_name }}</h1>
-                {% if status_concluded %}
-                  <p class="v3-text-secondary">This event has concluded.</p>
-                {% endif %}
                 <div class="v3-event-tags" aria-label="Event tags">
                   {% if doc.must_attend %}
                     {{ event_must_attend_tag() }}

--- a/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
+++ b/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
@@ -284,6 +284,9 @@
                 {{ chapter_branding_block(chapter) }}
 
                 <h1 class="ev-title">{{ doc.event_name }}</h1>
+                {% if status_concluded %}
+                  <p class="v3-text-secondary">This event has concluded.</p>
+                {% endif %}
                 <div class="v3-event-tags" aria-label="Event tags">
                   {% if doc.must_attend %}
                     {{ event_must_attend_tag() }}

--- a/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
+++ b/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
@@ -115,7 +115,7 @@
     {% if status_concluded %}
     <div class="v3-status v3-status--warning" role="status" aria-live="polite">
       <i class="ti ti-ban" aria-hidden="true"></i>
-      This event has concluded.
+      This event has concluded
     </div>
     {% endif %}
 


### PR DESCRIPTION
Adds a small UX improvement to event pages.

If an event has already concluded, a message "This event has concluded." is displayed below the event title. This helps users quickly understand that the event is no longer active when visiting the page.

The change is minimal and only introduces a conditional check in the event template to show the message when the event status is concluded.

Related to #1461