### PR TITLE
feat(participant): add disqualification control + link team & project to each participant

### DIFF
--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -52,6 +52,7 @@ declare module 'vue' {
     FreeTicketCodeSection: typeof import('./src/components/event/FreeTicketCodeSection.vue')['default']
     GuidelineSection: typeof import('./src/components/cfp-public/GuidelineSection.vue')['default']
     HackathonAttendanceMode: typeof import('./src/components/hackathon/HackathonAttendanceMode.vue')['default']
+    HackathonLayout: typeof import('./src/components/hackathon/HackathonLayout.vue')['default']
     HackathonParticipantHeader: typeof import('./src/components/hackathon/HackathonParticipantHeader.vue')['default']
     HackathonProjectDetails: typeof import('./src/components/hackathon/HackathonProjectDetails.vue')['default']
     HackathonProjectIssue: typeof import('./src/components/hackathon/HackathonProjectIssue.vue')['default']

--- a/dashboard/src/components/hackathon/HackathonLayout.vue
+++ b/dashboard/src/components/hackathon/HackathonLayout.vue
@@ -1,0 +1,90 @@
+<template>
+  <!-- Disqualification Dialog -->
+  <Dialog
+    v-model="showDisqualifiedDialog"
+    :options="{
+      title: 'Access Denied',
+      size: 'xl',
+    }"
+  >
+    <template #body-content>
+      <div class="space-y-4">
+        <div class="flex justify-center">
+          <div class="flex h-16 w-16 items-center justify-center rounded-full bg-red-100">
+            Icons
+          </div>
+        </div>
+
+        <div class="text-center">
+          <h3 class="text-xl font-semibold text-gray-900">You Have Been Disqualified</h3>
+          <p class="mt-2 text-sm text-gray-600">
+            You have been disqualified from
+            <span class="font-medium">{{ hackathonName }}</span> and cannot participant anymore.
+          </p>
+        </div>
+
+        <div v-if="rules" class="rounded-lg bg-red-50 p-4">
+          <h4 class="mb-2 text-sm font-semibold text-red-900">Hackathon Rules:</h4>
+          <div class="prose prose-sm max-w-none text-red-800" v-html="rules"></div>
+        </div>
+
+        <div class="rounded-lg bg-gray-50 p-4 text-center">
+          <p class="text-sm text-gray-600">
+            We are sure we had given fair warning to keep activity going on as per our rules. If
+            you think this is a mistake, please write email to fosshack@fossunited.org
+          </p>
+        </div>
+      </div>
+    </template>
+  </Dialog>
+
+  <div v-if="isValidated">
+    <slot />
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, watch, onUnmounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { Dialog, createResource } from 'frappe-ui'
+
+const route = useRoute()
+const router = useRouter()
+
+const isValidated = ref(false)
+const showDisqualifiedDialog = ref(false)
+const hackathonName = ref('')
+const rules = ref('')
+
+async function checkDisqualification() {
+  const check = createResource({
+    url: 'fossunited.api.hackathon.check_participant_disqualification',
+    params: {
+      hackathon_permalink: route.params.permalink,
+    },
+    auto: false,
+  })
+
+  try {
+    await check.fetch()
+    const data = check.data
+
+    if (data.is_disqualified) {
+      hackathonName.value = data.hackathon_name
+      rules.value = data.rules
+      showDisqualifiedDialog.value = true
+      isValidated.value = false
+    } else {
+      isValidated.value = true
+    }
+  } catch (error) {
+    console.error('Error checking disqualification:', error)
+    // Fail open - allow access on error
+    isValidated.value = true
+  }
+}
+
+onMounted(() => {
+  checkDisqualification()
+})
+</script>

--- a/dashboard/src/components/hackathon/HackathonLayout.vue
+++ b/dashboard/src/components/hackathon/HackathonLayout.vue
@@ -2,70 +2,65 @@
   <!-- Disqualification Message -->
   <div
     v-if="!isLoading && isDisqualified"
-    class="w-full min-h-screen flex items-center justify-center p-4 bg-gray-50 dark:bg-gray-900"
+    class="min-h-screen flex items-center justify-center p-4 bg-surface-gray-1"
   >
-    <div class="w-full max-w-2xl">
+    <div class="max-w-2xl w-full space-y-6">
+      <div class="text-center space-y-4">
+        <div class="flex justify-center">
+          <div class="h-16 w-16 rounded-full bg-surface-red-1 flex items-center justify-center">
+            <IconHandStop class="w-8 h-8 text-surface-red-5" />
+          </div>
+        </div>
+        <div>
+          <h2 class="text-2xl font-semibold text-ink-gray-7">Access Denied</h2>
+          <p class="mt-2 text-ink-gray-5">
+            You have been disqualified from {{ hackathonName }}. You won't be able to participate
+            anymore.
+          </p>
+        </div>
+      </div>
+
       <div
-        class="bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 overflow-hidden"
+        v-if="rules"
+        class="border border-outline-gray-3 rounded-lg p-6 space-y-3 bg-surface-white"
       >
-        <div
-          class="bg-red-50 dark:bg-red-900/20 border-b border-red-100 dark:border-red-800 px-6 py-8"
+        <h4 class="font-semibold flex items-center gap-2 text-ink-gray-7">
+          <IconFileInvoice class="w-5 h-5 text-ink-gray-5" />
+          Hackathon Rules
+        </h4>
+        <div class="prose prose-sm max-w-none text-ink-gray-6" v-html="rules"></div>
+      </div>
+
+      <div class="border border-outline-gray-3 rounded-lg p-4 bg-surface-white">
+        <p class="text-sm flex items-start gap-2 text-ink-gray-6">
+          <IconInfoCircle class="w-5 h-5 flex-shrink-0 mt-0.5 text-surface-blue-3" />
+          <span>
+            If you believe this is an error, please write to us at fosshack@fossunited.org
+          </span>
+        </p>
+      </div>
+
+      <div class="text-center pt-4">
+        <!-- an easter egg awaits.. -->
+        <button
+          @click="() => window.location.href = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'"
+          class="px-6 py-2.5 bg-surface-gray-7 text-ink-white rounded-lg font-medium hover:bg-surface-gray-6 transition-colors"
         >
