### PR TITLE
chore(dashboard): add Vite temp files to .gitignore

### DIFF
--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 dist-ssr
 *.local
+vite.config.js.timestamp-*.mjs


### PR DESCRIPTION
Fixes #1515

Added `vite.config.js.timestamp-*.mjs` to dashboard/.gitignore to prevent Vite’s temporary files from showing up in `git status` during local development.