### PR TITLE
refactor(tests): use factories for emailing, scheduled tasks, likes, and rsvp tests

### DIFF
--- a/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
+++ b/fossunited/chapters/doctype/foss_event_rsvp_submission/test_foss_event_rsvp_submission.py
@@ -3,29 +3,32 @@ from faker import Faker
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_days, nowdate
 
-from fossunited.doctype_ids import CHAPTER, EVENT, EVENT_RSVP
-from fossunited.tests.utils import (
-    insert_rsvp_form,
-    insert_rsvp_submission,
-    insert_test_chapter,
-    insert_test_event,
+from fossunited.doctype_ids import EVENT, EVENT_RSVP
+from fossunited.tests.factories.foss_chapter_event_factory import FOSSChapterEventFactory
+from fossunited.tests.factories.foss_chapter_factory import FOSSChapterFactory
+from fossunited.tests.factories.foss_event_rsvp_factory import FOSSEventRSVPFactory
+from fossunited.tests.factories.foss_event_rsvp_submission_factory import (
+    FOSSEventRSVPSubmissionFactory,
 )
+from fossunited.tests.factories.user_factory import UserFactory
 
 fake = Faker()
-
-WEBSITE_USER = "test2@example.com"
-CORE_TEAM = "test1@example.com"
 
 
 class TestFOSSEventRSVPSubmission(FrappeTestCase):
     def setUp(self):
-        self.chapter = insert_test_chapter(members=[CORE_TEAM])
-        self.event = insert_test_event(
-            chapter=self.chapter,
+        self.core_team_user = UserFactory.create("with_foss_website_user_role")
+        self.website_user = UserFactory.create("with_foss_website_user_role")
+
+        self.chapter = FOSSChapterFactory.create(
+            "with_members", members=[self.core_team_user.name]
+        )
+        self.event = FOSSChapterEventFactory.create(
+            chapter=self.chapter.name,
             event_start_date=add_days(nowdate(), -1),
             event_end_date=add_days(nowdate(), 1),
         )
-        self.rsvp = insert_rsvp_form(event=self.event.name)
+        self.rsvp = FOSSEventRSVPFactory.create(event=self.event.name)
         self.email_group = frappe.db.get_value(
             "Email Group",
             {
@@ -35,146 +38,110 @@ class TestFOSSEventRSVPSubmission(FrappeTestCase):
             },
         )
 
-    def tearDown(self):
-        frappe.set_user("Administrator")
-        frappe.delete_doc(CHAPTER, self.chapter.name, force=True)
-        frappe.delete_doc(EVENT, self.event.name, force=True)
-        frappe.delete_doc(EVENT_RSVP, self.rsvp.name, force=True)
-
     def test_unpublish_on_max_count(self):
-        # Given an RSVP form with max count
         rsvp = self.rsvp
 
-        # We are using distinct emails here to avoid any unintended duplicate error.
-        # So that we can insert the max count of submissions
         emails = set()
         while len(emails) < int(rsvp.max_rsvp_count):
             emails.add(fake.email())
 
-        # When submission count reaches the max count
         for email in emails:
-            insert_rsvp_submission(linked_rsvp=self.rsvp.name, email=email)
+            FOSSEventRSVPSubmissionFactory.create(linked_rsvp=self.rsvp.name, email=email)
 
-        # Then the RSVP must be unpublished
         is_published = frappe.db.get_value(EVENT_RSVP, rsvp.name, "is_published")
         self.assertFalse(is_published)
 
     def test_add_to_email_group(self):
-        # Given an RSVP form for an event
-        # When an RSVP response is done by a user
-        frappe.set_user("Guest")
-        insert_rsvp_submission(
-            linked_rsvp=self.rsvp.name,
-            email=WEBSITE_USER,
-            subscribe_chapter_mailing=1,
-            status="Accepted",
-        )
+        with self.set_user("Guest"):
+            FOSSEventRSVPSubmissionFactory.create(
+                linked_rsvp=self.rsvp.name,
+                email=self.website_user.name,
+                subscribe_chapter_mailing=1,
+                confirm_attendance=1,
+                status="Accepted",
+            )
 
-        # Then the email should be added to an email group linked to event for participants
         self.assertTrue(
             frappe.db.exists(
                 "Email Group Member",
-                {"email": WEBSITE_USER, "email_group": self.email_group},
+                {"email": self.website_user.name, "email_group": self.email_group},
             )
         )
 
     def test_acceptance_workflow(self):
-        # Given an RSVP form with accept all incoming responses
         rsvp = self.rsvp
 
-        frappe.set_user("Guest")
-        # When a submission is done
-        submission = insert_rsvp_submission(linked_rsvp=rsvp.name)
+        with self.set_user("Guest"):
+            submission = FOSSEventRSVPSubmissionFactory.create(linked_rsvp=rsvp.name)
 
-        # Then the submission status should be accepted
-        self.assertTrue(submission.status, "Accepted")
+        self.assertEqual(submission.status, "Accepted")
 
     def test_pending_workflow(self):
-        # Given an rsvp with requires_host_approval = True
         rsvp = self.rsvp
         rsvp.requires_host_approval = True
         rsvp.save()
 
-        frappe.set_user("Guest")
-        # When a submission is created
-        submission = insert_rsvp_submission(linked_rsvp=rsvp.name)
+        with self.set_user("Guest"):
+            submission = FOSSEventRSVPSubmissionFactory.create(
+                linked_rsvp=rsvp.name, status="Pending"
+            )
 
-        # Then the submission status should be pending
-        self.assertTrue(submission.status, "Pending")
+        self.assertEqual(submission.status, "Pending")
 
     def test_pending_to_acceptance_workflow(self):
-        # Given an rsvp with requires_host_approval = True
         rsvp = self.rsvp
         rsvp.requires_host_approval = True
         rsvp.save()
 
-        frappe.set_user("Guest")
-        # When a submission is created
-        submission = insert_rsvp_submission(linked_rsvp=rsvp.name)
-        # The status should be pending
-        self.assertTrue(submission.status, "Pending")
+        with self.set_user("Guest"):
+            submission = FOSSEventRSVPSubmissionFactory.create(
+                linked_rsvp=rsvp.name, status="Pending"
+            )
+        self.assertEqual(submission.status, "Pending")
 
-        # Now, as the chapter member,
-        frappe.set_user("test1@example.com")
-        # We know `test1@example.com` is a chapter member
-        # because of how insert_test_chapter is implemented
-
-        # When the submission is accepted
-        submission.status = "Accepted"
-        # Then it should save without any errors
-        submission.save()
-        submission.delete(force=True, ignore_permissions=True)
+        with self.set_user(self.core_team_user.name):
+            submission.status = "Accepted"
+            submission.save()
 
     def test_invalid_status_at_creation(self):
-        # Given an rsvp with requires_host_approval = False
         rsvp = self.rsvp
         rsvp.requires_host_approval = True
         rsvp.save()
 
-        frappe.set_user("Guest")
-        # When a submission is done with status accepted
-        # Then a frappe.PermissionError should be raised
-        with self.assertRaises(frappe.PermissionError):
-            insert_rsvp_submission(linked_rsvp=rsvp.name, status="Accepted")
+        with self.set_user("Guest"), self.assertRaises(frappe.PermissionError):
+            FOSSEventRSVPSubmissionFactory.create(linked_rsvp=rsvp.name, status="Accepted")
 
     def test_status_change_after_unpublish(self):
-        # Given an RSVP form which requires host approval
-        frappe.set_user(CORE_TEAM)
-        rsvp = self.rsvp
-        rsvp.requires_host_approval = True
-        rsvp.save()
+        with self.set_user(self.core_team_user.name):
+            rsvp = self.rsvp
+            rsvp.requires_host_approval = True
+            rsvp.save()
 
-        # When a submission is done
-        frappe.set_user("Guest")
-        submission = insert_rsvp_submission(linked_rsvp=rsvp.name)
+        with self.set_user("Guest"):
+            submission = FOSSEventRSVPSubmissionFactory.create(
+                linked_rsvp=rsvp.name, status="Pending"
+            )
 
-        # It should be saved with status as pending
         self.assertEqual(submission.status, "Pending")
 
-        frappe.set_user(CORE_TEAM)
-        # When the RSVP form is unpublished
-        rsvp.is_published = False
-        rsvp.save()
-        # and the lead user / system user try to make a change to status
-        # Then the status should change without errors
-        submission.status = "Rejected"
-        submission.save()
-        submission.delete(force=True, ignore_permissions=True)
+        with self.set_user(self.core_team_user.name):
+            rsvp.is_published = False
+            rsvp.save()
+
+            submission.status = "Rejected"
+            submission.save()
 
     def test_add_to_email_on_acceptance(self):
-        # Given an RSVP form which requires host approval
-        frappe.set_user(CORE_TEAM)
-        rsvp = self.rsvp
-        rsvp.requires_host_approval = True
-        rsvp.save()
+        with self.set_user(self.core_team_user.name):
+            rsvp = self.rsvp
+            rsvp.requires_host_approval = True
+            rsvp.save()
 
-        # When a submission is made
-        frappe.set_user("Guest")
-        submission = insert_rsvp_submission(linked_rsvp=rsvp.name)
+        with self.set_user("Guest"):
+            submission = FOSSEventRSVPSubmissionFactory.create(
+                linked_rsvp=rsvp.name, status="Pending"
+            )
         self.assertEqual(submission.status, "Pending")
-
-        # Then the email should not be added to email group
-        # When status is pending
 
         self.assertFalse(
             frappe.db.exists(
@@ -186,13 +153,12 @@ class TestFOSSEventRSVPSubmission(FrappeTestCase):
             )
         )
 
-        # When status is changed to "Accepted"
-        frappe.set_user(CORE_TEAM)
-        submission.status = "Accepted"
-        submission.subscribe_chapter_mailing = 1
-        submission.save()
+        with self.set_user(self.core_team_user.name):
+            submission.status = "Accepted"
+            submission.subscribe_chapter_mailing = 1
+            submission.confirm_attendance = 1
+            submission.save()
 
-        # Then the email should be added to email group
         self.assertTrue(
             frappe.db.exists(
                 "Email Group Member",
@@ -202,23 +168,19 @@ class TestFOSSEventRSVPSubmission(FrappeTestCase):
                 },
             )
         )
-        submission.delete(force=True, ignore_permissions=True)
 
     def test_no_add_to_email_on_rejection(self):
-        # Given an RSVP form which requires host approval
-        frappe.set_user(CORE_TEAM)
-        rsvp = self.rsvp
-        rsvp.requires_host_approval = True
-        rsvp.save()
+        with self.set_user(self.core_team_user.name):
+            rsvp = self.rsvp
+            rsvp.requires_host_approval = True
+            rsvp.save()
 
-        # When a submission is made
-        frappe.set_user("Guest")
-        submission = insert_rsvp_submission(linked_rsvp=rsvp.name)
+        with self.set_user("Guest"):
+            submission = FOSSEventRSVPSubmissionFactory.create(
+                linked_rsvp=rsvp.name, status="Pending"
+            )
         self.assertEqual(submission.status, "Pending")
 
-        # Then the email should not be added to email group
-        # When status is pending
-
         self.assertFalse(
             frappe.db.exists(
                 "Email Group Member",
@@ -229,12 +191,10 @@ class TestFOSSEventRSVPSubmission(FrappeTestCase):
             )
         )
 
-        # When status is changed to "Accepted"
-        frappe.set_user(CORE_TEAM)
-        submission.status = "Rejected"
-        submission.save()
+        with self.set_user(self.core_team_user.name):
+            submission.status = "Rejected"
+            submission.save()
 
-        # Then the email should be added to email group
         self.assertFalse(
             frappe.db.exists(
                 "Email Group Member",
@@ -244,37 +204,28 @@ class TestFOSSEventRSVPSubmission(FrappeTestCase):
                 },
             )
         )
