### PR TITLE
fix: sync dark mode transition between sidebar and main area

### DIFF
--- a/dashboard/src/pages/Home.vue
+++ b/dashboard/src/pages/Home.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-col md:flex-row">
     <SideNavbar v-if="navItems.data" :menu-items="navItems.data" />
-    <div class="flex-1 min-w-0">
+    <div class="flex-1 min-w-0 transition-colors duration-300">
       <RouterView />
     </div>
   </div>


### PR DESCRIPTION
Closes #1516

The sidebar had a transition applied while the main content switched instantly, causing a visible delay during theme toggle.

Added a matching transition to the main content so both switch consistently.

Kept the change minimal.