### PR TITLE
feat: inline edit for proposal data in cfp details page

### DIFF
--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -87,6 +87,15 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         unsure_reviews: DF.Data | None
     # end: auto-generated types
 
+    def has_permission(self, permtype="read", user=None):
+        """Allow speakers listed on the proposal to write/submit/cancel."""
+        if permtype in ("write", "submit", "cancel"):
+            _user = user or frappe.session.user
+            speaker_emails = [s.email for s in self.speakers if s.email]
+            if _user and _user != "Guest" and _user in speaker_emails:
+                return True
+        return super().has_permission(permtype)
+
     def validate(self):
         self.bio = sanitize_text_content(self.bio)
         self.talk_description = sanitize_text_content(self.talk_description)
@@ -235,6 +244,8 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
         )
 
         context.no_cache = 1
+        if context.is_owner:
+            context.cfp_data_json = frappe.as_json(self.as_dict())
 
     def get_meta(self, context):
         pagetitle = self.talk_title

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -245,7 +245,7 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
 
         context.no_cache = 1
         if context.is_owner:
-            context.cfp_data_json = frappe.as_json(self.as_dict())
+            context.cfp_data_json = frappe.as_json(self.as_dict()).replace("</", "<\\/")
 
     def get_meta(self, context):
         pagetitle = self.talk_title

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
@@ -342,11 +342,21 @@ function _openCfpDialog(doc) {
           { fieldtype: 'Data', fieldname: 'social_link', label: 'Social Link' },
         ]
       },