-        submission.delete(force=True, ignore_permissions=True)
 
     def test_submission_to_unpublished_form(self):
-        # Given an rsvp form which is unpublished
         rsvp = self.rsvp
         rsvp.is_published = False
         rsvp.save()
 
-        # When a user tries to create a submission
-        # Then a validation error must be thrown
-
-        frappe.set_user("Guest")
-        with self.assertRaises(frappe.ValidationError):
-            insert_rsvp_submission(linked_rsvp=rsvp.name)
+        with self.set_user("Guest"), self.assertRaises(frappe.ValidationError):
+            FOSSEventRSVPSubmissionFactory.create(linked_rsvp=rsvp.name)
 
     def test_email_group_is_not_duplicated(self):
-        frappe.set_user("Guest")
+        with self.set_user("Guest"):
+            FOSSEventRSVPSubmissionFactory.create(
+                linked_rsvp=self.rsvp.name,
+                email=fake.unique.email(),
+                subscribe_chapter_mailing=1,
+            )
 
-        # First submission
-        sub1 = insert_rsvp_submission(
-            linked_rsvp=self.rsvp.name,
-            email="test@example.com",
-            subscribe_chapter_mailing=1,
-        )
-
-        # Trigger again by second submission
-        sub2 = insert_rsvp_submission(
-            linked_rsvp=self.rsvp.name,
-            email="another@example.com",
-            subscribe_chapter_mailing=1,
-        )
+            FOSSEventRSVPSubmissionFactory.create(
+                linked_rsvp=self.rsvp.name,
+                email=fake.unique.email(),
+                subscribe_chapter_mailing=1,
+            )
 
         group_count = frappe.db.count(
             "Email Group",
@@ -285,112 +236,88 @@ class TestFOSSEventRSVPSubmission(FrappeTestCase):
             },
         )
 
-        # Only one email group should exist
         self.assertEqual(group_count, 1)
-        sub1.delete(force=True, ignore_permissions=True)
-        sub2.delete(force=True, ignore_permissions=True)
 
     def test_unsubscribe_from_email_group(self):
-        frappe.set_user("Guest")
+        subscriber_email = fake.unique.email()
 
-        # First subscribe
-        submission = insert_rsvp_submission(
-            linked_rsvp=self.rsvp.name,
-            email="unsubscribe@example.com",
-            subscribe_chapter_mailing=True,
-        )
+        with self.set_user("Guest"):
+            submission = FOSSEventRSVPSubmissionFactory.create(
+                linked_rsvp=self.rsvp.name,
+                email=subscriber_email,
+                subscribe_chapter_mailing=1,
+                confirm_attendance=1,
+            )
 
-        # Confirm user is added
         self.assertTrue(
             frappe.db.exists(
                 "Email Group Member",
-                {"email": "unsubscribe@example.com", "email_group": self.email_group},
+                {"email": subscriber_email, "email_group": self.email_group},
             )
         )
 
-        # Unsubscribe
-        frappe.set_user(CORE_TEAM)  # So user can update doc
-        submission.subscribe_chapter_mailing = 0
-        submission.confirm_attendance = 0
-        submission.save()
+        with self.set_user(self.core_team_user.name):
+            submission.subscribe_chapter_mailing = 0
+            submission.confirm_attendance = 0
+            submission.save()
 
-        # Confirm user is removed
         self.assertFalse(
             frappe.db.exists(
                 "Email Group Member",
-                {"email": "unsubscribe@example.com", "email_group": self.email_group},
+                {"email": subscriber_email, "email_group": self.email_group},
             )
         )
-        submission.delete(force=True, ignore_permissions=True)
 
     def test_successful_checkin(self):
-        frappe.set_user(CORE_TEAM)
+        with self.set_user(self.core_team_user.name):
+            submission = FOSSEventRSVPSubmissionFactory.create(linked_rsvp=self.rsvp.name)
 
-        submission = insert_rsvp_submission(linked_rsvp=self.rsvp.name)
+            submission.add_check_in()
 
-        submission.add_check_in()
-
-        self.assertEqual(len(submission.check_ins), 1)
-        self.assertTrue(submission.has_checked_in_today())
-
-        submission.delete(force=True, ignore_permissions=True)
+            self.assertEqual(len(submission.check_ins), 1)
+            self.assertTrue(submission.has_checked_in_today())
 
     def test_double_checkin_same_day_fails(self):
-        frappe.set_user(CORE_TEAM)
+        with self.set_user(self.core_team_user.name):
+            submission = FOSSEventRSVPSubmissionFactory.create(linked_rsvp=self.rsvp.name)
 
-        submission = insert_rsvp_submission(linked_rsvp=self.rsvp.name)
-
-        submission.add_check_in()
-
-        with self.assertRaises(frappe.ValidationError):
             submission.add_check_in()
 
-        submission.delete(force=True, ignore_permissions=True)
+            with self.assertRaises(frappe.ValidationError):
+                submission.add_check_in()
 
     def test_checkin_outside_event_dates_fails(self):
-        frappe.set_user(CORE_TEAM)
+        with self.set_user(self.core_team_user.name):
+            event = frappe.get_doc(EVENT, self.event.name)
+            event.event_start_date = add_days(nowdate(), -10)
+            event.event_end_date = add_days(nowdate(), -5)
+            event.save()
 
-        # Event is in the past
-        event = frappe.get_doc(EVENT, self.event.name)
-        event.event_start_date = add_days(nowdate(), -10)
-        event.event_end_date = add_days(nowdate(), -5)
-        event.save()
+            submission = FOSSEventRSVPSubmissionFactory.create(linked_rsvp=self.rsvp.name)
 
