### PR TITLE
feat(cfp): add "Edit proposal" button for proposal owner on public page

### DIFF
--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -229,7 +229,7 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         context.is_owner = user != "Guest" and (
             user == self.submitted_by or user == self.email or user in speaker_emails
         )
-        context.proposal_id = self.name
+
         context.no_cache = 1
 
     def get_meta(self, context):

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -227,9 +227,7 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         user = frappe.session.user
         speaker_emails = [s.email for s in self.speakers if s.email]
         context.is_owner = user != "Guest" and (
-            user == self.submitted_by or
-            user == self.email or
-            user in speaker_emails
+            user == self.submitted_by or user == self.email or user in speaker_emails
         )
         context.proposal_id = self.name
         context.no_cache = 1

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -223,6 +223,15 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
 
         context.talk_video = self.cfp_get_talk_video()
         context.youtube_embed_id = self.cfp_get_youtube_id(context.talk_video)
+
+        user = frappe.session.user
+        speaker_emails = [s.email for s in self.speakers if s.email]
+        context.is_owner = user != "Guest" and (
+            user == self.submitted_by or
+            user == self.email or
+            user in speaker_emails
+        )
+        context.proposal_id = self.name
         context.no_cache = 1
 
     def get_meta(self, context):

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
@@ -50,7 +50,7 @@
       <h1 class="text-3xl font-bold">{{ doc.talk_title }}</h1>
       <div class="flex gap-2 items-center">
         {% if is_owner %}
-          <a href="/dashboard/my-proposals/edit/{{ proposal_id }}" class="btn btn-default btn-sm">Edit proposal</a>
+<a href="/dashboard/my-proposals/edit/{{ doc.name }}" class="btn btn-default btn-sm">Edit proposal</a>
         {% endif %}
         {{ like_button() }}
       </div>

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
@@ -48,7 +48,12 @@
     </div>
     <div class="flex justify-between gap-4">
       <h1 class="text-3xl font-bold">{{ doc.talk_title }}</h1>
-      {{ like_button() }}
+      <div class="flex gap-2 items-center">
+        {% if is_owner %}
+          <a href="/dashboard/my-proposals/edit/{{ proposal_id }}" class="btn btn-default btn-sm">Edit proposal</a>
+        {% endif %}
+        {{ like_button() }}
+      </div>
     </div>
     <div class="flex items-center gap-2">
       <div class="w-fit">{{ badge(label=doc.status, theme=status_badge_theme[doc.status]) }}</div>


### PR DESCRIPTION
## Summary

On the public proposal page, the proposal owner didn’t have a direct way to edit their submission and had to navigate through the dashboard.

## Changes

- Added a check in `get_context` to verify if the logged-in user matches `submitted_by`, `email`, or speaker email
- Passed `is_owner` and `proposal_id` to the template context
- Conditionally rendered an "Edit proposal" button for the proposal owner
- Redirects to `/dashboard/my-proposals/edit/<proposal_id>`

## Closes

Closes #1502