### PR TITLE
fix(a11y): add aria-label attributes to icon-only buttons in FileUploaderArea and CommentBox

### DIFF
--- a/dashboard/src/components/HeaderWithNav.vue
+++ b/dashboard/src/components/HeaderWithNav.vue
@@ -1,7 +1,7 @@
 <template>
   <header class="sticky top-0 z-40 flex items-center justify-between border-b bg-surface-white px-5 py-2">
     <div>
-      <button class="block md:hidden" @click="handleToggleSidebar()">
+     <button class="block md:hidden" @click="handleToggleSidebar()" aria-label="Toggle sidebar">
         <IconMenu2 class="w-5 h-5" />
       </button>
     </div>

--- a/dashboard/src/components/event/schedule/ManageHallOptions.vue
+++ b/dashboard/src/components/event/schedule/ManageHallOptions.vue
@@ -59,7 +59,7 @@ const addHallOption = () => {
           class="flex items-center gap-2 text-sm border p-1 rounded-xs bg-surface-gray-1"
         >
           {{ option }}
-          <button @click.prevent="handleDeleteHall(option)"><IconX class="w-3 h-3" /></button>
+         <button @click.prevent="handleDeleteHall(option)" aria-label="Delete hall"><IconX class="w-3 h-3" /></button>
         </div>
       </div>
       <textarea

--- a/dashboard/src/components/ui/CommentBox.vue
+++ b/dashboard/src/components/ui/CommentBox.vue
@@ -7,7 +7,7 @@
           class="p-1 rounded-sm"
           :disabled="!editor.can().chain().focus().toggleBold().run()"
           :class="{ 'bg-surface-gray-3': editor.isActive('bold') }"
-          @click="editor.chain().focus().toggleBold().run()"
+          @click="editor.chain().focus().toggleBold().run()"  aria-label="Bold"
         >
           <IconBold class="w-4 h-4 sm:w-5 sm:h-5" />
         </button>
@@ -15,7 +15,7 @@
           class="p-1 rounded-sm"
           :disabled="!editor.can().chain().focus().toggleItalic().run()"
           :class="{ 'bg-surface-gray-3': editor.isActive('italic') }"
-          @click="editor.chain().focus().toggleItalic().run()"
+          @click="editor.chain().focus().toggleItalic().run()" aria-label="Italic"
         >
           <IconItalic class="w-4 h-4 sm:w-5 sm:h-5" />
         </button>
@@ -23,7 +23,7 @@
           class="p-1 rounded-sm"
           :disabled="!editor.can().chain().focus().toggleUnderline().run()"
           :class="{ 'bg-surface-gray-3': editor.isActive('underline') }"
-          @click="editor.chain().focus().toggleUnderline().run()"
+          @click="editor.chain().focus().toggleUnderline().run()" aria-label="Underline"
         >
           <IconUnderline class="w-4 h-4 sm:w-5 sm:h-5" />
         </button>
@@ -31,28 +31,28 @@
           class="p-1 rounded-sm"
           :disabled="!editor.can().chain().focus().toggleStrike().run()"
           :class="{ 'bg-surface-gray-3': editor.isActive('strike') }"
-          @click="editor.chain().focus().toggleStrike().run()"
+          @click="editor.chain().focus().toggleStrike().run()" aria-label="Strikethrough"
         >
           <IconStrikethrough class="w-4 h-4 sm:w-5 sm:h-5" />
         </button>
         <button
           class="p-1 rounded-sm"
           :class="{ 'bg-surface-gray-3': editor.isActive('bulletList') }"
-          @click="editor.chain().focus().toggleBulletList().run()"
+          @click="editor.chain().focus().toggleBulletList().run()" aria-label="Bullet list" 
         >
           <IconList class="w-4 h-4 sm:w-5 sm:h-5" />
         </button>
         <button
           class="p-1 rounded-sm"
           :class="{ 'bg-surface-gray-3': editor.isActive('orderedList') }"
-          @click="editor.chain().focus().toggleOrderedList().run()"
+          @click="editor.chain().focus().toggleOrderedList().run()" aria-label="Ordered list"
         >
           <IconListNumbers class="w-4 h-4 sm:w-5 sm:h-5" />
         </button>
         <button
           class="p-1 rounded-sm"
           :class="{ 'bg-surface-gray-3': editor.isActive('blockquote') }"
-          @click="editor.chain().focus().toggleBlockquote().run()"
+          @click="editor.chain().focus().toggleBlockquote().run()" aria-label="Blockquote"
         >
           <IconBlockquote class="w-4 h-4 sm:w-5 sm:h-5" />
         </button>

--- a/dashboard/src/components/ui/CommentBox.vue
+++ b/dashboard/src/components/ui/CommentBox.vue
@@ -38,8 +38,7 @@
         <button
           class="p-1 rounded-sm"
           :class="{ 'bg-surface-gray-3': editor.isActive('bulletList') }"
-          @click="editor.chain().focus().toggleBulletList().run()" aria-label="Bullet list" 
-        >
+       @click="editor.chain().focus().toggleBulletList().run()" aria-label="Bullet list">
           <IconList class="w-4 h-4 sm:w-5 sm:h-5" />
         </button>
         <button

--- a/dashboard/src/components/ui/FileUploaderArea.vue
+++ b/dashboard/src/components/ui/FileUploaderArea.vue
@@ -19,12 +19,14 @@
             <button
               class="p-2 rounded-full bg-surface-white/20 hover:bg-surface-white/30 transition-colors"
               @click="removeImage"
+              aria-label="Remove image"
             >
               <IconTrash class="w-5 h-5 text-ink-white" />
             </button>
             <button
               class="p-2 rounded-full bg-surface-white/20 hover:bg-surface-white/30 transition-colors"
               @click="$refs.fileUploader.openFileSelector()"
+              aria-label="Upload image"
             >
               <IconEdit class="w-5 h-5 text-ink-white" />
             </button>


### PR DESCRIPTION
## Status
- [ ] Draft
- [x] Ready for review

## Related Issue
Closes / Addresses: #788

## Problem
Icon-only buttons in FileUploaderArea and CommentBox were missing 
aria-label attributes, making them inaccessible to screen reader users.

## Solution
- Added aria-label="Remove image" and aria-label="Upload image" to 
  buttons in FileUploaderArea.vue
- Added aria-labels to all 7 toolbar buttons in CommentBox.vue 
  (Bold, Italic, Underline, Strikethrough, Bullet list, Ordered list, Blockquote)

## Progress
- [x] Tested locally
- [x] Follows existing code style

## Changelog
fix(a11y): add aria-label attributes to icon-only buttons in FileUploaderArea and CommentBox

## Visualization
No visual changes — accessibility improvement only.

## Further Ahead
Will continue fixing remaining icon-only buttons across the codebase.
