### PR TITLE
fix(proposalReview): filter + toggle reviewed + remove withdrawn proposals by default

### DIFF
--- a/dashboard/src/components/reviewers/ProposalDetails.vue
+++ b/dashboard/src/components/reviewers/ProposalDetails.vue
@@ -10,10 +10,8 @@
         <h2 class="font-semibold">{{ submission.data.talk_title }}</h2>
       </div>
       <div class="flex items-center gap-2">
-        <Badge
-          :label="submission.data.hasReviewed ? 'Reviewed' : submission.data.status"
-          :theme="getStatusBadgeTheme(submission.data.hasReviewed ? 'Yes' : 'No')"
-        />
+        <Badge :label="submission.data.status" :theme="getStatusBadgeTheme(submission.data.status)" />
+        <Badge v-if="submission.data.hasReviewed" label="Reviewed" theme="blue" />
         <span class="text-sm text-ink-gray-5">
           Submitted {{ dayjs(submission.data.creation).fromNow() }}
         </span>

--- a/dashboard/src/components/reviewers/ProposalDetails.vue
+++ b/dashboard/src/components/reviewers/ProposalDetails.vue
@@ -10,7 +10,10 @@
         <h2 class="font-semibold">{{ submission.data.talk_title }}</h2>
       </div>
       <div class="flex items-center gap-2">
-        <Badge :label="submission.data.status" :theme="getStatusBadgeTheme(submission.data.status)" />
+        <Badge
+          :label="submission.data.status"
+          :theme="getStatusBadgeTheme(submission.data.status)"
+        />
         <Badge v-if="submission.data.hasReviewed" label="Reviewed" theme="blue" />
         <span class="text-sm text-ink-gray-5">
           Submitted {{ dayjs(submission.data.creation).fromNow() }}
@@ -31,6 +34,13 @@
       <ProseContainer label="Key Takeaways" :value="submission.data.key_takeaways" />
       <RenderReferences :references="submission.data.references" />
       <RenderSessionCategories :categories="submission.data.session_categories" />
+      <div v-if="submission.data.talk_license" class="flex flex-col gap-1">
+        <span class="text-xs font-medium text-ink-gray-5 uppercase">License</span>
+        <div class="flex items-center gap-1.5 text-sm text-ink-gray-7">
+          <IconScale class="w-4 h-4 text-ink-gray-4 flex-shrink-0" />
+          <span>{{ submission.data.talk_license }}</span>
+        </div>
+      </div>
     </div>
     <div
       v-else-if="activeTab === 1 && !hasAnonymousSpeaker.data.anonymise_proposals"
@@ -52,7 +62,7 @@ import { provide, ref, watch, inject } from 'vue'
 import { useRoute } from 'vue-router'
 import { getStatusBadgeTheme } from '@/helpers/reviewer'
 import { createAbsoluteUrlFromRoute } from '@/helpers/utils'
-import { IconArrowUpRight } from '@tabler/icons-vue'
+import { IconArrowUpRight, IconScale } from '@tabler/icons-vue'
 import ProposalSpeakers from './ProposalSpeakers.vue'
 import ProseContainer from '@/components/ui/ProseContainer.vue'
 import ProposalBadgeGroup from './ProposalBadgeGroup.vue'

--- a/dashboard/src/components/reviewers/ProposalListItem.vue
+++ b/dashboard/src/components/reviewers/ProposalListItem.vue
@@ -10,7 +10,7 @@
     <h4 class="text-base transition-colors" :class="{ 'text-ink-gray-5': submission._is_seen }">
       {{ submission.talk_title }}
     </h4>
-    <div class="flex gap-2 items-center !text-sm">
+    <div class="flex gap-2 items-center !text-sm flex-wrap">
       <Badge :label="submission.status" :theme="getStatusBadgeTheme(submission.status)" />
       <Badge v-if="submission._is_reviewed === 'Yes'" label="Reviewed" theme="blue" />
       <Badge :label="submission._likes_count" variant="ghost" class="!text-ink-gray-4">
@@ -20,12 +20,16 @@
       </Badge>
       <span class="text-ink-gray-5">{{ dayjs(submission.creation).fromNow() }} </span>
     </div>
