### PR TITLE
feat(doctype): add user approval to create foss_user_profile

### DIFF
--- a/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
+++ b/fossunited/foss_profiles/doctype/foss_user_profile/test_foss_user_profile.py
@@ -26,7 +26,7 @@ class TestFOSSUserProfile(FrappeTestCase):
 
     def test_private_profile_access(self):
         test_name = fake.name()
-        test_user = frappe.get_doc(
+        user_doc = frappe.get_doc(
             {
                 "doctype": "User",
                 "email": str(uuid.uuid4()) + "@fossunited.org",
@@ -34,7 +34,9 @@ class TestFOSSUserProfile(FrappeTestCase):
                 "name": test_name,
                 "full_name": test_name,
             },
-        ).insert()
+        )
+        user_doc.flags.skip_approval_flow = True
+        test_user = user_doc.insert()
 
         # Given a private profile
         private_profile = frappe.get_doc(USER_PROFILE, {"user": test_user.name})
@@ -60,13 +62,15 @@ class TestFOSSUserProfile(FrappeTestCase):
         # When a user profile is created
         # Then the route for that profile should be of format: u/<username>
         test_email = fake.email()
-        test_user = frappe.get_doc(
+        user_doc = frappe.get_doc(
             {
                 "doctype": "User",
                 "email": test_email,
                 "first_name": fake.name().split()[0],
             },
-        ).insert()
+        )
+        user_doc.flags.skip_approval_flow = True
+        test_user = user_doc.insert()
 
         test_user.reload()
 
@@ -86,13 +90,15 @@ class TestFOSSUserProfile(FrappeTestCase):
 
         test_email = fake.email()
 
