### PR TITLE
docs: clarify event deletion and archival behavior

### DIFF
--- a/docs/docs/create-event.md
+++ b/docs/docs/create-event.md
@@ -48,3 +48,12 @@ events "disappear" from the public pages of chapters because the
 `"Upcoming Events"` because the date & time for the event is in the past.
 
 ![concluded event](./assets/concluded-event.png)
+
+
+## Archive / Delete Event
+
+Events cannot be deleted or archived directly from the platform.
+
+If you need to hide an event, you can set the `"Event Status"` to `"Unpublished"`, `"Draft"`, or `"Cancelled"`. This will remove it from public pages without losing any data.
+
+If you need an event to be permanently removed, please reach out to [developers@fossunited.org](mailto:developers@fossunited.org).


### PR DESCRIPTION
Adds a clarification under the event management section about how event deletion works.

Events cannot be deleted or archived directly from the platform. The docs now mention using "Unpublished", "Draft", or "Cancelled" to hide events, and reaching out to developers@fossunited.org if permanent removal is required.

Related to #1364