+    <div v-if="submission.talk_license" class="flex items-center gap-1 text-xs text-ink-gray-5">
+      <IconScale size="12" />
+      <span>{{ submission.talk_license }}</span>
+    </div>
   </div>
 </template>
 <script setup>
 import { inject } from 'vue'
 import { Badge } from 'frappe-ui'
-import { IconHeart } from '@tabler/icons-vue'
+import { IconHeart, IconScale } from '@tabler/icons-vue'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import ProposalBadgeGroup from './ProposalBadgeGroup.vue'
 import { getStatusBadgeTheme } from '@/helpers/reviewer'

--- a/dashboard/src/components/reviewers/ProposalListItem.vue
+++ b/dashboard/src/components/reviewers/ProposalListItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="border-t border-b py-4 px-2 gap-4 flex flex-col hover:bg-surface-gray-1 focus:bg-surface-gray-1 hover:cursor-pointer transition-colors duration-300"
+    class="border-t border-b py-4 px-2 gap-4 flex flex-col hover:bg-surface-gray-1 focus:bg-surface-gray-2 focus:outline-none hover:cursor-pointer transition-colors duration-300"
   >
     <ProposalBadgeGroup
       :session-type="submission.session_type"
@@ -11,10 +11,8 @@
       {{ submission.talk_title }}
     </h4>
     <div class="flex gap-2 items-center !text-sm">
-      <Badge
-        :label="submission._is_reviewed === 'Yes' ? 'Reviewed' : submission.status"
-        :theme="getStatusBadgeTheme(submission._is_reviewed || submission.status)"
-      />
+      <Badge :label="submission.status" :theme="getStatusBadgeTheme(submission.status)" />
+      <Badge v-if="submission._is_reviewed === 'Yes'" label="Reviewed" theme="blue" />
       <Badge :label="submission._likes_count" variant="ghost" class="!text-ink-gray-4">
         <template #prefix>
           <IconHeart size="14" />

--- a/dashboard/src/components/reviewers/ProposalsList.vue
+++ b/dashboard/src/components/reviewers/ProposalsList.vue
@@ -38,7 +38,7 @@
 </template>
 <script setup>
 import ProposalListItem from './ProposalListItem.vue'
-import { defineProps, watch, ref } from 'vue'
+import { watch, ref } from 'vue'
 import { createResource, FormControl, LoadingIndicator, Switch } from 'frappe-ui'
 import Filter from '../ui/Filter.vue'
 import { getCfpFilterFields, filterSubmissions } from '@/helpers/cfp'
