### PR TITLE
fix(dashboard): resolve profile dropdown not working on proposal pages

### DIFF
--- a/dashboard/src/components/NewAppSidebar.vue
+++ b/dashboard/src/components/NewAppSidebar.vue
@@ -191,9 +191,10 @@ const sidebarHeader = computed(() => ({
 </script>
 
 <style>
-/* DropdownMenuPortal teleports to <body> with no z-index, placing it behind
-   our fixed z-40/z-50 mobile overlay. Force it above. */
-.dropdown-content {
+/* DropdownMenuPortal teleports to <body>. Reka UI sets pointer-events: none
+   on body when dropdown opens, blocking interaction with the menu items. */
+[data-reka-popper-content-wrapper] {
   z-index: 9999 !important;
+  pointer-events: auto !important;
 }
 </style>


### PR DESCRIPTION
Closes #1499

## Problem
On the proposal-related pages (`/dashboard/cfp/all/...` and `/dashboard/cfp/apply/...`), clicking the profile picture would hide the scrollbar but the dropdown menu wouldn’t appear.

## Root Cause
The dropdown was actually being rendered, but it wasn’t visible or clickable. It seems `pointer-events: none` was being applied at a higher level, and the dropdown wrapper was also ending up behind other elements due to z-index.

## Solution
Added a small CSS fix to ensure the dropdown wrapper:
- allows pointer interactions
- appears above other elements

## Testing
Verified the fix using DevTools on the live site — the dropdown becomes visible and all items are clickable.