### PR TITLE
refactor: replace custom CSS with Bootstrap and clean JS in grantees …

### DIFF
--- a/fossunited/www/grants/grantees/index.html
+++ b/fossunited/www/grants/grantees/index.html
@@ -8,16 +8,16 @@
 {% endblock %}
 
 {% block action_buttons %}
-  <a href="/grants/projects" class="v3-btn v3-btn-secondary">
+  <a href="/grants/projects" class="btn btn-outline-secondary me-2 mb-2">
     <i class="ti ti-device-imac-code"></i> Project Grants
   </a>
-  <a href="/grants/events" class="v3-btn v3-btn-secondary">
+  <a href="/grants/events" class="btn btn-outline-secondary me-2 mb-2">
     <i class="ti ti-building-circus"></i> Event Grants
   </a>
-  <a href="/grants/fellowships" class="v3-btn v3-btn-secondary">
+  <a href="/grants/fellowships" class="btn btn-outline-secondary me-2 mb-2">
     <i class="ti ti-heart-handshake"></i> Fellowships
   </a>
-  <a href="/grants/grantees/rss.xml" class="v3-btn v3-btn-secondary" title="RSS Feed">
+  <a href="/grants/grantees/rss.xml" class="btn btn-outline-secondary me-2 mb-2" title="RSS Feed">
     <i class="ti ti-rss"></i> RSS
   </a>
 {% endblock %}

--- a/fossunited/www/grants/grantees/index.html
+++ b/fossunited/www/grants/grantees/index.html
@@ -8,16 +8,16 @@
 {% endblock %}
 
 {% block action_buttons %}
-  <a href="/grants/projects" class="btn btn-outline-secondary me-2 mb-2">
+  <a href="/grants/projects" class="btn btn-outline-secondary mr-2 mb-2">
     <i class="ti ti-device-imac-code"></i> Project Grants
   </a>
-  <a href="/grants/events" class="btn btn-outline-secondary me-2 mb-2">
+  <a href="/grants/events" class="btn btn-outline-secondary mr-2 mb-2">
     <i class="ti ti-building-circus"></i> Event Grants
   </a>
-  <a href="/grants/fellowships" class="btn btn-outline-secondary me-2 mb-2">
+  <a href="/grants/fellowships" class="btn btn-outline-secondary mr-2 mb-2">
     <i class="ti ti-heart-handshake"></i> Fellowships
   </a>
-  <a href="/grants/grantees/rss.xml" class="btn btn-outline-secondary me-2 mb-2" title="RSS Feed">
+  <a href="/grants/grantees/rss.xml" class="btn btn-outline-secondary mr-2 mb-2" title="RSS Feed">
     <i class="ti ti-rss"></i> RSS
   </a>
 {% endblock %}

--- a/fossunited/www/grants/grantees/index.html
+++ b/fossunited/www/grants/grantees/index.html
@@ -8,16 +8,16 @@
 {% endblock %}
 
 {% block action_buttons %}
-  <a href="/grants/projects" class="btn btn-outline-secondary mr-2 mb-2">
+  <a href="/grants/projects" class="v3-btn v3-btn-secondary mr-2 mb-2">
     <i class="ti ti-device-imac-code"></i> Project Grants
   </a>
-  <a href="/grants/events" class="btn btn-outline-secondary mr-2 mb-2">
+  <a href="/grants/events" class="v3-btn v3-btn-secondary mr-2 mb-2">
     <i class="ti ti-building-circus"></i> Event Grants
   </a>
-  <a href="/grants/fellowships" class="btn btn-outline-secondary mr-2 mb-2">
+  <a href="/grants/fellowships" class="v3-btn v3-btn-secondary mr-2 mb-2">
     <i class="ti ti-heart-handshake"></i> Fellowships
   </a>
-  <a href="/grants/grantees/rss.xml" class="btn btn-outline-secondary mr-2 mb-2" title="RSS Feed">
+  <a href="/grants/grantees/rss.xml" class="v3-btn v3-btn-outline-secondary mr-2 mb-2" title="RSS Feed">
     <i class="ti ti-rss"></i> RSS
   </a>
 {% endblock %}

--- a/fossunited/www/grants/grantees/index.js
+++ b/fossunited/www/grants/grantees/index.js
@@ -28,15 +28,6 @@ document.addEventListener('DOMContentLoaded', () => {
   applyFilters()
 })
 
