### PR TITLE
feat(cfpInsights): Assign proposal to reviewers via dashboard + notify them

### DIFF
--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -14,6 +14,7 @@ declare module 'vue' {
     AllDayGridView: typeof import('./src/components/schedule/AllDayGridView.vue')['default']
     AllProposalsBanner: typeof import('./src/components/proposals/AllProposalsBanner.vue')['default']
     AllProposalsBannerImage: typeof import('./src/components/proposals/AllProposalsBannerImage.vue')['default']
+    AssignReviewers: typeof import('./src/components/event/cfp/AssignReviewers.vue')['default']
     AttendeeCard: typeof import('./src/components/tickets/AttendeeCard.vue')['default']
     AttendeeRequestList: typeof import('./src/components/localhost/AttendeeRequestList.vue')['default']
     BillingForm: typeof import('./src/components/tickets/BillingForm.vue')['default']

--- a/dashboard/src/components/event/cfp/AssignReviewers.vue
+++ b/dashboard/src/components/event/cfp/AssignReviewers.vue
@@ -1,6 +1,18 @@
 <template>
   <div class="flex flex-col gap-2">
-    <span class="text-xs font-medium text-ink-gray-5 uppercase tracking-wide">Assign Reviewers</span>
+    <div class="flex items-center gap-1">
+      <span class="text-xs font-medium text-ink-gray-5 uppercase tracking-wide">Assign Reviewers</span>
+      <Tooltip text="Assigning a reviewer sends them an email notification. Use only to notify reviewers to review this proposal." placement="right">
+        <a
+          href="https://docs.fossunited.org/event-cfp#assign-reviewers-to-a-proposal"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-ink-gray-4 hover:text-ink-gray-6 leading-none"
+        >
+          <IconHelpCircle class="w-3.5 h-3.5" />
+        </a>
+      </Tooltip>
+    </div>
     <div class="flex gap-2 items-start">
       <Autocomplete
         v-model="selectedOptions"
@@ -26,7 +38,8 @@
 
 <script setup>
 import { ref, computed, watch, nextTick } from 'vue'
-import { createResource, Autocomplete, Avatar, Button } from 'frappe-ui'
+import { createResource, Autocomplete, Avatar, Button, Tooltip } from 'frappe-ui'
+import { IconHelpCircle } from '@tabler/icons-vue'
 import { toast } from 'vue-sonner'
 
 const props = defineProps({
@@ -93,6 +106,19 @@ const saveResource = createResource({
 })
 
 function saveAssignments() {
+  const newSet = new Set(selectedOptions.value.map((o) => o.value))
+  const removed = (currentAssignments.data || []).filter((u) => !newSet.has(u))
+
+  if (removed.length > 0) {
+    const names = removed
+      .map((u) => reviewers.data?.find((r) => r.user === u)?.full_name || u)
+      .join(', ')
+    const ok = window.confirm(
+      `Remove ${removed.length} reviewer${removed.length > 1 ? 's' : ''}: ${names}?\n\nThey will no longer see this proposal as assigned to them.`,
+    )
+    if (!ok) return
+  }
+
   saveResource.submit({
     submission_name: props.submissionId,
     reviewer_users: selectedOptions.value.map((o) => o.value),

--- a/dashboard/src/components/event/cfp/AssignReviewers.vue
+++ b/dashboard/src/components/event/cfp/AssignReviewers.vue
@@ -1,0 +1,101 @@
+<template>
+  <div class="flex flex-col gap-2">
+    <span class="text-xs font-medium text-ink-gray-5 uppercase tracking-wide">Assign Reviewers</span>
+    <div class="flex gap-2 items-start">
+      <Autocomplete
+        v-model="selectedOptions"
+        :options="reviewerOptions"
+        :multiple="true"
+        placeholder="Select reviewers..."
+        class="flex-1"
+      >
+        <template #item-prefix="{ option }">
+          <Avatar :image="option.user_image" :label="option.label" size="xs" class="mr-1.5" />
+        </template>
+      </Autocomplete>
+      <Button
+        label="Save"
+        size="sm"
+        variant="solid"
+        :loading="saveResource.loading"
+        @click="saveAssignments"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, nextTick } from 'vue'
+import { createResource, Autocomplete, Avatar, Button } from 'frappe-ui'
+import { toast } from 'vue-sonner'
+
+const props = defineProps({
+  submissionId: { type: String, required: true },
+  eventId: { type: String, required: true },
+})
+
+const reviewers = createResource({
+  url: 'fossunited.api.cfp.get_cfp_reviewers',
+  params: { event_id: props.eventId },
+  auto: true,
+})
+
+const currentAssignments = createResource({
+  url: 'fossunited.api.cfp.get_submission_reviewer_assignments',
+  makeParams() {
+    return { submission_name: props.submissionId }
+  },
+  auto: true,
+})
+
+const selectedOptions = ref([])
+let initializing = false
+
+watch(
+  [() => currentAssignments.data, () => reviewers.data],
+  ([assignments, reviewerList]) => {
+    if (!assignments || !reviewerList) return
+    initializing = true
+    selectedOptions.value = reviewerList
+      .filter((r) => assignments.includes(r.user))
+      .map((r) => ({ label: r.full_name, value: r.user, user_image: r.user_image }))
+    nextTick(() => {
+      initializing = false
+    })
+  },
+)
+
+watch(
+  () => props.submissionId,
+  () => {
+    selectedOptions.value = []
+    currentAssignments.reload()
+  },
+)
+
+const reviewerOptions = computed(
+  () =>
+    (reviewers.data || []).map((r) => ({
+      label: r.full_name,
+      value: r.user,
+      user_image: r.user_image,
+    })),
+)
+
+const saveResource = createResource({
+  url: 'fossunited.api.cfp.set_submission_reviewers',
+  onSuccess() {
+    toast.success('Reviewers updated')
+  },
+  onError(err) {
+    toast.error('Failed to update reviewers', { description: err.message })
+  },
+})
+
+function saveAssignments() {
+  saveResource.submit({
+    submission_name: props.submissionId,
+    reviewer_users: selectedOptions.value.map((o) => o.value),
+  })
+}
+</script>

--- a/dashboard/src/components/event/cfp/SubmissionDetails.vue
+++ b/dashboard/src/components/event/cfp/SubmissionDetails.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { createResource, LoadingIndicator, TabButtons } from 'frappe-ui'
-import { provide, ref, watch } from 'vue'
+import { provide, ref, watch, computed, inject } from 'vue'
 import SubmissionHeader from './SubmissionHeader.vue'
 import SubmissionInfoList from './SubmissionInfoList.vue'
 import SubmissionOverview from './SubmissionOverview.vue'
@@ -41,6 +41,15 @@ const submission = createResource({
 
 provide('curr_submission', submission)
 
+const event = inject('event')
+const showAssignReviewers = computed(() => {
+  if (!props.eventId) return false
+  if (submission.data?.status !== 'Review Pending') return false
+  const startDate = event?.doc?.event_start_date
+  if (!startDate) return true
+  return new Date() < new Date(startDate)
+})
+
 watch(
   () => submissionId.value,
   (newId) => {
@@ -56,7 +65,7 @@ watch(
   <Suspense>
     <div v-if="submission.data" class="w-full p-3 sm:p-6 flex flex-col gap-4 overflow-y-scroll max-h-svh">
       <SubmissionHeader />
-      <AssignReviewers v-if="props.eventId" :submission-id="submissionId" :event-id="props.eventId" />
+      <AssignReviewers v-if="showAssignReviewers" :submission-id="submissionId" :event-id="props.eventId" />
       <SubmissionInfoList />
       <TabButtons v-if="tabs.length > 1" v-model="activeTab" class="w-fit" :buttons="tabs" />
       <SubmissionOverview v-if="activeTab === 0" />

--- a/dashboard/src/components/event/cfp/SubmissionDetails.vue
+++ b/dashboard/src/components/event/cfp/SubmissionDetails.vue
@@ -6,7 +6,11 @@ import SubmissionInfoList from './SubmissionInfoList.vue'
 import SubmissionOverview from './SubmissionOverview.vue'
 import ProposalSpeakers from '@/components/reviewers/ProposalSpeakers.vue'
 import SubmissionReviews from './SubmissionReviews.vue'
+import AssignReviewers from './AssignReviewers.vue'
 
+const props = defineProps({
+  eventId: { type: String, default: '' },
+})
 const submissionId = defineModel('submissionId', { type: String, default: '' })
 const tabs = ref([
   {
@@ -52,6 +56,7 @@ watch(
   <Suspense>
     <div v-if="submission.data" class="w-full p-3 sm:p-6 flex flex-col gap-4 overflow-y-scroll max-h-svh">
       <SubmissionHeader />
+      <AssignReviewers v-if="props.eventId" :submission-id="submissionId" :event-id="props.eventId" />
       <SubmissionInfoList />
       <TabButtons v-if="tabs.length > 1" v-model="activeTab" class="w-fit" :buttons="tabs" />
       <SubmissionOverview v-if="activeTab === 0" />

--- a/dashboard/src/components/event/cfp/SubmissionDrawer.vue
+++ b/dashboard/src/components/event/cfp/SubmissionDrawer.vue
@@ -4,9 +4,12 @@ import SubmissionDetails from './SubmissionDetails.vue'
 
 const show = defineModel('show', { type: Boolean })
 const submissionId = defineModel('submissionId', { type: String, default: '' })
+defineProps({
+  eventId: { type: String, default: '' },
+})
 </script>
 <template>
   <Drawer v-model="show" title="Submission Details">
-    <SubmissionDetails :submission-id="submissionId" />
+    <SubmissionDetails :submission-id="submissionId" :event-id="eventId" />
   </Drawer>
 </template>

--- a/dashboard/src/components/event/cfp/SubmissionListItem.vue
+++ b/dashboard/src/components/event/cfp/SubmissionListItem.vue
@@ -2,10 +2,17 @@
 import { inject } from 'vue'
 import { IconHeart, IconScale } from '@tabler/icons-vue'
 import { getStatusBadgeTheme } from '@/helpers/reviewer'
-import { Badge } from 'frappe-ui'
+import { Avatar, Badge, Tooltip } from 'frappe-ui'
 import ReviewScoreIndicator from './ReviewScoreIndicator.vue'
 import ProposalBadgeGroup from '@/components/reviewers/ProposalBadgeGroup.vue'
 import relativeTime from 'dayjs/plugin/relativeTime'
+
+function verdictLabel(u) {
+  if (!u._review_verdict) return `${u.full_name} - Review Pending`
+  if (u._review_verdict === 'Yes') return `${u.full_name} - Approved ✓`
+  if (u._review_verdict === 'No') return `${u.full_name} - Rejected ✗`
+  return `${u.full_name} - Not Sure`
+}
 
 const dayjs = inject('$dayjs')
 dayjs.extend(relativeTime)
@@ -60,6 +67,27 @@ defineEmits(['open:submission'])
       <div v-if="submission.talk_license" class="flex items-center gap-1 text-xs text-ink-gray-5">
         <IconScale size="12" />
         <span>{{ submission.talk_license }}</span>
+      </div>
+      <div v-if="submission._assigned_users?.length" class="flex items-center gap-1">
+        <Tooltip
+          v-for="u in submission._assigned_users"
+          :key="u.user"
+          :text="verdictLabel(u)"
+          placement="top"
+        >
+          <Avatar
+            :image="u.user_image"
+            :label="u.full_name"
+            size="xs"
+            class="rounded-full"
+            :class="[
+              !u._review_verdict && 'opacity-40',
+              u._review_verdict === 'Yes' && 'ring-2 ring-green-500',
+              u._review_verdict === 'No' && 'ring-2 ring-red-500',
+              u._review_verdict === 'Maybe' && 'ring-2 ring-orange-400',
+            ]"
+          />
+        </Tooltip>
       </div>
     </div>
   </div>

--- a/dashboard/src/components/event/cfp/SubmissionListItem.vue
+++ b/dashboard/src/components/event/cfp/SubmissionListItem.vue
@@ -17,12 +17,27 @@ function verdictLabel(u) {
 const dayjs = inject('$dayjs')
 dayjs.extend(relativeTime)
 
-defineProps({
+const props = defineProps({
   submission: {
     type: Object,
     required: true,
   },
+  sortBy: {
+    type: String,
+    default: 'creation_desc',
+  },
 })
+
+function sortMeta(submission, sortBy) {
+  switch (sortBy) {
+    case 'review_count_desc':
+      return `${submission._review_count ?? 0} review${(submission._review_count ?? 0) !== 1 ? 's' : ''}`
+    case 'assigned_count_desc':
+      return `${submission._assigned_users?.length ?? 0} assigned`
+    default:
+      return dayjs(submission.creation).fromNow()
+  }
+}
 
 defineEmits(['open:submission'])
 </script>
@@ -61,14 +76,14 @@ defineEmits(['open:submission'])
             <IconHeart size="14" aria-hidden="true" />
           </template>
         </Badge>
-        <span class="text-ink-gray-5">{{ dayjs(submission.creation).fromNow() }}</span>
+        <span class="text-ink-gray-5">{{ sortMeta(submission, sortBy) }}</span>
         <ReviewScoreIndicator :submission="submission" />
       </div>
       <div v-if="submission.talk_license" class="flex items-center gap-1 text-xs text-ink-gray-5">
         <IconScale size="12" />
         <span>{{ submission.talk_license }}</span>
       </div>
-      <div v-if="submission._assigned_users?.length" class="flex items-center gap-1">
+      <div v-if="submission._assigned_users?.length" class="flex items-center gap-2">
         <Tooltip
           v-for="u in submission._assigned_users"
           :key="u.user"
@@ -78,10 +93,11 @@ defineEmits(['open:submission'])
           <Avatar
             :image="u.user_image"
             :label="u.full_name"
-            size="xs"
+            size="sm"
             class="rounded-full"
             :class="[
-              !u._review_verdict && 'opacity-40',
+              !u.user_image && '!bg-ink-gray-6 !text-surface-white',
+              !u._review_verdict && 'opacity-40 ring-2 ring-outline-gray-3',
               u._review_verdict === 'Yes' && 'ring-2 ring-green-500',
               u._review_verdict === 'No' && 'ring-2 ring-red-500',
               u._review_verdict === 'Maybe' && 'ring-2 ring-orange-400',

--- a/dashboard/src/components/event/cfp/SubmissionListItem.vue
+++ b/dashboard/src/components/event/cfp/SubmissionListItem.vue
@@ -64,8 +64,12 @@ defineEmits(['open:submission'])
         {{ submission.talk_title }}
       </h4>
       <div class="flex gap-2 items-center !text-sm flex-wrap">
-        <Badge :label="submission.status" :theme="getStatusBadgeTheme(submission.status)" />
-        <Badge v-if="submission._is_reviewed === 'Yes'" label="Reviewed" theme="blue" />
+        <Tooltip text="Proposal status managed event organizer" placement="top">
+          <Badge :label="submission.status" :theme="getStatusBadgeTheme(submission.status)" />
+        </Tooltip>
+        <Tooltip v-if="submission._is_reviewed === 'Yes'" text="You've added your review" placement="top">
+          <Badge label="Reviewed" theme="blue" />
+        </Tooltip>
         <Badge
           :label="submission._likes_count"
           variant="ghost"
@@ -96,7 +100,6 @@ defineEmits(['open:submission'])
             size="sm"
             class="rounded-full"
             :class="[
-              !u.user_image && '!bg-ink-gray-6 !text-surface-white',
               !u._review_verdict && 'opacity-40 ring-2 ring-outline-gray-3',
               u._review_verdict === 'Yes' && 'ring-2 ring-green-500',
               u._review_verdict === 'No' && 'ring-2 ring-red-500',

--- a/dashboard/src/components/event/cfp/SubmissionsList.vue
+++ b/dashboard/src/components/event/cfp/SubmissionsList.vue
@@ -103,13 +103,18 @@ const sortBy = ref('creation_desc')
 const filters = useStorage(storageKey, {})
 const docfields = await getCfpFilterFields(route.params.id)
 
-const SORT_OPTIONS = [
-  { label: 'Newest first', value: 'creation_desc' },
-  { label: 'Oldest first', value: 'creation_asc' },
-  { label: 'Review count ↓', value: 'review_count_desc' },
-  { label: 'Assigned count ↓', value: 'assigned_count_desc' },
-  { label: 'Title A–Z', value: 'title_asc' },
-]
+const SORT_OPTIONS = computed(() => {
+  const options = [
+    { label: 'Newest first', value: 'creation_desc' },
+    { label: 'Oldest first', value: 'creation_asc' },
+    { label: 'Review count ↓', value: 'review_count_desc' },
+    { label: 'Title A–Z', value: 'title_asc' },
+  ]
+  if (!props.reviewerMode) {
+    options.splice(3, 0, { label: 'Assigned count ↓', value: 'assigned_count_desc' })
+  }
+  return options
+})
 
 const STATUS_OPTIONS = [
   { value: '', label: 'All', activeClass: 'bg-surface-gray-7 text-ink-white' },

--- a/dashboard/src/components/event/cfp/SubmissionsList.vue
+++ b/dashboard/src/components/event/cfp/SubmissionsList.vue
@@ -190,7 +190,7 @@ function applyFilters() {
       case 'assigned_count_desc':
         return (b._assigned_users?.length ?? 0) - (a._assigned_users?.length ?? 0)
       case 'title_asc':
-        return a.talk_title.localeCompare(b.talk_title)
+        return (a.talk_title || '').localeCompare(b.talk_title || '')
       default:
         return new Date(b.creation) - new Date(a.creation)
     }

--- a/dashboard/src/components/event/cfp/SubmissionsList.vue
+++ b/dashboard/src/components/event/cfp/SubmissionsList.vue
@@ -35,7 +35,16 @@
           <Switch v-if="reviewerMode" v-model="showAssignedOnly" label="Assigned to me" />
         </Tooltip>
       </div>
-      <span class="text-xs text-ink-gray-5">Count: {{ cfpSubmissions.data?.length }}</span>
+      <div class="flex items-center gap-2">
+        <FormControl
+          v-model="sortBy"
+          type="select"
+          :options="SORT_OPTIONS"
+          size="sm"
+          class="text-xs"
+        />
+        <span class="text-xs text-ink-gray-5 whitespace-nowrap">Count: {{ cfpSubmissions.data?.length }}</span>
+      </div>
     </div>
   </div>
 
@@ -89,8 +98,17 @@ const searchQuery = ref('')
 const selectedStatus = ref('')
 const showNotReviewed = ref(true)
 const showAssignedOnly = ref(true)
+const sortBy = ref('creation_desc')
 const filters = useStorage(storageKey, {})
 const docfields = await getCfpFilterFields(route.params.id)
+
+const SORT_OPTIONS = [
+  { label: 'Newest first', value: 'creation_desc' },
+  { label: 'Oldest first', value: 'creation_asc' },
+  { label: 'Review count ↓', value: 'review_count_desc' },
+  { label: 'Assigned count ↓', value: 'assigned_count_desc' },
+  { label: 'Title A–Z', value: 'title_asc' },
+]
 
 const STATUS_OPTIONS = [
   { value: '', label: 'All', activeClass: 'bg-surface-gray-7 text-ink-white' },
@@ -157,10 +175,25 @@ function applyFilters() {
     data = filterSubmissions(data, fieldFilters)
   }
 
+  data = [...data].sort((a, b) => {
+    switch (sortBy.value) {
+      case 'creation_asc':
+        return new Date(a.creation) - new Date(b.creation)
+      case 'review_count_desc':
+        return (b._review_count ?? 0) - (a._review_count ?? 0)
+      case 'assigned_count_desc':
+        return (b._assigned_users?.length ?? 0) - (a._assigned_users?.length ?? 0)
+      case 'title_asc':
+        return a.talk_title.localeCompare(b.talk_title)
+      default:
+        return new Date(b.creation) - new Date(a.creation)
+    }
+  })
+
   cfpSubmissions.data = data
 }
 
-watch([filters, searchQuery, selectedStatus], applyFilters, { deep: true })
+watch([filters, searchQuery, selectedStatus, sortBy], applyFilters, { deep: true })
 watch([showNotReviewed, showAssignedOnly], applyFilters)
 
 function handleOpenSubmission(submission) {

--- a/dashboard/src/components/event/cfp/SubmissionsList.vue
+++ b/dashboard/src/components/event/cfp/SubmissionsList.vue
@@ -57,6 +57,7 @@
       v-for="submission in cfpSubmissions.data"
       :key="submission.name"
       :submission="submission"
+      :sort-by="sortBy"
       tabindex="0"
       @open:submission="handleOpenSubmission($event)"
     />

--- a/dashboard/src/pages/EventCfpInsights.vue
+++ b/dashboard/src/pages/EventCfpInsights.vue
@@ -60,11 +60,11 @@ provide('refreshSubmissions', refreshSubmissions)
       </Suspense>
     </div>
     <div v-if="!isSmallScreen" class="flex w-full basis-3/5 shrink-0">
-      <SubmissionDetails v-if="selectedSubmission" v-model:submission-id="selectedSubmission" />
+      <SubmissionDetails v-if="selectedSubmission" v-model:submission-id="selectedSubmission" :event-id="route.params.id" />
       <div v-else class="w-full h-svh flex items-center justify-center text-base text-ink-gray-5">
         Select a submission to view details.
       </div>
     </div>
-    <SubmissionDrawer v-else v-model:show="showDrawer" :submission-id="selectedSubmission" />
+    <SubmissionDrawer v-else v-model:show="showDrawer" :submission-id="selectedSubmission" :event-id="route.params.id" />
   </div>
 </template>

--- a/dashboard/src/pages/reviewers/ReviewPage.vue
+++ b/dashboard/src/pages/reviewers/ReviewPage.vue
@@ -38,7 +38,7 @@
 </template>
 <script setup>
 import { createResource, usePageMeta, LoadingIndicator } from 'frappe-ui'
-import { computed, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { isSmallScreen } from '@/helpers/utils'
 import ProposalDetailsDrawer from '@/components/reviewers/ProposalDetailsDrawer.vue'
@@ -61,6 +61,12 @@ const handleOpenSubmission = (submission) => {
     showDrawer.value = true
   }
 }
+
+onMounted(() => {
+  if (route.query.submission) {
+    handleOpenSubmission(route.query.submission)
+  }
+})
 
 watch(
   () => route.params.id,

--- a/docs/docs/event-cfp.md
+++ b/docs/docs/event-cfp.md
@@ -51,3 +51,13 @@ event.
 **Note:** Please note that responses to custom fields in the CFP form cannot
 be downloaded using the `"Download"` button on the `"Insights"` tab. Please
 reach out to the Foundation if and when that information is required.
+
+## Assign reviewers to a proposal
+
+From the **Insights** tab, click any proposal to open its detail panel. If the event is upcoming and the proposal is in **Review Pending** status, an **Assign Reviewers** section appears at the top.
+
+- Select one or more reviewers from the dropdown (any user with the **CFP Reviewer** role appears here)
+- Click **Save** - each newly assigned reviewer receives an email notification with a link to the reviewer dashboard
+- To remove a reviewer, deselect them and click **Save** - a confirmation prompt will appear before the change is applied
+
+> **Caution:** Assigning a reviewer sends them an email immediately. Removing a reviewer does not send a notification. Use this feature only to notify officially via email avoid assigning and then quickly unassigning the same person.

--- a/docs/docs/event-cfp.md
+++ b/docs/docs/event-cfp.md
@@ -60,4 +60,4 @@ From the **Insights** tab, click any proposal to open its detail panel. If the e
 - Click **Save** - each newly assigned reviewer receives an email notification with a link to the reviewer dashboard
 - To remove a reviewer, deselect them and click **Save** - a confirmation prompt will appear before the change is applied
 
-> **Caution:** Assigning a reviewer sends them an email immediately. Removing a reviewer does not send a notification. Use this feature only to notify officially via email avoid assigning and then quickly unassigning the same person.
+> **Caution:** Assigning a reviewer sends them an email immediately. Removing a reviewer does not send a notification. Use this feature to notify reviewers officially. Avoid assigning and then quickly unassigning the same person.

--- a/fossunited/api/cfp.py
+++ b/fossunited/api/cfp.py
@@ -158,6 +158,8 @@ def get_cfp_submissions(event: str) -> list:
 def _get_reviewed_by_current_user(submission_names: list) -> set[str]:
     """Submission names the current user has already reviewed."""
     reviewer_profile = frappe.db.get_value(USER_PROFILE, {"email": frappe.session.user}, "name")
+    if not reviewer_profile:
+        return set()
     rows = frappe.db.get_all(
         PROPOSAL_REVIEW,
         {
@@ -410,23 +412,18 @@ def get_proposal_filter_fields(event_id: str) -> list:
 @frappe.whitelist()
 def get_cfp_reviewers(event_id: str) -> list:
     frappe.only_for([CHAPTER_MEMBER])
-    members = frappe.db.get_all(
-        "FOSS Global CFP Review Member",
-        {"parent": "Global CFP Settings"},
-        ["profile", "full_name", "user", "email"],
+    reviewer_users = frappe.db.get_all(
+        "Has Role",
+        {"role": REVIEWER, "parenttype": "User"},
+        pluck="parent",
     )
-    unique_users = [m.user for m in members if m.user]
-    user_images: dict[str, str] = {}
-    if unique_users:
-        user_images = {
-            u.name: u.user_image
-            for u in frappe.db.get_all(
-                "User", {"name": ("in", unique_users)}, ["name", "user_image"]
-            )
-        }
-    for m in members:
-        m["user_image"] = user_images.get(m.user, "")
-    return members
+    if not reviewer_users:
+        return []
+    return frappe.db.get_all(
+        "User",
+        {"name": ("in", reviewer_users), "enabled": 1},
+        ["name as user", "full_name", "user_image"],
+    )
 
 
 @frappe.whitelist()

--- a/fossunited/api/cfp.py
+++ b/fossunited/api/cfp.py
@@ -157,9 +157,7 @@ def get_cfp_submissions(event: str) -> list:
 
 def _get_reviewed_by_current_user(submission_names: list) -> set[str]:
     """Submission names the current user has already reviewed."""
-    reviewer_profile = frappe.db.get_value(
-        USER_PROFILE, {"email": frappe.session.user}, "name"
-    )
+    reviewer_profile = frappe.db.get_value(USER_PROFILE, {"email": frappe.session.user}, "name")
     rows = frappe.db.get_all(
         PROPOSAL_REVIEW,
         {
@@ -357,9 +355,7 @@ def _get_bulk_reviewed_by_user_verdict(
 # nosemgrep: guest-whitelisted-method
 @frappe.whitelist(allow_guest=True)
 def get_global_cfp_guidelines() -> dict:
-    return {
-        "guidelines": frappe.db.get_single_value("Global CFP Settings", "guidelines")
-    }
+    return {"guidelines": frappe.db.get_single_value("Global CFP Settings", "guidelines")}
 
 
 @frappe.whitelist()
@@ -411,6 +407,7 @@ def get_proposal_filter_fields(event_id: str) -> list:
     return filtered_fields
 
 
+@frappe.whitelist()
 def get_cfp_reviewers(event_id: str) -> list:
     frappe.only_for([CHAPTER_MEMBER])
     members = frappe.db.get_all(
@@ -460,6 +457,11 @@ def set_submission_reviewers(submission_name: str, reviewer_users: list) -> None
     for user in existing_set - new_set:
         frappe.delete_doc("ToDo", existing_map[user], ignore_permissions=True)
 
+    if new_set - existing_set:
+        talk_title = (
+            frappe.db.get_value(PROPOSAL, submission_name, "talk_title") or submission_name
+        )
+
     for user in new_set - existing_set:
         frappe.get_doc(
             {
@@ -468,7 +470,7 @@ def set_submission_reviewers(submission_name: str, reviewer_users: list) -> None
                 "reference_name": submission_name,
                 "allocated_to": user,
                 "assigned_by": frappe.session.user,
-                "description": f"Review CFP Submission: {submission_name}",
+                "description": f"[RP]: {talk_title}",
             }
         ).insert(ignore_permissions=True)
 

--- a/fossunited/api/cfp.py
+++ b/fossunited/api/cfp.py
@@ -1,3 +1,4 @@
+import json
 from collections import defaultdict
 
 import frappe
@@ -12,6 +13,13 @@ from fossunited.doctype_ids import (
     USER_PROFILE,
 )
 from fossunited.id.roles import CHAPTER_MEMBER, REVIEWER
+
+_EMPTY_REVIEW_STATS = {
+    "approved_percent": 0,
+    "rejected_percent": 0,
+    "unsure_percent": 0,
+    "_review_count": 0,
+}
 
 
 # nosemgrep: guest-whitelisted-method
@@ -84,18 +92,14 @@ CFP_SUBMISSION_FIELDS = [
 @frappe.whitelist()
 def get_cfp_submissions(event: str) -> list:
     """
-    Get all the submissions for the given event
+    Returns enriched submissions for an event.
 
-    Args:
-        event (str): The id of the event
-
-    Returns:
-        list: List of submissions for the given event
+    Reviewers get: _is_reviewed, _is_assigned, review percentages, speakers, likes.
+    Organizers get everything above plus _assigned_users with review verdicts per assignee.
     """
     frappe.only_for([REVIEWER, CHAPTER_MEMBER])
 
     cfp = frappe.db.get_value(EVENT_CFP, {"event": event}, "name")
-
     submissions = frappe.db.get_list(
         PROPOSAL,
         {"linked_cfp": cfp},
@@ -107,23 +111,69 @@ def get_cfp_submissions(event: str) -> list:
     if not submissions:
         return submissions
 
-    submission_names = [submission.name for submission in submissions]
+    names = [s.name for s in submissions]
+    is_organizer = CHAPTER_MEMBER in frappe.get_roles(frappe.session.user)
 
-    # Fetch review statuses in bulk
-    reviews = frappe.db.get_all(
+    # Shared data (fetched for both reviewer and organizer)
+    like_counts = _get_bulk_like_counts(names)
+    custom_answers = _get_bulk_custom_answers_data(names)
+    review_percentages = _get_bulk_review_percentages(names)
+    speakers_by = _get_bulk_speakers(names)
+    reviewed_by_me = _get_reviewed_by_current_user(names)
+
+    # Role-specific assignment enrichment
+    # Organizer: full _assigned_users list with avatars + per-user verdict (3 extra queries)
+    # Reviewer: only _is_assigned for current user (1 cheap query)
+    assignment_data = (
+        _get_organizer_assignment_data(names)
+        if is_organizer
+        else _get_reviewer_assignment_data(names)
+    )
+
+    for s in submissions:
+        s.update(
+            {
+                "_is_reviewed": "Yes" if s.name in reviewed_by_me else "No",
+                "_is_seen": s.name in reviewed_by_me,
+                "_likes_count": like_counts.get(s.name, 0),
+            }
+        )
+        s.update(assignment_data.get(s.name, {}))
+        s.update(custom_answers.get(s.name, {}))
+        s.update(review_percentages.get(s.name, _EMPTY_REVIEW_STATS))
+        speakers = speakers_by.get(s.name, [])
+        s["speakers"] = speakers
+        s["speaker_name"] = ", ".join(
+            n for n in (sp.get("full_name", "").strip() for sp in speakers) if n
+        )
+
+    return submissions
+
+
+# -- private helpers -----------------------------------------------------------
+# Each helper takes submission_names and returns a shaped dict keyed by name.
+# Keep these focused: one query concern per function.
+
+
+def _get_reviewed_by_current_user(submission_names: list) -> set[str]:
+    """Submission names the current user has already reviewed."""
+    reviewer_profile = frappe.db.get_value(
+        USER_PROFILE, {"email": frappe.session.user}, "name"
+    )
+    rows = frappe.db.get_all(
         PROPOSAL_REVIEW,
         {
             "parent": ("in", submission_names),
             "parenttype": PROPOSAL,
-            "reviewer_profile": frappe.db.get_value(
-                USER_PROFILE, {"email": frappe.session.user}, "name"
-            ),
+            "reviewer_profile": reviewer_profile,
         },
         ["parent"],
     )
-    reviewed_submissions = {review.parent for review in reviews}
+    return {r.parent for r in rows}
 
-    # Fetch like counts in bulk
+
+def _get_bulk_like_counts(submission_names: list) -> dict[str, int]:
+    """Returns {submission_name: like_count}."""
     likes = frappe.db.get_all(
         "Comment",
         {
@@ -133,18 +183,46 @@ def get_cfp_submissions(event: str) -> list:
         },
         ["reference_name"],
     )
-    like_counts = {}
+    counts: dict[str, int] = {}
     for like in likes:
-        like_counts[like.reference_name] = like_counts.get(like.reference_name, 0) + 1
+        counts[like.reference_name] = counts.get(like.reference_name, 0) + 1
+    return counts
 
-    # Reuse bulk query functions from proposal.py
-    custom_answers_data = _get_bulk_custom_answers_data(submission_names)
 
-    # Bulk fetch review percentages
-    review_percentages_data = _get_bulk_review_percentages_data(submission_names)
+def _get_bulk_review_percentages(submission_names: list) -> dict[str, dict]:
+    """Returns {submission_name: {approved_percent, rejected_percent, unsure_percent, _review_count}}."""
+    if not submission_names:
+        return {}
 
-    # Bulk fetch speakers for all submissions (outside selected range)
-    speakers_raw = frappe.db.get_all(
+    from frappe import qb
+
+    Review = qb.DocType(PROPOSAL_REVIEW)
+    rows = (
+        qb.from_(Review)
+        .select(Review.parent, Review.to_approve)
+        .where((Review.parent.isin(submission_names)) & (Review.parenttype == PROPOSAL))
+        .run(as_dict=True)
+    )
+
+    grouped: dict[str, list] = {}
+    for r in rows:
+        grouped.setdefault(r.parent, []).append(r.to_approve)
+
+    result = {}
+    for name, votes in grouped.items():
+        total = len(votes)
+        result[name] = {
+            "approved_percent": int(votes.count("Yes") / total * 100),
+            "rejected_percent": int(votes.count("No") / total * 100),
+            "unsure_percent": int(votes.count("Maybe") / total * 100),
+            "_review_count": total,
+        }
+    return result
+
+
+def _get_bulk_speakers(submission_names: list) -> dict[str, list]:
+    """Returns {submission_name: [speaker_dict, ...]}."""
+    raw = frappe.db.get_all(
         SPEAKER,
         {"parent": ("in", submission_names)},
         [
@@ -158,159 +236,130 @@ def get_cfp_submissions(event: str) -> list:
             "bio",
         ],
     )
-    speakers_by_submission = defaultdict(list)
-
-    for s in speakers_raw:
-        speakers_by_submission[s["parent"]].append(s)
-
-    # Fetch assignment status in bulk
-    assigned_todos = frappe.db.get_all(
-        "ToDo",
-        {
-            "reference_type": PROPOSAL,
-            "reference_name": ("in", submission_names),
-            "allocated_to": frappe.session.user,
-        },
-        pluck="reference_name",
-    )
-    assigned_submissions = set(assigned_todos)
-
-    for submission in submissions:
-        is_reviewed = submission.name in reviewed_submissions
-        submission.update(
-            {
-                "_is_reviewed": "Yes" if is_reviewed else "No",
-                "_is_seen": is_reviewed,
-                "_is_assigned": "Yes" if submission.name in assigned_submissions else "No",
-            }
-        )
-        submission["_likes_count"] = like_counts.get(submission.name, 0)
-        submission.update(custom_answers_data.get(submission.name, {}))
-        submission.update(review_percentages_data.get(submission.name, {}))
-
-        speakers = speakers_by_submission.get(submission.name, [])
-        submission["speakers"] = speakers
-        submission["speaker_name"] = ", ".join(
-            name for name in ((s.get("full_name") or "").strip() for s in speakers) if name
-        )
-
-    return submissions
+    by_sub: dict[str, list] = defaultdict(list)
+    for s in raw:
+        by_sub[s["parent"]].append(s)
+    return by_sub
 
 
-def _get_bulk_review_percentages_data(submission_names: list) -> dict:
+def _get_reviewer_assignment_data(submission_names: list) -> dict[str, dict]:
     """
-    Bulk fetch review percentages for all submissions.
+    Reviewer context. Checks only the current user's ToDo assignment.
+    Returns {submission_name: {_is_assigned, _assigned_users: []}}.
+    """
+    assigned = set(
+        frappe.db.get_all(
+            "ToDo",
+            {
+                "reference_type": PROPOSAL,
+                "reference_name": ("in", submission_names),
+                "allocated_to": frappe.session.user,
+            },
+            pluck="reference_name",
+        )
+    )
+    return {
+        name: {
+            "_is_assigned": "Yes" if name in assigned else "No",
+            "_assigned_users": [],
+        }
+        for name in submission_names
+    }
 
-    Returns:
-        dict: {submission_name: {approved_percent: int, rejected_percent: int, ...}}
+
+def _get_organizer_assignment_data(submission_names: list) -> dict[str, dict]:
+    """
+    Organizer context. Fetches all assignees + their user profile data + review verdicts.
+    Returns {submission_name: {_is_assigned, _assigned_users: [{user, full_name, user_image, _review_verdict}]}}.
+    """
+    todos = frappe.db.get_all(
+        "ToDo",
+        {"reference_type": PROPOSAL, "reference_name": ("in", submission_names)},
+        ["reference_name", "allocated_to"],
+    )
+    todos_by_sub: dict[str, list] = defaultdict(list)
+    for t in todos:
+        todos_by_sub[t.reference_name].append(t.allocated_to)
+
+    # Bulk fetch user profile data for avatars
+    unique_users = {t.allocated_to for t in todos}
+    user_data: dict[str, object] = {}
+    if unique_users:
+        user_data = {
+            u.name: u
+            for u in frappe.db.get_all(
+                "User",
+                {"name": ("in", list(unique_users))},
+                ["name", "full_name", "user_image"],
+            )
+        }
+
+    verdict_by_sub = _get_bulk_reviewed_by_user_verdict(submission_names)
+    current_user = frappe.session.user
+
+    result = {}
+    for name in submission_names:
+        assignees = todos_by_sub.get(name, [])
+        verdicts = verdict_by_sub.get(name, {})
+        result[name] = {
+            "_is_assigned": "Yes" if current_user in assignees else "No",
+            "_assigned_users": [
+                {
+                    "user": email,
+                    "full_name": (user_data.get(email) or {}).get("full_name") or email,
+                    "user_image": (user_data.get(email) or {}).get("user_image") or "",
+                    "_review_verdict": verdicts.get(email),
+                }
+                for email in assignees
+            ],
+        }
+    return result
+
+
+def _get_bulk_reviewed_by_user_verdict(
+    submission_names: list,
+) -> dict[str, dict[str, str]]:
+    """
+    Maps {submission_name: {user_email: to_approve}} for organizer avatar verdict display.
+    Requires a USER_PROFILE lookup to convert reviewer_profile links → user emails.
     """
     if not submission_names:
         return {}
 
-    # Use frappe.qb for better performance
     from frappe import qb
 
     Review = qb.DocType(PROPOSAL_REVIEW)
-
-    reviews_query = (
+    rows = (
         qb.from_(Review)
-        .select(Review.parent, Review.to_approve)
+        .select(Review.parent, Review.to_approve, Review.reviewer_profile)
         .where((Review.parent.isin(submission_names)) & (Review.parenttype == PROPOSAL))
+        .run(as_dict=True)
     )
 
-    reviews_results = reviews_query.run(as_dict=True)
-
-    # Group reviews by submission and calculate percentages
-    review_percentages_data = {}
-    submission_reviews = {}
-
-    for review in reviews_results:
-        submission_name = review.parent
-        if submission_name not in submission_reviews:
-            submission_reviews[submission_name] = []
-        submission_reviews[submission_name].append(review.to_approve)
-
-    for submission_name, reviews in submission_reviews.items():
-        positive_reviews = reviews.count("Yes")
-        negative_reviews = reviews.count("No")
-        unsure_reviews = reviews.count("Maybe")
-
-        total_reviews = len(reviews)
-        if total_reviews == 0:
-            review_percentages_data[submission_name] = {
-                "approved_percent": 0,
-                "rejected_percent": 0,
-                "unsure_percent": 0,
-            }
-        else:
-            review_percentages_data[submission_name] = {
-                "approved_percent": int((positive_reviews / total_reviews) * 100),
-                "rejected_percent": int((negative_reviews / total_reviews) * 100),
-                "unsure_percent": int((unsure_reviews / total_reviews) * 100),
-            }
-
-    return review_percentages_data
-
-
-def get_review_percentages(submission: str) -> dict:
-    reviews = frappe.db.get_all(
-        PROPOSAL_REVIEW,
-        {"parent": submission, "parenttype": PROPOSAL},
-        pluck="to_approve",
-    )
-    positive_reviews = reviews.count("Yes")
-    negative_reviews = reviews.count("No")
-    unsure_reviews = reviews.count("Maybe")
-
-    total_reviews = len(reviews)
-    if total_reviews == 0:
-        return {
-            "approved_percent": 0,
-            "rejected_percent": 0,
-            "unsure_percent": 0,
+    unique_profiles = {r.reviewer_profile for r in rows if r.reviewer_profile}
+    profile_to_user: dict[str, str] = {}
+    if unique_profiles:
+        profile_to_user = {
+            p.name: p.user
+            for p in frappe.db.get_all(
+                USER_PROFILE, {"name": ("in", list(unique_profiles))}, ["name", "user"]
+            )
         }
 
-    return {
-        "approved_percent": int((positive_reviews / total_reviews) * 100),
-        "rejected_percent": int((negative_reviews / total_reviews) * 100),
-        "unsure_percent": int((unsure_reviews / total_reviews) * 100),
-    }
-
-
-def get_speakers(submission: str) -> list:
-    return frappe.db.get_all(
-        SPEAKER,
-        {"parent": submission},
-        [
-            "photo",
-            "full_name",
-            "designation",
-            "organization",
-            "linked_user",
-            "social_link",
-            "bio",
-        ],
-    )
-
-
-def get_custom_answers(submission: str) -> dict:
-    custom_answers = frappe.db.get_all("FOSS Custom Answer", {"parent": submission}, ["*"])
-
-    custom_answers_dict = {}
-
-    for answer in custom_answers:
-        custom_answers_dict[f"custom_question_{answer.idx}"] = answer.response
-
-    return custom_answers_dict
+    result: dict[str, dict] = {}
+    for r in rows:
+        user = profile_to_user.get(r.reviewer_profile)
+        if user:
+            result.setdefault(r.parent, {})[user] = r.to_approve
+    return result
 
 
 # nosemgrep: guest-whitelisted-method
 @frappe.whitelist(allow_guest=True)
 def get_global_cfp_guidelines() -> dict:
-    """
-    Get the global CFP guidelines.
-    """
-    return {"guidelines": frappe.db.get_single_value("Global CFP Settings", "guidelines")}
+    return {
+        "guidelines": frappe.db.get_single_value("Global CFP Settings", "guidelines")
+    }
 
 
 @frappe.whitelist()
@@ -360,6 +409,67 @@ def get_proposal_filter_fields(event_id: str) -> list:
         ]
 
     return filtered_fields
+
+
+def get_cfp_reviewers(event_id: str) -> list:
+    frappe.only_for([CHAPTER_MEMBER])
+    members = frappe.db.get_all(
+        "FOSS Global CFP Review Member",
+        {"parent": "Global CFP Settings"},
+        ["profile", "full_name", "user", "email"],
+    )
+    unique_users = [m.user for m in members if m.user]
+    user_images: dict[str, str] = {}
+    if unique_users:
+        user_images = {
+            u.name: u.user_image
+            for u in frappe.db.get_all(
+                "User", {"name": ("in", unique_users)}, ["name", "user_image"]
+            )
+        }
+    for m in members:
+        m["user_image"] = user_images.get(m.user, "")
+    return members
+
+
+@frappe.whitelist()
+def get_submission_reviewer_assignments(submission_name: str) -> list:
+    frappe.only_for([CHAPTER_MEMBER])
+    return frappe.db.get_all(
+        "ToDo",
+        {"reference_type": PROPOSAL, "reference_name": submission_name},
+        pluck="allocated_to",
+    )
+
+
+@frappe.whitelist()
+def set_submission_reviewers(submission_name: str, reviewer_users: list) -> None:
+    frappe.only_for([CHAPTER_MEMBER])
+    if isinstance(reviewer_users, str):
+        reviewer_users = json.loads(reviewer_users)
+
+    existing = frappe.db.get_all(
+        "ToDo",
+        {"reference_type": PROPOSAL, "reference_name": submission_name},
+        ["name", "allocated_to"],
+    )
+    existing_map = {t.allocated_to: t.name for t in existing}
+    new_set = set(reviewer_users)
+    existing_set = set(existing_map.keys())
+
+    for user in existing_set - new_set:
+        frappe.delete_doc("ToDo", existing_map[user], ignore_permissions=True)
+
+    for user in new_set - existing_set:
+        frappe.get_doc(
+            {
+                "doctype": "ToDo",
+                "reference_type": PROPOSAL,
+                "reference_name": submission_name,
+                "allocated_to": user,
+                "description": f"Review CFP Submission: {submission_name}",
+            }
+        ).insert(ignore_permissions=True)
 
 
 @frappe.whitelist()

--- a/fossunited/api/cfp.py
+++ b/fossunited/api/cfp.py
@@ -467,6 +467,7 @@ def set_submission_reviewers(submission_name: str, reviewer_users: list) -> None
                 "reference_type": PROPOSAL,
                 "reference_name": submission_name,
                 "allocated_to": user,
+                "assigned_by": frappe.session.user,
                 "description": f"Review CFP Submission: {submission_name}",
             }
         ).insert(ignore_permissions=True)

--- a/fossunited/hooks.py
+++ b/fossunited/hooks.py
@@ -86,6 +86,11 @@ doc_events = {
             "fossunited.ticketing.doctype.foss_event_ticket.foss_event_ticket.validate_payment_before_insert"
         ],
     },
+    # ToDO email is sent by frappe only when assigned from desk, we will have custom mail
+    # when a reviewer is assigned to a proposal so we give dashboard link itself to open
+    "ToDo": {
+        "after_insert": "fossunited.utils.notifications.notify_cfp_reviewer_assignment",
+    },
 }
 
 website_redirects = [

--- a/fossunited/utils/notifications.py
+++ b/fossunited/utils/notifications.py
@@ -1,6 +1,16 @@
 import frappe
+from frappe.desk.doctype.notification_log.notification_log import (
+    enqueue_create_notification,
+)
 
-from fossunited.doctype_ids import CAMPAIGN, CHAPTER, EMAIL_GROUP, EVENT
+from fossunited.doctype_ids import (
+    CAMPAIGN,
+    CHAPTER,
+    EMAIL_GROUP,
+    EVENT,
+    EVENT_CFP,
+    PROPOSAL,
+)
 
 
 def send_event_feedback_request(event_id):
@@ -63,4 +73,55 @@ for the broader community.</p><br/>
     frappe.log_error(
         title=f"Feedback email sent: {event_id}",
         message=f"Campaign {newsletter.name} sent to groups: {email_groups}",
+    )
+
+
+def notify_cfp_reviewer_assignment(doc, method=None) -> None:
+    """
+    doc_events hook: ToDo → after_insert.
+    Sends in-app + email notification when a CFP submission is assigned to a reviewer,
+    sending URL to the reviewer dashboard instead of the Frappe desk form.
+    """
+    if doc.reference_type != PROPOSAL:
+        return
+
+    assigned_by = doc.assigned_by or frappe.session.user
+    if assigned_by == doc.allocated_to:
+        return
+
+    submission = frappe.db.get_value(
+        PROPOSAL, doc.reference_name, ["linked_cfp", "talk_title"], as_dict=True
+    )
+    if not submission:
+        return
+
+    event_id = frappe.db.get_value(EVENT_CFP, submission.linked_cfp, "event")
+    if not event_id:
+        return
+
+    event_name = frappe.db.get_value(EVENT, event_id, "event_name") or event_id
+    assigner_name = frappe.get_cached_value("User", assigned_by, "full_name") or assigned_by
+    dashboard_url = (
+        f"{frappe.utils.get_url()}/dashboard/review/{event_id}?submission={doc.reference_name}"
+    )
+
+    subject = f'{assigner_name} assigned you a proposal to review: "{submission.talk_title}"'
+    email_content = f"""
+        <p><b>{assigner_name}</b> has assigned you a proposal to review
+        for <b>{event_name}</b>:</p>
+        <p style="margin: 12px 0; font-size: 15px;"><b>{submission.talk_title}</b></p>
+        <p><a href="{dashboard_url}">Open Reviewer Dashboard →</a></p>
+    """
+
+    enqueue_create_notification(
+        doc.allocated_to,
+        {
+            "type": "Assignment",
+            "document_type": PROPOSAL,
+            "document_name": doc.reference_name,
+            "subject": subject,
+            "from_user": assigned_by,
+            "email_content": email_content,
+            "link": dashboard_url,
+        },
     )

--- a/fossunited/utils/notifications.py
+++ b/fossunited/utils/notifications.py
@@ -105,12 +105,15 @@ def notify_cfp_reviewer_assignment(doc, method=None) -> None:
         f"{frappe.utils.get_url()}/dashboard/review/{event_id}?submission={doc.reference_name}"
     )
 
-    subject = f'{assigner_name} assigned you a proposal to review: "{submission.talk_title}"'
+    subject = f'New proposal to review: "{submission.talk_title}"'
     email_content = f"""
-        <p><b>{assigner_name}</b> has assigned you a proposal to review
-        for <b>{event_name}</b>:</p>
-        <p style="margin: 12px 0; font-size: 15px;"><b>{submission.talk_title}</b></p>
-        <p><a href="{dashboard_url}">Open Reviewer Dashboard →</a></p>
+        <p style="margin: 0 0 8px;">
+          <b>{assigner_name}</b> assigned you a proposal for <b>{event_name}</b>:
+        </p>
+        <p style="margin: 0 0 16px; font-size: 15px;"><b>{submission.talk_title}</b></p>
+        <a href="{dashboard_url}" style="display:inline-block; padding: 8px 16px; background:#2d6a4f; color:#fff; border-radius:6px; text-decoration:none; font-size:14px;">
+          Open Reviewer Dashboard
+        </a>
     """
 
     enqueue_create_notification(

--- a/fossunited/utils/notifications.py
+++ b/fossunited/utils/notifications.py
@@ -100,7 +100,6 @@ def notify_cfp_reviewer_assignment(doc, method=None) -> None:
         return
 
     event_name = frappe.db.get_value(EVENT, event_id, "event_name") or event_id
-    assigner_name = frappe.get_cached_value("User", assigned_by, "full_name") or assigned_by
     dashboard_url = (
         f"{frappe.utils.get_url()}/dashboard/review/{event_id}?submission={doc.reference_name}"
     )
@@ -108,7 +107,7 @@ def notify_cfp_reviewer_assignment(doc, method=None) -> None:
     subject = f'New proposal to review: "{submission.talk_title}"'
     email_content = f"""
         <p style="margin: 0 0 8px;">
-          <b>{assigner_name}</b> assigned you a proposal for <b>{event_name}</b>:
+          You have been assigned a proposal to review for <b>{event_name}</b>:
         </p>
         <p style="margin: 0 0 16px; font-size: 15px;"><b>{submission.talk_title}</b></p>
         <a href="{dashboard_url}" style="display:inline-block; padding: 8px 16px; background:#2d6a4f; color:#fff; border-radius:6px; text-decoration:none; font-size:14px;">


### PR DESCRIPTION
- Frappe has "ToDo" doctype which is meant to assign a doctype to work on and reminds as task tracking
- We've given IndiaFOSS co-chair desk access so they can assign user (email) to proposal they want people to review
  But with desk we fall to frappe's default way of sending hard coded notification which points to desk url (/app/doctype/...) although i've made sure to provide desk for review, we will still follow dashboard mode of approach since it can solve some UX issues.

- have added sort_by option so proposals list can be sorted based on: created date (old or newest first), review counts, assigned counts, title

- Not reinventing the wheel, just reusing the code and adapting to our platform need

Workflow:

- In "Manage chapter" organizer can goto > Cfp > Insights to see proposals list
- for each proposal they can assign multiple reviewers to it (completion populated for global reviewers)
- if assigned, the reviewer will receive email notification on the same to open "reviewers dashboard" to add review
- the list will also show who all have been assigned to in avatar with border-ring color to indicate their choice

Note :: No "ToDo" is marked as completed, since we decided to keep it open and we dont really track it (we track only review table). We can close it and show in UI otherways.. but rahul denied

Edit:
[2026-06-02]
- Query for reviewers by role so completions show for all
- Added small docs to inform the same with help tooltip icon
- Assigning only shows if event is upcoming and proposal is under "Review pending" only
- Confirm dialog before removing someone, since they won't be assigned anymore

https://github.com/user-attachments/assets/55e7e036-3ad3-4ba2-a0bd-3ca4f5f1cc19