-          <div class="flex flex-col items-center text-center">
-            <div
-              class="flex h-16 w-16 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/40 mb-4"
-            >
-              <IconHandStop class="w-5 h-5 text-red-500" />
-            </div>
-            <h2 class="text-2xl font-semibold text-gray-900 dark:text-gray-100">Access Denied</h2>
-            <p class="mt-2 text-base text-gray-600 dark:text-gray-400">
-              You have been disqualified from {{ hackathonName }}. You won't be able to participate
-              anymore.
-            </p>
-          </div>
-        </div>
-
-        <div class="px-6 py-6 space-y-6">
-          <div
-            v-if="rules"
-            class="bg-amber-50 dark:bg-amber-900/10 rounded-lg p-4 border border-amber-200 dark:border-amber-800"
-          >
-            <h4
-              class="text-sm font-semibold text-amber-900 dark:text-amber-300 mb-3 flex items-center gap-2"
-            >
-              <IconFileInvoice class="w-5 h-5 text-amber-500" />
-              Hackathon Rules
-            </h4>
-            <div
-              class="prose prose-sm dark:prose-invert max-w-none text-amber-900 dark:text-amber-200"
-              v-html="rules"
-            ></div>
-          </div>
-
-          <div
-            class="bg-blue-50 dark:bg-blue-900/10 rounded-lg p-4 border border-blue-200 dark:border-blue-800"
-          >
-            <p class="text-sm text-blue-900 dark:text-blue-300 flex items-start gap-2">
-              <IconInfoCircle class="w-5 h-5 text-blue-500" />
-              <span>
-                If you believe this is an error, please write to us at fosshack@fossunited.org
-              </span>
-            </p>
-          </div>
-        </div>
+          Better Luck Next Time!
+        </button>
       </div>
     </div>
   </div>
 
   <div
     v-else-if="isLoading"
-    class="flex items-center justify-center min-h-screen bg-gray-50 dark:bg-gray-900"
+    class="min-h-screen flex items-center justify-center bg-surface-gray-1"
   >
-    <div class="text-center">
+    <div class="text-center space-y-4">
       <div
-        class="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900 dark:border-gray-100 mx-auto"
+        class="h-12 w-12 border-b-2 border-surface-gray-7 rounded-full animate-spin mx-auto"
       ></div>
-      <p class="mt-4 text-gray-600 dark:text-gray-400">Loading...</p>
+      <p class="text-ink-gray-5">Loading...</p>
     </div>
   </div>
 

--- a/dashboard/src/components/hackathon/HackathonLayout.vue
+++ b/dashboard/src/components/hackathon/HackathonLayout.vue
@@ -43,7 +43,7 @@
       <div class="text-center pt-4">
         <!-- an easter egg awaits.. -->
         <button
-          @click="() => window.location.href = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'"
+          @click="redirectToExternalUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ')"
           class="px-6 py-2.5 bg-surface-gray-7 text-ink-white rounded-lg font-medium hover:bg-surface-gray-6 transition-colors"
         >
           Better Luck Next Time!
@@ -74,6 +74,7 @@ import { ref, onMounted, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { createResource } from 'frappe-ui'
 import { IconInfoCircle, IconHandStop, IconFileInvoice } from '@tabler/icons-vue'
+import { redirectToExternalUrl } from '@/helpers/utils'
 
 const route = useRoute()
 

--- a/dashboard/src/components/hackathon/HackathonLayout.vue
+++ b/dashboard/src/components/hackathon/HackathonLayout.vue
@@ -1,62 +1,95 @@
 <template>
-  <!-- Disqualification Dialog -->
-  <Dialog
-    v-model="showDisqualifiedDialog"
-    :options="{
-      title: 'Access Denied',
-      size: 'xl',
-    }"
+  <!-- Disqualification Message -->
+  <div
+    v-if="!isLoading && isDisqualified"
+    class="w-full min-h-screen flex items-center justify-center p-4 bg-gray-50 dark:bg-gray-900"
   >
-    <template #body-content>
-      <div class="space-y-4">
-        <div class="flex justify-center">
-          <div class="flex h-16 w-16 items-center justify-center rounded-full bg-red-100">
-            Icons
+    <div class="w-full max-w-2xl">
+      <div
+        class="bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 overflow-hidden"
+      >
+        <div
+          class="bg-red-50 dark:bg-red-900/20 border-b border-red-100 dark:border-red-800 px-6 py-8"
+        >
+          <div class="flex flex-col items-center text-center">
+            <div
+              class="flex h-16 w-16 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/40 mb-4"
+            >
+              <IconHandStop class="w-5 h-5 text-red-500" />
+            </div>
+            <h2 class="text-2xl font-semibold text-gray-900 dark:text-gray-100">Access Denied</h2>
+            <p class="mt-2 text-base text-gray-600 dark:text-gray-400">
+              You have been disqualified from {{ hackathonName }}. You won't be able to participate
+              anymore.
+            </p>
           </div>
         </div>
 
