### PR TITLE
feat(event): docshare event to it event_members table

### DIFF
--- a/dashboard/src/helpers/event.js
+++ b/dashboard/src/helpers/event.js
@@ -16,23 +16,30 @@ export const isChapterMember = async (chapter_id) => {
   return isMember.data
 }
 
+export const isEventMember = async (event_id) => {
+  const isMember = createResource({
+    url: 'fossunited.api.chapter.check_if_event_member',
+    params: { event: event_id },
+  })
+  await isMember.fetch()
+  return isMember.data
+}
+
 export const isEventOrganizer = async (event_id) => {
-  const isOrganizer = ref(false)
   const eventId = createResource({
     url: 'frappe.client.get_value',
     params: {
       doctype: 'FOSS Chapter Event',
       fieldname: 'chapter',
-      filters: {
-        name: event_id,
-      },
+      filters: { name: event_id },
     },
-    auto: true,
   })
   await eventId.fetch()
+
   if (eventId.data) {
-    isOrganizer.value = await isChapterMember(eventId.data.chapter)
+    const chapterMember = await isChapterMember(eventId.data.chapter)
+    if (chapterMember) return true
   }
 
-  return isOrganizer.value
+  return await isEventMember(event_id)
 }

--- a/fossunited/api/chapter.py
+++ b/fossunited/api/chapter.py
@@ -232,33 +232,49 @@ def get_my_chapter_dashboard():
     since_3w = add_days(now_datetime(), -21)
 
     chapter_names = get_my_chapters(user)
-
-    if not chapter_names:
-        return {
-            "chapters": [],
-            "scheduled": [],
-            "recent_concluded": [],
-        }
-
-    chapters = frappe.get_all(
-        CHAPTER,
-        filters={"name": ["in", chapter_names]},
-        fields=["*"],
-    )
-
+    chapters = []
     scheduled = []
     recent_concluded = []
 
-    for chapter in chapters:
-        doc = frappe.get_doc(CHAPTER, chapter.name)
+    if chapter_names:
+        chapters = frappe.get_all(
+            CHAPTER,
+            filters={"name": ["in", chapter_names]},
+            fields=["*"],
+        )
 
-        scheduled.extend(doc.get_upcoming_events())
+        for chapter in chapters:
+            doc = frappe.get_doc(CHAPTER, chapter.name)
+            scheduled.extend(doc.get_upcoming_events())
+            recent = [
+                e
+                for e in doc.get_past_events()
+                if e.event_end_date and (e.event_end_date >= since_3w)
+            ]
+            recent_concluded.extend(recent)
 
-        # past events to last 3 weeks only
-        recent = [
-            e for e in doc.get_past_events() if e.event_end_date and (e.event_end_date >= since_3w)
-        ]
-        recent_concluded.extend(recent)
+    # Also include events where user is an event volunteer (but not a chapter member)
+    chapter_event_names = {e.name for e in scheduled + recent_concluded}
+    volunteer_event_names = frappe.get_all(
+        EVENT_VOLUNTEER,
+        filters={"email": user, "parenttype": EVENT},
+        pluck="parent",
+    )
+    for event_name in volunteer_event_names:
+        if event_name in chapter_event_names:
+            continue
+        event = frappe.db.get_value(
+            EVENT,
+            event_name,
+            ["*"],
+            as_dict=True,
+        )
+        if not event:
+            continue
+        if event.status in ("Live", "Draft"):
+            scheduled.append(event)
+        elif event.event_end_date and event.event_end_date >= since_3w:
+            recent_concluded.append(event)
 
     return {
         "chapters": chapters,

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -136,6 +136,30 @@ class FOSSChapterEvent(WebsiteGenerator):
             else:
                 self.map_coordinate = None
 
+    def on_update(self):
+        self.sync_event_member_shares()
+
+    def sync_event_member_shares(self):
+        prev = self.get_doc_before_save()
+        prev_emails = {m.email for m in prev.event_members if m.email} if prev else set()
+        curr_emails = {m.email for m in self.event_members if m.email}
+
+        for email in curr_emails - prev_emails:
+            frappe.share.add_docshare(
+                self.doctype,
+                self.name,
+                user=email,
+                read=1,
+                write=0,
+                flags={"ignore_share_permission": True},
+            )
+
+        for email in prev_emails - curr_emails:
+            frappe.db.delete(
+                "DocShare",
+                {"share_doctype": self.doctype, "share_name": self.name, "user": email},
+            )
+
     def on_trash(self):
         self.delete_campaigns()
         self.delete_email_groups()


### PR DESCRIPTION
- this will help us for chennaiFoss (more on indiafoss) for volunteers to access an event page in dashboard to do checkins

- we simple share the doc with only read permission on adding so they can view the page (but not edit) and help us with checkins

- in future ideally everything should move to docshared for all items, since we've chapter and event doctype which aren't suitable to be managed by role (since everyone can have same role), we need doc level permissions to be shared just as user_profile is shared based on "user"

- partially on #769 

- We already have too many validation to check if user exists in that table or this table, which works fine tbh... But fundamentally could've been solved in frappe DB level to have more control on who can edit or has access, so we did not check for all api endpoints.

- Idea spur based on working with cfp reviewer role and permission, since we had all code required just added simple method so they can access "Manage chapter" in dashboard and access event page

- previously only way to make them help would be to add them to chapter member (which again gives more access)