### PR TITLE
fix(a11y): add aria-label attributes to icon-only buttons

### DIFF
--- a/dashboard/src/components/HeaderWithNav.vue
+++ b/dashboard/src/components/HeaderWithNav.vue
@@ -1,7 +1,7 @@
 <template>
   <header class="sticky top-0 z-40 flex items-center justify-between border-b bg-surface-white px-5 py-2">
     <div>
-      <button class="block md:hidden" @click="handleToggleSidebar()">
+     <button class="block md:hidden" @click="handleToggleSidebar()" aria-label="Toggle sidebar">
         <IconMenu2 class="w-5 h-5" />
       </button>
     </div>

--- a/dashboard/src/components/event/schedule/ManageHallOptions.vue
+++ b/dashboard/src/components/event/schedule/ManageHallOptions.vue
@@ -59,7 +59,7 @@ const addHallOption = () => {
           class="flex items-center gap-2 text-sm border p-1 rounded-xs bg-surface-gray-1"
         >
           {{ option }}
-          <button @click.prevent="handleDeleteHall(option)"><IconX class="w-3 h-3" /></button>
+         <button @click.prevent="handleDeleteHall(option)" aria-label="Delete hall"><IconX class="w-3 h-3" /></button>
         </div>
       </div>
       <textarea


### PR DESCRIPTION
## Status
- [ ] Draft
- [x] Ready for review

## Related Issue
Closes / Addresses: #788

## Problem
Several icon-only buttons across the codebase were missing aria-label 
attributes, making them inaccessible to screen reader users who cannot 
determine the purpose of these buttons.

## Solution
Added descriptive aria-label attributes to icon-only buttons in two components:
- ManageHallOptions.vue — Delete hall button
- HeaderWithNav.vue — Hamburger menu/sidebar toggle button

## Progress
- [x] Tested locally
- [x] Follows existing code style

## Changelog
a11y: add aria-label attributes to icon-only buttons for screen reader support

## Visualization
No visual changes — accessibility improvement only. Can be verified using 
a screen reader or browser accessibility audit tool.

## Further Ahead
More icon-only buttons across the codebase still need aria-label attributes. 
Will continue addressing remaining instances from issue #788 in follow-up PRs.