### PR TITLE
feat(user-profile): show event volunteership when not in chapter_member

### DIFF
--- a/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.py
@@ -6,6 +6,7 @@ import textwrap
 
 import frappe
 from frappe.exceptions import PermissionError
+from frappe.query_builder import DocType
 from frappe.website.website_generator import WebsiteGenerator
 
 from fossunited.api.profile import is_valid_username
@@ -289,31 +290,70 @@ class FOSSUserProfile(WebsiteGenerator):
                     | val
                 )
 
-        # City Chapters/FOSS Clubs user volunteers for
+        ChapterMember = DocType(CHAPTER_MEMBER)
+        Chapter = DocType(CHAPTER)
+
+        chapters = (
+            frappe.qb.from_(ChapterMember)
+            .join(Chapter)
+            .on(Chapter.name == ChapterMember.parent)
+            .select(
+                ChapterMember.parent,
+                ChapterMember.role,
+                Chapter.name,
+                Chapter.route,
+                Chapter.chapter_name.as_("title"),
+                Chapter.chapter_type,
+                Chapter.chapter_status,
+            )
+            .where((ChapterMember.chapter_member == self.name) & (Chapter.is_published == 1))
+        ).run(as_dict=True)
         volunteered = []
+        chapter_ids = [c["parent"] for c in chapters]
 
-        volunteer_chapters = frappe.db.get_all(
-            CHAPTER_MEMBER,
-            fields=["parent", "role"],
-            filters={"chapter_member": self.name},
-            page_length=9999,
-        )
-
-        for val in volunteer_chapters:
+        for c in chapters:
             volunteered.append(
-                frappe.db.get_value(
-                    CHAPTER,
-                    fieldname=[
-                        "name",
-                        "route",
-                        "chapter_type",
-                        "chapter_name",
-                        "chapter_status",
-                    ],
-                    filters={"name": val.parent, "is_published": 1},
-                    as_dict=1,
-                )
-                | val
+                {
+                    "type": "chapter",
+                    "name": c.name,
+                    "route": c.route,
+                    "title": c.title,
+                    "role": c.role,
+                    "meta": f"{c.chapter_type} | {c.chapter_status}",
+                    "chapter_type": c.chapter_type,
+                }
+            )
+
+        EventMember = DocType(EVENT_VOLUNTEER)
+        Event = DocType(EVENT)
+
+        events = (
+            frappe.qb.from_(EventMember)
+            .join(Event)
+            .on(Event.name == EventMember.parent)
+            .select(
+                EventMember.parent,
+                EventMember.role,
+                Event.name,
+                Event.route,
+                Event.event_name.as_("title"),
+                Event.chapter,
+                Event.event_start_date,
+                Event.event_location,
+            )
+            .where((EventMember.member == self.name) & (~Event.chapter.isin(chapter_ids)))
+        ).run(as_dict=True)
+        for e in events:
+            volunteered.append(
+                {
+                    "type": "event",
+                    "name": e.name,
+                    "route": e.route,
+                    "title": e.title,
+                    "role": e.role,
+                    "meta": f"Event | {frappe.utils.formatdate(e.event_start_date, 'd MMM yyyy')}",
+                    "event_date": e.event_start_date,
+                }
             )
 
         return attended, attended_hack, talked, cfps, volunteered
@@ -332,13 +372,14 @@ class FOSSUserProfile(WebsiteGenerator):
             experiences_dict[experience.company].append(experience.as_dict())
         context.experiences_dict = experiences_dict
 
-        (
-            context.attended,
-            context.attended_hack,
-            context.talked,
-            context.cfps,
-            context.volunteered,
-        ) = self.get_user_activity()
+        if self.show_activity:
+            (
+                context.attended,
+                context.attended_hack,
+                context.talked,
+                context.cfps,
+                context.volunteered,
+            ) = self.get_user_activity()
 
         context.pagetitle, context.description, context.image = self.get_meta()
 

--- a/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/foss_user_profile.py
@@ -341,9 +341,11 @@ class FOSSUserProfile(WebsiteGenerator):
                 Event.event_start_date,
                 Event.event_location,
             )
-            .where((EventMember.member == self.name) & (~Event.chapter.isin(chapter_ids)))
+            .where((EventMember.member == self.name) & (Event.is_published == 1))
         ).run(as_dict=True)
         for e in events:
+            if e.chapter in chapter_ids:
+                continue
             volunteered.append(
                 {
                     "type": "event",

--- a/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
@@ -231,8 +231,8 @@
       {% endif %}
 
       <div class="container">
-        <h3 class="subtitle">Chapter Volunteership</h3>
-        {% for chapter in volunteered %}{{ volunteer_chapter_card(chapter) }}{% endfor %}
+        <h3 class="subtitle">Chapter & Event Volunteership</h3>
+        {% for item in volunteered %}{{ volunteer_card(item) }}{% endfor %}
       </div>
 
       <div class="container">
@@ -252,45 +252,50 @@
     {% endif %}
   </div>
 {% endmacro %}
-{% macro volunteer_chapter_card(chapter) %}
-  <a
-    class="talk-card"
-    data-docname="{{ chapter.chapter_name }}"
-    data-route="{{ chapter.route }}"
-    href="/{{ chapter.route }}"
-    aria-label="{{ chapter.chapter_name }}, {{ chapter.chapter_type }}, {{ chapter.role }}"
-  >
-    <div class="talk-card--container">
-      <div class="talk-card--meta">
-        <div
-          class="chapter-brand-block {% if chapter.chapter_type == 'FOSS Club' %}club-brand{% endif %} talk-card--event-name"
-        >
-          {% if chapter.chapter_type == 'FOSS Club' %}
-            <img src="/assets/fossunited/images/chapter/fossclub_logo.svg" alt="FOSS Club Logo" />
-            <span>{{ chapter.chapter_name | truncate(25, True, '...', 0) }}</span>
-          {% else %}
-            <span class="fff-forward"
-              >{{ chapter.chapter_name.upper() | truncate(25, True, '...', 0) }}</span
-            >
-          {% endif %}
-        </div>
-      </div>
-      <div class="talk-card--title">{{ chapter.chapter_name }}</div>
-      <div class="chapter-volunteer-card--type">
-        <svg width="9" height="9" viewBox="0 0 9 9" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
-          <path
-            d="M4.0869 0.906652C4.27429 0.595275 4.72571 0.595274 4.9131 0.906652L6.05745 2.80815L8.2195 3.30889C8.57355 3.39089 8.71305 3.82022 8.47482 4.09466L7.02 5.77059L7.21188 7.98157C7.2433 8.34362 6.87809 8.60896 6.54347 8.4672L4.5 7.60148L2.45653 8.4672C2.12191 8.60896 1.75669 8.34362 1.78812 7.98157L1.98 5.77059L0.525185 4.09466C0.286954 3.82022 0.426453 3.39089 0.780497 3.30889L2.94255 2.80815L4.0869 0.906652Z"
-            fill="#08B74F"
-          />
-        </svg>
-        <div class="chapter-volunteer-card--role">{{ chapter.role }}</div>
+{% macro volunteer_card(item) %}
+<a
+  class="talk-card"
+  data-docname="{{ item.name }}"
+  data-route="{{ item.route }}"
+  href="/{{ item.route }}"
+  aria-label="{{ item.title }}, {{ item.role }}"
+>
+  <div class="talk-card--container">
+    <div class="talk-card--meta">
+      <div class="chapter-brand-block
+          {% if item.chapter_type == 'FOSS Club' %}club-brand{% endif %}
+          talk-card--event-name">
+        {% if item.chapter_type == 'FOSS Club' %}
+          <img src="/assets/fossunited/images/chapter/fossclub_logo.svg">
+          <span>{{ item.title | truncate(25, True, '...', 0) }}</span>
+        {% else %}
+          <span class="fff-forward">
+            {{ item.title.upper() | truncate(25, True, '...', 0) }}
+          </span>
+        {% endif %}
       </div>
     </div>
-    <div class="talk-card--location-date">
-      {{ chapter.chapter_type }} | {{ chapter.chapter_status }}
+
+    <div class="talk-card--title">
+      {{ item.title }}
     </div>
-  </a>
-  <br />
+
+    <div class="chapter-volunteer-card--type">
+      <svg width="9" height="9" viewBox="0 0 9 9">
+        <path d="M4.0869 0.906652C4.27429 0.595275 4.72571 0.595274 4.9131 0.906652L6.05745 2.80815L8.2195 3.30889C8.57355 3.39089 8.71305 3.82022 8.47482 4.09466L7.02 5.77059L7.21188 7.98157C7.2433 8.34362 6.87809 8.60896 6.54347 8.4672L4.5 7.60148L2.45653 8.4672C2.12191 8.60896 1.75669 8.34362 1.78812 7.98157L1.98 5.77059L0.525185 4.09466C0.286954 3.82022 0.426453 3.39089 0.780497 3.30889L2.94255 2.80815L4.0869 0.906652Z"
+        fill="#08B74F"/>
+      </svg>
+
+      <div class="chapter-volunteer-card--role">
+        {{ item.role }}
+      </div>
+    </div>
+  </div>
+  <div class="talk-card--location-date">
+      {{ item.meta }}
+  </div>
+</a>
+<br>
 {% endmacro %}
 {% macro speaker_card(talk) %}
   <a


### PR DESCRIPTION
- Many indiafoss volunteers come for an event, their profile does not show that they've volunteers.

- Its creditable to show all other events they've volunteered if they are not in a chapter_members table

- We already had chapter member for core team, but event volunteership was hidden.
- So group data show as same card.

<img width="953" height="768" alt="image" src="https://github.com/user-attachments/assets/eef0c8de-599d-4acb-89e5-6c88ec242383" />
