### PR TITLE
feat(tests): add factories for FOSSChapter, FOSSChapterEvent, and RSVP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
       - name: Install App and Setup Site
         working-directory: ${{ env.BENCH_PATH }}
         run: |
+          bench get-app harshtandiya/frappe_factory_bot --branch main
           bench get-app fossunited $GITHUB_WORKSPACE
           bench setup requirements --dev
           bench new-site --db-root-password root --admin-password admin ${{ env.SITE_NAME }}

--- a/fossunited/chapters/doctype/foss_chapter/test_foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/test_foss_chapter.py
@@ -1,98 +1,69 @@
 import frappe
-from faker import Faker
 from frappe.tests.utils import FrappeTestCase
 
-from fossunited.doctype_ids import CHAPTER, USER_PROFILE
-from fossunited.tests.utils import insert_test_chapter
-
-fake = Faker()
+from fossunited.doctype_ids import CHAPTER, EMAIL_GROUP, USER_PROFILE
+from fossunited.id.roles import CHAPTER_MEMBER
+from fossunited.tests.factories import FOSSChapterFactory, UserFactory, get_foss_profile_id
 
 
 class TestFOSSChapter(FrappeTestCase):
     def setUp(self):
-        self.chapter = insert_test_chapter(members=["test1@example.com", "member2@example.com"])
+        self.team_member_user = UserFactory.create("with_foss_website_user_role")
+        self.chapter = FOSSChapterFactory.create(
+            "with_members", members=[self.team_member_user.name]
+        )
 
     def tearDown(self):
         frappe.delete_doc(CHAPTER, self.chapter.name, force=True)
 
     def test_role_assignment_on_create(self):
-        # Given a chapter
-        chapter = self.chapter
-
-        # user must have 'Chapter Team Member' role given
-        user = frappe.db.get_value(USER_PROFILE, chapter.chapter_members[0].chapter_member, "user")
-        self.assertTrue(self.has_team_member_role(user))
+        self.assertTrue(self.has_team_member_role(self.team_member_user.name))
 
     def test_role_assignment_on_member_addition(self):
-        # Given a chapter: self.chapter
-        chapter = frappe.get_doc(CHAPTER, self.chapter.name)
+        new_user = UserFactory.create("with_foss_website_user_role")
+        profile_name = get_foss_profile_id(new_user.name)
+        self.assertFalse(self.has_team_member_role(new_user.name))
 
-        # When a new member is added to the chapter
-        new_member = frappe.get_doc(USER_PROFILE, {"user": "test1@example.com"})
+        # Add user as chapter member
+        with self.set_user(self.team_member_user.name):
+            self.chapter.append(
+                "chapter_members",
+                {"chapter_member": profile_name, "role": "Core Team Member"},
+            )
+            self.chapter.save()
 
-        chapter.append(
-            "chapter_members",
-            {"chapter_member": new_member.name, "role": "Core Team Member"},
-        )
-        chapter.save()
-
-        # Then the new member should have the role of 'Chapter Team Member'
-        user = frappe.db.get_value(USER_PROFILE, new_member.name, "user")
-        self.assertTrue(self.has_team_member_role(user))
+        self.assertTrue(self.has_team_member_role(new_user.name))
 
     def test_role_deassignment_on_member_removal(self):