@@ -61,7 +61,7 @@ const props = defineProps({
 
 const emit = defineEmits(['open:submission'])
 
-const showNotReviewed = ref(false)
+const showNotReviewed = ref(true)
 const searchTitle = ref('')
 const filters = useStorage(`review-filters:${route.params.id}`, {})
 const docfields = await getCfpFilterFields(route.params.id)
@@ -72,29 +72,31 @@ const cfpSubmissions = createResource({
     event: props.event,
   },
   auto: true,
-
-  onSuccess(data) {
-    if (filters.value) {
-      cfpSubmissions.data = filterSubmissions(data, filters.value)
-    }
-  },
   transform(data) {
-    cfpSubmissions.originalData = data
+    // Exclude withdrawn proposals from the list
+    const withoutWithdrawn = data.filter((s) => s.status !== 'Withdrawn')
+    cfpSubmissions.originalData = withoutWithdrawn
+    return withoutWithdrawn
+  },
+  onSuccess() {
+    applyFilters()
   },
 })
 
+function applyFilters() {
+  if (!cfpSubmissions.originalData) return
+  const _filters = {
+    ...filters.value,
+    ...(searchTitle.value ? { talk_title: ['like', searchTitle.value] } : {}),
+    ...(showNotReviewed.value ? { _is_not_reviewed: ['=', 'Yes'] } : {}),
+  }
+  cfpSubmissions.data = filterSubmissions(cfpSubmissions.originalData, _filters)
+}
+
 watch(
   [() => filters.value, () => searchTitle.value, () => showNotReviewed.value],
-  ([newFilters, newTitle, notReviewed]) => {
-    const _filters = {
-      ...newFilters,
-      ...(newTitle ? { talk_title: ['like', newTitle] } : {}),
-      ...(notReviewed ? { _is_not_reviewed: ['=', 'Yes'] } : {}),
-    }
-
-    cfpSubmissions.data = filterSubmissions(cfpSubmissions.originalData, _filters)
-  },
-  { deep: true, immediate: true },
+  () => applyFilters(),
+  { deep: true },
 )
 
 const handleOpenSubmission = (submission) => {

--- a/dashboard/src/components/reviewers/ProposalsList.vue
+++ b/dashboard/src/components/reviewers/ProposalsList.vue
@@ -88,7 +88,9 @@ function applyFilters() {
   const _filters = {
     ...filters.value,
     ...(searchTitle.value ? { talk_title: ['like', searchTitle.value] } : {}),
-    ...(showNotReviewed.value ? { _is_reviewed: ['=', 'No'] } : {}),
+    ...(showNotReviewed.value && !filters.value?._is_reviewed
+      ? { _is_reviewed: ['=', 'No'] }
+      : {}),
   }
   cfpSubmissions.data = filterSubmissions(cfpSubmissions.originalData, _filters)
 }

--- a/dashboard/src/components/reviewers/ProposalsList.vue
+++ b/dashboard/src/components/reviewers/ProposalsList.vue
@@ -9,7 +9,7 @@
     <div class="flex flex-wrap items-center justify-between gap-4">
       <div class="flex items-center gap-4">
         <Filter v-model="filters" :docfields="docfields.data" />
-        <Switch v-model="showNotReviewed" label="Only show not reviewed" />
+          <Switch v-model="showNotReviewed" label="Hide reviewed (By Me)" />
       </div>
       <span class="text-xs text-ink-gray-5">Count: {{ cfpSubmissions.data?.length }}</span>
     </div>
@@ -88,7 +88,7 @@ function applyFilters() {
   const _filters = {
     ...filters.value,
     ...(searchTitle.value ? { talk_title: ['like', searchTitle.value] } : {}),
-    ...(showNotReviewed.value ? { _is_not_reviewed: ['=', 'Yes'] } : {}),
+    ...(showNotReviewed.value ? { _is_reviewed: ['=', 'No'] } : {}),
   }
   cfpSubmissions.data = filterSubmissions(cfpSubmissions.originalData, _filters)
 }

--- a/dashboard/src/components/ui/Filter.vue
+++ b/dashboard/src/components/ui/Filter.vue
@@ -80,11 +80,9 @@
             </div>
             <div class="flex items-center justify-between gap-2">
               <Autocomplete
-                v-model="newFilter"
-                value=""
                 :options="fields"
                 placeholder="Filter by..."
-                @change="(field) => addFilter(field.value)"
+                @update:model-value="(option) => option && addFilter(option.value)"
               >
                 <template #target="{ togglePopover }">
                   <Button
@@ -104,7 +102,7 @@
                 class="!text-ink-gray-5"
                 variant="ghost"
                 label="Clear all filter"
-                @click="model = []"
+                @click="model = {}"
               />
             </div>
           </div>
@@ -171,11 +169,9 @@
             </div>
             <div class="flex items-center justify-between gap-2">
               <Autocomplete
-                v-model="newFilter"
-                value=""
                 :options="fields"
                 placeholder="Filter by..."
-                @change="(field) => addFilter(field.value)"
+                @update:model-value="(option) => option && addFilter(option.value)"
               >
                 <template #target="{ togglePopover }">
                   <Button
@@ -195,7 +191,7 @@
                 class="!text-ink-gray-5"
                 variant="ghost"
                 label="Clear all filter"
-                @click="model = []"
+                @click="model = {}"
               />
             </div>
           </div>
@@ -207,7 +203,7 @@
 
 <script setup>
 import { Autocomplete, Badge, FeatherIcon, FormControl } from 'frappe-ui'
-import { computed, h, ref, watch } from 'vue'
+import { computed, h } from 'vue'
 import NestedPopover from './NestedPopover.vue'
 import SearchComplete from './SearchComplete.vue'
 import { IconFilter2 } from '@tabler/icons-vue'
@@ -230,18 +226,6 @@ const props = defineProps({
   },
 })
 
-const newFilter = ref({})
-
-watch(
-  () => newFilter.value,
-  () => {
-    if (!newFilter.value) {
-      return
-    }
-    addFilter(newFilter.value.fieldname)
-    newFilter.value = null
-  },
-)
 
 const fields = computed(() => {
   const fields = props.docfields
@@ -388,8 +372,10 @@ function addFilter(fieldname) {
 }
 
 function removeFilter(index) {
-  const fieldname = Object.keys(model.value)[index]
-  delete model.value[fieldname]
+  const newModel = { ...model.value }
+  const fieldname = Object.keys(newModel)[index]
+  delete newModel[fieldname]
+  model.value = newModel
 }
 
 function editFilter(filter, index, field) {

--- a/dashboard/src/helpers/reviewer.js
+++ b/dashboard/src/helpers/reviewer.js
@@ -1,17 +1,12 @@
-export const getStatusBadgeTheme = (status) => {
-  switch (status) {
-    case 'Yes':
-    case 'Approved':
-      return 'green'
-    case 'No':
-    case 'Review Pending':
-      return 'orange'
-    case 'Rejected':
-      return 'red'
-    default:
-      return 'gray'
-  }
+const STATUS_THEMES = {
+  Approved: 'green',
+  Rejected: 'red',
+  'Review Pending': 'orange',
+  Screening: 'blue',
+  Withdrawn: 'gray',
 }
+
+export const getStatusBadgeTheme = (status) => STATUS_THEMES[status] ?? 'gray'
 
 export const defaultSelectedReviewValue = () => {
   return {

--- a/dashboard/src/pages/reviewers/ReviewPage.vue
+++ b/dashboard/src/pages/reviewers/ReviewPage.vue
@@ -1,18 +1,6 @@
 <template>
   <div class="flex flex-col md:flex-row">
-    <Sidebar>
-      <template #pre-nav-items>
-        <Button
-          class="w-fit"
-          label="Go Back"
-          icon-left="arrow-left"
-          variant="ghost"
-          route="/review"
-        />
-        <h4 class="text-sm uppercase font-medium text-ink-gray-6">Proposal Review</h4>
-        <p class="text-sm text-ink-gray-5">Review the session proposals for this event.</p>
-      </template>
-    </Sidebar>
+    <Sidebar :menu-items="sidebarMenuItems" />
     <div class="flex-1 min-w-0 flex">
       <div
         v-if="event.data"
@@ -92,6 +80,31 @@ const event = createResource({
       link: `${window.location.origin}/${data.route}`,
     })
   },
+})
+
+const allCfpEvents = createResource({
+  url: 'fossunited.api.reviewer.get_events_by_open_cfp',
+  auto: true,
+})
+
+const sidebarMenuItems = computed(() => {
+  const items = [
+    {
+      items: [{ icon: 'arrow-left', label: 'Go Back', route: '/review' }],
+    },
+  ]
+
+  if (allCfpEvents.data?.length) {
+    items.push({
+      parent_label: 'Open CFPs',
+      items: allCfpEvents.data.map((e) => ({
+        label: e.event_name,
+        route: `/review/${e.event}`,
+      })),
+    })
+  }
+
+  return items
 })
 
 const breadcrumbItems = ref([

--- a/fossunited/api/cfp.py
+++ b/fossunited/api/cfp.py
@@ -164,7 +164,6 @@ def get_cfp_submissions(event: str) -> list:
         submission.update(
             {
                 "_is_reviewed": "Yes" if is_reviewed else "No",
-                "_is_not_reviewed": "No" if is_reviewed else "Yes",
                 "_is_seen": is_reviewed,
             }
         )
@@ -370,13 +369,7 @@ def get_proposal_filter_fields(event_id: str) -> list:
             {
                 "fieldname": "_is_reviewed",
                 "fieldtype": "Check",
-                "label": "Only show reviewed (By Me)",
-                "reqd": 0,
-            },
-            {
-                "fieldname": "_is_not_reviewed",
-                "fieldtype": "Check",
-                "label": "Only show not reviewed (By Me)",
+                "label": "Reviewed (By Me)",
                 "reqd": 0,
             },
         ]

--- a/fossunited/api/cfp.py
+++ b/fossunited/api/cfp.py
@@ -66,6 +66,19 @@ def get_cfp_submissions_insight(event_id: str) -> list:
     return insight_values
 
 
+CFP_SUBMISSION_FIELDS = [
+    "name",
+    "talk_title",
+    "status",
+    "session_categories",
+    "session_type",
+    "is_first_talk",
+    "intended_audience",
+    "talk_license",
+    "creation",
+]
+
+
 @frappe.whitelist()
 def get_cfp_submissions(event: str) -> list:
     """
@@ -81,21 +94,10 @@ def get_cfp_submissions(event: str) -> list:
 
     cfp = frappe.db.get_value(EVENT_CFP, {"event": event}, "name")
 
-    fields = [
-        "name",
-        "talk_title",
-        "status",
-        "session_categories",
-        "session_type",
-        "is_first_talk",
-        "intended_audience",
-        "creation",
-    ]
-
     submissions = frappe.db.get_list(
         PROPOSAL,
         {"linked_cfp": cfp},
-        fields,
+        CFP_SUBMISSION_FIELDS,
         page_length=9999,
         order_by="creation desc",
     )
@@ -288,7 +290,15 @@ def get_speakers(submission: str) -> list:
     return frappe.db.get_all(
         SPEAKER,
         {"parent": submission},
-        ["photo", "full_name", "designation", "organization", "linked_user", "social_link", "bio"],
+        [
+            "photo",
+            "full_name",
+            "designation",
+            "organization",
+            "linked_user",
+            "social_link",
+            "bio",
+        ],
     )
 
 
@@ -313,40 +323,23 @@ def get_global_cfp_guidelines() -> dict:
 
 @frappe.whitelist()
 def get_proposal_filter_fields(event_id: str) -> list:
-    fields = frappe.get_meta(PROPOSAL).fields
-
-    fieldtypes_to_remove = ["Section Break", "Tab Break", "Column Break"]
-    fields_to_remove = [
-        "talk_title",
-        "is_published",
-        "route",
-        "linked_cfp",
-        "chapter",
-        "event",
-        "submitted_by",
-        "event_name",
-        "attendance_confirmed",
-        "first_name",
-        "last_name",
-        "talk_reference",
-        "full_name",
-        "email",
-        "picture_url",
-        "designation",
+    # excluding non-filterable ones (name, creation, talk_title handled by search)
+    FILTERABLE_FIELDNAMES = {
+        f for f in CFP_SUBMISSION_FIELDS if f not in ("name", "talk_title")
+    } | {
+        "is_withdrawn",
+        "talk_license",
+        "speakers",
+        "custom_answers",
+        "is_first_talk",
         "organization",
-        "bio",
-        "positive_reviews",
-        "negative_reviews",
-        "unsure_reviews",
-        "approvability",
-    ]
+        "session_categories",
+        "submitted_by",
+    }
 
-    fieldnames_to_remove = set(fields_to_remove)
+    all_meta_fields = frappe.get_meta(PROPOSAL).fields
     filtered_fields = [
-        field
-        for field in fields
-        if field.fieldtype not in fieldtypes_to_remove
-        and field.fieldname not in fieldnames_to_remove
+        field for field in all_meta_fields if field.fieldname in FILTERABLE_FIELDNAMES
     ]
 
     cfp = frappe.get_doc(EVENT_CFP, {"event": event_id})


### PR DESCRIPTION
- fixes #1538 
- #1539 
- #1540 
- #1541

<img width="700" height="600" alt="image" src="https://github.com/user-attachments/assets/1a9fa552-c61f-4ae9-a519-a6f8201f7a36" />

- Fixed autocomplete (filter) to use @update handler (prev used depreciated @change)
- Show proper colors for proposal list based on status
  prev had it based on "yes" or "No" case and thus got only 2 colors
  
  
- remove withdrawn proposals by default

- show talk license if given

- add sidebar nav items to jump to other event proposals to review

- Update wording as "hide reviewed (by me)" to make switch work as expected