### PR TITLE
feat(notify): send feedback link to participants after event ends

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
@@ -44,6 +44,7 @@
   "event_start_date",
   "column_break_ae9v",
   "event_end_date",
+  "feedback_sent",
   "livestreaming_section",
   "livestream_link",
   "livestream_embed_link",
@@ -483,6 +484,13 @@
    "fieldname": "map_coordinate",
    "fieldtype": "Data",
    "label": "Map Coordinates"
+  },
+  {
+   "default": "0",
+   "fieldname": "feedback_sent",
+   "fieldtype": "Check",
+   "label": "Feedback sent?",
+   "read_only": 1
   }
  ],
  "has_web_view": 1,
@@ -515,7 +523,7 @@
    "link_fieldname": "event"
   }
  ],
- "modified": "2026-03-24 16:46:54.159578",
+ "modified": "2026-05-07 16:53:25.160146",
  "modified_by": "Administrator",
  "module": "Chapters",
  "name": "FOSS Chapter Event",

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -45,18 +45,14 @@ class FOSSChapterEvent(WebsiteGenerator):
         from fossunited.fossunited.doctype.event_project_showcase.event_project_showcase import (
             EventProjectShowcase,
         )
-        from fossunited.fossunited.doctype.foss_event_field.foss_event_field import (
-            FOSSEventField,
-        )
+        from fossunited.fossunited.doctype.foss_event_field.foss_event_field import FOSSEventField
         from fossunited.fossunited.doctype.foss_event_schedule.foss_event_schedule import (
             FOSSEventSchedule,
         )
         from fossunited.fossunited.doctype.foss_event_sponsor.foss_event_sponsor import (
             FOSSEventSponsor,
         )
-        from fossunited.ticketing.doctype.foss_ticket_tier.foss_ticket_tier import (
-            FOSSTicketTier,
-        )
+        from fossunited.ticketing.doctype.foss_ticket_tier.foss_ticket_tier import FOSSTicketTier
 
         banner_image: DF.AttachImage | None
         chapter: DF.Link | None
@@ -84,6 +80,7 @@ class FOSSChapterEvent(WebsiteGenerator):
             "Linux Installation Party",
         ]
         external_event_url: DF.Data | None
+        feedback_sent: DF.Check
         hall_options: DF.SmallText | None
         has_external_webpage: DF.Check
         is_external_event: DF.Check
@@ -119,6 +116,22 @@ class FOSSChapterEvent(WebsiteGenerator):
     def before_insert(self):
         self.copy_team_members()
 
+    def on_update(self):
+        self.sync_event_member_shares()
+        if (
+            self.has_value_changed("status")
+            and self.status == "Concluded"
+            and not self.feedback_sent
+            and self.event_end_date
+            and datetime.now() >= frappe.utils.get_datetime(self.event_end_date)
+        ):
+            frappe.enqueue(
+                "fossunited.utils.notifications.send_event_feedback_request",
+                event_id=self.name,
+                queue="long",
+                enqueue_after_commit=True,
+            )
+
     def validate(self):
         self.validate_permalink()
 
@@ -136,9 +149,6 @@ class FOSSChapterEvent(WebsiteGenerator):
                 self.map_coordinate = f"{lat},{lng}" if (lat and lng) else None
             else:
                 self.map_coordinate = None
-
-    def on_update(self):
-        self.sync_event_member_shares()
 
     def sync_event_member_shares(self):
         prev = self.get_doc_before_save()