-        <div class="text-center">
-          <h3 class="text-xl font-semibold text-gray-900">You Have Been Disqualified</h3>
-          <p class="mt-2 text-sm text-gray-600">
-            You have been disqualified from
-            <span class="font-medium">{{ hackathonName }}</span> and cannot participant anymore.
-          </p>
-        </div>
+        <div class="px-6 py-6 space-y-6">
+          <div
+            v-if="rules"
+            class="bg-amber-50 dark:bg-amber-900/10 rounded-lg p-4 border border-amber-200 dark:border-amber-800"
+          >
+            <h4
+              class="text-sm font-semibold text-amber-900 dark:text-amber-300 mb-3 flex items-center gap-2"
+            >
+              <IconFileInvoice class="w-5 h-5 text-amber-500" />
+              Hackathon Rules
+            </h4>
+            <div
+              class="prose prose-sm dark:prose-invert max-w-none text-amber-900 dark:text-amber-200"
+              v-html="rules"
+            ></div>
+          </div>
 
-        <div v-if="rules" class="rounded-lg bg-red-50 p-4">
-          <h4 class="mb-2 text-sm font-semibold text-red-900">Hackathon Rules:</h4>
-          <div class="prose prose-sm max-w-none text-red-800" v-html="rules"></div>
-        </div>
-
-        <div class="rounded-lg bg-gray-50 p-4 text-center">
-          <p class="text-sm text-gray-600">
-            We are sure we had given fair warning to keep activity going on as per our rules. If
-            you think this is a mistake, please write email to fosshack@fossunited.org
-          </p>
+          <div
+            class="bg-blue-50 dark:bg-blue-900/10 rounded-lg p-4 border border-blue-200 dark:border-blue-800"
+          >
+            <p class="text-sm text-blue-900 dark:text-blue-300 flex items-start gap-2">
+              <IconInfoCircle class="w-5 h-5 text-blue-500" />
+              <span>
+                If you believe this is an error, please write to us at fosshack@fossunited.org
+              </span>
+            </p>
+          </div>
         </div>
       </div>
-    </template>
-  </Dialog>
+    </div>
+  </div>
 
-  <div v-if="isValidated">
-    <slot />
+  <div
+    v-else-if="isLoading"
+    class="flex items-center justify-center min-h-screen bg-gray-50 dark:bg-gray-900"
+  >
+    <div class="text-center">
+      <div
+        class="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900 dark:border-gray-100 mx-auto"
+      ></div>
+      <p class="mt-4 text-gray-600 dark:text-gray-400">Loading...</p>
+    </div>
+  </div>
+
+  <div v-else-if="isValidated">
+    <RouterView />
   </div>
 </template>
 
 <script setup>
-import { ref, onMounted, watch, onUnmounted } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
-import { Dialog, createResource } from 'frappe-ui'
+import { ref, onMounted, watch } from 'vue'
+import { useRoute } from 'vue-router'
+import { createResource } from 'frappe-ui'
+import { IconInfoCircle, IconHandStop, IconFileInvoice } from '@tabler/icons-vue'
 
 const route = useRoute()
-const router = useRouter()
 
+const isLoading = ref(true)
 const isValidated = ref(false)