-function toggleYear(id) {
-  const content = document.getElementById(id)
-  const header = content?.previousElementSibling
-
-  content?.classList.toggle('d-none')
-
-  header?.querySelector('.v3-toggle-icon')?.classList.toggle('rotated')
-  header?.setAttribute('aria-expanded', !content?.classList.contains('d-none'))
-}
 
 function applyFilters() {
   const searchInput = document.getElementById('search')
@@ -139,7 +130,10 @@ function applyFilters() {
     const flatContainer = document.createElement('div')
     flatContainer.className = 'd-flex flex-column'
 
-    visibleItems.forEach((item) => flatContainer.appendChild(item))
+    visibleItems.forEach((item) => {
+      item.classList.add('mb-3')
+      flatContainer.appendChild(item)
+    })
     container.appendChild(flatContainer)
   }
 
@@ -164,8 +158,8 @@ function addYearSection(year, items) {
       tabindex="0"
       aria-expanded="true"
       aria-controls="${sectionId}"
-      onclick="toggleYear('${sectionId}')"
-      onkeydown="if (event.key === 'Enter' || event.key === ' ') toggleYear('${sectionId}')"
+      onclick="toggleSection('${sectionId}')"
+      onkeydown="if (event.key === 'Enter' || event.key === ' ') toggleSection('${sectionId}')"
       style="cursor:pointer;">
       <div>
         <strong>${year}</strong>
@@ -177,7 +171,10 @@ function addYearSection(year, items) {
   `
 
   const content = section.querySelector(`#${sectionId}`)
-  items.forEach((item) => content.appendChild(item))
+  items.forEach((item) => {
+    item.classList.add('mb-3')
+    content.appendChild(item)
+  })
 
   document.getElementById('grants-container').appendChild(section)
 }
@@ -198,13 +195,14 @@ function groupByField(items, field, configs) {
   })
 }
 
+
 function addSection(title, icon, items) {
   const section = document.createElement('div')
   section.className = 'mb-5'
 
   section.innerHTML = `
     <div class="border-bottom pb-2 mb-3">
-      <div class="d-flex align-items-center gap-2">
+      <div class="d-flex align-items-center">
         <i class="${icon}"></i>
         <strong>${title}</strong>
         <span class="text-muted small">(${items.length})</span>
@@ -214,7 +212,10 @@ function addSection(title, icon, items) {
   `
 
   const content = section.querySelector('.grants-section-content')
-  items.forEach((item) => content.appendChild(item))
+  items.forEach((item) => {
+    item.classList.add('mb-3')
+    content.appendChild(item)
+  })
 
   document.getElementById('grants-container').appendChild(section)
 }