-        # Given a chapter: self.chapter
-        chapter = frappe.get_doc(CHAPTER, self.chapter.name)
-
-        new_members = frappe.get_all(
-            USER_PROFILE,
-            filters=[
-                ["user", "like", "%test%"],
-                ["name", "not in", [m.chapter_member for m in chapter.chapter_members]],
-            ],
-        )
-        for new_member in new_members:
-            chapter.append(
+        # Add two new members
+        new_members = UserFactory.create_list(2, "with_foss_website_user_role")
+        self.chapter.chapter_members = []
+        for user in new_members:
+            self.chapter.append(
                 "chapter_members",
-                {"chapter_member": new_member.name, "role": "Core Team Member"},
+                {"chapter_member": get_foss_profile_id(user.name), "role": "Core Team Member"},
             )
-        chapter.save()
+        self.chapter.save()
 
-        removed_member = chapter.chapter_members[len(new_members)]
-        removed_user = frappe.db.get_value(USER_PROFILE, removed_member.chapter_member, "user")
+        # Check that all members have the team member role
+        self.assertTrue(all(self.has_team_member_role(user.name) for user in new_members))
 
-        # Make sure the member to be removed has the role "Chapter Team Member" before removal
-        self.assertTrue(self.has_team_member_role(removed_user))
-
-        # When a member is removed from the chapter
-        chapter.chapter_members = [
-            m for m in chapter.chapter_members if m.chapter_member != removed_member.chapter_member
+        # Remove first member
+        removed_member_profile = get_foss_profile_id(new_members[0].name)
+        self.chapter.chapter_members = [
+            m for m in self.chapter.chapter_members if m.chapter_member != removed_member_profile
         ]
-        chapter.save()
+        self.chapter.save()
 
-        # Then the removed member should not have the role of 'Chapter Team Member'
-        self.assertFalse(self.has_team_member_role(removed_user))
+        # Check that the first member no longer has the team member role
+        self.assertFalse(self.has_team_member_role(new_members[0].name))
 
-        # check other members retain the role
-        for member in chapter.chapter_members:
-            user = frappe.db.get_value(USER_PROFILE, member.chapter_member, "user")
-            if not self.has_team_member_role(user):
-                self.fail(f"Role not retained for {member}")
-
-    def has_team_member_role(self, user: str):
-        """
-        user id of format `test@example.com`
-        """
-        return bool(frappe.db.exists("Has Role", {"role": "Chapter Team Member", "parent": user}))
+    def has_team_member_role(self, user: str) -> bool:
+        return bool(frappe.db.exists("Has Role", {"role": CHAPTER_MEMBER, "parent": user}))
 
     def test_unique_chapter_slug(self):
-        # Given a chapter: self.chapter
-        chapter = self.chapter
-
-        # When a new chapter is created with the same slug
-        # Then an exception should be raised
         with self.assertRaises(frappe.UniqueValidationError):
-            insert_test_chapter(slug=chapter.slug)
+            FOSSChapterFactory.create(slug=self.chapter.slug)
 
     def test_email_groups_are_created_on_chapter_insert(self):
         expected_group_types = [
@@ -103,23 +74,17 @@ class TestFOSSChapter(FrappeTestCase):
         for group_type in expected_group_types:
             self.assertTrue(
                 frappe.db.exists(
-                    "Email Group",
+                    EMAIL_GROUP,
                     {
                         "group_type": group_type,
                         "reference_document": self.chapter.name,
                         "document_type": CHAPTER,
                     },
                 ),
-                msg=f"Email Group '{group_type}' not created for event {self.chapter.name}",
+                msg=f"Email Group '{group_type}' not created for chapter {self.chapter.name}",
             )
 
-        groups = frappe.get_all(
-            "Email Group",
-            filters={
-                "reference_document": self.chapter.name,
-                "document_type": CHAPTER,
-            },
-            pluck="name",
+        frappe.db.delete(
+            EMAIL_GROUP,
+            {"reference_document": self.chapter.name, "document_type": CHAPTER},
         )
-        for group_name in groups:
-            frappe.delete_doc("Email Group", group_name, force=True)

--- a/fossunited/chapters/doctype/foss_chapter/test_foss_chapter.py
+++ b/fossunited/chapters/doctype/foss_chapter/test_foss_chapter.py
@@ -1,7 +1,7 @@
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from fossunited.doctype_ids import CHAPTER, EMAIL_GROUP, USER_PROFILE
+from fossunited.doctype_ids import CHAPTER, EMAIL_GROUP
 from fossunited.id.roles import CHAPTER_MEMBER
 from fossunited.tests.factories import FOSSChapterFactory, UserFactory, get_foss_profile_id
 

--- a/fossunited/tests/factories/__init__.py
+++ b/fossunited/tests/factories/__init__.py
@@ -1,0 +1,14 @@
+from fossunited.tests.factories.foss_chapter_event_factory import FOSSChapterEventFactory
+from fossunited.tests.factories.foss_chapter_factory import FOSSChapterFactory
+from fossunited.tests.factories.foss_event_rsvp_factory import (
+    FOSSEventRSVPFactory,
+)
+from fossunited.tests.factories.user_factory import UserFactory, get_foss_profile_id
+
+__all__ = [
+    "FOSSChapterFactory",
+    "FOSSChapterEventFactory",
+    "FOSSEventRSVPFactory",
+    "UserFactory",
+    "get_foss_profile_id",
+]

--- a/fossunited/tests/factories/foss_chapter_event_factory.py
+++ b/fossunited/tests/factories/foss_chapter_event_factory.py
@@ -1,0 +1,80 @@
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+import frappe
+from faker import Faker
+from frappe_factory_bot.frappe_factory_bot.base_factory import BaseFactory
+
+from fossunited.doctype_ids import EVENT
+from fossunited.tests.factories.foss_chapter_factory import FOSSChapterFactory
+
+if TYPE_CHECKING:
+    from fossunited.chapters.doctype.foss_chapter_event.foss_chapter_event import (
+        FOSSChapterEvent,
+    )
+
+fake = Faker()
+
+
+class FOSSChapterEventFactory(BaseFactory["FOSSChapterEvent"]):
+    doctype = EVENT
+
+    @property
+    def default_attributes(self) -> dict[str, Any]:
+        return {
+            "chapter": self.overrides.get("chapter", FOSSChapterFactory.create().name),
+            "event_name": self.overrides.get("event_name", fake.text(max_nb_chars=20).strip()),
+            "event_permalink": fake.slug().replace("-", "_"),
+            "status": "Live",
+            "event_type": self.overrides.get("event_type", "Meet Up"),
+            "event_start_date": self.overrides.get(
+                "event_start_date", frappe.utils.add_days(frappe.utils.today(), 1)
+            ),
+            "event_end_date": self.overrides.get(
+                "event_end_date", frappe.utils.add_days(frappe.utils.today(), 2)
+            ),
+            "event_description": self.overrides.get("event_description", fake.text(max_nb_chars=200).strip()),
+            "is_paid_event": 0,
+            "tickets_status": "Closed",
+        }
+
+    @property
+    def with_chapter(self) -> dict[str, Any]:
+        chapter = self.overrides.get("chapter")
+        if not chapter:
+            chapter = FOSSChapterFactory.create()
+        chapter_name = chapter.name if hasattr(chapter, "name") else chapter
+        return {"chapter": chapter_name}
+
+    @property
+    def with_paid_tickets(self) -> dict[str, Any]:
+        return {
+            "is_paid_event": 1,
+            "tickets_status": "Open",
+            "tiers": [
+                {
+                    "enabled": 1,
+                    "title": "General",
+                    "price": 100,
+                }
+            ],
+        }
+
+    @property
+    def with_map_link(self) -> dict[str, Any]:
+        map_link = self.overrides.get("map_link") or "https://maps.google.com/?q=12.9716,77.5946"
+        return {"map_link": map_link}
+
+    @property
+    def with_past_dates(self) -> dict[str, Any]:
+        return {
+            "event_start_date": datetime.today() - timedelta(days=10),
+            "event_end_date": datetime.today() - timedelta(days=5),
+        }
+
+    @property
+    def with_ongoing_dates(self) -> dict[str, Any]:
+        return {
+            "event_start_date": datetime.today() - timedelta(days=1),
+            "event_end_date": datetime.today() + timedelta(days=1),
+        }

--- a/fossunited/tests/factories/foss_chapter_event_factory.py
+++ b/fossunited/tests/factories/foss_chapter_event_factory.py
@@ -1,22 +1,20 @@
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import frappe
 from faker import Faker
 from frappe_factory_bot.frappe_factory_bot.base_factory import BaseFactory
 
+from fossunited.chapters.doctype.foss_chapter_event.foss_chapter_event import (
+    FOSSChapterEvent,
+)
 from fossunited.doctype_ids import EVENT
 from fossunited.tests.factories.foss_chapter_factory import FOSSChapterFactory
-
-if TYPE_CHECKING:
-    from fossunited.chapters.doctype.foss_chapter_event.foss_chapter_event import (
-        FOSSChapterEvent,
-    )
 
 fake = Faker()
 
 
-class FOSSChapterEventFactory(BaseFactory["FOSSChapterEvent"]):
+class FOSSChapterEventFactory(BaseFactory[FOSSChapterEvent]):
     doctype = EVENT
 
     @property
@@ -33,7 +31,9 @@ class FOSSChapterEventFactory(BaseFactory["FOSSChapterEvent"]):
             "event_end_date": self.overrides.get(
                 "event_end_date", frappe.utils.add_days(frappe.utils.today(), 2)
             ),
-            "event_description": self.overrides.get("event_description", fake.text(max_nb_chars=200).strip()),
+            "event_description": self.overrides.get(
+                "event_description", fake.text(max_nb_chars=200).strip()
+            ),
             "is_paid_event": 0,
             "tickets_status": "Closed",
         }

--- a/fossunited/tests/factories/foss_chapter_factory.py
+++ b/fossunited/tests/factories/foss_chapter_factory.py
@@ -1,19 +1,16 @@
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-import frappe
 from faker import Faker
 from frappe_factory_bot.frappe_factory_bot.base_factory import BaseFactory
 
-from fossunited.doctype_ids import CHAPTER, CITY_COMMUNITY, USER_PROFILE
+from fossunited.chapters.doctype.foss_chapter.foss_chapter import FOSSChapter
+from fossunited.doctype_ids import CHAPTER, CITY_COMMUNITY
 from fossunited.tests.factories.user_factory import UserFactory, get_foss_profile_id
-
-if TYPE_CHECKING:
-    from fossunited.chapters.doctype.foss_chapter.foss_chapter import FOSSChapter
 
 fake = Faker()
 
 
-class FOSSChapterFactory(BaseFactory["FOSSChapter"]):
+class FOSSChapterFactory(BaseFactory[FOSSChapter]):
     doctype = CHAPTER
 
     @property

--- a/fossunited/tests/factories/foss_chapter_factory.py
+++ b/fossunited/tests/factories/foss_chapter_factory.py
@@ -1,0 +1,54 @@
+from typing import TYPE_CHECKING, Any
+
+import frappe
+from faker import Faker
+from frappe_factory_bot.frappe_factory_bot.base_factory import BaseFactory
+
+from fossunited.doctype_ids import CHAPTER, CITY_COMMUNITY, USER_PROFILE
+from fossunited.tests.factories.user_factory import UserFactory, get_foss_profile_id
+
+if TYPE_CHECKING:
+    from fossunited.chapters.doctype.foss_chapter.foss_chapter import FOSSChapter
+
+fake = Faker()
+
+
+class FOSSChapterFactory(BaseFactory["FOSSChapter"]):
+    doctype = CHAPTER
+
+    @property
+    def default_attributes(self) -> dict[str, Any]:
+        return {
+            "chapter_name": self.overrides.get("chapter_name", fake.text(max_nb_chars=40).strip()),
+            "chapter_type": self.overrides.get("chapter_type", CITY_COMMUNITY),
+            "slug": self.overrides.get("slug", fake.slug().replace("-", "_")),
+            "city": self.overrides.get("city", "Bangalore"),
+            "state": self.overrides.get("state", "Karnataka"),
+            "country": "India",
+            "email": self.overrides.get("email", fake.email()),
+            "facebook": self.overrides.get("facebook", fake.url()),
+            "instagram": self.overrides.get("instagram", fake.url()),
+            "linkedin": self.overrides.get("linkedin", fake.url()),
+            "mastodon": self.overrides.get("mastodon", fake.url()),
+            "matrix": self.overrides.get("matrix", fake.url()),
+            "x": self.overrides.get("x", fake.url()),
+        }
+
+    @property
+    def with_members(self) -> dict[str, Any]:
+        members = self.overrides.get(
+            "members",
+            [user.name for user in UserFactory.create_list(2, "with_foss_website_user_role")],
+        )
+        chapter_members = []
+
+        for user in members:
+            profile_name = get_foss_profile_id(user)
+            chapter_members.append(
+                {
+                    "chapter_member": profile_name,
+                    "role": "Core Team Member",
+                }
+            )
+
+        return {"chapter_members": chapter_members}

--- a/fossunited/tests/factories/foss_event_rsvp_factory.py
+++ b/fossunited/tests/factories/foss_event_rsvp_factory.py
@@ -1,22 +1,16 @@
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-import frappe
 from faker import Faker
 from frappe_factory_bot.frappe_factory_bot.base_factory import BaseFactory
 
-from fossunited.doctype_ids import EVENT_RSVP, RSVP_RESPONSE
+from fossunited.chapters.doctype.foss_event_rsvp.foss_event_rsvp import FOSSEventRSVP
+from fossunited.doctype_ids import EVENT_RSVP
 from fossunited.tests.factories.foss_chapter_event_factory import FOSSChapterEventFactory
-
-if TYPE_CHECKING:
-    from fossunited.chapters.doctype.foss_event_rsvp.foss_event_rsvp import FOSSEventRSVP
-    from fossunited.chapters.doctype.foss_event_rsvp_submission.foss_event_rsvp_submission import (
-        FOSSEventRSVPSubmission,
-    )
 
 fake = Faker()
 
 
-class FOSSEventRSVPFactory(BaseFactory["FOSSEventRSVP"]):
+class FOSSEventRSVPFactory(BaseFactory[FOSSEventRSVP]):
     doctype = EVENT_RSVP
 
     @property

--- a/fossunited/tests/factories/foss_event_rsvp_factory.py
+++ b/fossunited/tests/factories/foss_event_rsvp_factory.py
@@ -1,0 +1,39 @@
+from typing import TYPE_CHECKING, Any
+
+import frappe
+from faker import Faker
+from frappe_factory_bot.frappe_factory_bot.base_factory import BaseFactory
+
+from fossunited.doctype_ids import EVENT_RSVP, RSVP_RESPONSE
+from fossunited.tests.factories.foss_chapter_event_factory import FOSSChapterEventFactory
+
+if TYPE_CHECKING:
+    from fossunited.chapters.doctype.foss_event_rsvp.foss_event_rsvp import FOSSEventRSVP
+    from fossunited.chapters.doctype.foss_event_rsvp_submission.foss_event_rsvp_submission import (
+        FOSSEventRSVPSubmission,
+    )
+
+fake = Faker()
+
+
+class FOSSEventRSVPFactory(BaseFactory["FOSSEventRSVP"]):
+    doctype = EVENT_RSVP
+
+    @property
+    def default_attributes(self) -> dict[str, Any]:
+        return {
+            "event": self.overrides.get("event", FOSSChapterEventFactory.create().name),
+            "allow_edit": 1,
+            "max_rsvp_count": 5,
+            "requires_host_approval": False,
+            "rsvp_description": fake.text(max_nb_chars=200).strip(),
+            "custom_questions": [],
+        }
+
+    @property
+    def with_host_approval(self) -> dict[str, Any]:
+        return {"requires_host_approval": True}
+
+    @property
+    def with_large_capacity(self) -> dict[str, Any]:
+        return {"max_rsvp_count": 100}

--- a/fossunited/tests/factories/user_factory.py
+++ b/fossunited/tests/factories/user_factory.py
@@ -1,0 +1,39 @@
+from typing import TYPE_CHECKING, Any
+
+import frappe
+from faker import Faker
+from frappe_factory_bot.frappe_factory_bot.base_factory import BaseFactory
+
+from fossunited.doctype_ids import USER_PROFILE
+
+if TYPE_CHECKING:
+    from frappe.core.doctype.user.user import User  # noqa: F401
+
+fake = Faker()
+
+
+def get_foss_profile_id(user: str) -> str | None:
+    """Get the FOSS User Profile ID for a given user email."""
+    return frappe.db.get_value(USER_PROFILE, {"user": user}, "name")
+
+
+class UserFactory(BaseFactory["User"]):
+    doctype = "User"
+
+    @property
+    def default_attributes(self) -> dict[str, Any]:
+        email = self.overrides.get("email", fake.email())
+        first_name = self.overrides.get("first_name", fake.first_name())
+        last_name = self.overrides.get("last_name", fake.last_name())
+        return {
+            "email": email,
+            "first_name": first_name,
+            "last_name": last_name,
+            "enabled": 1,
+        }
+
+    @property
+    def with_foss_website_user_role(self) -> dict[str, Any]:
+        return {
+            "roles": [{"role": "FOSS Website User"}],
+        }


### PR DESCRIPTION
- Introduced factory classes to streamline the creation of test data for chapters, events, and RSVPs.
- Updated test cases to utilize new factories for improved readability and maintainability.
- Added a new CI step to install the frappe_factory_bot application.

## Status

- [ ] Draft
- [x] Ready for review

---

## Related Issue

Addresses: #1416 

---

## Problem

Streamlining tests for better readability, maintainability and ease of writing them
---

## Solution

Using a factory system to create documents on tests. A very bad version of it exists in codebase at tests/utils.py. This is much better. 

https://github.com/harshtandiya/frappe_factory_bot

<!-- Describe your solution and what you changed -->

---

## Progress (All must be checked to merge)

- [x] Tested locally
 

---

## Changelog

<commit>: <!-- e.g., feat: add user login endpoint -->

---

## Visualization

<!-- Add screenshots, diagrams, or screen recordings if applicable -->

---

## Further Ahead

<!-- Mention any follow-up work or related PRs planned -->
Refactoring existing tests and getting rid of methods in test/utils.py