-        submission = insert_rsvp_submission(linked_rsvp=self.rsvp.name)
-
-        with self.assertRaises(frappe.ValidationError):
-            submission.add_check_in()
-
-        submission.delete(force=True, ignore_permissions=True)
+            with self.assertRaises(frappe.ValidationError):
+                submission.add_check_in()
 
     def test_has_checked_in_today_initially_false(self):
-        frappe.set_user(CORE_TEAM)
+        with self.set_user(self.core_team_user.name):
+            submission = FOSSEventRSVPSubmissionFactory.create(linked_rsvp=self.rsvp.name)
 
-        submission = insert_rsvp_submission(linked_rsvp=self.rsvp.name)
-
-        self.assertFalse(submission.has_checked_in_today())
-
-        submission.delete(force=True, ignore_permissions=True)
+            self.assertFalse(submission.has_checked_in_today())
 
     def test_can_check_in_only_during_event_days(self):
-        frappe.set_user(CORE_TEAM)
+        with self.set_user(self.core_team_user.name):
+            submission = FOSSEventRSVPSubmissionFactory.create(linked_rsvp=self.rsvp.name)
 
-        submission = insert_rsvp_submission(linked_rsvp=self.rsvp.name)
+            event = frappe.get_doc(EVENT, self.event.name)
+            event.event_start_date = add_days(nowdate(), 1)
+            event.event_end_date = add_days(nowdate(), 2)
+            event.save()
 
-        # --- Case 1: Before event starts (should be False) ---
-        event = frappe.get_doc(EVENT, self.event.name)
-        event.event_start_date = add_days(nowdate(), 1)  # starts tomorrow
-        event.event_end_date = add_days(nowdate(), 2)
-        event.save()
+            self.assertFalse(submission.can_check_in(event.event_start_date, event.event_end_date))
 
-        self.assertFalse(submission.can_check_in(event.event_start_date, event.event_end_date))
+            event = frappe.get_doc(EVENT, self.event.name)
+            event.event_start_date = add_days(nowdate(), -1)
+            event.event_end_date = add_days(nowdate(), 1)
+            event.save()
 
-        # --- Case 2: During event (should be True) ---
-        event = frappe.get_doc(EVENT, self.event.name)
-        event.event_start_date = add_days(nowdate(), -1)
-        event.event_end_date = add_days(nowdate(), 1)
-        event.save()
-
-        self.assertTrue(submission.can_check_in(event.event_start_date, event.event_end_date))
-
-        submission.delete(force=True, ignore_permissions=True)
+            self.assertTrue(submission.can_check_in(event.event_start_date, event.event_end_date))

--- a/fossunited/tests/factories/__init__.py
+++ b/fossunited/tests/factories/__init__.py
@@ -14,6 +14,17 @@ from fossunited.tests.factories.foss_event_ticket_factory import FOSSEventTicket
 from fossunited.tests.factories.foss_event_ticket_transfer_factory import (
     FOSSEventTicketTransferFactory,
 )
+from fossunited.tests.factories.foss_hackathon_factory import FOSSHackathonFactory
+from fossunited.tests.factories.foss_hackathon_join_team_request_factory import (
+    FOSSHackathonJoinTeamRequestFactory,
+)
+from fossunited.tests.factories.foss_hackathon_localhost_factory import (
+    FOSSHackathonLocalHostFactory,
+)
+from fossunited.tests.factories.foss_hackathon_participant_factory import (
+    FOSSHackathonParticipantFactory,
+)
+from fossunited.tests.factories.foss_hackathon_team_factory import FOSSHackathonTeamFactory
 from fossunited.tests.factories.razorpay_payment_factory import RazorpayPaymentFactory
 from fossunited.tests.factories.user_factory import UserFactory, get_foss_profile_id
 
