### PR TITLE
refactor(tests): use factories in ticketing tests

### DIFF
--- a/fossunited/tests/factories/foss_chapter_event_factory.py
+++ b/fossunited/tests/factories/foss_chapter_event_factory.py
@@ -56,6 +56,7 @@ class FOSSChapterEventFactory(BaseFactory[FOSSChapterEvent]):
                     "enabled": 1,
                     "title": "General",
                     "price": 100,
+                    "maximum_tickets": 100,
                 }
             ],
         }

--- a/fossunited/ticketing/doctype/foss_event_ticket/test_foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/test_foss_event_ticket.py
@@ -1,33 +1,23 @@
 import frappe
-from faker import Faker
 from frappe.tests.utils import FrappeTestCase
 
 from fossunited.api.checkins import checkin_attendee
 from fossunited.doctype_ids import CHAPTER, EVENT, EVENT_TICKET
-from fossunited.tests.utils import (
-    insert_test_chapter,
-    insert_test_event,
-    insert_test_ticket,
+from fossunited.tests.factories import (
+    FOSSChapterEventFactory,
+    FOSSChapterFactory,
+    FOSSEventTicketFactory,
+    UserFactory,
 )
 
 
 class TestFOSSEventTicket(FrappeTestCase):
     def setUp(self):
-        self.core_team_email = "test1@example.com"
-        self.chapter = insert_test_chapter(members=[self.core_team_email])
-        self.event = insert_test_event(
-            chapter=self.chapter,
-            is_paid_event=True,
-            tickets_status="Live",
-            tiers=[
-                {
-                    "enabled": 1,
-                    "title": "Test",
-                    "price": 100,
-                    "maximum_tickets": 5,
-                }
-            ],
+        self.team_member_user = UserFactory.create("with_foss_website_user_role")
+        self.chapter = FOSSChapterFactory.create(
+            "with_members", members=[self.team_member_user.name]
         )
+        self.event = FOSSChapterEventFactory.create("with_paid_tickets", chapter=self.chapter.name)
 
     def tearDown(self):
         frappe.set_user("Administrator")
@@ -35,26 +25,14 @@ class TestFOSSEventTicket(FrappeTestCase):
         frappe.delete_doc(CHAPTER, self.chapter.name, force=True)
 
     def test_checkin(self):
-        fake = Faker()
-
         # Given that a ticket is created for an event
-        ticket = frappe.get_doc(
-            {
-                "doctype": EVENT_TICKET,
-                "event": self.event.name,
-                "full_name": fake.name(),
-                "email": fake.email(),
-                "tier": "General",
-            }
-        )
-        ticket.insert(ignore_permissions=True)
-        ticket.reload()
+        ticket = FOSSEventTicketFactory.create(event=self.event.name)
 
         # There should be no check-ins for that event
         self.assertFalse(ticket.check_ins)
 
         # Set the user as a chapter member
-        frappe.set_user(self.core_team_email)
+        frappe.set_user(self.team_member_user.name)
 
         # When the user checks in the attendee
         checkin_attendee(self.event.name, ticket.as_dict())
@@ -69,24 +47,14 @@ class TestFOSSEventTicket(FrappeTestCase):
             checkin_attendee(self.event.name, ticket.as_dict())
 
     def test_checkin_as_non_chapter_member(self):
-        fake = Faker()
-
         # Given that a ticket is created for an event
-        ticket = frappe.get_doc(
-            {
-                "doctype": EVENT_TICKET,
-                "event": self.event.name,
-                "full_name": fake.name(),
-                "email": fake.email(),
-                "tier": "General",
-            }
-        )
-        ticket.insert(ignore_permissions=True)
-        ticket.reload()
+        ticket = FOSSEventTicketFactory.create(event=self.event.name)
 
         self.assertFalse(ticket.check_ins)
-        # Set the user as a random user
-        frappe.set_user("test2@example.com")
+
+        # Set the user as a non-member
+        non_member = UserFactory.create()
+        frappe.set_user(non_member.name)
 
         # When the user checks in the attendee
         # Then the user should not have permission to check-in the attendee
@@ -100,7 +68,7 @@ class TestFOSSEventTicket(FrappeTestCase):
         # When a ticket is created for this event
         # Then an error must be thrown
         with self.assertRaises(frappe.PermissionError):
-            insert_test_ticket(event=self.event.name)
+            FOSSEventTicketFactory.create(event=self.event.name)
 
     def test_ticket_creation(self):
         # Given an event
@@ -109,12 +77,12 @@ class TestFOSSEventTicket(FrappeTestCase):
         self.event.save()
 
         # Then a ticket for this event should be created without any problem
-        ticket = insert_test_ticket(event=self.event.name)
+        ticket = FOSSEventTicketFactory.create(event=self.event.name)
         ticket.delete(force=True)
 
     def test_ticket_tier_closing(self):
         # Given an event with a ticket tier
-        tier = self.event.get("tiers")[0]
+        tier = self.event.tiers[0]
 
         # Make sure this tier is enabled
         self.assertTrue(tier.enabled)
@@ -134,16 +102,16 @@ class TestFOSSEventTicket(FrappeTestCase):
         # When maximum number of tickets are created of this tier type
         tickets = []
         for _ in range(tier.maximum_tickets):
-            _ticket = insert_test_ticket(
+            ticket = FOSSEventTicketFactory.create(
                 event=self.event.name,
                 tier=tier.title,
             )
-            tickets.append(_ticket)
+            tickets.append(ticket)
 
         self.event.reload()
 
         # Then the tier should be disabled
-        tier = self.event.get("tiers")[0]
+        tier = self.event.tiers[0]
         self.assertEqual(tier.enabled, 0)
 
         for ticket in tickets:
@@ -156,7 +124,7 @@ class TestFOSSEventTicket(FrappeTestCase):
 
         attendee_email = "test4@example.com"
         # When a ticket is created with attendee's email
-        ticket = insert_test_ticket(event=self.event.name, email=attendee_email)
+        ticket = FOSSEventTicketFactory.create(event=self.event.name, email=attendee_email)
         ticket.subscribe_chapter_mailing = 1
         ticket.save()
         # Then the email should be added to an email group linked to event for participants
@@ -180,8 +148,8 @@ class TestFOSSEventTicket(FrappeTestCase):
     def test_remove_from_email_group_on_unsubscribe(self):
         attendee_email = "test4@example.com"
 
-        # Given: Ticket created with subscription ON (default behavior)
-        ticket = insert_test_ticket(event=self.event.name, email=attendee_email)
+        # Given: Ticket created with subscription ON
+        ticket = FOSSEventTicketFactory.create(event=self.event.name, email=attendee_email)
         ticket.subscribe_chapter_mailing = 1
         ticket.save()
 
@@ -244,8 +212,8 @@ class TestFOSSEventTicket(FrappeTestCase):
     def test_resub_from_email_group(self):
         attendee_email = "test4@example.com"
 
-        # Insert with default subscription (subscribe_chapter_mailing=1)
-        ticket = insert_test_ticket(event=self.event.name, email=attendee_email)
+        # Insert with default subscription
+        ticket = FOSSEventTicketFactory.create(event=self.event.name, email=attendee_email)
 
         ticket.subscribe_chapter_mailing = 0
         ticket.handle_add_to_email_group()

--- a/fossunited/ticketing/doctype/foss_event_ticket_transfer/test_foss_event_ticket_transfer.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket_transfer/test_foss_event_ticket_transfer.py
@@ -3,27 +3,19 @@ from faker import Faker
 from frappe.tests.utils import FrappeTestCase
 
 from fossunited.doctype_ids import CHAPTER, EVENT, EVENT_TICKET, TICKET_TRANSFER
-from fossunited.tests.utils import insert_test_chapter, insert_test_event, insert_test_ticket
+from fossunited.tests.factories import (
+    FOSSChapterEventFactory,
+    FOSSChapterFactory,
+    FOSSEventTicketFactory,
+)
 
 fake = Faker()
 
 
 class TestFOSSEventTicketTransfer(FrappeTestCase):
     def setUp(self):
-        self.chapter = insert_test_chapter()
-        self.event = insert_test_event(
-            chapter=self.chapter,
-            is_paid_event=True,
-            tickets_status="Live",
-            tiers=[
-                {
-                    "enabled": 1,
-                    "title": "Test",
-                    "price": 100,
-                    "maximum_tickets": 5,
-                }
-            ],
-        )
+        self.chapter = FOSSChapterFactory.create()
+        self.event = FOSSChapterEventFactory.create("with_paid_tickets", chapter=self.chapter.name)
 
     def tearDown(self):
         frappe.set_user("Administrator")
@@ -42,7 +34,7 @@ class TestFOSSEventTicketTransfer(FrappeTestCase):
         }
 
         # Given for an event, a ticket is created. For that ticket, a transfer is generated.
-        ticket = insert_test_ticket(
+        ticket = FOSSEventTicketFactory.create(
             event=self.event.name,
             full_name=sender["full_name"],
             email=sender["email"],
@@ -91,7 +83,7 @@ class TestFOSSEventTicketTransfer(FrappeTestCase):
         # Given an event and a ticket linked to the event
         # With a ticket created for a user, try to transfer this ticket to another user while
         # passing "Completed" as the status
-        ticket = insert_test_ticket(event=self.event.name)
+        ticket = FOSSEventTicketFactory.create(event=self.event.name)
 
         # Then verify that this operation raises a ValidationError
         with self.assertRaises(frappe.exceptions.ValidationError):
@@ -121,7 +113,7 @@ class TestFOSSEventTicketTransfer(FrappeTestCase):
             "email": fake.email(),
         }
 
-        ticket = insert_test_ticket(
+        ticket = FOSSEventTicketFactory.create(
             event=self.event.name,
             full_name=sender["full_name"],
             email=sender["email"],


### PR DESCRIPTION
## Summary
- Adds `maximum_tickets: 100` default to `with_paid_tickets` trait on `FOSSChapterEventFactory`
- Refactors `test_foss_event_ticket.py` to use `FOSSChapterFactory`, `FOSSChapterEventFactory`, `FOSSEventTicketFactory`, `UserFactory` (drops `insert_test_chapter/event/ticket` helpers, removes hardcoded test emails)
- Refactors `test_foss_event_ticket_transfer.py` to use factories

Part of the ongoing migration from `tests/utils.py` `insert_*` helpers to the factory bot pattern (follow-up to #1560).

## Test plan
- [x] `bench --site fossunited.localhost run-tests --module fossunited.ticketing.doctype.foss_event_ticket.test_foss_event_ticket` (8/8)
- [x] `bench --site fossunited.localhost run-tests --module fossunited.ticketing.doctype.foss_event_ticket_transfer.test_foss_event_ticket_transfer` (3/3)
- [x] Regression check on existing `with_paid_tickets` users: `bench --site fossunited.localhost run-tests --module fossunited.payments.doctype.razorpay_payment.test_razorpay_payment` (12/12)
- [x] basedpyright clean on touched files