-        test_user = frappe.get_doc(
+        user_doc = frappe.get_doc(
             {
                 "doctype": "User",
                 "email": test_email,
                 "first_name": fake.name().split()[0],
             },
-        ).insert(ignore_permissions=True)
+        )
+        user_doc.flags.skip_approval_flow = True
+        test_user = user_doc.insert(ignore_permissions=True)
         test_user.reload()
 
         profile_id = frappe.db.get_value(

--- a/fossunited/fossunited/user_utils.py
+++ b/fossunited/fossunited/user_utils.py
@@ -137,6 +137,8 @@ def generate_username(username: str, count: int = 1) -> str:
         username = username.ljust(3, "_")
 
     username = username[:30]
-    if frappe.db.exists(USER_PROFILE, {"username": username}):
+    if frappe.db.exists(USER_PROFILE, {"username": username}) or frappe.db.exists(
+        "User", {"username": username}
+    ):
         return generate_username(username.lower() + str(count), count + 1)
     return username

--- a/fossunited/fossunited/user_utils.py
+++ b/fossunited/fossunited/user_utils.py
@@ -7,7 +7,7 @@ from fossunited.doctype_ids import USER_PROFILE
 APPROVAL_EMAIL = "dilip@fossunited.org"
 
 
-def set_unique_username(doc, method):
+def set_unique_username(doc: "frappe.Document", method: str | None) -> None:
     full_name = doc.full_name.lower()
     doc.first_name = full_name.split(" ")[0]
     doc.last_name = " ".join(full_name.split(" ")[1:])
@@ -15,17 +15,18 @@ def set_unique_username(doc, method):
     doc.username = generate_username(initial_username)
 
 
-def handle_user_signup(doc, method):
+def handle_user_signup(doc: "frappe.Document", method: str | None) -> None:
     """
     After insert hook for User:
-    - Web signups (Website User): disable + queue for approval + notify
+    - Web signups (Website User): disable + persist username + queue for approval + notify
     - Desk-created users: create profile immediately (original behavior)
     """
     if doc.user_type == "Website User":
-        # Disable until approved
         frappe.db.set_value("User", doc.name, "enabled", 0, update_modified=False)
+        # set_unique_username sets doc.username in memory only - persist it so
+        # approve_user / _create_profile receive the correct username later
+        frappe.db.set_value("User", doc.name, "username", doc.username, update_modified=False)
 
-        # Notify user: pending
         frappe.sendmail(
             recipients=[doc.email],
             subject="Your FOSS United account is pending approval",
@@ -37,12 +38,11 @@ def handle_user_signup(doc, method):
         )
 
     else:
-        # Desk-created system users: create profile immediately
         _create_profile(doc)
 
 
 @frappe.whitelist()
-def approve_user(user):
+def approve_user(user: str) -> str:
     frappe.only_for("System Manager")
 
     user_doc = frappe.get_doc("User", user)
@@ -67,15 +67,13 @@ def approve_user(user):
 
 
 @frappe.whitelist()
-def deny_user(user, reason="", notify=True):
+def deny_user(user: str, reason: str = "", notify: bool = True) -> str:
     frappe.only_for("System Manager")
 
-    if not frappe.db.exists("User", user):
-        return "denied"
+    user_exists = frappe.db.exists("User", user)
 
-    user_doc = frappe.get_doc("User", user)
-
-    if frappe.utils.cint(notify):
+    if user_exists and frappe.utils.cint(notify):
+        user_doc = frappe.get_doc("User", user)
         reason_html = (
             f"<p><strong>Reason:</strong> {frappe.utils.escape_html(reason)}</p>" if reason else ""
         )
@@ -89,29 +87,32 @@ def deny_user(user, reason="", notify=True):
 <p>— FOSS United Team</p>""",
         )
 
-    frappe.delete_doc("User", user, ignore_permissions=True, force=True)
+    # Delete profiles first; FOSSUserProfile.on_trash applies to User
+    for profile in frappe.get_all(USER_PROFILE, filters={"user": user}, pluck="name"):
+        frappe.delete_doc(USER_PROFILE, profile, ignore_permissions=True, force=True)
+
+    # User may already be gone via on_trash; delete if still present
+    if frappe.db.exists("User", user):
+        frappe.delete_doc("User", user, ignore_permissions=True, force=True)
 
     return "denied"
 
 
 @frappe.whitelist()
-def delete_user_and_profile(user):
+def delete_user_and_profile(user: str) -> str:
     frappe.only_for("System Manager")
 
-    if not frappe.db.exists("User", user):
-        return "deleted"
+    # Delete profiles first; on_trash applies to User
+    for profile in frappe.get_all(USER_PROFILE, filters={"user": user}, pluck="name"):
+        frappe.delete_doc(USER_PROFILE, profile, ignore_permissions=True, force=True)
 
-    profile_name = frappe.db.get_value(USER_PROFILE, {"user": user}, "name")
-    if profile_name:
-        # on_trash on FOSSUserProfile also deletes the User — so just delete profile
-        frappe.delete_doc(USER_PROFILE, profile_name, ignore_permissions=True, force=True)
-    else:
+    if frappe.db.exists("User", user):
         frappe.delete_doc("User", user, ignore_permissions=True, force=True)
 
     return "deleted"
 
 
-def _create_profile(doc):
+def _create_profile(doc: "frappe.Document") -> None:
     """Create FOSS User Profile for a user doc."""
     if frappe.db.exists(USER_PROFILE, {"user": doc.name}):
         return
@@ -130,10 +131,8 @@ def _create_profile(doc):
     frappe.db.set_value("User", doc.name, "username", profile.username, update_modified=False)
 
 
-def generate_username(username, count=1):
-    """
-    Generate a Unique Username between 3 and 30 characters
-    """
+def generate_username(username: str, count: int = 1) -> str:
+    """Generate a unique username between 3 and 30 characters."""
     if len(username) < 3:
         username = username.ljust(3, "_")
 

--- a/fossunited/fossunited/user_utils.py
+++ b/fossunited/fossunited/user_utils.py
@@ -21,7 +21,7 @@ def handle_user_signup(doc: "frappe.Document", method: str | None) -> None:
     - Web signups (Website User): disable + persist username + queue for approval + notify
     - Desk-created users: create profile immediately (original behavior)
     """
-    if doc.user_type == "Website User":
+    if doc.user_type == "Website User" and not doc.flags.get("skip_approval_flow"):
         frappe.db.set_value("User", doc.name, "enabled", 0, update_modified=False)
         # set_unique_username sets doc.username in memory only - persist it so
         # approve_user / _create_profile receive the correct username later

--- a/fossunited/fossunited/user_utils.py
+++ b/fossunited/fossunited/user_utils.py
@@ -4,6 +4,8 @@ import frappe
 
 from fossunited.doctype_ids import USER_PROFILE
 
+APPROVAL_EMAIL = "dilip@fossunited.org"
+
 
 def set_unique_username(doc, method):
     full_name = doc.full_name.lower()
@@ -13,31 +15,119 @@ def set_unique_username(doc, method):
     doc.username = generate_username(initial_username)
 
 
-def create_profile_on_user_create(doc, method):
+def handle_user_signup(doc, method):
     """
-    Automatically Create a FOSS User Profile on User Creation / Signup
+    After insert hook for User:
+    - Web signups (Website User): disable + queue for approval + notify
+    - Desk-created users: create profile immediately (original behavior)
     """
-    if not frappe.db.exists(
-        USER_PROFILE,
-        {"email": doc.email},
-    ):
-        profile = frappe.get_doc(
-            {
-                "doctype": USER_PROFILE,
-                "user": doc.name,
-                "full_name": doc.full_name,
-                "username": doc.username,
-                "is_published": 1,
-            }
-        )
-        profile.insert(ignore_permissions=True)
+    if doc.user_type == "Website User":
+        # Disable until approved
+        frappe.db.set_value("User", doc.name, "enabled", 0, update_modified=False)
 
-    try:
-        frappe.db.set_value(
-            "User", profile.user, "username", profile.username, update_modified=False
+        # Notify user: pending
+        frappe.sendmail(
+            recipients=[doc.email],
+            subject="Your FOSS United account is pending approval",
+            message=f"""<p>Hi {frappe.utils.escape_html(doc.full_name)},</p>
+<p>Thank you for signing up on FOSS United! Your account is currently <strong>pending review</strong> by our team.</p>
+<p>We'll email you once approved. This usually takes 1–2 working days.</p>
+<p>In case you need account ASAP, please contact us via telegram public channel or mail to <a href="mailto:{APPROVAL_EMAIL}">{APPROVAL_EMAIL}</a>.</p>
+<p>— FOSS United Team</p>""",
         )
-    except Exception as e:
-        frappe.throw("Error updating username. Error: " + str(e))
+
+    else:
+        # Desk-created system users: create profile immediately
+        _create_profile(doc)
+
+
+@frappe.whitelist()
+def approve_user(user):
+    frappe.only_for("System Manager")
+
+    user_doc = frappe.get_doc("User", user)
+    already_approved = user_doc.enabled and frappe.db.exists(USER_PROFILE, {"user": user})
+
+    frappe.db.set_value("User", user, "enabled", 1)
+
+    if not frappe.db.exists(USER_PROFILE, {"user": user}):
+        _create_profile(user_doc)
+
+    if not already_approved:
+        frappe.sendmail(
+            recipients=[user_doc.email],
+            subject="Your FOSS United account has been approved!",
+            message=f"""<p>Hi {frappe.utils.escape_html(user_doc.full_name)},</p>
+<p>Your FOSS United account has been <strong>approved</strong>.</p>
+<p>You can now <a href="{frappe.utils.get_url()}/login">log in here</a>.</p>
+<p>— FOSS United Team</p>""",
+        )
+
+    return "approved"
+
+
+@frappe.whitelist()
+def deny_user(user, reason="", notify=True):
+    frappe.only_for("System Manager")
+
+    if not frappe.db.exists("User", user):
+        return "denied"
+
+    user_doc = frappe.get_doc("User", user)
+
+    if frappe.utils.cint(notify):
+        reason_html = (
+            f"<p><strong>Reason:</strong> {frappe.utils.escape_html(reason)}</p>" if reason else ""
+        )
+        frappe.sendmail(
+            recipients=[user_doc.email],
+            subject="Your FOSS United account signup was not approved",
+            message=f"""<p>Hi {frappe.utils.escape_html(user_doc.full_name)},</p>
+<p>Unfortunately, your account signup on FOSS United was not approved.</p>
+{reason_html}
+<p>If you think this is a mistake, contact us at <a href="mailto:{APPROVAL_EMAIL}">{APPROVAL_EMAIL}</a>.</p>
+<p>— FOSS United Team</p>""",
+        )
+
+    frappe.delete_doc("User", user, ignore_permissions=True, force=True)
+
+    return "denied"
+
+
+@frappe.whitelist()
+def delete_user_and_profile(user):
+    frappe.only_for("System Manager")
+
+    if not frappe.db.exists("User", user):
+        return "deleted"
+
+    profile_name = frappe.db.get_value(USER_PROFILE, {"user": user}, "name")
+    if profile_name:
+        # on_trash on FOSSUserProfile also deletes the User — so just delete profile
+        frappe.delete_doc(USER_PROFILE, profile_name, ignore_permissions=True, force=True)
+    else:
+        frappe.delete_doc("User", user, ignore_permissions=True, force=True)
+
+    return "deleted"
+
+
+def _create_profile(doc):
+    """Create FOSS User Profile for a user doc."""
+    if frappe.db.exists(USER_PROFILE, {"user": doc.name}):
+        return
+
+    profile = frappe.get_doc(
+        {
+            "doctype": USER_PROFILE,
+            "user": doc.name,
+            "full_name": doc.full_name,
+            "username": doc.username,
+            "is_published": 1,
+        }
+    )
+    profile.insert(ignore_permissions=True)
+
+    frappe.db.set_value("User", doc.name, "username", profile.username, update_modified=False)
 
 
 def generate_username(username, count=1):

--- a/fossunited/hooks.py
+++ b/fossunited/hooks.py
@@ -71,11 +71,15 @@ signup_form_template = "fossunited.plugins.show_custom_signup"
 # ---------------
 # Hook on document methods and events
 
+doctype_js = {
+    "User": "public/js/user_approval.js",
+}
+
 doc_events = {
     "User": {
         "after_insert": [
             "fossunited.fossunited.user_utils.set_unique_username",
-            "fossunited.fossunited.user_utils.create_profile_on_user_create",
+            "fossunited.fossunited.user_utils.handle_user_signup",
         ],
     },
     "Razorpay Payment": {

--- a/fossunited/public/js/user_approval.js
+++ b/fossunited/public/js/user_approval.js
@@ -1,0 +1,114 @@
+frappe.ui.form.on('User', {
+  setup(frm) {
+    // Frappe bug: frm.module_editor is never initialized for Website Users,
+    // causing refresh to crash at `frm.module_editor.disable = ...` (user.js:253).
+    // Provide a safe no-op so Frappe's refresh doesn't abort before our handler runs.
+    if (!frm.module_editor) {
+      frm.module_editor = { disable: 0, show() {} }
+    }
+  },
+
+  refresh(frm) {
+    if (
+      frm.doc.user_type === 'Website User' &&
+      !frm.is_new() &&
+      frappe.user.has_role('System Manager')
+    ) {
+      frm.add_custom_button(
+        __('Delete User & Profile'),
+        () => {
+          frappe.confirm(
+            `Permanently delete <strong>${frappe.utils.escape_html(frm.doc.full_name)}</strong> and their FOSS profile?`,
+            () => {
+              frappe.call({
+                method: 'fossunited.fossunited.user_utils.delete_user_and_profile',
+                args: { user: frm.doc.name },
+                callback(r) {
+                  if (r.message === 'deleted') {
+                    frappe.show_alert({ message: __('User and profile deleted'), indicator: 'red' })
+                    frappe.set_route('List', 'User')
+                  }
+                },
+              })
+            },
+          )
+        },
+        __('Spam'),
+      )
+    }
+
+    if (
+      frm.doc.user_type === 'Website User' &&
+      !frm.doc.enabled &&
+      !frm.is_new() &&
+      frappe.user.has_role('System Manager')
+    ) {
+      frm.add_custom_button(
+        __('Approve'),
+        () => {
+          frappe.confirm(
+            `Approve account for <strong>${frappe.utils.escape_html(frm.doc.full_name)}</strong>?`,
+            () => {
+              frappe.call({
+                method: 'fossunited.fossunited.user_utils.approve_user',
+                args: { user: frm.doc.name },
+                callback(r) {
+                  if (r.message === 'approved') {
+                    frappe.show_alert({
+                      message: __('User approved and notified by email'),
+                      indicator: 'green',
+                    })
+                    frm.reload_doc()
+                  }
+                },
+              })
+            },
+          )
+        },
+        __('Approval'),
+      )
+
+      frm.add_custom_button(
+        __('Deny'),
+        () => {
+          let d = new frappe.ui.Dialog({
+            title: __('Deny Signup'),
+            fields: [
+              {
+                label: __('Notify user by email'),
+                fieldname: 'notify',
+                fieldtype: 'Check',
+                default: 0,
+              },
+              {
+                label: __('Reason (optional — sent to user)'),
+                fieldname: 'reason',
+                fieldtype: 'Small Text',
+                depends_on: 'notify',
+              },
+            ],
+            primary_action_label: __('Deny & Delete User'),
+            primary_action({ notify, reason }) {
+              frappe.call({
+                method: 'fossunited.fossunited.user_utils.deny_user',
+                args: { user: frm.doc.name, reason: reason || '', notify: notify ? 1 : 0 },
+                callback(r) {
+                  if (r.message === 'denied') {
+                    d.hide()
+                    frappe.show_alert({
+                      message: __('User denied and deleted'),
+                      indicator: 'red',
+                    })
+                    frappe.set_route('List', 'User')
+                  }
+                },
+              })
+            },
+          })
+          d.show()
+        },
+        __('Approval'),
+      )
+    }
+  },
+})

--- a/fossunited/public/js/user_approval.js
+++ b/fossunited/public/js/user_approval.js
@@ -1,19 +1,12 @@
 frappe.ui.form.on('User', {
   setup(frm) {
-    // Frappe bug: frm.module_editor is never initialized for Website Users,
-    // causing refresh to crash at `frm.module_editor.disable = ...` (user.js:253).
-    // Provide a safe no-op so Frappe's refresh doesn't abort before our handler runs.
     if (!frm.module_editor) {
       frm.module_editor = { disable: 0, show() {} }
     }
   },
 
   refresh(frm) {
-    if (
-      frm.doc.user_type === 'Website User' &&
-      !frm.is_new() &&
-      frappe.user.has_role('System Manager')
-    ) {
+    if (frappe.user.has_role('System Manager') && !frm.is_new()) {
       frm.add_custom_button(
         __('Delete User & Profile'),
         () => {
@@ -37,12 +30,7 @@ frappe.ui.form.on('User', {
       )
     }
 
-    if (
-      frm.doc.user_type === 'Website User' &&
-      !frm.doc.enabled &&
-      !frm.is_new() &&
-      frappe.user.has_role('System Manager')
-    ) {
+    if (!frm.doc.enabled && frappe.user.has_role('System Manager') && !frm.is_new()) {
       frm.add_custom_button(
         __('Approve'),
         () => {

--- a/fossunited/tests/test_user_approval.py
+++ b/fossunited/tests/test_user_approval.py
@@ -1,0 +1,176 @@
+"""
+Tests for user signup approval flow (fossunited.fossunited.user_utils).
+
+Run:
+    bench --site foss.localhost run-tests --module fossunited.tests.test_user_approval
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from fossunited.doctype_ids import USER_PROFILE
+from fossunited.fossunited.user_utils import approve_user, deny_user, handle_user_signup
+
+
+def _make_web_user(email, full_name="Test User"):
+    if frappe.db.exists("User", email):
+        frappe.delete_doc("User", email, force=True, ignore_permissions=True)
+    user = frappe.get_doc(
+        {
+            "doctype": "User",
+            "email": email,
+            "first_name": full_name.split()[0],
+            "last_name": " ".join(full_name.split()[1:]),
+            "enabled": 1,
+            "user_type": "Website User",
+        }
+    )
+    user.flags.ignore_permissions = True
+    user.flags.ignore_password_policy = True
+    user.insert()
+    return user
+
+
+def _mock_system_doc(email):
+    # Frappe auto-downgrades System User → Website User in validate if no desk
+    # roles exist, so test handle_user_signup directly with a controlled doc.
+    return frappe._dict(
+        {
+            "name": email,
+            "email": email,
+            "user_type": "System User",
+            "full_name": "Desk User",
+            "username": "deskuser",
+        }
+    )
+
+
+def _cleanup(email):
+    frappe.set_user("Administrator")
+    frappe.db.delete(USER_PROFILE, {"user": email})
+    if frappe.db.exists("User", email):
+        frappe.delete_doc("User", email, force=True, ignore_permissions=True)
+
+
+class TestWebSignup(FrappeTestCase):
+    EMAIL = "web_signup_test@example.com"
+
+    def setUp(self):
+        frappe.flags.mute_emails = True
+        frappe.set_user("Administrator")
+
+    def tearDown(self):
+        frappe.flags.mute_emails = False
+        _cleanup(self.EMAIL)
+
+    def test_web_signup_disables_user(self):
+        _make_web_user(self.EMAIL)
+        self.assertEqual(frappe.db.get_value("User", self.EMAIL, "enabled"), 0)
+
+    def test_web_signup_does_not_create_profile(self):
+        _make_web_user(self.EMAIL)
+        self.assertFalse(frappe.db.exists(USER_PROFILE, {"user": self.EMAIL}))
+
+
+class TestDeskUserCreation(FrappeTestCase):
+    EMAIL = "desk_user_test@example.com"
+
+    def setUp(self):
+        frappe.flags.mute_emails = True
+        frappe.set_user("Administrator")
+        if not frappe.db.exists("User", self.EMAIL):
+            frappe.get_doc(
+                {
+                    "doctype": "User",
+                    "email": self.EMAIL,
+                    "first_name": "Desk",
+                    "enabled": 1,
+                    "user_type": "Website User",
+                    "new_password": frappe.utils.random_string(10),
+                }
+            ).insert(ignore_permissions=True)
+            frappe.db.set_value("User", self.EMAIL, "enabled", 1)
+
+    def tearDown(self):
+        frappe.flags.mute_emails = False
+        _cleanup(self.EMAIL)
+
+    def test_system_user_hook_creates_profile(self):
+        handle_user_signup(_mock_system_doc(self.EMAIL), method=None)
+        self.assertTrue(frappe.db.exists(USER_PROFILE, {"user": self.EMAIL}))
+
+    def test_system_user_hook_does_not_disable(self):
+        handle_user_signup(_mock_system_doc(self.EMAIL), method=None)
+        self.assertEqual(frappe.db.get_value("User", self.EMAIL, "enabled"), 1)
+
+
+class TestApproveUser(FrappeTestCase):
+    EMAIL = "approve_flow_test@example.com"
+
+    def setUp(self):
+        frappe.flags.mute_emails = True
+        frappe.set_user("Administrator")
+        _make_web_user(self.EMAIL, "Approve Me")
+
+    def tearDown(self):
+        frappe.flags.mute_emails = False
+        _cleanup(self.EMAIL)
+
+    def test_approve_enables_user(self):
+        approve_user(self.EMAIL)
+        self.assertEqual(frappe.db.get_value("User", self.EMAIL, "enabled"), 1)
+
+    def test_approve_creates_profile(self):
+        approve_user(self.EMAIL)
+        self.assertTrue(frappe.db.exists(USER_PROFILE, {"user": self.EMAIL}))
+
+    def test_approve_is_idempotent(self):
+        approve_user(self.EMAIL)
+        approve_user(self.EMAIL)
+        self.assertEqual(frappe.db.count(USER_PROFILE, {"user": self.EMAIL}), 1)
+
+    def test_approve_blocked_for_non_system_manager(self):
+        with patch(
+            "fossunited.fossunited.user_utils.frappe.only_for", side_effect=frappe.PermissionError
+        ):
+            with self.assertRaises(frappe.PermissionError):
+                approve_user(self.EMAIL)
+
+
+class TestDenyUser(FrappeTestCase):
+    EMAIL = "deny_flow_test@example.com"
+
+    def setUp(self):
+        frappe.flags.mute_emails = True
+        frappe.set_user("Administrator")
+        _make_web_user(self.EMAIL, "Deny Me")
+
+    def tearDown(self):
+        frappe.flags.mute_emails = False
+        _cleanup(self.EMAIL)
+
+    def test_deny_deletes_user(self):
+        deny_user(self.EMAIL)
+        self.assertFalse(frappe.db.exists("User", self.EMAIL))
+
+    def test_deny_no_orphan_profile(self):
+        deny_user(self.EMAIL)
+        self.assertFalse(frappe.db.exists(USER_PROFILE, {"user": self.EMAIL}))
+
+    def test_deny_idempotent(self):
+        deny_user(self.EMAIL)
+        deny_user(self.EMAIL)  # must not raise
+
+    def test_deny_approved_user_removes_both(self):
+        approve_user(self.EMAIL)
+        deny_user(self.EMAIL)
+        self.assertFalse(frappe.db.exists("User", self.EMAIL))
+
+    def test_deny_blocked_for_non_system_manager(self):
+        with patch(
+            "fossunited.fossunited.user_utils.frappe.only_for", side_effect=frappe.PermissionError
+        ):
+            with self.assertRaises(frappe.PermissionError):
+                deny_user(self.EMAIL)

--- a/fossunited/tests/test_user_approval.py
+++ b/fossunited/tests/test_user_approval.py
@@ -55,7 +55,7 @@ def _cleanup(email):
 
 
 class TestWebSignup(FrappeTestCase):
-    EMAIL = "web_signup_test@example.com"
+    EMAIL = "foss_approval_web_signup@example.com"
 
     def setUp(self):
         frappe.flags.mute_emails = True
@@ -75,7 +75,7 @@ class TestWebSignup(FrappeTestCase):
 
 
 class TestDeskUserCreation(FrappeTestCase):
-    EMAIL = "desk_user_test@example.com"
+    EMAIL = "foss_approval_desk_user@example.com"
 
     def setUp(self):
         frappe.flags.mute_emails = True
@@ -107,7 +107,7 @@ class TestDeskUserCreation(FrappeTestCase):
 
 
 class TestApproveUser(FrappeTestCase):
-    EMAIL = "approve_flow_test@example.com"
+    EMAIL = "foss_approval_approve_flow@example.com"
 
     def setUp(self):
         frappe.flags.mute_emails = True
@@ -140,7 +140,7 @@ class TestApproveUser(FrappeTestCase):
 
 
 class TestDenyUser(FrappeTestCase):
-    EMAIL = "deny_flow_test@example.com"
+    EMAIL = "foss_approval_deny_flow@example.com"
 
     def setUp(self):
         frappe.flags.mute_emails = True

--- a/fossunited/tests/utils.py
+++ b/fossunited/tests/utils.py
@@ -38,7 +38,7 @@ def insert_user_profile(email=None, **kwargs):
 
     if not frappe.db.exists("User", email):
         name_parts = email.split("@")[0].title()
-        frappe.get_doc(
+        user = frappe.get_doc(
             {
                 "doctype": "User",
                 "email": email,
@@ -46,7 +46,9 @@ def insert_user_profile(email=None, **kwargs):
                 "last_name": kwargs.get("last_name", name_parts),
                 "enabled": 1,
             }
-        ).insert(ignore_permissions=True)
+        )
+        user.flags.skip_approval_flow = True
+        user.insert(ignore_permissions=True)
 
     profile_name = frappe.db.get_value(USER_PROFILE, {"user": email}, "name")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,10 +47,9 @@ fix = true
 [tool.ruff.lint]
 select = ["F", "E", "W", "I", "Q"] # from frappe
 # ^ add more rules as well? RUF, UP and more?
-ignore = ["F722", "F821"]
+ignore = ["F722", "F821", "E501"]
 [tool.ruff.lint.per-file-ignores]
 "**/doctype/**/*.py" = ["F821", "F722"]
-"fossunited/www/fosshack/results/index.py" = ["E501"]
 
 [tool.ruff.format]
 quote-style = "double"


### PR DESCRIPTION
- We've been only getting spam account creation running ads via user profile page at `/u/<username>`
  All new accounts have been that

- Frappe does not have a way to do approval basis signups for "user"

- So we add simple controller to disable by default and add buttons to approve or deny user (system manager via desk)
- and they get email to await for approval

- workflow is:

  user -> disabled by default (with nothing to do)
  approve -> enabled + foss_user_profile is created
  denied -> user doctype is deleted (with optional email)

<img width="1593" height="229" alt="image" src="https://github.com/user-attachments/assets/4beda476-a577-443e-8bec-b2b2158e639d" />

- "spam" button allows us to delete both user profile and user doctype 
  only used for spam accounts signed up
  
Note: No reinventing of wheel, just added convenience controller and button to access quick.

Added tests to make sure functionality remains same