--- a/fossunited/chapters/doctype/foss_chapter_event/test_foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/test_foss_chapter_event.py
@@ -1,67 +1,61 @@
+from unittest.mock import patch
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from fossunited.doctype_ids import (
-    CHAPTER,
-    EVENT,
-    EVENT_VOLUNTEER,
+from fossunited.doctype_ids import CHAPTER, EVENT, EVENT_VOLUNTEER
+from fossunited.tests.factories import (
+    FOSSChapterEventFactory,
+    FOSSChapterFactory,
+    FOSSEventRSVPFactory,
+    FOSSEventRSVPSubmissionFactory,
+    FOSSEventTicketFactory,
 )
-from fossunited.tests.utils import insert_test_chapter, insert_test_event
+from fossunited.utils.notifications import send_event_feedback_request
+
+ENQUEUE_PATH = "fossunited.chapters.doctype.foss_chapter_event.foss_chapter_event.frappe.enqueue"
+SENDMAIL_PATH = "fossunited.utils.notifications.frappe.sendmail"
 
 
 class TestFOSSChapterEvent(FrappeTestCase):
     def setUp(self):
-        self.core_team_email = "test1@example.com"
-        self.chapter = insert_test_chapter(members=[self.core_team_email])
-        self.event = insert_test_event(
-            chapter=self.chapter,
-        )
+        self.chapter = FOSSChapterFactory.create("with_members")
+        self.event = FOSSChapterEventFactory.create(chapter=self.chapter.name)
 
     def tearDown(self):
-        frappe.delete_doc(CHAPTER, self.chapter.name, force=True)
         frappe.delete_doc(EVENT, self.event.name, force=True)
+        frappe.delete_doc(CHAPTER, self.chapter.name, force=True)
 
     def test_members_are_added_to_event(self):
-        # Given a chapter
-        chapter = self.chapter
-
-        # When an event is created for the chapter
-        event = self.event
-
-        # Then the existing members of the chapter should be added to the event
-        for member in chapter.chapter_members:
+        for member in self.chapter.chapter_members:
             self.assertTrue(
                 frappe.db.exists(
                     EVENT_VOLUNTEER,
                     {
-                        "parent": event.name,
+                        "parent": self.event.name,
                         "member": member.chapter_member,
                     },
                 )
             )
 
     def test_unique_event_slug(self):
-        """Test that event slugs must be unique within a chapter
-        but can be reused across chapters."""
+        """Slugs must be unique within a chapter but reusable across chapters."""
+        existing_permalink = self.event.event_permalink
 
-        original_chapter = self.chapter
-        original_event = self.event
-        existing_permalink = original_event.event_permalink
-
-        # Test 1: Same chapter, same slug (should fail)
+        # Same chapter, same slug → should fail
         with self.assertRaises(frappe.exceptions.ValidationError):
-            insert_test_event(chapter=original_chapter, event_permalink=existing_permalink)
+            FOSSChapterEventFactory.create(
+                chapter=self.chapter.name, event_permalink=existing_permalink
+            )
 
-        # Test 2: Different chapter, same slug (should succeed)
-        new_chapter = insert_test_chapter(city="Kochi", state="Kerala")
-
-        insert_test_event(
-            chapter=new_chapter,
-            event_permalink=existing_permalink,
+        # Different chapter, same slug → should succeed
+        other_chapter = FOSSChapterFactory.create()
+        FOSSChapterEventFactory.create(
+            chapter=other_chapter.name, event_permalink=existing_permalink
         )
 
-        # Test 3: Same chapter, different slug (should succeed)
-        insert_test_event(chapter=original_chapter)
+        # Same chapter, different slug → should succeed
+        FOSSChapterEventFactory.create(chapter=self.chapter.name)
 
     def test_email_groups_are_created_on_event_insert(self):
         expected_group_types = [
@@ -93,23 +87,19 @@ class TestFOSSChapterEvent(FrappeTestCase):
         )
 
     def test_map_link_extracts_coordinates(self):
-        """Test that a new event with map_link extracts and stores coordinates."""
-        map_coord = "12.9716,77.5946"
         map_link = "https://maps.google.com/?q=12.9716,77.5946"
-
-        event = insert_test_event(
-            chapter=self.chapter,
-            map_link=map_link,
+        event = FOSSChapterEventFactory.create(
+            "with_map_link", chapter=self.chapter.name, map_link=map_link
         )
-        self.assertIsNotNone(event.map_coordinate)
-        self.assertEqual(event.map_coordinate, map_coord)
 
+        self.assertIsNotNone(event.map_coordinate)
+        self.assertEqual(event.map_coordinate, "12.9716,77.5946")
         frappe.delete_doc(EVENT, event.name, force=True)
 
     def test_map_link_updates_coordinates(self):
-        """Test that changing map_link triggers coordinate re-extraction."""
-        event = insert_test_event(
-            chapter=self.chapter,
+        event = FOSSChapterEventFactory.create(
+            "with_map_link",
+            chapter=self.chapter.name,
             map_link="https://osmapp.org/node/abcdedfg/#69/12.9716/77.5946",
         )
         initial_coordinate = event.map_coordinate
@@ -120,21 +110,103 @@ class TestFOSSChapterEvent(FrappeTestCase):
 
         self.assertEqual(initial_coordinate, "12.9716,77.5946")
         self.assertEqual(event.map_coordinate, "69.007,420.911")
-
         frappe.delete_doc(EVENT, event.name, force=True)
 
     def test_event_without_map_link_has_no_coordinates(self):
-        """Test that events created without map_link have no coordinates."""
-        event = insert_test_event(chapter=self.chapter)
+        event = FOSSChapterEventFactory.create(chapter=self.chapter.name)
         self.assertIsNone(event.map_coordinate)
         frappe.delete_doc(EVENT, event.name, force=True)
 
     def test_invalid_map_link_sets_none(self):
-        """Test that invalid map links result in None coordinates."""
-        event = insert_test_event(
-            chapter=self.chapter,
-            map_link="https://invalid-url.com",
+        event = FOSSChapterEventFactory.create(
+            "with_map_link", chapter=self.chapter.name, map_link="https://invalid-url.com"
         )
-
         self.assertIsNone(event.map_coordinate)
         frappe.delete_doc(EVENT, event.name, force=True)
+
+
+class TestFeedbackEmail(FrappeTestCase):
+    def setUp(self):
+        self.chapter = FOSSChapterFactory.create()
+        self.event = FOSSChapterEventFactory.create("with_past_dates", chapter=self.chapter.name)
+
+    def tearDown(self):
+        frappe.delete_doc(EVENT, self.event.name, force=True)
+        frappe.delete_doc(CHAPTER, self.chapter.name, force=True)
+
+    @patch(ENQUEUE_PATH)
+    def test_concluding_past_event_enqueues_feedback(self, mock_enqueue):
+        event = frappe.get_doc(EVENT, self.event.name)
+        event.status = "Concluded"
+        event.save()
+
+        mock_enqueue.assert_called_once_with(
+            "fossunited.utils.notifications.send_event_feedback_request",
+            event_id=self.event.name,
+            queue="long",
+            enqueue_after_commit=True,
+        )
+
+    @patch(ENQUEUE_PATH)
+    def test_no_enqueue_if_feedback_already_sent(self, mock_enqueue):
+        frappe.db.set_value(EVENT, self.event.name, "feedback_sent", 1)
+        event = frappe.get_doc(EVENT, self.event.name)
+        event.status = "Concluded"
+        event.save()
+
+        mock_enqueue.assert_not_called()
+
+    @patch(ENQUEUE_PATH)
+    def test_no_enqueue_if_end_date_in_future(self, mock_enqueue):
+        event = FOSSChapterEventFactory.create(chapter=self.chapter.name)
+        event = frappe.get_doc(EVENT, event.name)
+        event.status = "Concluded"
+        event.save()
+
+        mock_enqueue.assert_not_called()
+        frappe.delete_doc(EVENT, event.name, force=True)
+
+    @patch(SENDMAIL_PATH)
+    def test_sends_to_accepted_rsvp_skips_pending(self, mock_sendmail):
+        rsvp = FOSSEventRSVPFactory.create(event=self.event.name)
+        FOSSEventRSVPSubmissionFactory.create(
+            linked_rsvp=rsvp.name, email="accepted@test.com", status="Accepted"
+        )
+        FOSSEventRSVPSubmissionFactory.create(
+            linked_rsvp=rsvp.name, email="pending@test.com", status="Pending"
+        )
+
+        send_event_feedback_request(self.event.name)
+
+        sent_to = {c.kwargs["recipients"][0] for c in mock_sendmail.call_args_list}
+        self.assertIn("accepted@test.com", sent_to)
+        self.assertNotIn("pending@test.com", sent_to)
+
+    @patch(SENDMAIL_PATH)
+    def test_sends_to_ticket_holders_for_paid_event(self, mock_sendmail):
+        paid_event = FOSSChapterEventFactory.create(
+            "with_past_dates", "with_paid_tickets", chapter=self.chapter.name
+        )
+        FOSSEventTicketFactory.create(event=paid_event.name, email="ticket@test.com")
+
+        send_event_feedback_request(paid_event.name)
+
+        sent_to = {c.kwargs["recipients"][0] for c in mock_sendmail.call_args_list}
+        self.assertIn("ticket@test.com", sent_to)
+        frappe.delete_doc(EVENT, paid_event.name, force=True)
+
+    @patch(SENDMAIL_PATH)
+    def test_feedback_sent_flag_set_after_send(self, mock_sendmail):
+        rsvp = FOSSEventRSVPFactory.create(event=self.event.name)
+        FOSSEventRSVPSubmissionFactory.create(
+            linked_rsvp=rsvp.name, email="flag@test.com", status="Accepted"
+        )
+
+        send_event_feedback_request(self.event.name)
+
+        self.assertEqual(frappe.db.get_value(EVENT, self.event.name, "feedback_sent"), 1)
+
+    @patch(SENDMAIL_PATH)
+    def test_no_send_if_no_participants(self, mock_sendmail):
+        send_event_feedback_request(self.event.name)
+        mock_sendmail.assert_not_called()

--- a/fossunited/tests/factories/__init__.py
+++ b/fossunited/tests/factories/__init__.py
@@ -7,6 +7,9 @@ from fossunited.tests.factories.foss_event_cfp_submission_factory import (
     FOSSEventCFPSubmissionFactory,
 )
 from fossunited.tests.factories.foss_event_rsvp_factory import FOSSEventRSVPFactory
+from fossunited.tests.factories.foss_event_rsvp_submission_factory import (
+    FOSSEventRSVPSubmissionFactory,
+)
 from fossunited.tests.factories.foss_event_ticket_factory import FOSSEventTicketFactory
 from fossunited.tests.factories.razorpay_payment_factory import RazorpayPaymentFactory
 from fossunited.tests.factories.user_factory import UserFactory, get_foss_profile_id
@@ -17,6 +20,7 @@ __all__ = [
     "FOSSEventCFPFactory",
     "FOSSEventCFPSubmissionFactory",
     "FOSSEventRSVPFactory",
+    "FOSSEventRSVPSubmissionFactory",
     "FOSSEventTicketFactory",
     "RazorpayPaymentFactory",
     "UserFactory",

--- a/fossunited/tests/factories/foss_event_rsvp_submission_factory.py
+++ b/fossunited/tests/factories/foss_event_rsvp_submission_factory.py
@@ -1,0 +1,58 @@
+from typing import Any
+
+import frappe
+from faker import Faker
+from frappe_factory_bot.frappe_factory_bot.base_factory import BaseFactory
+
+from fossunited.doctype_ids import EVENT, EVENT_RSVP, RSVP_RESPONSE
+from fossunited.tests.factories.foss_event_rsvp_factory import FOSSEventRSVPFactory
+
+fake = Faker()
+
+
+class FOSSEventRSVPSubmissionFactory(BaseFactory):
+    doctype = RSVP_RESPONSE
+
+    @property
+    def default_attributes(self) -> dict[str, Any]:
+        linked_rsvp = self.overrides.get("linked_rsvp") or FOSSEventRSVPFactory.create().name
+        event = self.overrides.get("event") or frappe.db.get_value(
+            EVENT_RSVP, linked_rsvp, "event"
+        )
+        chapter = frappe.db.get_value(EVENT, event, "chapter")
+        return {
+            "linked_rsvp": linked_rsvp,
+            "event": event,
+            "chapter": chapter,
+            "name1": self.overrides.get("name1", fake.name()),
+            "email": self.overrides.get("email", fake.email()),
+            "im_a": self.overrides.get("im_a", "FOSS Enthusiast"),
+            "status": self.overrides.get("status", "Accepted"),
+            "accept_coc": 1,
+            "subscribe_chapter_mailing": 0,
+            "confirm_attendance": 0,
+            "custom_answers": [],
+        }
+
+    @classmethod
+    def create(cls, *traits, **overrides):
+        """Override to force status via db.set_value after insert,
+        bypassing handle_submission_status in before_insert."""
+        desired_status = overrides.get("status", "Accepted")
+        doc = super().create(*traits, **overrides)
+        if doc.status != desired_status:
+            frappe.db.set_value(RSVP_RESPONSE, doc.name, "status", desired_status)
+            doc.reload()
+        return doc
+
+    @property
+    def with_accepted(self) -> dict[str, Any]:
+        return {"status": "Accepted"}
+
+    @property
+    def with_rejected(self) -> dict[str, Any]:
+        return {"status": "Rejected"}
+
+    @property
+    def with_pending(self) -> dict[str, Any]:
+        return {"status": "Pending"}

--- a/fossunited/utils/notifications.py
+++ b/fossunited/utils/notifications.py
@@ -1,0 +1,50 @@
+import frappe
+
+from fossunited.doctype_ids import CHAPTER, EVENT, EVENT_TICKET, RSVP_RESPONSE
+
+
+def send_event_feedback_request(event_id):
+    """Enqueued after event status -> Concluded. Sends feedback request to all participants."""
+    doc = frappe.get_doc(EVENT, event_id)
+
+    if doc.is_paid_event:
+        emails = frappe.db.get_all(EVENT_TICKET, filters={"event": event_id}, pluck="email")
+        feedback_url = f"https://fossunited.org/main-events-feedback/new?event={event_id}"
+    else:
+        emails = frappe.db.get_all(
+            RSVP_RESPONSE,
+            filters={"event": event_id, "status": "Accepted"},
+            pluck="email",
+        )
+        feedback_url = f"https://fossunited.org/chapter-events-feedback/new?event={event_id}"
+
+    emails = list({e.strip().lower() for e in emails if e and e.strip()})
+    if not emails:
+        return
+
+    chapter_email = frappe.db.get_value(CHAPTER, doc.chapter, "email")
+    sender = chapter_email or None
+
+    subject = f"Feedback for {doc.event_name}"
+    message = f"""<p>Thank you for RSVPing to <strong>{doc.event_name}</strong>.</p>
+<p>Whether you were able to join us or missed out this time, we would love to hear
+your thoughts. Please take a moment to complete our
+<a href="{feedback_url}">Feedback Survey</a> as it helps us improve our programs
+for the broader community.</p>
+<p>— Team {doc.event_name}</p>"""
+
+    for email in emails:
+        frappe.sendmail(
+            recipients=[email],
+            subject=subject,
+            message=message,
+            sender=sender,
+            reference_doctype=EVENT,
+            reference_name=event_id,
+        )
+
+    frappe.db.set_value(EVENT, event_id, "feedback_sent", 1)
+    frappe.log_error(
+        title=f"Feedback email sent: {event_id}",
+        message=f"Sent to {len(emails)} participants.",
+    )


### PR DESCRIPTION
- We've 2 forms for feedback

- https://fossunited.org/main-events-feedback/new   (for paid big events)
- https://fossunited.org/chapter-events-feedback/new  (for rsvp'd/club small events)

- In frappe desk via "Notification" we cannot send to all participants

So in codebase simply trigger on update via a field tracking to see if its sent.

Bulk send email to all email that have participated based on mode.

- Added frappe factory tests so its reliable

Update: 76e9152da

In next commit I basically moved direct sending to email and instead just send this as Campaign "Newsletter" item itself.
Since that respects user subscription choice per event rsvp.

We can also track in newsletter desk, and we already have email group for all participants and speakers.
So all good!