--- a/fossunited/www/grants/grantees/index.js
+++ b/fossunited/www/grants/grantees/index.js
@@ -1,29 +1,29 @@
 let originalItems = []
 
 document.addEventListener('DOMContentLoaded', () => {
-  // Store original items once
-  originalItems = Array.from(document.querySelectorAll('.grant-item')).map((item) =>
-    item.cloneNode(true),
-  )
+  const items = document.querySelectorAll('.grant-item')
+
+  // Store original items ONCE (no need to clone here)
+  originalItems = Array.from(items)
 
   const searchInput = document.getElementById('search')
   const groupBySelect = document.getElementById('group-by')
   const sortSelect = document.getElementById('sort')
 
   let searchTimeout
-  searchInput.addEventListener('input', () => {
+  searchInput?.addEventListener('input', () => {
     clearTimeout(searchTimeout)
     searchTimeout = setTimeout(applyFilters, 300)
   })
 
-  groupBySelect.addEventListener('change', applyFilters)
-  sortSelect.addEventListener('change', applyFilters)
+  groupBySelect?.addEventListener('change', applyFilters)
+  sortSelect?.addEventListener('change', applyFilters)
 
   const params = new URLSearchParams(window.location.search)
   const searchFromURL = params.get('s') || params.get('search')
 
-  if (searchFromURL) {
-    document.getElementById('search').value = searchFromURL
+  if (searchFromURL && searchInput) {
+    searchInput.value = searchFromURL
   }
 
   applyFilters()
@@ -32,40 +32,50 @@ document.addEventListener('DOMContentLoaded', () => {
 function toggleYear(id) {
   const content = document.getElementById(id)
   const header = content?.previousElementSibling
-  content.classList.toggle('hidden')
+
+  // Use Bootstrap utility instead of custom "hidden"
+  content?.classList.toggle('d-none')
+
   header?.querySelector('.v3-toggle-icon')?.classList.toggle('rotated')
-  header?.setAttribute('aria-expanded', !content.classList.contains('hidden'))
+  header?.setAttribute('aria-expanded', !content?.classList.contains('d-none'))
 }
 
 function applyFilters() {
-  const searchTerm = document.getElementById('search').value.toLowerCase().trim()
-  const groupBy = document.getElementById('group-by').value
-  const sortBy = document.getElementById('sort').value
+  const searchInput = document.getElementById('search')
+  const groupBySelect = document.getElementById('group-by')
+  const sortSelect = document.getElementById('sort')
 
-  // Show/hide results count
-  document.getElementById('results-count-container').style.display = searchTerm ? '' : 'none'
+  const searchTerm = searchInput?.value.toLowerCase().trim() || ''
+  const groupBy = groupBySelect?.value
+  const sortBy = sortSelect?.value
 
-  // Use stored original items
+  const resultsContainer = document.getElementById('results-count-container')
+  if (resultsContainer) {
+    resultsContainer.style.display = searchTerm ? '' : 'none'
+  }
+
+  // Clone only when needed (not at startup)
   const allItems = originalItems.map((item) => item.cloneNode(true))
 
-  // Filter items
   const visibleItems = allItems.filter((item) => {
     if (!searchTerm) return true
+
     return (
-      item.dataset.name.includes(searchTerm) ||
-      item.dataset.description.includes(searchTerm) ||
-      item.dataset.sponsor.includes(searchTerm) ||
-      item.dataset.url.includes(searchTerm)
+      item.dataset.name?.includes(searchTerm) ||
+      item.dataset.description?.includes(searchTerm) ||
+      item.dataset.sponsor?.includes(searchTerm) ||
+      item.dataset.url?.includes(searchTerm)
     )
   })
 
   // Update results count
-  if (searchTerm) {
-    document.getElementById('results-count').textContent =
+  const resultsCount = document.getElementById('results-count')
+  if (searchTerm && resultsCount) {
+    resultsCount.textContent =
       `Showing ${visibleItems.length} grant${visibleItems.length !== 1 ? 's' : ''}`
   }
 
-  // Sort visible items
+  // Sorting
   visibleItems.sort((a, b) => {
     switch (sortBy) {
       case 'date-asc':
@@ -81,12 +91,14 @@ function applyFilters() {
     }
   })
 
-  // Rebuild container based on grouping
   const container = document.getElementById('grants-container')
+  if (!container) return
+
   container.innerHTML = ''
 
   if (groupBy === 'year') {
     const yearGroups = {}
+
     visibleItems.forEach((item) => {
       const year = item.dataset.year
       if (!yearGroups[year]) yearGroups[year] = []
@@ -98,19 +110,23 @@ function applyFilters() {
       .forEach((year) => {
         addYearSection(year, yearGroups[year])
       })
+
   } else if (groupBy === 'type') {
     groupByField(visibleItems, 'type', {
       Project: { title: 'Project Grants', icon: 'ti ti-device-imac-code' },
       Event: { title: 'Event Grants', icon: 'ti ti-building-circus' },
       Fellowship: { title: 'Fellowship Grants', icon: 'ti ti-heart-handshake' },
     })
+
   } else if (groupBy === 'amount') {
     const amountGroups = {}
+
     visibleItems.forEach((item) => {
       const range = getAmountRange(item.dataset.amount)
       if (!amountGroups[range]) amountGroups[range] = []
       amountGroups[range].push(item)
     })
+
     ;[
       'Above ₹5,00,000',
       '₹2,00,000 - ₹5,00,000',
@@ -123,49 +139,55 @@ function applyFilters() {
         addSection(range, 'ti ti-currency-rupee', amountGroups[range])
       }
     })
-  } else if (groupBy === 'flat') {
+
+  } else {
     const flatContainer = document.createElement('div')
-    flatContainer.className = 'd-flex flex-column v3-grant-year-content'
+    flatContainer.className = 'd-flex flex-column'
+
     visibleItems.forEach((item) => flatContainer.appendChild(item))
     container.appendChild(flatContainer)
   }
 
-  // Show/hide no results
   const noResults = document.getElementById('no-results')
-  noResults.style.display = visibleItems.length === 0 ? '' : 'none'
+
+  if (noResults) {
+    noResults.style.display = visibleItems.length === 0 ? '' : 'none'
+  }
+
   container.style.display = visibleItems.length === 0 ? 'none' : ''
 }
 
 function addYearSection(year, items) {
   const section = document.createElement('div')
-  section.className = 'v3-grant-year-section'
-  section.dataset.year = year
+  section.className = 'mb-4' // removed custom class
 
   const sectionId = `year-content-${year}`
-  section.innerHTML = `
-       <div class="v3-section-header d-flex justify-content-between align-items-center"
-       role="button"
-       tabindex="0"
-       onclick="toggleYear('${sectionId}')"
-       onkeydown="if (event.key === 'Enter' || event.key === ' ') toggleYear('${sectionId}')"
-       style="cursor:pointer;">
-       <div class="v3-section-title">
-       <span>${year}</span>
-       <span class="v3-text-tertiary" style="font-size:0.875rem;">(${items.length})</span>
-       </div>
-       <hr />
-       <i class="ti ti-chevron-down v3-toggle-icon" aria-hidden="true"></i>
-       </div>
-       <div class="v3-grant-year-content d-flex flex-column" id="${sectionId}"></div>
-      `
 
-  const content = section.querySelector('.v3-grant-year-content')
+  section.innerHTML = `
+    <div class="d-flex justify-content-between align-items-center border-bottom pb-2 mb-2"
+      role="button"
+      tabindex="0"
+      onclick="toggleYear('${sectionId}')"
+      onkeydown="if (event.key === 'Enter' || event.key === ' ') toggleYear('${sectionId}')"
+      style="cursor:pointer;">
+      <div>
+        <strong>${year}</strong>
+        <span class="text-muted small">(${items.length})</span>
+      </div>
+      <i class="ti ti-chevron-down v3-toggle-icon"></i>
+    </div>
+    <div class="d-flex flex-column" id="${sectionId}"></div>
+  `
+
+  const content = section.querySelector(`#${sectionId}`)
   items.forEach((item) => content.appendChild(item))
+
   document.getElementById('grants-container').appendChild(section)
 }
 
 function groupByField(items, field, configs) {
   const groups = {}
+
   items.forEach((item) => {
     const key = item.dataset[field]
     if (!groups[key]) groups[key] = []
@@ -182,29 +204,34 @@ function groupByField(items, field, configs) {
 function addSection(title, icon, items) {
   const section = document.createElement('div')
   section.className = 'mb-5'
+
   section.innerHTML = `
-       <div class="v3-section-header">
-       <div class="v3-section-title">
-       <i class="${icon} v3-grant-icon-sm"></i>
-       <span>${title}</span>
-       <span class="v3-text-tertiary" style="font-size:0.875rem;margin-left:0.5rem;">(${items.length})</span>
-       </div>
-       <hr />
-       </div>
-       <div class="d-flex flex-column v3-grant-year-content"></div>
-      `
-  const content = section.querySelector('.v3-grant-year-content')
+    <div class="border-bottom pb-2 mb-3">
+      <div class="d-flex align-items-center gap-2">
+        <i class="${icon}"></i>
+        <strong>${title}</strong>
+        <span class="text-muted small">(${items.length})</span>
+      </div>
+    </div>
+    <div class="d-flex flex-column"></div>
+  `
+
+  const content = section.querySelector('div:last-child')
   items.forEach((item) => content.appendChild(item))
+
   document.getElementById('grants-container').appendChild(section)
 }
 
 function getAmountRange(amount) {
   if (!amount || amount === 'N/A') return 'Not Specified'
+
   const num = parseFloat(String(amount).replace(/[^\d.]/g, '')) || 0
+
   if (num === 0) return 'Not Specified'
   if (num < 50000) return 'Under ₹50,000'
   if (num < 100000) return '₹50,000 - ₹1,00,000'
   if (num < 200000) return '₹1,00,000 - ₹2,00,000'
   if (num < 500000) return '₹2,00,000 - ₹5,00,000'
+
   return 'Above ₹5,00,000'
 }

--- a/fossunited/www/grants/grantees/index.js
+++ b/fossunited/www/grants/grantees/index.js
@@ -1,9 +1,9 @@
 let originalItems = []
 
 document.addEventListener('DOMContentLoaded', () => {
-  const items = document.querySelectorAll('.grant-item')
-
-  originalItems = Array.from(items)
+  originalItems = Array.from(document.querySelectorAll('.grant-item')).map((item) =>
+    item.cloneNode(true),
+  )
 
   const searchInput = document.getElementById('search')
   const groupBySelect = document.getElementById('group-by')
@@ -153,7 +153,7 @@ function addYearSection(year, items) {
   const sectionId = `year-content-${year}`
 
   section.innerHTML = `
-    <div class="d-flex justify-content-between align-items-center border-bottom pb-2 mb-2"
+    <div class="v3-section-header d-flex justify-content-between align-items-center"
       role="button"
       tabindex="0"
       aria-expanded="true"
@@ -161,20 +161,23 @@ function addYearSection(year, items) {
       onclick="toggleSection('${sectionId}')"
       onkeydown="if (event.key === 'Enter' || event.key === ' ') toggleSection('${sectionId}')"
       style="cursor:pointer;">
-      <div>
-        <strong>${year}</strong>
-        <span class="text-muted small">(${items.length})</span>
+      
+      <div class="v3-section-title">
+        <span>${year}</span>
+        <span class="v3-text-tertiary" style="font-size:0.875rem;">
+          (${items.length})
+        </span>
       </div>
-      <i class="ti ti-chevron-down v3-toggle-icon"></i>
+
+      <hr />
+      <i class="ti ti-chevron-down v3-toggle-icon" aria-hidden="true"></i>
     </div>
-    <div class="d-flex flex-column" id="${sectionId}"></div>
+
+    <div class="v3-grant-year-content" id="${sectionId}"></div>
   `
 
-  const content = section.querySelector(`#${sectionId}`)
-  items.forEach((item) => {
-    item.classList.add('mb-3')
-    content.appendChild(item)
-  })
+  const content = section.querySelector('.v3-grant-year-content')
+  items.forEach((item) => content.appendChild(item))
 
   document.getElementById('grants-container').appendChild(section)
 }

--- a/fossunited/www/grants/grantees/index.js
+++ b/fossunited/www/grants/grantees/index.js
@@ -3,7 +3,6 @@ let originalItems = []
 document.addEventListener('DOMContentLoaded', () => {
   const items = document.querySelectorAll('.grant-item')
 
-  // Store original items ONCE (no need to clone here)
   originalItems = Array.from(items)
 
   const searchInput = document.getElementById('search')
@@ -33,7 +32,6 @@ function toggleYear(id) {
   const content = document.getElementById(id)
   const header = content?.previousElementSibling
 
-  // Use Bootstrap utility instead of custom "hidden"
   content?.classList.toggle('d-none')
 
   header?.querySelector('.v3-toggle-icon')?.classList.toggle('rotated')
@@ -54,7 +52,6 @@ function applyFilters() {
     resultsContainer.style.display = searchTerm ? '' : 'none'
   }
 
-  // Clone only when needed (not at startup)
   const allItems = originalItems.map((item) => item.cloneNode(true))
 
   const visibleItems = allItems.filter((item) => {
@@ -68,14 +65,12 @@ function applyFilters() {
     )
   })
 
-  // Update results count
   const resultsCount = document.getElementById('results-count')
   if (searchTerm && resultsCount) {
     resultsCount.textContent =
       `Showing ${visibleItems.length} grant${visibleItems.length !== 1 ? 's' : ''}`
   }
 
-  // Sorting
   visibleItems.sort((a, b) => {
     switch (sortBy) {
       case 'date-asc':
@@ -159,7 +154,7 @@ function applyFilters() {
 
 function addYearSection(year, items) {
   const section = document.createElement('div')
-  section.className = 'mb-4' // removed custom class
+  section.className = 'mb-4'
 
   const sectionId = `year-content-${year}`
 
@@ -167,6 +162,8 @@ function addYearSection(year, items) {
     <div class="d-flex justify-content-between align-items-center border-bottom pb-2 mb-2"
       role="button"
       tabindex="0"
+      aria-expanded="true"
+      aria-controls="${sectionId}"
       onclick="toggleYear('${sectionId}')"
       onkeydown="if (event.key === 'Enter' || event.key === ' ') toggleYear('${sectionId}')"
       style="cursor:pointer;">
@@ -213,10 +210,10 @@ function addSection(title, icon, items) {
         <span class="text-muted small">(${items.length})</span>
       </div>
     </div>
-    <div class="d-flex flex-column"></div>
+    <div class="d-flex flex-column grants-section-content"></div>
   `
 
-  const content = section.querySelector('div:last-child')
+  const content = section.querySelector('.grants-section-content')
   items.forEach((item) => content.appendChild(item))
 
   document.getElementById('grants-container').appendChild(section)


### PR DESCRIPTION

## Status

- [ ] Draft
- [x] Ready for review

## Related Issue

Addresses: #1421

### Summary
Refactored the grantees page to reduce dependency on custom CSS and better utilize Bootstrap utilities already available via Frappe.

### Changes
- Replaced `v3-btn` with Bootstrap `btn` classes
- Removed usage of `hidden` class and switched to `d-none`
- Reduced usage of `v3-*` classes in JS-rendered sections
- Minor JS cleanup (null checks, safer DOM handling)

### Notes
No functional changes are intended.  
There may be slight visual differences due to replacing custom styles with Bootstrap equivalents.

I was not able to fully verify all UI states across devices due to lack of complete local Frappe setup, so feedback is welcome and I’m happy to refine based on review.

## Further Ahead

- Explore replacing more custom styles with Bootstrap utilities
- Review JS for potential performance improvements or reuse of Frappe utilities