@@ -26,6 +37,11 @@ __all__ = [
     "FOSSEventRSVPSubmissionFactory",
     "FOSSEventTicketFactory",
     "FOSSEventTicketTransferFactory",
+    "FOSSHackathonFactory",
+    "FOSSHackathonJoinTeamRequestFactory",
+    "FOSSHackathonLocalHostFactory",
+    "FOSSHackathonParticipantFactory",
+    "FOSSHackathonTeamFactory",
     "RazorpayPaymentFactory",
     "UserFactory",
     "get_foss_profile_id",

--- a/fossunited/tests/factories/foss_hackathon_factory.py
+++ b/fossunited/tests/factories/foss_hackathon_factory.py
@@ -1,0 +1,48 @@
+from datetime import datetime, timedelta
+from typing import Any
+
+from faker import Faker
+from frappe_factory_bot.frappe_factory_bot.base_factory import BaseFactory
+
+from fossunited.doctype_ids import HACKATHON
+from fossunited.foss_hackathon.doctype.foss_hackathon.foss_hackathon import FOSSHackathon
+from fossunited.tests.factories.foss_chapter_factory import FOSSChapterFactory
+
+fake = Faker()
+
+
+class FOSSHackathonFactory(BaseFactory[FOSSHackathon]):
+    doctype = HACKATHON
+
+    @property
+    def default_attributes(self) -> dict[str, Any]:
+        chapter = self.overrides.get("chapter") or FOSSChapterFactory.create().name
+        return {
+            "chapter": chapter,
+            "permalink": fake.slug().replace("-", "_"),
+            "hackathon_name": fake.text(max_nb_chars=20).strip(),
+            "hackathon_type": "Hybrid",
+            "start_date": datetime.today() + timedelta(days=1),
+            "end_date": datetime.today() + timedelta(days=2),
+            "hackathon_description": "Test Hackathon",
+            "is_registration_live": 1,
+            "max_team_members": 4,
+        }
+
+    @property
+    def registration_closed(self) -> dict[str, Any]:
+        return {"is_registration_live": 0}
+
+    @property
+    def with_past_dates(self) -> dict[str, Any]:
+        return {
+            "start_date": datetime.today() - timedelta(days=10),
+            "end_date": datetime.today() - timedelta(days=5),
+        }
+
+    @property
+    def with_ongoing_dates(self) -> dict[str, Any]:
+        return {
+            "start_date": datetime.today() - timedelta(days=1),
+            "end_date": datetime.today() + timedelta(days=1),
+        }

--- a/fossunited/tests/factories/foss_hackathon_join_team_request_factory.py
+++ b/fossunited/tests/factories/foss_hackathon_join_team_request_factory.py
@@ -1,0 +1,47 @@
+from typing import Any
+
+from faker import Faker
+from frappe_factory_bot.frappe_factory_bot.base_factory import BaseFactory
+
+from fossunited.doctype_ids import JOIN_TEAM_REQUEST
+from fossunited.foss_hackathon.doctype.foss_hackathon_join_team_request.foss_hackathon_join_team_request import (
+    FOSSHackathonJoinTeamRequest,
+)
+from fossunited.tests.factories.foss_hackathon_factory import FOSSHackathonFactory
+from fossunited.tests.factories.foss_hackathon_team_factory import FOSSHackathonTeamFactory
+from fossunited.tests.factories.user_factory import UserFactory
+
+fake = Faker()
+
+
+class FOSSHackathonJoinTeamRequestFactory(BaseFactory[FOSSHackathonJoinTeamRequest]):
+    doctype = JOIN_TEAM_REQUEST
+
+    @property
+    def default_attributes(self) -> dict[str, Any]:
+        hackathon = self.overrides.get("hackathon")
+        team = self.overrides.get("team")
+
+        if not hackathon and not team:
+            hackathon_doc = FOSSHackathonFactory.create()
+            hackathon = hackathon_doc.name
+            team = FOSSHackathonTeamFactory.create(hackathon=hackathon).name
+        elif not team:
+            team = FOSSHackathonTeamFactory.create(hackathon=hackathon).name
+        elif not hackathon:
+            import frappe
+
+            hackathon = frappe.db.get_value("FOSS Hackathon Team", team, "hackathon")
+
+        requested_by = self.overrides.get("requested_by") or UserFactory.create().name
+
+        return {
+            "hackathon": hackathon,
+            "team": team,
+            "requested_by": requested_by,
+            "reciever_email": fake.email(),
+        }
+
+    @property
+    def outgoing(self) -> dict[str, Any]:
+        return {"is_outgoing_request": 1}

--- a/fossunited/tests/factories/foss_hackathon_localhost_factory.py
+++ b/fossunited/tests/factories/foss_hackathon_localhost_factory.py
@@ -1,0 +1,31 @@
+from typing import Any
+
+from faker import Faker
+from frappe_factory_bot.frappe_factory_bot.base_factory import BaseFactory
+
+from fossunited.doctype_ids import HACKATHON_LOCALHOST
+from fossunited.foss_hackathon.doctype.foss_hackathon_localhost.foss_hackathon_localhost import (
+    FOSSHackathonLocalHost,
+)
+from fossunited.tests.factories.foss_hackathon_factory import FOSSHackathonFactory
+
+fake = Faker()
+
+
+class FOSSHackathonLocalHostFactory(BaseFactory[FOSSHackathonLocalHost]):
+    doctype = HACKATHON_LOCALHOST
+
+    @property
+    def default_attributes(self) -> dict[str, Any]:
+        parent_hackathon = (
+            self.overrides.get("parent_hackathon") or FOSSHackathonFactory.create().name
+        )
+        return {
+            "parent_hackathon": parent_hackathon,
+            "localhost_name": fake.unique.name(),
+            "is_accepting_attendees": 1,
+        }
+
+    @property
+    def closed_to_attendees(self) -> dict[str, Any]:
+        return {"is_accepting_attendees": 0}

--- a/fossunited/tests/factories/foss_hackathon_participant_factory.py
+++ b/fossunited/tests/factories/foss_hackathon_participant_factory.py
@@ -1,0 +1,36 @@
+from typing import Any
+
+from faker import Faker
+from frappe_factory_bot.frappe_factory_bot.base_factory import BaseFactory
+
+from fossunited.doctype_ids import HACKATHON_PARTICIPANT
+from fossunited.foss_hackathon.doctype.foss_hackathon_participant.foss_hackathon_participant import (
+    FOSSHackathonParticipant,
+)
+from fossunited.tests.factories.foss_hackathon_factory import FOSSHackathonFactory
+
+fake = Faker()
+
+
+class FOSSHackathonParticipantFactory(BaseFactory[FOSSHackathonParticipant]):
+    doctype = HACKATHON_PARTICIPANT
+
+    @property
+    def default_attributes(self) -> dict[str, Any]:
+        hackathon = self.overrides.get("hackathon") or FOSSHackathonFactory.create().name
+        return {
+            "hackathon": hackathon,
+            "full_name": fake.name(),
+            "email": fake.unique.email(),
+        }
+
+    @property
+    def with_user(self) -> dict[str, Any]:
+        from fossunited.tests.factories.user_factory import UserFactory
+
+        user = self.overrides.get("user") or UserFactory.create().name
+        return {"user": user}
+
+    @property
+    def attending_locally(self) -> dict[str, Any]:
+        return {"wants_to_attend_locally": 1}

--- a/fossunited/tests/factories/foss_hackathon_team_factory.py
+++ b/fossunited/tests/factories/foss_hackathon_team_factory.py
@@ -1,0 +1,28 @@
+from typing import Any
+
+from faker import Faker
+from frappe_factory_bot.frappe_factory_bot.base_factory import BaseFactory
+
+from fossunited.doctype_ids import HACKATHON_TEAM
+from fossunited.foss_hackathon.doctype.foss_hackathon_team.foss_hackathon_team import (
+    FOSSHackathonTeam,
+)
+from fossunited.tests.factories.foss_hackathon_factory import FOSSHackathonFactory
+
+fake = Faker()
+
+
+class FOSSHackathonTeamFactory(BaseFactory[FOSSHackathonTeam]):
+    doctype = HACKATHON_TEAM
+
+    @property
+    def default_attributes(self) -> dict[str, Any]:
+        hackathon = self.overrides.get("hackathon") or FOSSHackathonFactory.create().name
+        return {
+            "hackathon": hackathon,
+            "team_name": fake.unique.name(),
+        }
+
+    @property
+    def looking_for_members(self) -> dict[str, Any]:
+        return {"looking_for_members": 1}

--- a/fossunited/tests/test_emailing.py
+++ b/fossunited/tests/test_emailing.py
@@ -10,86 +10,66 @@ from fossunited.api.emailing import (
     send_campaign,
     send_test_email,
 )
-from fossunited.doctype_ids import CHAPTER, EMAIL_GROUP, EVENT
-
-from .utils import insert_test_chapter, insert_test_event
+from fossunited.doctype_ids import EMAIL_GROUP
+from fossunited.tests.factories.foss_chapter_event_factory import FOSSChapterEventFactory
+from fossunited.tests.factories.foss_chapter_factory import FOSSChapterFactory
+from fossunited.tests.factories.user_factory import UserFactory
 
 fake = Faker()
 
 
 class TestEmailing(FrappeTestCase):
     def setUp(self):
-        self.core_team_email = "test1@example.com"
-        self.chapter = insert_test_chapter(members=[self.core_team_email])
-        self.event = insert_test_event(chapter=self.chapter)
+        self.core_team_user = UserFactory.create("with_foss_website_user_role")
+        self.chapter = FOSSChapterFactory.create(
+            "with_members", members=[self.core_team_user.name]
+        )
+        self.event = FOSSChapterEventFactory.create(chapter=self.chapter.name)
 
         self.setup_campaign()
 
-    def tearDown(self):
-        frappe.set_user("Administrator")
-        frappe.delete_doc(CHAPTER, self.chapter.name, force=True)
-        frappe.delete_doc(EVENT, self.event.name, force=True)
-        # Delete all email groups for the event
-        groups = frappe.get_all(
-            "Email Group",
-            filters={"reference_document": self.event.name},
-            pluck="name",
-        )
-        for group_name in groups:
-            frappe.delete_doc("Email Group", group_name, force=True)
-
     def setup_campaign(self):
-        frappe.set_user(self.core_team_email)
+        with self.set_user(self.core_team_user.name):
+            email_group = frappe.get_doc(
+                EMAIL_GROUP,
+                {
+                    "reference_document": self.event.name,
+                    "document_type": self.event.doctype,
+                    "group_type": "Event Participants",
+                },
+            )
 
-        email_group = frappe.get_doc(
-            EMAIL_GROUP,
-            {
-                "reference_document": self.event.name,
-                "document_type": self.event.doctype,
-                "group_type": "Event Participants",
-            },
-        )
+            for _ in range(3):
+                add_to_email_group(email_group.name, fake.unique.email())
 
-        recipient_emails = [
-            "test2@example.com",
-            "test3@example.com",
-            "test5@example.com",
-        ]
-        for email in recipient_emails:
-            add_to_email_group(email_group.name, email)
-
-        recipient_groups = [
-            {
-                "label": email_group.group_type,
-                "value": email_group.name,
-                "description": "",
+            recipient_groups = [
+                {
+                    "label": email_group.group_type,
+                    "value": email_group.name,
+                    "description": "",
+                }
+            ]
+            newsletter_data = {
+                "subject": fake.sentence(),
+                "content_type": "Rich Text",
+                "message": fake.paragraph(),
+                "email_group": recipient_groups,
+                "attachments": [],
             }
-        ]
-        newsletter_data = {
-            "subject": fake.sentence(),
-            "content_type": "Rich Text",
-            "message": fake.paragraph(),
-            "email_group": recipient_groups,
-            "attachments": [],
-        }
-        self.newsletter = create_newsletter_campaign(
-            data=newsletter_data,
-            reference_document=self.event.name,
-            document_type=self.event.doctype,
-            chapter=self.chapter.name,
-        )
+            self.newsletter = create_newsletter_campaign(
+                data=newsletter_data,
+                reference_document=self.event.name,
+                document_type=self.event.doctype,
+                chapter=self.chapter.name,
+            )
 
     def test_send_test_email(self):
-        frappe.set_user(self.core_team_email)
-
-        test_email = fake.email()
-
-        send_test_email(campaign_id=self.newsletter.name, email=test_email)
+        with self.set_user(self.core_team_user.name):
+            send_test_email(campaign_id=self.newsletter.name, email=fake.email())
 
     def test_send_campaign(self):
-        frappe.set_user(self.core_team_email)
-
-        send_campaign(campaign_id=self.newsletter.name)
+        with self.set_user(self.core_team_user.name):
+            send_campaign(campaign_id=self.newsletter.name)
 
     def test_create_email_group_creates_group(self):
         group = create_email_group(
@@ -104,14 +84,12 @@ class TestEmailing(FrappeTestCase):
         self.assertEqual(group.chapter, self.chapter.name)
 
     def test_create_email_group_returns_existing(self):
-        # First call creates it
         group1 = create_email_group(
             type="Event Participants",
             reference_document=self.event.name,
             document_type=self.event.doctype,
         )
 
-        # Second call should not create a new one
         group2 = create_email_group(
             type="Event Participants",
             reference_document=self.event.name,
@@ -129,7 +107,7 @@ class TestEmailing(FrappeTestCase):
             reference_document=self.event.name,
             document_type=self.event.doctype,
         )
-        email = "added@example.com"
+        email = fake.unique.email()
         add_to_email_group(group.name, email)
 
         self.assertTrue(
@@ -142,7 +120,7 @@ class TestEmailing(FrappeTestCase):
             reference_document=self.event.name,
             document_type=self.event.doctype,
         )
-        email = "remove@example.com"
+        email = fake.unique.email()
         add_to_email_group(group.name, email)
 
         self.assertTrue(
@@ -157,4 +135,4 @@ class TestEmailing(FrappeTestCase):
 
     def test_add_to_nonexistent_email_group_raises(self):
         with self.assertRaises(frappe.DoesNotExistError):
-            add_to_email_group("non-existent-group", "test@example.com")
+            add_to_email_group("non-existent-group", fake.email())

--- a/fossunited/tests/test_likes.py
+++ b/fossunited/tests/test_likes.py
@@ -2,68 +2,33 @@ import frappe
 from faker import Faker
 from frappe.tests.utils import FrappeTestCase
 
-from fossunited.doctype_ids import PROPOSAL, USER_PROFILE
-
-# Import the like functions from your module (adjust path if your module path differs)
+from fossunited.doctype_ids import PROPOSAL
 from fossunited.templates.includes.like.like import add_like, delete_like, like
-from fossunited.tests.utils import (
-    insert_cfp_form,
-    insert_cfp_submission,
-    insert_test_chapter,
-    insert_test_event,
+from fossunited.tests.factories.foss_chapter_event_factory import FOSSChapterEventFactory
+from fossunited.tests.factories.foss_chapter_factory import FOSSChapterFactory
+from fossunited.tests.factories.foss_event_cfp_submission_factory import (
+    FOSSEventCFPFactory,
+    FOSSEventCFPSubmissionFactory,
 )
+from fossunited.tests.factories.user_factory import UserFactory
 
 fake = Faker()
-CoreTeam = "test1@example.com"
 
 
 class TestLikeOnProposal(FrappeTestCase):
     def setUp(self):
-        # create the environment similar to your CFP tests
-        self.chapter = insert_test_chapter(members=[CoreTeam])
-        self.event = insert_test_event(chapter=self.chapter)
-        self.cfp = insert_cfp_form(event=self.event.name, status="Live")
+        self.core_team_user = UserFactory.create("with_foss_website_user_role")
+        self.chapter = FOSSChapterFactory.create(
+            "with_members", members=[self.core_team_user.name]
+        )
+        self.event = FOSSChapterEventFactory.create(chapter=self.chapter.name)
+        self.cfp = FOSSEventCFPFactory.create(event=self.event.name, status="Live")
 
-        speakers = [
-            {
-                "full_name": fake.name(),
-                "email": fake.email(),
-                "designation": fake.job(),
-                "organization": fake.company(),
-                "bio": "Test Submission",
-            }
-        ]
-        self.submission = insert_cfp_submission(
+        self.submission = FOSSEventCFPSubmissionFactory.create(
             linked_cfp=self.cfp.name,
             event=self.event.name,
-            speakers=speakers,
-            submitted_by=CoreTeam,
+            submitted_by=self.core_team_user.name,
         )
-
-        frappe.set_user(CoreTeam)
-
-    def tearDown(self):
-        # cleanup comments created by tests
-        frappe.set_user("Administrator")
-        frappe.db.delete(
-            "Comment",
-            {
-                "reference_doctype": PROPOSAL,
-                "reference_name": self.submission.name,
-                "comment_type": "Like",
-            },
-        )
-
-        # remove created docs
-        submissions = frappe.get_all(PROPOSAL, {"event": self.event.name}, pluck="name")
-        for submission in submissions:
-            frappe.delete_doc(PROPOSAL, submission, force=True)
-        frappe.db.delete(USER_PROFILE, {"email": CoreTeam})
-        self.cfp.delete(force=True)
-        self.event.delete(force=True)
-        self.chapter.delete(force=True)
-
-        frappe.set_user("Administrator")
 
     def _get_like_comments(self):
         return frappe.get_all(
@@ -77,150 +42,111 @@ class TestLikeOnProposal(FrappeTestCase):
         )
 
     def test_add_like_creates_comment_once(self):
-        """
-        Add a like once and assert exactly one Comment is created.
-        """
-        # ensure no likes initially
-        before = self._get_like_comments()
-        assert len(before) == 0
+        with self.set_user(self.core_team_user.name):
+            before = self._get_like_comments()
+            assert len(before) == 0
 
-        # call the backend helper directly (simulates internal call)
-        like(PROPOSAL, self.submission.name, True)
+            like(PROPOSAL, self.submission.name, True)
 
-        likes = self._get_like_comments()
-        self.assertEqual(len(likes), 1)
-        # the comment_email should match the current user
-        self.assertEqual(likes[0]["comment_email"], frappe.session.user)
+            likes = self._get_like_comments()
+            self.assertEqual(len(likes), 1)
+            self.assertEqual(likes[0]["comment_email"], frappe.session.user)
 
     def test_repeated_add_like_does_not_create_duplicates(self):
-        """
-        Repeated calls to add_like should not create multiple Comment rows for same identity.
-        """
-        # first add
-        add_like(PROPOSAL, self.submission.name)
-        # repeated add attempts
-        like(PROPOSAL, self.submission.name, True)
-        add_like(PROPOSAL, self.submission.name)
+        with self.set_user(self.core_team_user.name):
+            add_like(PROPOSAL, self.submission.name)
+            like(PROPOSAL, self.submission.name, True)
+            add_like(PROPOSAL, self.submission.name)
 
-        likes = self._get_like_comments()
-        # still only one comment for this user
-        self.assertEqual(len(likes), 1)
+            likes = self._get_like_comments()
+            self.assertEqual(len(likes), 1)
 
     def test_delete_like_removes_comment(self):
-        """
-        add then delete a like, ensure comment is removed.
-        """
-        add_like(PROPOSAL, self.submission.name)
-        add_like(PROPOSAL, self.submission.name)
-        likes = self._get_like_comments()
-        self.assertEqual(len(likes), 1)
+        with self.set_user(self.core_team_user.name):
+            add_like(PROPOSAL, self.submission.name)
+            add_like(PROPOSAL, self.submission.name)
+            likes = self._get_like_comments()
+            self.assertEqual(len(likes), 1)
 
-        delete_like(PROPOSAL, self.submission.name)
-        delete_like(PROPOSAL, self.submission.name)
-        likes_after = self._get_like_comments()
-        self.assertEqual(len(likes_after), 0)
+            delete_like(PROPOSAL, self.submission.name)
+            delete_like(PROPOSAL, self.submission.name)
+            likes_after = self._get_like_comments()
+            self.assertEqual(len(likes_after), 0)
 
     def test_different_users_create_multiple_likes(self):
-        """
-        Likes from different logged-in users should create multiple Comment rows.
-        """
-        frappe.set_user("user1@example.com")
-        add_like(PROPOSAL, self.submission.name)
+        user1 = UserFactory.create("with_foss_website_user_role")
+        user2 = UserFactory.create("with_foss_website_user_role")
 
-        frappe.set_user("user2@example.com")
-        add_like(PROPOSAL, self.submission.name)
+        with self.set_user(user1.name):
+            add_like(PROPOSAL, self.submission.name)
+
+        with self.set_user(user2.name):
+            add_like(PROPOSAL, self.submission.name)
 
         likes = self._get_like_comments()
-        # expect 2 likes (distinct comment_email)
         self.assertEqual(len(likes), 2)
         emails = {c["comment_email"] for c in likes}
-        self.assertEqual(emails, {"user1@example.com", "user2@example.com"})
-
-        # restore user for tearDown
-        frappe.set_user(CoreTeam)
+        self.assertEqual(emails, {user1.name, user2.name})
 
     def test_guest_like_uses_ip_address(self):
-        """
-        When user is Guest, the comment should store ip_address and delete_like must match ip.
-        """
-        frappe.set_user("Guest")
-        frappe.local.request_ip = "203.0.113.45"
+        with self.set_user("Guest"):
+            frappe.local.request_ip = "203.0.113.45"
 
-        # even if tried multiple
-        like(PROPOSAL, self.submission.name, True)
-        add_like(PROPOSAL, self.submission.name)
-        like(PROPOSAL, self.submission.name, True)
+            like(PROPOSAL, self.submission.name, True)
+            add_like(PROPOSAL, self.submission.name)
+            like(PROPOSAL, self.submission.name, True)
 
-        likes = frappe.get_all(
-            "Comment",
-            filters={
-                "reference_doctype": PROPOSAL,
-                "reference_name": self.submission.name,
-                "comment_type": "Like",
-                "ip_address": "203.0.113.45",
-            },
-            fields=["name"],
-        )
-        self.assertEqual(len(likes), 1)
+            likes = frappe.get_all(
+                "Comment",
+                filters={
+                    "reference_doctype": PROPOSAL,
+                    "reference_name": self.submission.name,
+                    "comment_type": "Like",
+                    "ip_address": "203.0.113.45",
+                },
+                fields=["name"],
+            )
+            self.assertEqual(len(likes), 1)
 
-        delete_like(PROPOSAL, self.submission.name)
-        likes_after = self._get_like_comments()
-        self.assertEqual(len(likes_after), 0)
+            delete_like(PROPOSAL, self.submission.name)
+            likes_after = self._get_like_comments()
+            self.assertEqual(len(likes_after), 0)
 
-        # cleanup guest state
-        frappe.local.request_ip = None
-        frappe.set_user(CoreTeam)
+            frappe.local.request_ip = None
 
     def test_get_likes_unique_guest_by_ip(self):
-        """
-        Multiple guests with different IPs should be counted separately,
-        and get_likes() should properly identify each guest's like.
-        """
-        # Guest 1 likes
-        frappe.set_user("Guest")
-        frappe.local.request_ip = "203.0.113.10"
-        add_like(PROPOSAL, self.submission.name)
+        with self.set_user("Guest"):
+            frappe.local.request_ip = "203.0.113.10"
+            add_like(PROPOSAL, self.submission.name)
 
-        # Guest 2 likes (different IP)
-        frappe.local.request_ip = "203.0.113.20"
-        add_like(PROPOSAL, self.submission.name)
+            frappe.local.request_ip = "203.0.113.20"
+            add_like(PROPOSAL, self.submission.name)
 
-        likes = self.submission.get_likes()
+            likes = self.submission.get_likes()
 
-        # Should return 2 distinct likes
-        self.assertEqual(len(likes), 2)
+            self.assertEqual(len(likes), 2)
 
-        # Both should have comment_email = "Guest" but different ip_address
-        guest_likes = [lik for lik in likes if lik.get("comment_email") == "Guest"]
-        self.assertEqual(len(guest_likes), 2)
+            guest_likes = [lik for lik in likes if lik.get("comment_email") == "Guest"]
+            self.assertEqual(len(guest_likes), 2)
 
-        ips = {lik.get("ip_address") for lik in guest_likes}
-        self.assertEqual(ips, {"203.0.113.10", "203.0.113.20"})
+            ips = {lik.get("ip_address") for lik in guest_likes}
+            self.assertEqual(ips, {"203.0.113.10", "203.0.113.20"})
 
-        frappe.local.request_ip = None
-        frappe.set_user(CoreTeam)
+            frappe.local.request_ip = None
 
     def test_context_like_flag_per_guest_ip(self):
-        """
-        Context should show like=1 only for the guest with matching IP,
-        not for all guests.
-        """
-        # Guest 1 likes
-        frappe.set_user("Guest")
-        frappe.local.request_ip = "203.0.113.10"
-        add_like(PROPOSAL, self.submission.name)
+        with self.set_user("Guest"):
+            frappe.local.request_ip = "203.0.113.10"
+            add_like(PROPOSAL, self.submission.name)
 
-        # Simulate context building for Guest 1
-        likes = self.submission.get_likes()
-        current_ip = frappe.local.request_ip
-        like_flag = 1 if any(lik.get("ip_address") == current_ip for lik in likes) else 0
-        self.assertEqual(like_flag, 1, "Guest 1 should see like=1")
+            likes = self.submission.get_likes()
+            current_ip = frappe.local.request_ip
+            like_flag = 1 if any(lik.get("ip_address") == current_ip for lik in likes) else 0
+            self.assertEqual(like_flag, 1, "Guest 1 should see like=1")
 
-        # Simulate context building for Guest 2 (different IP, hasn't liked)
-        frappe.local.request_ip = "203.0.113.99"
-        current_ip = frappe.local.request_ip
-        like_flag = 1 if any(lik.get("ip_address") == current_ip for lik in likes) else 0
-        self.assertEqual(like_flag, 0, "Guest 2 should see like=0")
+            frappe.local.request_ip = "203.0.113.99"
+            current_ip = frappe.local.request_ip
+            like_flag = 1 if any(lik.get("ip_address") == current_ip for lik in likes) else 0
+            self.assertEqual(like_flag, 0, "Guest 2 should see like=0")
 
-        frappe.local.request_ip = None
-        frappe.set_user(CoreTeam)
+            frappe.local.request_ip = None

--- a/fossunited/tests/test_rsvp_insights.py
+++ b/fossunited/tests/test_rsvp_insights.py
@@ -8,79 +8,58 @@ from fossunited.api.rsvp import (
     get_submissions_with_answers,
     if_rsvp_show_checkins,
 )
-from fossunited.doctype_ids import (
-    CHAPTER,
-    CHAPTER_MEMBER,
-    EVENT,
-    EVENT_RSVP,
-    RSVP_RESPONSE,
-    USER_PROFILE,
+from fossunited.tests.factories.foss_chapter_event_factory import FOSSChapterEventFactory
+from fossunited.tests.factories.foss_chapter_factory import FOSSChapterFactory
+from fossunited.tests.factories.foss_event_rsvp_factory import FOSSEventRSVPFactory
+from fossunited.tests.factories.foss_event_rsvp_submission_factory import (
+    FOSSEventRSVPSubmissionFactory,
 )
-from fossunited.tests.utils import (
-    insert_rsvp_form,
-    insert_rsvp_submission,
-    insert_test_chapter,
-    insert_test_event,
-)
+from fossunited.tests.factories.user_factory import UserFactory
 
 
 class TestRSVPInsightsAPI(FrappeTestCase):
     """Test cases for RSVP insights API functions."""
 
     def setUp(self):
-        self.core_team_email = "core1@example.com"
-        self.other_chapter_core = "othercore@example.com"
+        self.core_team_user = UserFactory.create("with_foss_website_user_role")
+        self.other_chapter_core_user = UserFactory.create("with_foss_website_user_role")
 
-        self.chapter = insert_test_chapter(members=[self.core_team_email])
-        self.event = insert_test_event(
-            chapter=self.chapter,
+        self.chapter = FOSSChapterFactory.create(
+            "with_members", members=[self.core_team_user.name]
+        )
+        self.event = FOSSChapterEventFactory.create(
+            chapter=self.chapter.name,
             event_start_date=add_days(now_datetime(), -1),
             event_end_date=add_days(now_datetime(), 3),
         )
-        self.rsvp = insert_rsvp_form(self.event)
+        self.rsvp = FOSSEventRSVPFactory.create(event=self.event.name)
 
-        self.other_chapter = insert_test_chapter(
-            members=[self.other_chapter_core],
+        self.other_chapter = FOSSChapterFactory.create(
+            "with_members", members=[self.other_chapter_core_user.name]
         )
 
-        self._submissions = []
-
-    def tearDown(self):
-        frappe.set_user("Administrator")
-        for sub in self._submissions:
-            frappe.delete_doc(RSVP_RESPONSE, sub.name, force=True)
-        frappe.delete_doc(EVENT_RSVP, self.rsvp.name, force=True)
-        frappe.delete_doc(EVENT, self.event.name, force=True)
-        frappe.delete_doc(CHAPTER, self.chapter.name, force=True)
-        frappe.delete_doc(CHAPTER, self.other_chapter.name, force=True)
-        frappe.db.delete(USER_PROFILE, {"email": self.core_team_email})
-        frappe.db.delete(CHAPTER_MEMBER, {"email": self.core_team_email})
-
     def test_get_submissions_guest_denied(self):
-        """Guest users should not access RSVP submissions."""
-        frappe.set_user("Guest")
-        with self.assertRaises(frappe.PermissionError):
+        with self.set_user("Guest"), self.assertRaises(frappe.PermissionError):
             get_submissions_with_answers(event_id=self.event.name)
 
     def test_get_submissions_other_chapter_core_denied(self):
-        """Core members from other chapters should not access submissions."""
-        frappe.set_user(self.other_chapter_core)
-        with self.assertRaises(frappe.PermissionError):
+        with (
+            self.set_user(self.other_chapter_core_user.name),
+            self.assertRaises(frappe.PermissionError),
+        ):
             get_submissions_with_answers(event_id=self.event.name)
 
     def test_get_submissions_chapter_core_allowed(self):
-        """Chapter core team should access submissions."""
-        # Create a submission
-        sub = insert_rsvp_submission(
+        FOSSEventRSVPSubmissionFactory.create(
             linked_rsvp=self.rsvp.name,
-            name="John Doe",
+            name1="John Doe",
             email="john@example.com",
             im_a="Student",
+            status="Pending",
         )
-        self._submissions.append(sub)
 
-        frappe.set_user(self.core_team_email)
-        result = get_submissions_with_answers(event_id=self.event.name)
+        with self.set_user(self.core_team_user.name):
+            result = get_submissions_with_answers(event_id=self.event.name)
 
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 1)
@@ -88,21 +67,20 @@ class TestRSVPInsightsAPI(FrappeTestCase):
         self.assertEqual(result[0]["email"], "john@example.com")
 
     def test_get_submissions_flattens_custom_fields(self):
-        """Custom field answers should be flattened into submission dict."""
-        sub = insert_rsvp_submission(
+        FOSSEventRSVPSubmissionFactory.create(
             linked_rsvp=self.rsvp.name,
-            name="Alice",
+            name1="Alice",
             email="alice@example.com",
             im_a="Professional",
+            status="Pending",
             custom_answers=[
                 {"question": "What's your goal?", "response": "Learn Frappe"},
                 {"question": "Experience level?", "response": "Beginner"},
             ],
         )
-        self._submissions.append(sub)
 
-        frappe.set_user(self.core_team_email)
-        result = get_submissions_with_answers(event_id=self.event.name)
+        with self.set_user(self.core_team_user.name):
+            result = get_submissions_with_answers(event_id=self.event.name)
 
         self.assertEqual(len(result), 1)
         self.assertIn("What's your goal?", result[0])
@@ -111,65 +89,61 @@ class TestRSVPInsightsAPI(FrappeTestCase):
         self.assertEqual(result[0]["Experience level?"], "Beginner")
 
     def test_get_submissions_empty_response_handled(self):
-        """Empty custom field responses should be stored as empty string."""
-        sub = insert_rsvp_submission(
+        FOSSEventRSVPSubmissionFactory.create(
             linked_rsvp=self.rsvp.name,
-            name="Bob",
+            name1="Bob",
             email="bob@example.com",
             im_a="Student",
+            status="Pending",
             custom_answers=[
                 {"question": "Optional question?", "response": None},
             ],
         )
-        self._submissions.append(sub)
 
-        frappe.set_user(self.core_team_email)
-        result = get_submissions_with_answers(event_id=self.event.name)
+        with self.set_user(self.core_team_user.name):
+            result = get_submissions_with_answers(event_id=self.event.name)
 
         self.assertIn("Optional question?", result[0])
         self.assertEqual(result[0]["Optional question?"], "")
 
     def test_get_submissions_multiple_submissions(self):
-        """Should return all submissions for the event."""
-        sub1 = insert_rsvp_submission(
+        FOSSEventRSVPSubmissionFactory.create(
             linked_rsvp=self.rsvp.name,
-            name="Alice",
+            name1="Alice",
             email="alice@example.com",
             im_a="Student",
+            status="Pending",
         )
-        sub2 = insert_rsvp_submission(
+        FOSSEventRSVPSubmissionFactory.create(
             linked_rsvp=self.rsvp.name,
-            name="Bob",
+            name1="Bob",
             email="bob@example.com",
             im_a="Professional",
+            status="Pending",
         )
-        self._submissions.extend([sub1, sub2])
 
-        frappe.set_user(self.core_team_email)
-        result = get_submissions_with_answers(event_id=self.event.name)
+        with self.set_user(self.core_team_user.name):
+            result = get_submissions_with_answers(event_id=self.event.name)
 
         self.assertEqual(len(result), 2)
         names = {r["name1"] for r in result}
         self.assertEqual(names, {"Alice", "Bob"})
 
     def test_get_checkins_guest_denied(self):
-        """Guest users should not access check-ins."""
-        frappe.set_user("Guest")
-        with self.assertRaises(frappe.PermissionError):
+        with self.set_user("Guest"), self.assertRaises(frappe.PermissionError):
             get_rsvp_checkins(event_id=self.event.name)
 
     def test_get_checkins_other_chapter_core_denied(self):
-        """Core members from other chapters should not access check-ins."""
-        frappe.set_user(self.other_chapter_core)
-        with self.assertRaises(frappe.PermissionError):
+        with (
+            self.set_user(self.other_chapter_core_user.name),
+            self.assertRaises(frappe.PermissionError),
+        ):
             get_rsvp_checkins(event_id=self.event.name)
 
     def test_get_checkins_returns_accepted_attendees_only(self):
-        """Should only return check-ins for accepted attendees."""
-        # Accepted submission with check-in
-        accepted_sub = insert_rsvp_submission(
+        accepted_sub = FOSSEventRSVPSubmissionFactory.create(
             linked_rsvp=self.rsvp.name,
-            name="Checked In User",
+            name1="Checked In User",
             email="checkedin@example.com",
             im_a="Student",
             status="Accepted",
@@ -178,20 +152,17 @@ class TestRSVPInsightsAPI(FrappeTestCase):
         accepted_sub.append("check_ins", {"check_in_time": now_datetime()})
         accepted_sub.save()
 
-        # Rejected submission (should not appear)
-        rejected_sub = insert_rsvp_submission(
+        FOSSEventRSVPSubmissionFactory.create(
             linked_rsvp=self.rsvp.name,
-            name="Rejected User",
+            name1="Rejected User",
             email="rejected@example.com",
             im_a="Student",
             status="Rejected",
             confirm_attendance=0,
         )
 
-        self._submissions.extend([accepted_sub, rejected_sub])
-
-        frappe.set_user(self.core_team_email)
-        result = get_rsvp_checkins(event_id=self.event.name)
+        with self.set_user(self.core_team_user.name):
+            result = get_rsvp_checkins(event_id=self.event.name)
 
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["name1"], "Checked In User")
@@ -199,10 +170,9 @@ class TestRSVPInsightsAPI(FrappeTestCase):
         self.assertIn("check_in_time", result[0])
 
     def test_get_checkins_ordered_by_time_desc(self):
-        """Check-ins should be ordered by time (most recent first)."""
-        sub1 = insert_rsvp_submission(
+        sub1 = FOSSEventRSVPSubmissionFactory.create(
             linked_rsvp=self.rsvp.name,
-            name="First Check-in",
+            name1="First Check-in",
             email="first@example.com",
             im_a="Student",
             status="Accepted",
@@ -211,9 +181,9 @@ class TestRSVPInsightsAPI(FrappeTestCase):
         sub1.append("check_ins", {"check_in_time": add_days(now_datetime(), -2)})
         sub1.save()
 
-        sub2 = insert_rsvp_submission(
+        sub2 = FOSSEventRSVPSubmissionFactory.create(
             linked_rsvp=self.rsvp.name,
-            name="Recent Check-in",
+            name1="Recent Check-in",
             email="recent@example.com",
             im_a="Professional",
             status="Accepted",
@@ -222,65 +192,52 @@ class TestRSVPInsightsAPI(FrappeTestCase):
         sub2.append("check_ins", {"check_in_time": now_datetime()})
         sub2.save()
 
-        self._submissions.extend([sub1, sub2])
+        with self.set_user(self.core_team_user.name):
+            result = get_rsvp_checkins(event_id=self.event.name)
 
-        frappe.set_user(self.core_team_email)
-        result = get_rsvp_checkins(event_id=self.event.name)
-
-        # Most recent should be first
         self.assertEqual(result[0]["name1"], "Recent Check-in")
         self.assertEqual(result[1]["name1"], "First Check-in")
 
     def test_show_checkins_returns_true_for_started_event(self):
-        """Should return True if event has started."""
-        frappe.set_user(self.core_team_email)
-        result = if_rsvp_show_checkins(event_id=self.event.name)
+        with self.set_user(self.core_team_user.name):
+            result = if_rsvp_show_checkins(event_id=self.event.name)
         self.assertTrue(result)
 
     def test_get_stats_guest_denied(self):
-        """Guest users should not access stats."""
-        frappe.set_user("Guest")
-        with self.assertRaises(frappe.PermissionError):
+        with self.set_user("Guest"), self.assertRaises(frappe.PermissionError):
             get_rsvp_checkin_stats(event_id=self.event.name)
 
     def test_get_stats_counts_accepted_confirmed_only(self):
-        """Should only count accepted submissions with confirmed attendance."""
-        # Accepted + Confirmed
-        accepted1 = insert_rsvp_submission(
+        FOSSEventRSVPSubmissionFactory.create(
             linked_rsvp=self.rsvp.name,
-            name="Accepted 1",
+            name1="Accepted 1",
             email="a1@example.com",
             im_a="Student",
             status="Accepted",
             confirm_attendance=1,
         )
-        accepted2 = insert_rsvp_submission(
+        FOSSEventRSVPSubmissionFactory.create(
             linked_rsvp=self.rsvp.name,
-            name="Accepted 2",
+            name1="Accepted 2",
             email="a2@example.com",
             im_a="Professional",
             status="Accepted",
             confirm_attendance=1,
         )
-
-        # Accepted but not confirmed (should not count)
-        not_confirmed = insert_rsvp_submission(
+        FOSSEventRSVPSubmissionFactory.create(
             linked_rsvp=self.rsvp.name,
-            name="Not Confirmed",
+            name1="Not Confirmed",
             email="nc@example.com",
             im_a="Student",
             status="Accepted",
             confirm_attendance=0,
         )
 
-        self._submissions.extend([accepted1, accepted2, not_confirmed])
-
-        frappe.set_user(self.core_team_email)
-        result = get_rsvp_checkin_stats(event_id=self.event.name)
+        with self.set_user(self.core_team_user.name):
+            result = get_rsvp_checkin_stats(event_id=self.event.name)
         self.assertEqual(result["total_accepted"], 2)
 
     def test_get_stats_returns_zero_for_no_submissions(self):
-        """Should return 0 when no accepted submissions exist."""
-        frappe.set_user(self.core_team_email)
-        result = get_rsvp_checkin_stats(event_id=self.event.name)
+        with self.set_user(self.core_team_user.name):
+            result = get_rsvp_checkin_stats(event_id=self.event.name)
         self.assertEqual(result["total_accepted"], 0)

--- a/fossunited/tests/test_scheduled_tasks.py
+++ b/fossunited/tests/test_scheduled_tasks.py
@@ -1,65 +1,46 @@
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
-import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from fossunited.doctype_ids import CHAPTER, EVENT, EVENT_CFP, EVENT_RSVP
 from fossunited.scheduled_tasks import conclude_events
-
-from .utils import (
-    insert_cfp_form,
-    insert_rsvp_form,
-    insert_test_chapter,
-    insert_test_event,
-)
+from fossunited.tests.factories.foss_chapter_event_factory import FOSSChapterEventFactory
+from fossunited.tests.factories.foss_chapter_factory import FOSSChapterFactory
+from fossunited.tests.factories.foss_event_cfp_submission_factory import FOSSEventCFPFactory
+from fossunited.tests.factories.foss_event_rsvp_factory import FOSSEventRSVPFactory
 
 
 class TestScheduledTasks(FrappeTestCase):
     def setUp(self):
         today = datetime.today()
-        self.chapter = insert_test_chapter()
+        self.chapter = FOSSChapterFactory.create()
 
-        # Event 1 is live and is to end tomorrow
-        self.event1 = insert_test_event(
-            chapter=self.chapter,
+        self.event1 = FOSSChapterEventFactory.create(
+            chapter=self.chapter.name,
             status="Live",
             event_start_date=today.replace(hour=9, minute=00),
             event_end_date=today.replace(hour=15, minute=30),
         )
+        self.event1_cfp = FOSSEventCFPFactory.create(event=self.event1.name, status="Live")
+        self.event1_rsvp = FOSSEventRSVPFactory.create(event=self.event1.name, is_published=1)
 
-        self.event1_cfp = insert_cfp_form(event=self.event1.name, status="Live")
-        self.event1_rsvp = insert_rsvp_form(event=self.event1.name, is_published=1)
-
-        # Event 2 is cancelled, and was supposed to end tomorrow
-        self.event2 = insert_test_event(
-            chapter=self.chapter,
+        self.event2 = FOSSChapterEventFactory.create(
+            chapter=self.chapter.name,
             status="Cancelled",
             event_start_date=today.replace(hour=9, minute=00),
             event_end_date=today.replace(hour=15, minute=30),
         )
-        self.event2_cfp = insert_cfp_form(event=self.event2.name, status="Live")
-        self.event2_rsvp = insert_rsvp_form(event=self.event2.name, is_published=1)
+        self.event2_cfp = FOSSEventCFPFactory.create(event=self.event2.name, status="Live")
+        self.event2_rsvp = FOSSEventRSVPFactory.create(event=self.event2.name, is_published=1)
 
-        # Event 3 starts tomorrow, and ends the day-after tomorrow
-        self.event3 = insert_test_event(
-            chapter=self.chapter,
+        self.event3 = FOSSChapterEventFactory.create(
+            chapter=self.chapter.name,
             event_start_date=today.replace(hour=9, minute=00) + timedelta(days=1),
             event_end_date=today.replace(hour=14, minute=00) + timedelta(days=2),
         )
-        self.event3_cfp = insert_cfp_form(event=self.event3.name, status="Live")
-        self.event3_rsvp = insert_rsvp_form(event=self.event3.name, is_published=1)
+        self.event3_cfp = FOSSEventCFPFactory.create(event=self.event3.name, status="Live")
+        self.event3_rsvp = FOSSEventRSVPFactory.create(event=self.event3.name, is_published=1)
 
-    def tearDown(self):
-        frappe.set_user("Administrator")
-        frappe.delete_doc(CHAPTER, self.chapter.name, force=True)
-        frappe.delete_doc(EVENT_CFP, self.event1_cfp.name, force=True)
-        frappe.delete_doc(EVENT_RSVP, self.event1_rsvp.name, force=True)
-        frappe.delete_doc(EVENT, self.event1.name, force=True)
-        frappe.delete_doc(EVENT, self.event2.name, force=True)
-        frappe.delete_doc(EVENT, self.event3.name, force=True)
-
-    # Only patching the datetime within the `scheduled_tasks` module
     @patch("fossunited.scheduled_tasks.now_datetime")
     def test_concluded_events(self, mock_now_datetime):
         mock_now_datetime.return_value = datetime.today().replace(hour=0, minute=1) + timedelta(
@@ -67,7 +48,6 @@ class TestScheduledTasks(FrappeTestCase):
         )
         conclude_events()
 
-        # Fetch events to check their status
         self.event1.reload()
         self.event1_cfp.reload()
         self.event1_rsvp.reload()
@@ -78,17 +58,14 @@ class TestScheduledTasks(FrappeTestCase):
         self.event3_cfp.reload()
         self.event3_rsvp.reload()
 
-        # First event should change the status to concluded
         self.assertEqual(self.event1.status, "Concluded")
         self.assertEqual(self.event1_cfp.status, "Closed")
         self.assertEqual(self.event1_rsvp.is_published, 0)
 
-        # Second event should not change it's status, since it was cancelled
         self.assertEqual(self.event2.status, "Cancelled")
         self.assertEqual(self.event2_cfp.status, "Live")
         self.assertEqual(self.event2_rsvp.is_published, 1)
 
-        # Third event is still live, since its end_date > mock date set here
         self.assertEqual(self.event3.status, "Live")
         self.assertEqual(self.event3_cfp.status, "Live")
         self.assertEqual(self.event3_rsvp.is_published, 1)


### PR DESCRIPTION
## Summary
- Adds 5 hackathon factories (`FOSSHackathonFactory`, `FOSSHackathonTeamFactory`, `FOSSHackathonParticipantFactory`, `FOSSHackathonJoinTeamRequestFactory`, `FOSSHackathonLocalHostFactory`) so upcoming hackathon test refactors can drop the corresponding `insert_test_hackathon*` helpers.
- Refactors `test_emailing.py`, `test_scheduled_tasks.py`, `test_likes.py`, `test_rsvp_insights.py`, and `test_foss_event_rsvp_submission.py` to use factories instead of the `insert_*` helpers from `fossunited/tests/utils.py`. Hardcoded `test1@example.com` / `test2@example.com` / `core1@example.com` users are replaced with `UserFactory.create("with_foss_website_user_role")`.
- Replaces every `frappe.set_user(...)` call in the touched tests with the `self.set_user(...)` context manager from `FrappeTestCase`, so user state is auto-reverted on exit and the explicit `frappe.set_user("Administrator")` cleanups in `tearDown` are no longer needed.
- `confirm_attendance=1` is now passed explicitly on the RSVP submissions where the test asserts the submitter ends up in the event participants email group. The factory default is `0`, while the legacy `insert_rsvp_submission` defaulted to `1` and the email subscription side effect only fires when `confirm_attendance` is truthy.

Part of the ongoing migration from `tests/utils.py` `insert_*` helpers to the factory bot pattern (follow-up to #1583, #1584, #1585).

## Test plan
- [x] `bench --site fossunited.localhost run-tests --module fossunited.tests.test_emailing` (7/7)
- [x] `bench --site fossunited.localhost run-tests --module fossunited.tests.test_scheduled_tasks` (1/1)
- [x] `bench --site fossunited.localhost run-tests --module fossunited.tests.test_likes` (7/7)
- [x] `bench --site fossunited.localhost run-tests --module fossunited.tests.test_rsvp_insights` (14/14)
- [x] `bench --site fossunited.localhost run-tests --module fossunited.chapters.doctype.foss_event_rsvp_submission.test_foss_event_rsvp_submission` (17/17)
- [x] `bench --site fossunited.localhost run-tests --module fossunited.tests.test_volunteers --module fossunited.fossunited.test_permissions` (sanity, 9/9)