### PR TITLE
feat(speaker): add contact_info field to collect for indiafoss event

### DIFF
--- a/dashboard/src/components/cfp-public/SpeakersForm.vue
+++ b/dashboard/src/components/cfp-public/SpeakersForm.vue
@@ -1,41 +1,41 @@
 <template>
-  <div class="grid grid-cols-1 md:grid-cols-2 gap-8 w-full p-4 md:p-8 border rounded bg-surface-white">
+  <div class="flex flex-col gap-6 w-full p-4 md:p-8 border rounded bg-surface-white">
     <h4 v-if="showTitle" class="flex gap-2 items-center font-semibold">
       <IconUserCircle />
       <span>Speaker Information</span>
     </h4>
-    <div
-      v-for="(speaker, index) in speakers"
-      :key="index"
-      class="flex flex-col gap-4 p-6 border rounded border-outline-gray-2"
-    >
+    <div :class="speakers.length > 1 ? 'grid md:grid-cols-2 gap-8' : 'flex flex-col gap-8'">
       <div
-        v-if="speakers.length > 1"
-        class="border-b border-outline-gray-4 pb-2 col-span-2 flex justify-between"
+        v-for="(speaker, index) in speakers"
+        :key="index"
+        class="flex flex-col gap-4 p-6 border rounded border-outline-gray-2"
       >
-        <h5 class="font-medium text-base">Speaker #{{ index + 1 }}</h5>
-        <Button icon="trash" theme="red" @click="deleteSpeaker(index)" />
+        <div
+          v-if="speakers.length > 1"
+          class="border-b border-outline-gray-4 pb-2 flex justify-between"
+        >
+          <h5 class="font-medium text-base">Speaker #{{ index + 1 }}</h5>
+          <Button icon="trash" theme="red" @click="deleteSpeaker(index)" />
+        </div>
+        <FileUploaderArea
+          v-model="speaker[getFieldIndex(speaker, 'photo')].value"
+          label="Speaker Image"
+          description="Please keep the image ratio as 1:1"
+          :required="true"
+        />
+        <RenderField
+          v-for="(field, _index) in fields"
+          :key="_index"
+          v-model:fields="speakers[index]"
+          :field="field"
+        />
+        <TextEditor
+          v-model="speaker[getFieldIndex(speaker, 'bio')].value"
+          label="Speaker Bio"
+          required="true"
+          description="A short bio of the speaker"
+        />
       </div>
-      <FileUploaderArea
-        v-model="speaker[getFieldIndex(speaker, 'photo')].value"
-        class="col-span-2"
-        label="Speaker Image"
-        description="Please keep the image ratio as 1:1"
-        :required="true"
-      />
-      <RenderField
-        v-for="(field, _index) in fields"
-        :key="_index"
-        v-model:fields="speakers[index]"
-        :field="field"
-      />
-      <TextEditor
-        v-model="speaker[getFieldIndex(speaker, 'bio')].value"
-        label="Speaker Bio"
-        class="col-span-2"
-        required="true"
-        description="A short bio of the speaker"
-      />
     </div>
     <Button label="Add Speaker" icon-left="plus" class="w-fit" @click="addSpeaker" />
   </div>

--- a/dashboard/src/helpers/cfp.js
+++ b/dashboard/src/helpers/cfp.js
@@ -246,6 +246,13 @@ export const getSpeakerFields = () => {
       value: '',
     },
     {
+      label: 'Contact Info',
+      fieldname: 'contact_info',
+      fieldtype: 'text',
+      value: '',
+      description: 'Phone number or signal handle for volunteers to reach out.',
+    },
+    {
       label: 'Speaker Bio',
       fieldname: 'bio',
       fieldtype: 'text_editor',

--- a/fossunited/fossunited/doctype/cfp_submission_speaker/cfp_submission_speaker.json
+++ b/fossunited/fossunited/doctype/cfp_submission_speaker/cfp_submission_speaker.json
@@ -12,6 +12,7 @@
     "designation",
     "organization",
     "social_link",
+    "contact_info",
     "column_break_nvuo",
     "bio",
     "linked_user"
@@ -68,12 +69,18 @@
       "fieldname": "social_link",
       "fieldtype": "Data",
       "label": "Social Link"
+    },
+    {
+      "description": "Phone number or Signal contact for immediate calls",
+      "fieldname": "contact_info",
+      "fieldtype": "Data",
+      "label": "Contact Info"
     }
   ],
   "grid_page_length": 50,
   "istable": 1,
   "links": [],
-  "modified": "2026-03-07 16:37:00.275368",
+  "modified": "2026-04-09 16:45:25.939351",
   "modified_by": "Administrator",
   "module": "FOSSUnited",
   "name": "CFP Submission Speaker",

--- a/fossunited/fossunited/doctype/cfp_submission_speaker/cfp_submission_speaker.py
+++ b/fossunited/fossunited/doctype/cfp_submission_speaker/cfp_submission_speaker.py
@@ -15,6 +15,7 @@ class CFPSubmissionSpeaker(Document):
         from frappe.types import DF
 
         bio: DF.TextEditor | None
+        contact_info: DF.Data | None
         designation: DF.Data
         email: DF.Data
         full_name: DF.Data


### PR DESCRIPTION
- #1545

- especially we need this for indiafoss event
- strictly shared only for volunteers and used only for necessary communication
- optional for them to submit any info (no strict phone, even telegram or signal handle will do)

- for other LOC, just fixed default 2 grid col issue for speaker info (if >1 speaker then it should be grid column, if not it can take full width)

<img width="1203" height="700" alt="image" src="https://github.com/user-attachments/assets/e7e05e4d-ba72-4959-9be5-1dbcba16349f" />
