### PR TITLE
fix(dashboard): remove redundant theme and collapse buttons from sidebar

### DIFF
--- a/dashboard/src/components/NewAppSidebar.vue
+++ b/dashboard/src/components/NewAppSidebar.vue
@@ -33,7 +33,7 @@
     <Sidebar
       v-model:collapsed="resolvedCollapsed"
       :class="mobileOpen ? '!w-60' : ''"
-      :sections="allSections"
+      :sections="navSections"
       :header="sidebarHeader"
     >
       <template #footer-items>
@@ -155,9 +155,6 @@ const navSections = computed(() =>
   })),
 )
 
-const allSections = computed(() => [
-  ...navSections.value,
-])
 
 const sidebarHeader = computed(() => ({
   title: 'FOSS United',

--- a/dashboard/src/components/NewAppSidebar.vue
+++ b/dashboard/src/components/NewAppSidebar.vue
@@ -67,8 +67,6 @@ import {
   IconSun,
   IconMoon,
   IconExternalLink,
-  IconLayoutSidebarLeftCollapse,
-  IconLayoutSidebarLeftExpand,
 } from '@tabler/icons-vue'
 import { useRoute } from 'vue-router'
 
@@ -158,23 +156,6 @@ const navSections = computed(() =>
 )
 
 const allSections = computed(() => [
-  {
-    items: [
-      {
-        label: currentTheme.value === 'dark' ? 'Switch to Light' : 'Switch to Dark',
-        onClick: toggleTheme,
-        icon: () => h(currentTheme.value === 'dark' ? IconSun : IconMoon, { class: 'w-4 h-4' }),
-      },
-      {
-        label: isCollapsed.value ? 'Expand Sidebar' : 'Collapse Sidebar',
-        onClick: () => { resolvedCollapsed.value = !isCollapsed.value },
-        icon: () =>
-          h(isCollapsed.value ? IconLayoutSidebarLeftExpand : IconLayoutSidebarLeftCollapse, {
-            class: 'w-4 h-4',
-          }),
-      },
-    ],
-  },
   ...navSections.value,
 ])
 


### PR DESCRIPTION
Fixes #1506

The sidebar had duplicate controls for theme toggle and collapse that were already available elsewhere (header dropdown and frappe-ui footer).

Removed these from `allSections` and cleaned up unused icon imports.

No changes to layout or behavior — only removes duplication.