### PR TITLE
fix: align Activity section and restore top border

### DIFF
--- a/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
@@ -48,7 +48,7 @@
 
       <div class="profile-content-section mt-10">
         <div class="d-flex align-items-center">
-          <h5 style="padding: 2rem 2.5rem;">
+          <h5 style="padding-left: 2.5rem;">
             Activity
           </h5>
           <a
@@ -216,32 +216,32 @@
     from
     'fossunited/templates/macros/hackathon_card.html' import hackathon_card
   %}
-  <div class="profile-content-div p-5">
+  <div class="profile-content-div">
     {% if doc.show_activity %}
 
       {% if talked | length > 0 %}
-      <div class="container">
+      <div>
         <h3 class="subtitle">Talks Given</h3>
         {% for talk in talked %}{{ speaker_card(talk) }}{% endfor %}
       </div>
       {% endif %}
 
       {% if cfps | length > 0 %}
-        <div class="container">
+        <div>
           <h3 class="subtitle">CFPs Proposed</h3>
           {% for talk in cfps %}{{ speaker_card(talk) }}{% endfor %}
         </div>
       {% endif %}
 
       {% if volunteered | length > 0 %}
-      <div class="container">
+      <div>
         <h3 class="subtitle">Chapter & Event Volunteership</h3>
         {% for item in volunteered %}{{ volunteer_card(item) }}{% endfor %}
       </div>
       {% endif %}
 
       {% if attended | length > 0 %}
-      <div class="container">
+      <div>
         <h3 class="subtitle">Events Attended</h3>
         <div class="events-grid-4">
           {% for event in attended %}{{ event_card(event) }}{% endfor %}
@@ -250,7 +250,7 @@
       {% endif %}
 
       {% if attended_hack | length > 0 %}
-      <div class="container">
+      <div>
         <h3 class="subtitle">Hackathons Attended</h3>
         <div class="events-grid-4">
           {% for hackathon in attended_hack %}{{ hackathon_card(hackathon) }}{% endfor %}

--- a/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
@@ -47,8 +47,8 @@
       </div>
 
       <div class="profile-content-section mt-10">
-        <div class="d-flex align-items-center border-top-0 border">
-          <h5 class="p-5 pl-10">
+        <div class="d-flex align-items-center border">
+          <h5 class="p-5">
             Activity
           </h5>
           <a

--- a/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/templates/foss_user_profile.html
@@ -47,8 +47,8 @@
       </div>
 
       <div class="profile-content-section mt-10">
-        <div class="d-flex align-items-center border">
-          <h5 class="p-5">
+        <div class="d-flex align-items-center">
+          <h5 style="padding: 2rem 2.5rem;">
             Activity
           </h5>
           <a


### PR DESCRIPTION
Closes #1520

Fixed the alignment issue in the Activity section and restored the missing top border.

- Removed `border-top-0` so the top border is visible again
- Adjusted heading padding to align it with the content below

Kept the changes minimal and consistent with the existing layout.

Before:
<img width="951" height="437" alt="Screenshot 2026-03-27 111613" src="https://github.com/user-attachments/assets/9177c51d-eaab-4ff1-91e8-ea2db931be0f" />
 
After:
<img width="940" height="209" alt="Screenshot 2026-03-27 112114" src="https://github.com/user-attachments/assets/48756b63-2b40-48a3-936c-b5192c7a1812" />