-const showDisqualifiedDialog = ref(false)
+const isDisqualified = ref(false)
 const hackathonName = ref('')
 const rules = ref('')
 
 async function checkDisqualification() {
+  isLoading.value = true
   const check = createResource({
     url: 'fossunited.api.hackathon.check_participant_disqualification',
     params: {
@@ -70,19 +103,29 @@ async function checkDisqualification() {
     const data = check.data
 
     if (data.is_disqualified) {
+      isDisqualified.value = true
       hackathonName.value = data.hackathon_name
       rules.value = data.rules
-      showDisqualifiedDialog.value = true
       isValidated.value = false
     } else {
+      isDisqualified.value = false
       isValidated.value = true
     }
   } catch (error) {
     console.error('Error checking disqualification:', error)
-    // Fail open - allow access on error
     isValidated.value = true
+  } finally {
+    isLoading.value = false
   }
 }
+
+// Re-check when route changes (moving between children)
+watch(
+  () => route.name,
+  () => {
+    checkDisqualification()
+  },
+)
 
 onMounted(() => {
   checkDisqualification()

--- a/dashboard/src/components/localhost/LocalhostValidation.js
+++ b/dashboard/src/components/localhost/LocalhostValidation.js
@@ -10,7 +10,7 @@ export function LocalhostValidation(localhostId, redirectRoute = 'MyLocalhosts')
 
   const validateSessionUser = (onSuccessCallback) => {
     createResource({
-      url: 'fossunited.api.hackathon.is_localhost_organizer',
+      url: 'fossunited.utils.decorators.is_localhost_organizer',
       params: {
         localhost_id: localhostId,
       },

--- a/dashboard/src/components/localhost/LocalhostValidation.js
+++ b/dashboard/src/components/localhost/LocalhostValidation.js
@@ -10,7 +10,7 @@ export function LocalhostValidation(localhostId, redirectRoute = 'MyLocalhosts')
 
   const validateSessionUser = (onSuccessCallback) => {
     createResource({
-      url: 'fossunited.api.hackathon.validate_user_as_localhost_member',
+      url: 'fossunited.api.hackathon.is_localhost_organizer',
       params: {
         localhost_id: localhostId,
       },

--- a/dashboard/src/helpers/utils.js
+++ b/dashboard/src/helpers/utils.js
@@ -14,6 +14,10 @@ export const createAbsoluteUrlFromRoute = (route) => {
   return window.location.origin + '/' + route
 }
 
+export const redirectToExternalUrl = (url) => {
+  window.open(url, '_blank')
+}
+
 export const copyToClipboard = (text) => {
   navigator.clipboard.writeText(text)
 }

--- a/dashboard/src/pages/hackathon/Register.vue
+++ b/dashboard/src/pages/hackathon/Register.vue
@@ -199,6 +199,7 @@ let participant = reactive({
   organization: '',
   wants_to_attend_locally: '',
   localhost: '',
+  subscribe_chapter_mailing: 1,
 })
 
 const hackathonId = ref(null)

--- a/dashboard/src/router.js
+++ b/dashboard/src/router.js
@@ -254,6 +254,7 @@ const routes = [
   },
   {
     path: '/hack/:permalink',
+    component: () => import('@/components/hackathon/HackathonLayout.vue'),
     children: [
       {
         path: '',

--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -53,7 +53,7 @@ def get_hackathon_from_permalink(permalink: str) -> dict:
 
 
 @frappe.whitelist()
-def create_participant(hackathon, participant):
+def create_participant(hackathon: str, participant: str) -> dict:
     """
     This method is used to create a participant for a hackathon.
 
@@ -673,7 +673,7 @@ def check_participant_disqualification(hackathon_permalink: str):
     )
 
     if not hackathon:
-        frappe.throw("Hackathon not found")
+        frappe.throw(frappe._("Hackathon not found"))
 
     participant = frappe.db.get_value(
         HACKATHON_PARTICIPANT,

--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -53,7 +53,7 @@ def get_hackathon_from_permalink(permalink: str) -> dict:
 
 
 @frappe.whitelist()
-def create_participant(hackathon: str, participant: str) -> dict:
+def create_participant(hackathon: dict, participant: dict) -> dict:
     """
     This method is used to create a participant for a hackathon.
 

--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -560,39 +560,6 @@ def validate_participant_for_localhost(participant_id: str):
 
 
 @frappe.whitelist()
-def is_localhost_organizer(localhost_id: str, user=None) -> bool:
-    """
-    Check if user is a localhost organizer.
-    """
-    if not user:
-        user = frappe.session.user
-
-    # System Manager bypass
-    if "System Manager" in frappe.get_roles(user):
-        return True
-
-    profile = frappe.db.get_value(USER_PROFILE, {"user": user}, "name")
-    # Check if profile exists in localhost organizers
-    is_member = frappe.db.exists(
-        LOCALHOST_ORGANIZER,
-        {
-            "parent": localhost_id,
-            "parenttype": HACKATHON_LOCALHOST,
-            "profile": profile,
-            "parentfield": "organizers",
-        },
-    )
-
-    if not is_member:
-        frappe.throw(
-            "You are not a member of this Localhost. You are not authorized to view this page"
-        )
-        return False
-
-    return True
-
-
-@frappe.whitelist()
 def get_issue_pr_title(url: str) -> dict:
     """
     Get title of the issue/PR/Discussion from the URL

--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -667,7 +667,7 @@ def check_participant_disqualification(hackathon_permalink: str):
     user = frappe.session.user
     hackathon = frappe.db.get_value(
         HACKATHON,
-        {"route": hackathon_permalink},
+        {"permalink": hackathon_permalink},
         ["name", "hackathon_name", "hackathon_rules"],
         as_dict=True,
     )

--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -683,3 +683,44 @@ def get_localhost_checkin_stats(localhost_id: str):
     )
 
     return {"total_accepted": total_accepted}
+
+
+@frappe.whitelist()
+def check_participant_disqualification(hackathon_permalink: str):
+    """
+    Check if current user is disqualified from a hackathon.
+
+    Returns:
+        dict: {
+            'is_disqualified': bool,
+            'hackathon_name': str,
+            'rules': str (HTML/markdown),
+        }
+    """
+    user = frappe.session.user
+    hackathon = frappe.db.get_value(
+        HACKATHON,
+        {"route": hackathon_permalink},
+        ["name", "hackathon_name", "hackathon_rules"],
+        as_dict=True,
+    )
+
+    if not hackathon:
+        frappe.throw("Hackathon not found")
+
+    participant = frappe.db.get_value(
+        HACKATHON_PARTICIPANT,
+        {"hackathon": hackathon.name, "user": user},
+        ["disqualified", "name"],
+        as_dict=True,
+    )
+
+    if not participant:
+        return {"is_disqualified": False, "registered": False}
+
+    return {
+        "is_disqualified": bool(participant.disqualified),
+        "registered": True,
+        "hackathon_name": hackathon.hackathon_name,
+        "rules": hackathon.hackathon_rules or "",
+    }

--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -560,30 +560,34 @@ def validate_participant_for_localhost(participant_id: str):
 
 
 @frappe.whitelist()
-def validate_user_as_localhost_member(localhost_id: str):
-    if not frappe.db.exists(
-        "Has Role",
-        {
-            "parent": frappe.session.user,
-            "role": "Localhost Organizer",
-        },
-    ):
-        frappe.throw("You are not a Localhost Organizer. You are not authorized to view this page")
+def is_localhost_organizer(localhost_id: str, user=None) -> bool:
+    """
+    Check if user is a localhost organizer.
+    """
+    if not user:
+        user = frappe.session.user
 
-    if not frappe.db.exists(
+    # System Manager bypass
+    if "System Manager" in frappe.get_roles(user):
+        return True
+
+    profile = frappe.db.get_value(USER_PROFILE, {"user": user}, "name")
+    # Check if profile exists in localhost organizers
+    is_member = frappe.db.exists(
         LOCALHOST_ORGANIZER,
         {
             "parent": localhost_id,
-            "profile": frappe.db.get_value(
-                USER_PROFILE,
-                {"user": frappe.session.user},
-                "name",
-            ),
+            "parenttype": HACKATHON_LOCALHOST,
+            "profile": profile,
+            "parentfield": "organizers",
         },
-    ):
+    )
+
+    if not is_member:
         frappe.throw(
             "You are not a member of this Localhost. You are not authorized to view this page"
         )
+        return False
 
     return True
 

--- a/fossunited/api/hackathon.py
+++ b/fossunited/api/hackathon.py
@@ -97,7 +97,7 @@ def create_participant(hackathon, participant):
             "git_profile": participant.get("git_profile", ""),
             "wants_to_attend_locally": participant.get("wants_to_attend_locally", 0),
             "localhost": participant.get("localhost", ""),
-            "subscribe_chapter_mailing": participant.get("subscribe_chapter_mailing", 0),
+            "subscribe_chapter_mailing": 1,
         }
     )
     participant_doc.insert(ignore_permissions=True)

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.json
@@ -20,6 +20,7 @@
   "column_break_hkri",
   "organization",
   "git_profile",
+  "team",
   "localhost_tab",
   "wants_to_attend_locally",
   "section_break_pijd",
@@ -152,12 +153,19 @@
    "default": "0",
    "fieldname": "disqualified",
    "fieldtype": "Check",
-   "label": "User Disqualified?",
+   "label": "Participant Disqualified",
    "permlevel": 1
+  },
+  {
+   "fieldname": "team",
+   "fieldtype": "Link",
+   "in_standard_filter": 1,
+   "label": "Team Joined",
+   "options": "FOSS Hackathon Team"
   }
  ],
  "links": [],
- "modified": "2026-03-11 13:26:05.214340",
+ "modified": "2026-03-11 14:19:26.627153",
  "modified_by": "Administrator",
  "module": "FOSS Hackathon",
  "name": "FOSS Hackathon Participant",

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.json
@@ -8,6 +8,7 @@
  "field_order": [
   "meta_section",
   "hackathon",
+  "disqualified",
   "column_break_pxgj",
   "user",
   "participant_details_section",
@@ -144,11 +145,19 @@
    "fieldname": "check_ins",
    "fieldtype": "Table",
    "label": "Host Checkin",
-   "options": "Event Check In"
+   "options": "Event Check In",
+   "permlevel": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "disqualified",
+   "fieldtype": "Check",
+   "label": "User Disqualified?",
+   "permlevel": 1
   }
  ],
  "links": [],
- "modified": "2026-03-01 13:37:07.177860",
+ "modified": "2026-03-11 13:26:05.214340",
  "modified_by": "Administrator",
  "module": "FOSS Hackathon",
  "name": "FOSS Hackathon Participant",
@@ -160,6 +169,18 @@
    "delete": 1,
    "email": 1,
    "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "permlevel": 2,
    "print": 1,
    "read": 1,
    "report": 1,

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.json
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.json
@@ -21,6 +21,7 @@
   "organization",
   "git_profile",
   "team",
+  "project",
   "localhost_tab",
   "wants_to_attend_locally",
   "section_break_pijd",
@@ -162,10 +163,17 @@
    "in_standard_filter": 1,
    "label": "Team Joined",
    "options": "FOSS Hackathon Team"
+  },
+  {
+   "fetch_from": "team.project",
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "label": "Project",
+   "options": "FOSS Hackathon Project"
   }
  ],
  "links": [],
- "modified": "2026-03-11 14:19:26.627153",
+ "modified": "2026-03-11 17:07:25.071724",
  "modified_by": "Administrator",
  "module": "FOSS Hackathon",
  "name": "FOSS Hackathon Participant",

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -27,9 +27,7 @@ class FOSSHackathonParticipant(Document):
     if TYPE_CHECKING:
         from frappe.types import DF
 
-        from fossunited.fossunited.doctype.event_check_in.event_check_in import (
-            EventCheckIn,
-        )
+        from fossunited.fossunited.doctype.event_check_in.event_check_in import EventCheckIn
 
         check_ins: DF.Table[EventCheckIn]
         disqualified: DF.Check
@@ -43,6 +41,7 @@ class FOSSHackathonParticipant(Document):
             "Pending", "Pending Confirmation", "Accepted", "Rejected"
         ]
         organization: DF.Data | None
+        project: DF.Link | None
         subscribe_chapter_mailing: DF.Check
         team: DF.Link | None
         user: DF.Link | None

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -27,7 +27,9 @@ class FOSSHackathonParticipant(Document):
     if TYPE_CHECKING:
         from frappe.types import DF
 
-        from fossunited.fossunited.doctype.event_check_in.event_check_in import EventCheckIn
+        from fossunited.fossunited.doctype.event_check_in.event_check_in import (
+            EventCheckIn,
+        )
 
         check_ins: DF.Table[EventCheckIn]
         disqualified: DF.Check
@@ -158,7 +160,7 @@ class FOSSHackathonParticipant(Document):
                 event_type="Event Participants",
                 custom_group_title=f"{old_status}-{self.localhost}-Localhost",
                 subscribe_to_chapter=self.subscribe_chapter_mailing,
-                subscribe_to_event=True,
+                subscribe_to_event=False,
                 document_type_event=HACKATHON_LOCALHOST,
             )
 
@@ -198,7 +200,7 @@ class FOSSHackathonParticipant(Document):
                     event_type="Event Participants",
                     custom_group_title=f"{status}-{target_localhost}-Localhost",
                     subscribe_to_chapter=self.subscribe_chapter_mailing,
-                    subscribe_to_event=True,
+                    subscribe_to_event=False,
                     document_type_event=HACKATHON_LOCALHOST,
                 )
             except Exception:

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -13,6 +13,8 @@ from fossunited.api.emailing import handle_email_group_subscription
 from fossunited.doctype_ids import (
     HACKATHON,
     HACKATHON_LOCALHOST,
+    HACKATHON_TEAM,
+    HACKATHON_TEAM_MEMBER,
 )
 
 
@@ -40,6 +42,7 @@ class FOSSHackathonParticipant(Document):
         ]
         organization: DF.Data | None
         subscribe_chapter_mailing: DF.Check
+        team: DF.Link | None
         user: DF.Link | None
         user_profile: DF.Link | None
         wants_to_attend_locally: DF.Check
@@ -78,6 +81,7 @@ class FOSSHackathonParticipant(Document):
             self.sync_localhost_status_groups(new_status=self.localhost_request_status)
 
     def before_save(self):
+        self.update_team_link()
         if self.has_value_changed("wants_to_attend_locally"):
             self.handle_localhost_request()
 
@@ -280,3 +284,12 @@ class FOSSHackathonParticipant(Document):
             checkin_date = frappe.utils.nowdate()
             self.sync_localhost_status_groups(old_status=f"Checkin-{checkin_date}")
         return result
+
+    def update_team_link(self):
+        """Find and link the team this participant belongs to"""
+        team = frappe.db.get_value(
+            HACKATHON_TEAM_MEMBER,
+            {"member": self.name, "parenttype": HACKATHON_TEAM},
+            "parent",
+        )
+        self.team = team if team else None

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -27,7 +27,9 @@ class FOSSHackathonParticipant(Document):
     if TYPE_CHECKING:
         from frappe.types import DF
 
-        from fossunited.fossunited.doctype.event_check_in.event_check_in import EventCheckIn
+        from fossunited.fossunited.doctype.event_check_in.event_check_in import (
+            EventCheckIn,
+        )
 
         check_ins: DF.Table[EventCheckIn]
         disqualified: DF.Check
@@ -137,7 +139,7 @@ class FOSSHackathonParticipant(Document):
             chapter=event_doc.chapter,
             event=self.hackathon,
             subscribe_to_chapter=self.subscribe_chapter_mailing,
-            subscribe_to_event=self.subscribe_chapter_mailing,
+            subscribe_to_event=True,
             document_type_event=HACKATHON,
         )
 
@@ -157,7 +159,7 @@ class FOSSHackathonParticipant(Document):
                 event_type="Event Participants",
                 custom_group_title=f"{old_status}-{self.localhost}-Localhost",
                 subscribe_to_chapter=self.subscribe_chapter_mailing,
-                subscribe_to_event=False,
+                subscribe_to_event=True,
                 document_type_event=HACKATHON_LOCALHOST,
             )
 
@@ -197,7 +199,7 @@ class FOSSHackathonParticipant(Document):
                     event_type="Event Participants",
                     custom_group_title=f"{status}-{target_localhost}-Localhost",
                     subscribe_to_chapter=self.subscribe_chapter_mailing,
-                    subscribe_to_event=False,
+                    subscribe_to_event=True,
                     document_type_event=HACKATHON_LOCALHOST,
                 )
             except Exception:

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_participant/foss_hackathon_participant.py
@@ -25,11 +25,10 @@ class FOSSHackathonParticipant(Document):
     if TYPE_CHECKING:
         from frappe.types import DF
 
-        from fossunited.fossunited.doctype.event_check_in.event_check_in import (
-            EventCheckIn,
-        )
+        from fossunited.fossunited.doctype.event_check_in.event_check_in import EventCheckIn
 
         check_ins: DF.Table[EventCheckIn]
+        disqualified: DF.Check
         email: DF.Data
         full_name: DF.Data
         git_profile: DF.Data | None

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_team/foss_hackathon_team.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_team/foss_hackathon_team.py
@@ -47,7 +47,7 @@ class FOSSHackathonTeam(Document):
     def on_trash(self):
         """Clear team link when team is deleted"""
         for participant in self.members:
-            if member.member:
+            if participant.member:
                 frappe.db.set_value(
                     HACKATHON_PARTICIPANT,
                     participant.member,
@@ -145,18 +145,11 @@ class FOSSHackathonTeam(Document):
 
     def auto_delete_if_empty(self):
         """Delete team if it has no members or no project"""
+        if frappe.flags.in_test:
+            return
         has_content = bool(self.members or self.project or self.partner_project)
-
         if not has_content:
-            # Use frappe.enqueue to avoid deleting during the save transaction
-            frappe.enqueue(
-                method="frappe.client.delete",
-                queue="short",
-                timeout=300,
-                is_async=False,
-                doctype=HACKATHON_TEAM,
-                name=self.name,
-            )
+            frappe.db.after_commit.add(lambda: delete_team_if_exists(self.name))
 
     def update_member_team_links(self):
         """Update team link for added members, clear for removed members"""
@@ -191,3 +184,17 @@ class FOSSHackathonTeam(Document):
                 None,
                 update_modified=False,
             )
+
+
+def delete_team_if_exists(team_name):
+    """Helper function to delete team"""
+    try:
+        if frappe.db.exists(HACKATHON_TEAM, team_name):
+            frappe.delete_doc(
+                HACKATHON_TEAM,
+                team_name,
+                ignore_permissions=True,
+                force=True,
+            )
+    except Exception:
+        pass

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_team/foss_hackathon_team.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_team/foss_hackathon_team.py
@@ -197,4 +197,7 @@ def delete_team_if_exists(team_name):
                 force=True,
             )
     except Exception:
-        pass
+        frappe.log_error(
+            frappe.get_traceback(),
+            f"Failed to auto-delete team {team_name}",
+        )

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_team/foss_hackathon_team.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_team/foss_hackathon_team.py
@@ -41,7 +41,20 @@ class FOSSHackathonTeam(Document):
         self.validate_new_members_not_in_other_teams()
 
     def on_update(self):
-        self.delete_if_empty_team()
+        self.update_member_team_links()
+        self.auto_delete_if_empty()
+
+    def on_trash(self):
+        """Clear team link when team is deleted"""
+        for participant in self.members:
+            if member.member:
+                frappe.db.set_value(
+                    HACKATHON_PARTICIPANT,
+                    participant.member,
+                    "team",
+                    None,
+                    update_modified=False,
+                )
 
     def validate_team_size(self):
         """Check team size limits"""
@@ -130,26 +143,51 @@ class FOSSHackathonTeam(Document):
 
         return user in participant_users
 
-    def delete_if_empty_team(self):
-        """Auto-delete team if it becomes empty after having content."""
-        prev_doc = self.get_doc_before_save()
+    def auto_delete_if_empty(self):
+        """Delete team if it has no members or no project"""
+        has_content = bool(self.members or self.project or self.partner_project)
 
-        if not prev_doc:
-            return
-        # Only delete if team had members before
-        previously_had_content = bool(
-            prev_doc.members or prev_doc.project or prev_doc.partner_project
-        )
+        if not has_content:
+            # Use frappe.enqueue to avoid deleting during the save transaction
+            frappe.enqueue(
+                method="frappe.client.delete",
+                queue="short",
+                timeout=300,
+                is_async=False,
+                doctype=HACKATHON_TEAM,
+                name=self.name,
+            )
 
-        if not previously_had_content:
-            return
+    def update_member_team_links(self):
+        """Update team link for added members, clear for removed members"""
+        old_doc = self.get_doc_before_save()
 
-        is_now_empty = not (self.members or self.project or self.partner_project)
+        # Get current member IDs
+        current_member_ids = {m.member for m in self.members if m.member}
 
-        if is_now_empty:
-            frappe.delete_doc(
-                HACKATHON_TEAM,
+        # Get previous member IDs
+        old_member_ids = set()
+        if old_doc:
+            old_member_ids = {m.member for m in old_doc.members if m.member}
+
+        # Added members: Set team link
+        added_members = current_member_ids - old_member_ids
+        for member_id in added_members:
+            frappe.db.set_value(
+                HACKATHON_PARTICIPANT,
+                member_id,
+                "team",
                 self.name,
-                ignore_permissions=True,
-                force=True,
+                update_modified=False,
+            )
+
+        # Removed members: Clear team link
+        removed_members = old_member_ids - current_member_ids
+        for member_id in removed_members:
+            frappe.db.set_value(
+                HACKATHON_PARTICIPANT,
+                member_id,
+                "team",
+                None,
+                update_modified=False,
             )

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_team/test_foss_hackathon_team.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_team/test_foss_hackathon_team.py
@@ -148,8 +148,8 @@ class TestFOSSHackathonTeam(FrappeTestCase):
             team.partner_project = None
             team.members = []
             team.save()
-
-            frappe.db.commit()
+            # just to check if empty teams are deleted automatically
+            frappe.db.commit()  # nosemgrep
             self.assertFalse(frappe.db.exists(HACKATHON_TEAM, team_name))
         finally:
             frappe.flags.in_test = True

--- a/fossunited/foss_hackathon/doctype/foss_hackathon_team/test_foss_hackathon_team.py
+++ b/fossunited/foss_hackathon/doctype/foss_hackathon_team/test_foss_hackathon_team.py
@@ -36,7 +36,8 @@ class TestFOSSHackathonTeam(FrappeTestCase):
     def tearDown(self):
         frappe.set_user("Administrator")
         self.chapter.delete(force=True)
-        self.team.delete(force=True)
+        if frappe.db.exists(HACKATHON_TEAM, self.team.name):
+            self.team.delete(force=True)
         for participant in self.participants:
             participant.delete(force=True)
         self.hackathon.delete(force=True)
@@ -138,10 +139,17 @@ class TestFOSSHackathonTeam(FrappeTestCase):
         team_name = self.team.name
         self.assertTrue(frappe.db.exists(HACKATHON_TEAM, team_name))
 
-        team = frappe.get_doc(HACKATHON_TEAM, team_name)
-        team.project = None
-        team.partner_project = None
-        team.members = []
-        team.save()
+        # Temporarily disable test flag to allow auto-delete
+        frappe.flags.in_test = False
 
-        self.assertFalse(frappe.db.exists(HACKATHON_TEAM, team_name))
+        try:
+            team = frappe.get_doc(HACKATHON_TEAM, team_name)
+            team.project = None
+            team.partner_project = None
+            team.members = []
+            team.save()
+
+            frappe.db.commit()
+            self.assertFalse(frappe.db.exists(HACKATHON_TEAM, team_name))
+        finally:
+            frappe.flags.in_test = True

--- a/fossunited/utils/decorators.py
+++ b/fossunited/utils/decorators.py
@@ -247,7 +247,7 @@ def is_localhost_organizer(localhost_id: str, user=None) -> bool:
 
     if not is_member:
         frappe.throw(
-            "You are not a member of this Localhost. You are not authorized to view this page"
+            _("You are not a member of this Localhost. You are not authorized to view this page")
         )
         return False
 

--- a/fossunited/utils/decorators.py
+++ b/fossunited/utils/decorators.py
@@ -12,13 +12,12 @@ from fossunited.api.chapter import (
     check_if_chapter_or_event_core_member,
     check_if_event_member,
 )
+from fossunited.api.hackathon import is_localhost_organizer
 from fossunited.doctype_ids import (
     CAMPAIGN,
     HACKATHON_LOCALHOST,
     HACKATHON_PARTICIPANT,
     HACKATHON_TEAM,
-    LOCALHOST_ORGANIZER,
-    USER_PROFILE,
 )
 
 
@@ -196,32 +195,6 @@ def require_chapter_or_event_member(event_id="event"):
         return wrapper
 
     return decorator
-
-
-def is_localhost_organizer(localhost_id, user=None):
-    """Check if user is a localhost organizer"""
-    if not user:
-        user = frappe.session.user
-
-    # System Manager bypass
-    if "System Manager" in frappe.get_roles(user):
-        return True
-
-    # Get user's profile
-    profile = frappe.db.get_value(USER_PROFILE, {"user": user}, "name")
-    if not profile:
-        return False
-
-    # Check if profile exists in localhost organizers
-    return frappe.db.exists(
-        LOCALHOST_ORGANIZER,
-        {
-            "parent": localhost_id,
-            "parenttype": HACKATHON_LOCALHOST,
-            "profile": profile,
-            "parentfield": "organizers",
-        },
-    )
 
 
 def require_localhost_organizer(localhost_param="localhost_id"):

--- a/fossunited/utils/decorators.py
+++ b/fossunited/utils/decorators.py
@@ -222,7 +222,7 @@ def require_chapter_or_event_member(event_id="event"):
 
 
 @frappe.whitelist()
-def is_localhost_organizer(localhost_id: str, user=str | None) -> bool:
+def is_localhost_organizer(localhost_id: str, user: str | None = None) -> bool:
     """
     Check if user is a localhost organizer.
     """

--- a/fossunited/utils/decorators.py
+++ b/fossunited/utils/decorators.py
@@ -222,7 +222,7 @@ def require_chapter_or_event_member(event_id="event"):
 
 
 @frappe.whitelist()
-def is_localhost_organizer(localhost_id: str, user=None) -> bool:
+def is_localhost_organizer(localhost_id: str, user=str | None) -> bool:
     """
     Check if user is a localhost organizer.
     """

--- a/fossunited/utils/decorators.py
+++ b/fossunited/utils/decorators.py
@@ -40,12 +40,22 @@ def require_hackathon_participant(hackathon_id="hackathon"):
             if not hackathon:
                 frappe.throw(_("Hackathon data is required"), frappe.ValidationError)
 
-            if not frappe.db.exists(
+            participant = frappe.db.get_value(
                 HACKATHON_PARTICIPANT,
                 {"hackathon": hackathon, "user": frappe.session.user},
-            ):
+                ["name", "disqualified"],
+                as_dict=True,
+            )
+
+            if not participant:
                 frappe.throw(
                     _("You are not a participant of this hackathon"),
+                    frappe.PermissionError,
+                )
+
+            if participant.disqualified:
+                frappe.throw(
+                    _("You have been disqualified from this hackathon"),
                     frappe.PermissionError,
                 )
 
@@ -83,13 +93,15 @@ def require_hackathon_team(team_id="team", hackathon_id="hackathon"):
             if hackathon and team_doc.hackathon != hackathon:
                 frappe.throw(_("Team does not belong to this hackathon"), frappe.ValidationError)
 
-            # Check if user is a member
+            # Check if user is a member and get participant ID
             is_member = False
+            participant_id = None
             user_email = frappe.session.user
 
             for member in team_doc.members:
                 if member.email == user_email:
                     is_member = True
+                    participant_id = member.member
                     break
 
                 if member.member:
@@ -98,10 +110,21 @@ def require_hackathon_team(team_id="team", hackathon_id="hackathon"):
                     )
                     if participant_email == user_email:
                         is_member = True
+                        participant_id = member.member
                         break
 
             if not is_member:
                 frappe.throw(_("You are not a member of this team"), frappe.PermissionError)
+
+            if participant_id:
+                is_disqualified = frappe.db.get_value(
+                    HACKATHON_PARTICIPANT, participant_id, "disqualified"
+                )
+                if is_disqualified:
+                    frappe.throw(
+                        _("You have been disqualified from this hackathon"),
+                        frappe.PermissionError,
+                    )
 
             return func(*args, **kwargs)
 
@@ -198,6 +221,7 @@ def require_chapter_or_event_member(event_id="event"):
     return decorator
 
 
+@frappe.whitelist()
 def is_localhost_organizer(localhost_id: str, user=None) -> bool:
     """
     Check if user is a localhost organizer.

--- a/fossunited/utils/decorators.py
+++ b/fossunited/utils/decorators.py
@@ -12,12 +12,13 @@ from fossunited.api.chapter import (
     check_if_chapter_or_event_core_member,
     check_if_event_member,
 )
-from fossunited.api.hackathon import is_localhost_organizer
 from fossunited.doctype_ids import (
     CAMPAIGN,
     HACKATHON_LOCALHOST,
     HACKATHON_PARTICIPANT,
     HACKATHON_TEAM,
+    LOCALHOST_ORGANIZER,
+    USER_PROFILE,
 )
 
 
@@ -195,6 +196,38 @@ def require_chapter_or_event_member(event_id="event"):
         return wrapper
 
     return decorator
+
+
+def is_localhost_organizer(localhost_id: str, user=None) -> bool:
+    """
+    Check if user is a localhost organizer.
+    """
+    if not user:
+        user = frappe.session.user
+
+    # System Manager bypass
+    if "System Manager" in frappe.get_roles(user):
+        return True
+
+    profile = frappe.db.get_value(USER_PROFILE, {"user": user}, "name")
+    # Check if profile exists in localhost organizers
+    is_member = frappe.db.exists(
+        LOCALHOST_ORGANIZER,
+        {
+            "parent": localhost_id,
+            "parenttype": HACKATHON_LOCALHOST,
+            "profile": profile,
+            "parentfield": "organizers",
+        },
+    )
+
+    if not is_member:
+        frappe.throw(
+            "You are not a member of this Localhost. You are not authorized to view this page"
+        )
+        return False
+
+    return True
 
 
 def require_localhost_organizer(localhost_param="localhost_id"):


### PR DESCRIPTION
<img width="1078" height="961" alt="image" src="https://github.com/user-attachments/assets/72b4cce9-a726-4409-b39d-15c3e224e6b1" />


- Since we have 5k + participants, and its hard to filter and evaluate, we can disqualify participants on stages who has no activity regards to project.
  Although we've fair warning mail going on, we can have some check on each so we can ignore them

- Also link project and team to each participant before save. (so we dont have to query child table or join in cross referring)

- Some fixes over api and subscribe all participant to email (with one commit i accidentally removed that line and only 800 were added - ps: though we use listmonk)