+      ...(_CFP_DATA.custom_answers && _CFP_DATA.custom_answers.length ? [
+        { fieldtype: 'Section Break', label: 'Custom Answers' },
+        { fieldtype: 'Table', fieldname: 'custom_answers', options: 'FOSS Custom Answer',
+          fields: [
+            { fieldtype: 'Small Text', fieldname: 'question', label: 'Question', in_list_view: 1, read_only: 1 },
+            { fieldtype: 'Long Text', fieldname: 'response', label: 'Response', in_list_view: 1 },
+          ]
+        },
+      ] : []),
     ],
     primary_action_label: 'Save',
     primary_action(values) {
       const EDITABLE = ['talk_title','session_type','intended_audience','is_first_talk',
-                        'talk_license','talk_description','key_takeaways','references','speakers']
+                        'talk_license','talk_description','key_takeaways','references','speakers',
+                        'custom_answers']
       const payload = { doctype: _CFP_DATA.doctype, name: _CFP_DATA.name }
       EDITABLE.forEach(f => { if (f in values) payload[f] = values[f] })
       frappe.call({
@@ -374,6 +384,7 @@ function _openCfpDialog(doc) {
   }
   _loadTable('references', doc.references)
   _loadTable('speakers', doc.speakers)
+  _loadTable('custom_answers', doc.custom_answers)
 }
 </script>
 {% endif %}

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
@@ -29,9 +29,6 @@
   .speaker-social { min-width: 0; overflow: hidden; }
   .speaker-social-url { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
-  /* Owner action buttons */
-  .owner-btn:hover { background: var(--v3-button-border) !important; }
-
   /* Misc */
   .yt-icon { color: oklch(0.62 0.22 29); line-height: 1; transition: color 0.2s; }
   .dot-sep { font-size: 0.5rem; }
@@ -60,7 +57,7 @@
 {% endblock %}
 
 {% macro like_button() %}
-<div class="btn btn-sm v3-border v3-bg-card d-inline-flex align-items-center text-nowrap px-2">
+<div class="v3-border v3-bg-card rounded d-inline-flex align-items-center px-2" style="height:35px;">
   {% include "templates/includes/like/like.html" %}
 </div>
 {% endmacro %}
@@ -94,7 +91,7 @@
       {% if is_owner %}
         <a
           href="/dashboard/my-proposals/edit/{{ doc.name }}"
-          class="btn btn-sm v3-border v3-bg-card v3-text-secondary owner-btn"
+          class="v3-btn v3-btn--sm v3-border v3-bg-card v3-text-secondary"
           title="Edit full proposal in dashboard"
           data-toggle="tooltip"
         >
@@ -103,7 +100,7 @@
         </a>
         <button
           type="button"
-          class="btn btn-sm v3-border v3-bg-card v3-text-secondary owner-btn"
+          class="v3-btn v3-btn--sm v3-border v3-bg-card v3-text-secondary"
           onclick="cfpEditAll()"
           title="Quick-edit this proposal inline"
           data-toggle="tooltip"

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
@@ -91,6 +91,9 @@
     <div class="d-flex align-items-center flex-shrink-0 gap-2">
       {% if is_owner %}
         <a href="/dashboard/my-proposals/edit/{{ doc.name }}" class="btn btn-default btn-sm border">Edit proposal</a>
+        <button type="button" class="btn btn-default btn-sm border" onclick="cfpEditAll()" aria-label="Quick edit fields">
+          <i class="ti ti-pencil" aria-hidden="true"></i>
+        </button>
       {% endif %}
       {{ like_button() }}
     </div>
@@ -293,6 +296,88 @@
   </div>
 </div>
 {% endmacro %}
+
+{% block script %}
+{{ super() }}
+{% if is_owner %}
+<script>
+frappe.ready(function() {
+  frappe.require('controls.bundle.js')
+})
+
+const _CFP_DATA = {{ cfp_data_json }}
+
+function cfpEditAll() {
+  _openCfpDialog(_CFP_DATA)
+}
+
+function _openCfpDialog(doc) {
+  const d = new frappe.ui.Dialog({
+    title: 'Edit Proposal',
+    size: 'extra-large',
+    fields: [
+      { fieldtype: 'Section Break', label: 'Talk Info' },
+      { fieldtype: 'Data', fieldname: 'talk_title', label: 'Talk Title', reqd: 1 },
+      { fieldtype: 'Select', fieldname: 'session_type', label: 'Session Type',
+        options: 'Talk\nLightning Talk\nPanel Discussion\nBirds of Feather(BoF)\nWorkshop' },
+      { fieldtype: 'Column Break' },
+      { fieldtype: 'Select', fieldname: 'intended_audience', label: 'Intended Audience',
+        options: 'Beginner\nIntermediate\nAdvanced' },
+      { fieldtype: 'Select', fieldname: 'is_first_talk', label: 'First Talk?', options: 'Yes\nNo' },
+      { fieldtype: 'Data', fieldname: 'talk_license', label: 'Talk License' },
+      { fieldtype: 'Section Break', label: 'Content' },
+      { fieldtype: 'Text Editor', fieldname: 'talk_description', label: 'Session Description', reqd: 1 },
+      { fieldtype: 'Text Editor', fieldname: 'key_takeaways', label: 'Key Takeaways' },
+      { fieldtype: 'Section Break', label: 'References' },
+      { fieldtype: 'Table', fieldname: 'references', options: 'CFP Submission Reference',
+        fields: [{ fieldtype: 'Data', fieldname: 'link', label: 'Link', in_list_view: 1, reqd: 1 }] },
+      { fieldtype: 'Section Break', label: 'Speakers' },
+      { fieldtype: 'Table', fieldname: 'speakers', options: 'CFP Submission Speaker',
+        fields: [
+          { fieldtype: 'Data', fieldname: 'full_name', label: 'Full Name', in_list_view: 1, reqd: 1 },
+          { fieldtype: 'Data', fieldname: 'email', label: 'Email', in_list_view: 1 },
+          { fieldtype: 'Data', fieldname: 'designation', label: 'Designation', in_list_view: 1 },
+          { fieldtype: 'Data', fieldname: 'organization', label: 'Organization' },
+          { fieldtype: 'Text', fieldname: 'bio', label: 'Bio' },
+          { fieldtype: 'Data', fieldname: 'social_link', label: 'Social Link' },
+        ]
+      },
+    ],
+    primary_action_label: 'Save',
+    primary_action(values) {
+      const EDITABLE = ['talk_title','session_type','intended_audience','is_first_talk',
+                        'talk_license','talk_description','key_takeaways','references','speakers']
+      const payload = { doctype: _CFP_DATA.doctype, name: _CFP_DATA.name }
+      EDITABLE.forEach(f => { if (f in values) payload[f] = values[f] })
+      frappe.call({
+        method: 'frappe.client.save',
+        args: { doc: Object.assign({}, _CFP_DATA, payload) },
+        callback() { d.hide(); location.reload() },
+        error(e) { frappe.msgprint({ message: e.message || 'Save failed', indicator: 'red' }) }
+      })
+    }
+  })
+
+  d.show()
+
+  // Simple fields can be set immediately
+  const simple = ['talk_title','session_type','intended_audience','is_first_talk',
+                  'talk_license','talk_description','key_takeaways']
+  simple.forEach(f => d.set_value(f, doc[f]))
+
+  // Tables must be populated after show() so the grid is initialized
+  function _loadTable(fieldname, rows) {
+    const fd = d.fields_dict[fieldname]
+    if (!fd) return
+    fd.df.data = (rows || []).map(r => Object.assign({}, r))
+    fd.grid.refresh()
+  }
+  _loadTable('references', doc.references)
+  _loadTable('speakers', doc.speakers)
+}
+</script>
+{% endif %}
+{% endblock %}
 
 {% macro review_card(review) %}
 <div class="d-flex flex-column my-2 gap-1">

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
@@ -11,12 +11,11 @@
 {% block page_content %}
 <style>
   /* Fieldset/legend prose boxes */
-  .prose-box { border-color: oklch(0.92 0.01 255) !important; }
+  .prose-box { border-color: oklch(0.80 0.01 255) !important; }
   .prose-box legend { font-size: 0.875rem; font-weight: 500; }
 
   /* More prominent borders for sections */
-  .border-section { border-color: oklch(0.92 0.01 255) !important; }
-  [data-theme='dark'] .border-section { border-color: oklch(0.45 0.02 255) !important; }
+  .border-section { border-color: oklch(0.80 0.01 255) !important; }
 
   /* 16:9 video aspect ratio */
   .video-wrapper { padding-top: 56.25%; }
@@ -29,6 +28,9 @@
   .speaker-col { min-width: 0; }
   .speaker-social { min-width: 0; overflow: hidden; }
   .speaker-social-url { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+  /* Owner action buttons */
+  .owner-btn:hover { background: var(--v3-button-border) !important; }
 
   /* Misc */
   .yt-icon { color: oklch(0.62 0.22 29); line-height: 1; transition: color 0.2s; }
@@ -58,7 +60,7 @@
 {% endblock %}
 
 {% macro like_button() %}
-<div class="rounded border p-2 d-inline-flex v3-bg-card text-nowrap">
+<div class="btn btn-sm v3-border v3-bg-card d-inline-flex align-items-center text-nowrap px-2">
   {% include "templates/includes/like/like.html" %}
 </div>
 {% endmacro %}
@@ -86,13 +88,29 @@
     {% endif %}
   </div>
 
-  <div class="d-flex justify-content-between gap-2">
-    <h1 class="v3-text-primary text-3xl font-weight-bold">{{ doc.talk_title }}</h1>
-    <div class="d-flex align-items-center flex-shrink-0 gap-2">
+  <div class="d-flex flex-column flex-md-row justify-content-md-between gap-2">
+    <h1 class="v3-text-primary text-3xl font-weight-bold mb-0">{{ doc.talk_title }}</h1>
+    <div class="d-flex align-items-center flex-shrink-0 flex-wrap gap-2">
       {% if is_owner %}
-        <a href="/dashboard/my-proposals/edit/{{ doc.name }}" class="btn btn-default btn-sm border">Edit proposal</a>
-        <button type="button" class="btn btn-default btn-sm border" onclick="cfpEditAll()" aria-label="Quick edit fields">
+        <a
+          href="/dashboard/my-proposals/edit/{{ doc.name }}"
+          class="btn btn-sm v3-border v3-bg-card v3-text-secondary owner-btn"
+          title="Edit full proposal in dashboard"
+          data-toggle="tooltip"
+        >
+          <i class="ti ti-external-link" aria-hidden="true"></i>
+          Dashboard
+        </a>
+        <button
+          type="button"
+          class="btn btn-sm v3-border v3-bg-card v3-text-secondary owner-btn"
+          onclick="cfpEditAll()"
+          title="Quick-edit this proposal inline"
+          data-toggle="tooltip"
+          aria-label="Quick edit proposal"
+        >
           <i class="ti ti-pencil" aria-hidden="true"></i>
+          Edit
         </button>
       {% endif %}
       {{ like_button() }}
@@ -303,6 +321,7 @@
 <script>
 frappe.ready(function() {
   frappe.require('controls.bundle.js')
+  $('[data-toggle="tooltip"]').tooltip()
 })
 
 const _CFP_DATA = {{ cfp_data_json }}

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
@@ -351,7 +351,7 @@ function _openCfpDialog(doc) {
       { fieldtype: 'Table', fieldname: 'speakers', options: 'CFP Submission Speaker',
         fields: [
           { fieldtype: 'Data', fieldname: 'full_name', label: 'Full Name', in_list_view: 1, reqd: 1 },
-          { fieldtype: 'Data', fieldname: 'email', label: 'Email', in_list_view: 1 },
+          { fieldtype: 'Data', fieldname: 'email', label: 'Email', in_list_view: 1, reqd: 1 },
           { fieldtype: 'Data', fieldname: 'designation', label: 'Designation', in_list_view: 1 },
           { fieldtype: 'Data', fieldname: 'organization', label: 'Organization' },
           { fieldtype: 'Text', fieldname: 'bio', label: 'Bio' },

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -1749,6 +1749,16 @@ body:has(.v3-page) {
   z-index: 999;
   white-space: nowrap;
 }
+.v3-btn--sm {
+  padding: 0.375rem 0.625rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1.5;
+  text-transform: none;
+  letter-spacing: 0;
+  border-radius: 0.375rem;
+  gap: 0.25rem;
+}
 .v3-btn:hover {
   background: var(--v3-button-border);
 }


### PR DESCRIPTION
- closes #1502

<img width="1246" height="246" alt="image" src="https://github.com/user-attachments/assets/87833512-c505-4895-b75f-88f709030a59" />

first one takes to dashboard, second pencil one does inplace modal UI edit.

<img width="1801" height="1893" alt="image" src="https://github.com/user-attachments/assets/509d6dee-4b38-42f7-b14b-5d8553e8fa82" />


- Added a controller (`has_permission`) so another speaker matching email can also edit the proposal on page

- Added js guard to only allow owner to get modal UI to modify the data as required.
- Only shows specific necessary fields

- Thought to do field by field edit button, but single one seems good enough and easy code

- Since I refactored CFP roles and perm on #1553, it should be safe since frappe can throw error on perm error from server/backend itself


Known Issue: Dark mode does not play well with Modal UI here.
Frappe css hardcodes color, it will too much override from our custom.css if we add. Frappe should solve this