### PR TITLE
feat(buyTicket): show remaining ticket slots + show billing summary in right aside

### DIFF
--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -16,6 +16,7 @@ declare module 'vue' {
     AllProposalsBannerImage: typeof import('./src/components/proposals/AllProposalsBannerImage.vue')['default']
     AttendeeCard: typeof import('./src/components/tickets/AttendeeCard.vue')['default']
     AttendeeRequestList: typeof import('./src/components/localhost/AttendeeRequestList.vue')['default']
+    BillingForm: typeof import('./src/components/tickets/BillingForm.vue')['default']
     Breadcrumb: typeof import('./src/components/Breadcrumb.vue')['default']
     CampaignList: typeof import('./src/components/mailing/CampaignList.vue')['default']
     ChapterCard: typeof import('./src/components/ChapterCard.vue')['default']

--- a/dashboard/src/components/tickets/AttendeeCard.vue
+++ b/dashboard/src/components/tickets/AttendeeCard.vue
@@ -6,7 +6,7 @@
       <div class="flex items-center gap-1.5 min-w-0">
         <IconUserCircle class="w-5 h-5 shrink-0 text-ink-gray-7" />
         <span class="font-semibold text-ink-gray-9 tracking-tight truncate">
-          {{ attendee.full_name ? `Attendee: ${attendee.full_name}` : `Attendee #${index + 1}` }}
+          Attendee Details #{{ index + 1 }}
         </span>
       </div>
       <div class="flex items-center gap-1.5 shrink-0">

--- a/dashboard/src/components/tickets/AttendeeCard.vue
+++ b/dashboard/src/components/tickets/AttendeeCard.vue
@@ -2,26 +2,28 @@
   <div
     class="bg-surface-white border border-outline-gray-2 rounded-lg p-6 md:p-8 flex flex-col gap-6"
   >
-    <div class="flex items-center justify-between">
-      <div class="flex items-center gap-1.5">
-        <IconUserCircle class="w-6 h-6 text-ink-gray-7" />
-        <span class="font-semibold text-ink-gray-9 tracking-tight">
-          Attendee Details #{{ index + 1 }}
+    <div class="flex items-center justify-between gap-2">
+      <div class="flex items-center gap-1.5 min-w-0">
+        <IconUserCircle class="w-5 h-5 shrink-0 text-ink-gray-7" />
+        <span class="font-semibold text-ink-gray-9 tracking-tight truncate">
+          {{ attendee.full_name ? `Attendee: ${attendee.full_name}` : `Attendee #${index + 1}` }}
         </span>
       </div>
-      <span
-        class="bg-green-100 text-green-700 text-xs font-semibold tracking-wider uppercase px-3 py-1.5 rounded-lg"
-      >
-        {{ tierTitle }}
-      </span>
-      <button
-        v-if="canDelete"
-        class="bg-red-50 rounded-lg p-2.5 hover:bg-red-100 transition-colors"
-        :aria-label="`Remove attendee #${index + 1}`"
-        @click="$emit('delete')"
-      >
-        <IconTrash class="w-5 h-5 text-red-500" />
-      </button>
+      <div class="flex items-center gap-1.5 shrink-0">
+        <span
+          class="bg-green-100 text-green-700 text-[10px] font-semibold tracking-wider uppercase px-2 py-1 rounded-md"
+        >
+          {{ tierTitle }}
+        </span>
+        <button
+          v-if="canDelete"
+          class="bg-red-50 rounded-lg p-1.5 hover:bg-red-100 transition-colors"
+          :aria-label="`Remove attendee ${attendee.full_name || `#${index + 1}`}`"
+          @click="$emit('delete')"
+        >
+          <IconTrash class="w-4 h-4 text-red-500" />
+        </button>
+      </div>
     </div>
 
     <div class="flex flex-col gap-6">
@@ -95,7 +97,14 @@
           size="sm"
           variant="subtle"
           label="I want a T-shirt"
-          @update:model-value="(value) => emit('update:attendee', { ...attendee, wants_tshirt: value, tshirt_size: value ? attendee.tshirt_size : '' })"
+          @update:model-value="
+            (value) =>
+              emit('update:attendee', {
+                ...attendee,
+                wants_tshirt: value,
+                tshirt_size: value ? attendee.tshirt_size : '',
+              })
+          "
         />
         <div v-if="attendee.wants_tshirt" class="flex items-center gap-2">
           <FormControl
@@ -110,7 +119,9 @@
             class="min-w-[110px]"
             @update:model-value="update('tshirt_size', $event)"
           />
-          <span v-if="!tshirtIncluded" class="text-sm text-ink-gray-5">(+ ₹{{ tshirtPrice }})</span>
+          <span v-if="!tshirtIncluded" class="text-sm text-ink-gray-5"
+            >(+ ₹{{ tshirtPrice }})</span
+          >
         </div>
       </div>
     </div>

--- a/dashboard/src/components/tickets/BillingForm.vue
+++ b/dashboard/src/components/tickets/BillingForm.vue
@@ -1,0 +1,175 @@
+<template>
+  <div
+    class="bg-surface-white border border-outline-gray-2 rounded-lg p-6 md:p-8 flex flex-col gap-6"
+    role="form"
+    aria-label="Billing details"
+  >
+    <div class="flex items-center gap-2">
+      <IconReceipt class="w-6 h-6 text-ink-gray-7" aria-hidden="true" />
+      <span class="font-semibold text-ink-gray-9" id="billing-heading">Billing Details</span>
+    </div>
+    <FormControl
+      v-model="billing.buyer_name"
+      type="text"
+      label="Name"
+      size="sm"
+      variant="subtle"
+      placeholder="John Doe"
+      required
+      autocomplete="name"
+    />
+    <FormControl
+      v-model="billing.state"
+      type="select"
+      label="State"
+      size="sm"
+      variant="subtle"
+      :options="stateOptions"
+      required
+    />
+    <FormControl
+      v-model="billing.email"
+      type="email"
+      label="Email"
+      size="sm"
+      variant="subtle"
+      placeholder="example@email.com"
+      required
+      autocomplete="email"
+    />
+    <div class="flex flex-col gap-1.5">
+      <div class="flex items-center gap-2">
+        <input
+          id="gst-toggle"
+          v-model="billing.hasGST"
+          type="checkbox"
+          class="rounded-sm"
+          :aria-expanded="billing.hasGST"
+          aria-controls="gst-fields"
+        />
+        <label for="gst-toggle" class="text-sm text-ink-gray-7 cursor-pointer"
+          >Add GST Details</label
+        >
+      </div>
+      <p class="text-xs text-ink-gray-4 ml-6" aria-live="polite">
+        Invoice will be generated with GST details
+      </p>
+    </div>
+    <template v-if="billing.hasGST">
+      <div id="gst-fields" class="contents">
+        <FormControl
+          v-model="billing.company_name"
+          type="text"
+          label="Company Name"
+          size="sm"
+          variant="subtle"
+          required
+          autocomplete="organization"
+        />
+        <FormControl
+          v-model="billing.gstn"
+          type="text"
+          label="GST Details (GSTN)"
+          size="sm"
+          variant="subtle"
+          placeholder="22AAAAA0000A1Z5"
+          required
+        />
+        <FormControl
+          v-model="billing.billing_address"
+          type="textarea"
+          label="Billing Address"
+          size="sm"
+          variant="subtle"
+          required
+          autocomplete="street-address"
+        />
+      </div>
+    </template>
+    <div class="flex items-start gap-2">
+      <input
+        id="refund-policy"
+        v-model="billing.readRefundPolicy"
+        type="checkbox"
+        class="mt-0.5 rounded-sm"
+        required
+        aria-required="true"
+      />
+      <label for="refund-policy" class="text-sm text-ink-gray-7 cursor-pointer leading-relaxed">
+        I understand that tickets are non-refundable and have read the
+        <a
+          href="https://fossunited.org/refund-transfer-policy"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="font-semibold underline"
+          >Refund Policy</a
+        ><span class="text-ink-red-3 ml-0.5" aria-label="required">*</span>
+      </label>
+    </div>
+    <div class="flex items-start gap-2">
+      <input
+        id="coc-agreement"
+        v-model="billing.acceptCoC"
+        type="checkbox"
+        class="mt-0.5 rounded-sm"
+        required
+        aria-required="true"
+      />
+      <label for="coc-agreement" class="text-sm text-ink-gray-7 cursor-pointer leading-relaxed">
+        By registering for this event, you agree to abide by the FOSS United
+        <a
+          href="https://fossunited.org/code-of-conduct"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="font-semibold underline"
+          >Code of Conduct</a
+        >. The code of conduct and anti-harassment policies apply to everyone participating in the
+        event including sponsors, judges, mentors, volunteers, organisers and the FOSS United
+        staff.
+        <span class="text-ink-red-3 ml-0.5" aria-label="required">*</span>
+      </label>
+    </div>
+    <div class="flex items-start gap-2">
+      <input
+        id="subscribe-newsletter"
+        v-model="billing.subscribeNewsletter"
+        type="checkbox"
+        class="mt-0.5 rounded-sm"
+      />
+      <label
+        for="subscribe-newsletter"
+        class="text-sm text-ink-gray-7 cursor-pointer leading-relaxed"
+      >
+        Subscribe to the
+        <a
+          href="https://fossunited.org/newsletter"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="font-semibold underline"
+          >FOSS United newsletter</a
+        >
+        for updates on upcoming events and community news.
+      </label>
+    </div>
+    <p class="text-xs text-ink-gray-4">
+      By completing your registration, you also agree to our
+      <a
+        href="https://fossunited.org/privacy-policy"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="underline"
+        >Privacy Policy</a
+      >.
+    </p>
+  </div>
+</template>
+
+<script setup>
+import { FormControl } from 'frappe-ui'
+import { IconReceipt } from '@tabler/icons-vue'
+
+defineProps({
+  billing: { type: Object, required: true },
+  stateOptions: { type: Array, default: () => [] },
+})
+</script>

--- a/dashboard/src/components/tickets/TicketSummary.vue
+++ b/dashboard/src/components/tickets/TicketSummary.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="bg-surface-white border border-outline-gray-2 rounded-lg p-6 flex flex-col gap-6 w-full md:max-w-[360px] md:sticky md:top-20"
+    class="bg-surface-white border border-outline-gray-2 rounded-lg p-6 flex flex-col gap-6 w-full"
   >
     <div>
       <p class="font-semibold text-ink-gray-9">Ticket Summary</p>
@@ -35,9 +35,17 @@
 
     <ErrorMessage v-if="errorMessage" :message="errorMessage" />
 
-    <Button class="w-full" variant="solid" size="md" :loading="loading" @click="$emit('proceed')">
+    <Button
+      v-if="showProceedButton"
+      class="w-full"
+      variant="solid"
+      size="md"
+      :loading="loading"
+      aria-label="Proceed to payment"
+      @click="$emit('proceed')"
+    >
       <span class="flex items-center justify-center gap-1.5 uppercase tracking-wider">
-        Proceed to Pay <IconChevronRight class="w-4 h-4" />
+        Proceed to Pay <IconChevronRight class="w-4 h-4" aria-hidden="true" />
       </span>
     </Button>
   </div>
@@ -57,6 +65,7 @@ const props = defineProps({
   loading: { type: Boolean, default: false },
   couponCode: { type: String, default: '' },
   errorMessage: { type: String, default: '' },
+  showProceedButton: { type: Boolean, default: false },
 })
 
 defineEmits(['proceed', 'update:couponCode'])

--- a/dashboard/src/components/tickets/TicketSummary.vue
+++ b/dashboard/src/components/tickets/TicketSummary.vue
@@ -34,41 +34,20 @@
     </div>
 
     <ErrorMessage v-if="errorMessage" :message="errorMessage" />
-
-    <Button
-      v-if="showProceedButton"
-      class="w-full"
-      variant="solid"
-      size="md"
-      :loading="loading"
-      aria-label="Proceed to payment"
-      @click="$emit('proceed')"
-    >
-      <span class="flex items-center justify-center gap-1.5 uppercase tracking-wider">
-        Proceed to Pay <IconChevronRight class="w-4 h-4" aria-hidden="true" />
-      </span>
-    </Button>
   </div>
 </template>
 
 <script setup>
 import { computed } from 'vue'
-import { Button, ErrorMessage } from 'frappe-ui'
-import { IconChevronRight } from '@tabler/icons-vue'
+import { ErrorMessage } from 'frappe-ui'
 
 const props = defineProps({
   activeTierCounts: { type: Object, default: () => ({}) },
   allTiers: { type: Array, default: () => [] },
   tshirtCount: { type: Number, default: 0 },
   tshirtPrice: { type: Number, default: 0 },
-  showGst: { type: Boolean, default: false },
-  loading: { type: Boolean, default: false },
-  couponCode: { type: String, default: '' },
   errorMessage: { type: String, default: '' },
-  showProceedButton: { type: Boolean, default: false },
 })
-
-defineEmits(['proceed', 'update:couponCode'])
 
 function getTierTitle(tierName) {
   return props.allTiers.find((t) => t.name === tierName)?.title || tierName

--- a/dashboard/src/pages/BuyTickets.vue
+++ b/dashboard/src/pages/BuyTickets.vue
@@ -8,11 +8,12 @@
   />
 
   <div v-if="event.data" class="bg-surface-gray-1 min-h-screen">
-    <main
-      id="main-content"
-      class="max-w-[800px] mx-auto w-full flex flex-col gap-4 px-4 pb-24"
-      aria-label="Ticket registration"
-    >
+    <div class="mx-auto w-full max-w-[1100px] px-4">
+      <main
+        id="main-content"
+        class="flex flex-col gap-4 pb-24 md:pb-8"
+        aria-label="Ticket registration"
+      >
       <Breadcrumb :items="breadcrumbItems" />
 
       <!-- Page Header -->
@@ -43,6 +44,10 @@
         class="my-2 prose prose-sm max-w-none bg-surface-gray-2 rounded-lg px-4 py-3"
         v-html="markdownToHTML(event.data.ticket_form_description)"
       ></div>
+
+      <!-- Steps + Sidebar two-column -->
+      <div class="flex flex-col md:flex-row md:items-start md:gap-6">
+        <div class="flex-1 min-w-0 flex flex-col gap-4">
 
       <!-- Step Progress -->
       <nav aria-label="Registration steps">
@@ -85,7 +90,7 @@
               :key="tier.name"
               role="listitem"
               class="bg-surface-white border border-outline-gray-2 rounded-2xl flex flex-wrap items-stretch gap-3 p-4 w-full"
-              :class="!isTierActive(tier) ? 'opacity-50' : 'shadow-sm'"
+              :class="!isTierActive(tier) ? (isTierComingSoon(tier) ? 'opacity-70' : 'opacity-50') : 'shadow-sm'"
               :aria-label="`${tier.title} ticket, ₹${tier.price}`"
               :aria-disabled="!isTierActive(tier)"
             >
@@ -114,13 +119,20 @@
                     >T-shirt Included</Badge
                   >
                   <Badge
-                    v-if="tier.valid_till && isTierActive(tier)"
+                    v-if="isTierSoldOut(tier)"
                     class="w-fit"
-                    variant="outline"
-                    theme="green"
-                    >Available till {{ dayjs(tier.valid_till).format('MMM D, YYYY') }}</Badge
+                    variant="solid"
+                    theme="red"
+                    >Sold Out</Badge
                   >
-                  <Badge v-if="!tier.enabled" class="w-fit" variant="outline" theme="red"
+                  <Badge
+                    v-else-if="isTierComingSoon(tier)"
+                    class="w-fit"
+                    variant="subtle"
+                    theme="blue"
+                    >Coming Soon</Badge
+                  >
+                  <Badge v-else-if="!tier.enabled" class="w-fit" variant="outline" theme="red"
                     >Disabled</Badge
                   >
                   <Badge
@@ -130,11 +142,27 @@
                     theme="orange"
                     >Expired</Badge
                   >
+                  <Badge
+                    v-if="tier.maximum_tickets > 0 && isTierActive(tier)"
+                    :theme="tierRemainingTheme(tier)"
+                    variant="subtle"
+                    class="w-fit"
+                    :aria-label="`${tierRemainingLabel(tier)} for ${tier.title}`"
+                    >{{ tierRemainingLabel(tier) }}</Badge
+                  >
+                  <Badge
+                    v-if="tier.valid_till && isTierActive(tier)"
+                    class="w-fit"
+                    variant="outline"
+                    theme="green"
+                    >Available till {{ dayjs(tier.valid_till).format('MMM D, YYYY') }}</Badge
+                  >
                 </div>
               </div>
 
-              <!-- Counter: on mobile order-last (after description); on desktop back in row -->
+              <!-- Counter: only shown for active tiers -->
               <div
+                v-if="isTierActive(tier)"
                 class="order-last md:order-none w-full md:w-auto flex items-center gap-1 justify-center md:justify-end md:self-center md:shrink-0 md:pl-2"
                 :aria-label="`${tier.title} ticket quantity`"
               >
@@ -201,7 +229,7 @@
               :tshirt-price="event.data.t_shirt_price || 0"
               :tshirt-included="isTierTshirtIncluded(attendee.ticket_type)"
               :can-delete="attendees.length > 1"
-              @update:attendee="attendees[idx] = $event"
+              @update:attendee="onUpdateAttendee(idx, $event)"
               @delete="removeAttendee(idx)"
             />
 
@@ -303,175 +331,8 @@
           </div>
 
           <!-- STEP 4: Billing -->
-          <div v-else-if="currentStep === 4" class="flex flex-col md:flex-row gap-4 items-start">
-            <div
-              class="bg-surface-white border border-outline-gray-2 rounded-lg p-6 md:p-8 flex flex-col gap-6 flex-1"
-            >
-              <div class="flex items-center gap-2">
-                <IconReceipt class="w-6 h-6 text-ink-gray-7" />
-                <span class="font-semibold text-ink-gray-9">Billing Details</span>
-              </div>
-              <FormControl
-                v-model="billing.buyer_name"
-                type="text"
-                label="Name"
-                size="sm"
-                variant="subtle"
-                placeholder="John Doe"
-                required
-              />
-              <FormControl
-                v-model="billing.state"
-                type="select"
-                label="State"
-                size="sm"
-                variant="subtle"
-                :options="stateOptions.data"
-                required
-              />
-              <FormControl
-                v-model="billing.email"
-                type="email"
-                label="Email"
-                size="sm"
-                variant="subtle"
-                placeholder="example@email.com"
-                required
-              />
-              <div class="flex flex-col gap-1.5">
-                <div class="flex items-center gap-2">
-                  <input
-                    id="gst-toggle"
-                    v-model="billing.hasGST"
-                    type="checkbox"
-                    class="rounded-sm"
-                  />
-                  <label for="gst-toggle" class="text-sm text-ink-gray-7 cursor-pointer"
-                    >Add GST Details</label
-                  >
-                </div>
-                <p class="text-xs text-ink-gray-4 ml-6">
-                  Invoice will be generated with GST details
-                </p>
-              </div>
-              <template v-if="billing.hasGST">
-                <FormControl
-                  v-model="billing.company_name"
-                  type="text"
-                  label="Company Name"
-                  size="sm"
-                  variant="subtle"
-                  required
-                />
-                <FormControl
-                  v-model="billing.gstn"
-                  type="text"
-                  label="GST Details (GSTN)"
-                  size="sm"
-                  variant="subtle"
-                  placeholder="22AAAAA0000A1Z5"
-                  required
-                />
-                <FormControl
-                  v-model="billing.billing_address"
-                  type="textarea"
-                  label="Billing Address"
-                  size="sm"
-                  variant="subtle"
-                  required
-                />
-              </template>
-              <div class="flex items-start gap-2">
-                <input
-                  id="refund-policy"
-                  v-model="billing.readRefundPolicy"
-                  type="checkbox"
-                  class="mt-0.5 rounded-sm"
-                />
-                <label
-                  for="refund-policy"
-                  class="text-sm text-ink-gray-7 cursor-pointer leading-relaxed"
-                >
-                  I understand that tickets are non-refundable and have read the
-                  <a
-                    href="https://fossunited.org/refund-transfer-policy"
-                    target="_blank"
-                    class="font-semibold underline"
-                    >Refund Policy</a
-                  ><span class="text-ink-red-3 ml-0.5">*</span>
-                </label>
-              </div>
-              <div class="flex items-start gap-2">
-                <input
-                  id="coc-agreement"
-                  v-model="billing.acceptCoC"
-                  type="checkbox"
-                  class="mt-0.5 rounded-sm"
-                />
-                <label
-                  for="coc-agreement"
-                  class="text-sm text-ink-gray-7 cursor-pointer leading-relaxed"
-                >
-                  By registering for this event, you agree to abide by the FOSS United
-                  <a
-                    href="https://fossunited.org/code-of-conduct"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="font-semibold underline"
-                    >Code of Conduct</a
-                  >. The code of conduct and anti-harassment policies apply to everyone
-                  participating in the event including sponsors, judges, mentors, volunteers,
-                  organisers and the FOSS United staff.
-                  <span class="text-ink-red-3 ml-0.5">*</span>
-                </label>
-              </div>
-              <div class="flex items-start gap-2">
-                <input
-                  id="subscribe-newsletter"
-                  v-model="billing.subscribeNewsletter"
-                  type="checkbox"
-                  class="mt-0.5 rounded-sm"
-                />
-                <label
-                  for="subscribe-newsletter"
-                  class="text-sm text-ink-gray-7 cursor-pointer leading-relaxed"
-                >
-                  Subscribe to the
-                  <a
-                    href="https://fossunited.org/newsletter"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="font-semibold underline"
-                    >FOSS United newsletter</a
-                  >
-                  for updates on upcoming events and community news.
-                </label>
-              </div>
-              <p class="text-xs text-ink-gray-4">
-                By completing your registration, you also agree to our
-                <a
-                  href="https://fossunited.org/privacy-policy"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="underline"
-                  >Privacy Policy</a
-                >.
-              </p>
-            </div>
-
-            <!-- Ticket Summary Sidebar -->
-            <TicketSummary
-              :active-tier-counts="activeTierCounts"
-              :all-tiers="allTiers"
-              :tshirt-count="numTShirtsAdded"
-              :tshirt-price="event.data.t_shirt_price || 0"
-              :show-gst="billing.hasGST"
-              :loading="rzpCheckout?.resource.loading"
-              :coupon-code="billing.coupon_code"
-              :error-message="errorMessage || ''"
-              @proceed="createOrder"
-              @update:coupon-code="billing.coupon_code = $event"
-            />
+          <div v-else-if="currentStep === 4">
+            <BillingForm :billing="billing" :state-options="stateOptions.data" />
           </div>
         </div>
       </transition>
@@ -499,7 +360,7 @@
           />
         </div>
       </template>
-      <div v-else class="flex justify-end">
+      <div v-else class="flex justify-between">
         <Button
           label="Back"
           size="lg"
@@ -509,11 +370,21 @@
           aria-label="Go back to verify details"
           @click="prevStep"
         />
+        <Button
+          label="Proceed to Pay"
+          size="lg"
+          variant="solid"
+          icon-right="chevron-right"
+          class="uppercase !font-medium !px-6"
+          :loading="rzpCheckout?.resource.loading"
+          aria-label="Proceed to payment"
+          @click="createOrder"
+        />
       </div>
 
-      <!-- Error messages at bottom (step 4 uses TicketSummary instead) -->
+      <!-- Error messages -->
       <ul
-        v-if="errorMessages.length && currentStep !== 4"
+        v-if="errorMessages.length"
         role="alert"
         aria-live="assertive"
         class="flex flex-col gap-1 p-3 rounded-lg bg-surface-red-1 border border-outline-red-2"
@@ -527,7 +398,65 @@
           <span>{{ msg }}</span>
         </li>
       </ul>
-    </main>
+        </div>
+
+        <aside
+          class="hidden md:block shrink-0 w-[300px] self-start sticky top-6"
+          aria-label="Order summary"
+        >
+          <TicketSummary
+            :active-tier-counts="activeTierCounts"
+            :all-tiers="allTiers"
+            :tshirt-count="numTShirtsAdded"
+            :tshirt-price="event.data.t_shirt_price || 0"
+            :error-message="currentStep === 4 ? (errorMessage || '') : ''"
+          />
+        </aside>
+      </div>
+      </main>
+    </div>
+
+    <!-- Mobile order summary drawer -->
+    <div
+      class="fixed bottom-0 inset-x-0 z-40 md:hidden bg-surface-white border-t border-outline-gray-2 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.1)]"
+      role="region"
+      aria-label="Order summary"
+    >
+      <!-- Expanded breakdown -->
+      <div
+        v-if="mobileBarExpanded"
+        id="mobile-order-summary"
+        class="px-4 pt-4 pb-2 max-h-[55vh] overflow-y-auto border-b border-outline-gray-2"
+      >
+        <TicketSummary
+          :active-tier-counts="activeTierCounts"
+          :all-tiers="allTiers"
+          :tshirt-count="numTShirtsAdded"
+          :tshirt-price="event.data.t_shirt_price || 0"
+          :error-message="currentStep === 4 ? (errorMessage || '') : ''"
+        />
+      </div>
+      <!-- Always visible: total toggle row -->
+      <button
+        class="w-full flex items-center justify-between px-4 py-3"
+        :aria-expanded="String(mobileBarExpanded)"
+        aria-controls="mobile-order-summary"
+        @click="mobileBarExpanded = !mobileBarExpanded"
+      >
+        <div class="text-left">
+          <p class="text-xs font-semibold text-ink-gray-5 uppercase tracking-wider">Total</p>
+          <p
+            class="text-lg font-bold text-ink-gray-9 leading-none"
+            aria-live="polite"
+            :aria-label="`Total amount: ₹${summaryTotal}`"
+          >
+            ₹{{ summaryTotal }}
+          </p>
+        </div>
+        <IconChevronUp v-if="mobileBarExpanded" class="w-5 h-5 text-ink-gray-5" aria-hidden="true" />
+        <IconChevronDown v-else class="w-5 h-5 text-ink-gray-5" aria-hidden="true" />
+      </button>
+    </div>
   </div>
 
   <!-- Loading / Error -->
@@ -570,13 +499,15 @@ import EventHeader from '@/components/common/EventHeader.vue'
 import RazorpayCheckout from '@/components/common/RazorpayCheckout.vue'
 import AttendeeCard from '@/components/tickets/AttendeeCard.vue'
 import TicketSummary from '@/components/tickets/TicketSummary.vue'
+import BillingForm from '@/components/tickets/BillingForm.vue'
 import {
   IconInfoCircle,
   IconPlus,
   IconMinus,
   IconShirt,
   IconSoup,
-  IconReceipt,
+  IconChevronUp,
+  IconChevronDown,
 } from '@tabler/icons-vue'
 import { cleanedHTML, showError } from '@/helpers/utils'
 
@@ -615,6 +546,7 @@ const errorMessages = ref([])
 const showDialog = ref(false)
 const dialogError = ref('')
 const rzpCheckout = ref(null)
+const mobileBarExpanded = ref(false)
 
 const tierCounts = reactive({})
 const attendees = ref([])
@@ -667,6 +599,14 @@ const numTShirtsAdded = computed(() =>
   attendees.value.filter((a) => a.wants_tshirt && !isTierTshirtIncluded(a.ticket_type)).length
 )
 
+const summaryTotal = computed(() => {
+  const tierTotal = Object.entries(activeTierCounts.value).reduce((sum, [name, count]) => {
+    const tier = allTiers.value.find((t) => t.name === name)
+    return sum + (tier?.price || 0) * (count || 0)
+  }, 0)
+  return tierTotal + numTShirtsAdded.value * (event.data?.t_shirt_price || 0)
+})
+
 const stepTitle = computed(
   () =>
     ({
@@ -716,6 +656,38 @@ function getTierDescription(tierName) {
 
 function isTierTshirtIncluded(tierName) {
   return Boolean(allTiers.value.find((t) => t.name === tierName)?.tshirt_included)
+}
+
+function isTierSoldOut(tier) {
+  return tier.maximum_tickets > 0 && (tier.sold_count || 0) >= tier.maximum_tickets
+}
+
+function isTierComingSoon(tier) {
+  return !tier.enabled && !isTierSoldOut(tier) && tier.valid_till && !isTierExpired(tier)
+}
+
+function tierRemainingCount(tier) {
+  if (!tier.maximum_tickets) return null
+  return tier.maximum_tickets - (tier.sold_count || 0)
+}
+
+function tierRemainingTheme(tier) {
+  const r = tierRemainingCount(tier)
+  if (r === null) return 'gray'
+  const pct = r / tier.maximum_tickets
+  if (r <= 5 || pct <= 0.1) return 'red'
+  if (r <= 15 || pct <= 0.25) return 'orange'
+  return 'green'
+}
+
+function tierRemainingLabel(tier) {
+  const r = tierRemainingCount(tier)
+  if (r === null || r < 0) return ''
+  if (r === 0) return 'Sold Out'
+  const pct = r / tier.maximum_tickets
+  if (r <= 5 || pct <= 0.1) return `Only ${r} left!`
+  if (r <= 15 || pct <= 0.25) return `${r} left`
+  return `${r} available`
 }
 
 function getTierImage(tier) {
@@ -794,6 +766,16 @@ function removeAttendee(index) {
   if (removed?.ticket_type && (tierCounts[removed.ticket_type] || 0) > 0) {
     tierCounts[removed.ticket_type]--
   }
+}
+
+function onUpdateAttendee(idx, newAttendee) {
+  const old = attendees.value[idx]
+  if (old.ticket_type !== newAttendee.ticket_type) {
+    if (old.ticket_type && (tierCounts[old.ticket_type] || 0) > 0) tierCounts[old.ticket_type]--
+    if (newAttendee.ticket_type)
+      tierCounts[newAttendee.ticket_type] = (tierCounts[newAttendee.ticket_type] || 0) + 1
+  }
+  attendees.value[idx] = newAttendee
 }
 
 // Navigation

--- a/dashboard/src/pages/BuyTickets.vue
+++ b/dashboard/src/pages/BuyTickets.vue
@@ -14,405 +14,420 @@
         class="flex flex-col gap-4 pb-24 md:pb-8"
         aria-label="Ticket registration"
       >
-      <Breadcrumb :items="breadcrumbItems" />
+        <Breadcrumb :items="breadcrumbItems" />
 
-      <!-- Page Header -->
-      <div class="flex flex-col gap-1">
-        <h1 class="text-2xl font-bold tracking-tight text-ink-gray-9">Registration</h1>
-      </div>
+        <!-- Page Header -->
+        <div class="flex flex-col gap-1">
+          <h1 class="text-2xl font-bold tracking-tight text-ink-gray-9">Registration</h1>
+        </div>
 
-      <EventHeader :event="event.data" />
+        <EventHeader :event="event.data" />
 
-      <div
-        role="note"
-        class="flex items-center gap-2 px-3 py-2 rounded-lg border border-outline-amber-2 bg-surface-amber-1 text-ink-amber-3 text-sm self-center"
-      >
-        <IconInfoCircle class="w-5 h-5 shrink-0" aria-hidden="true" />
-        <span
-          >Tickets are non-cancellable.
-          <a
-            href="https://fossunited.org/refund-transfer-policy"
-            target="_blank"
-            class="underline font-semibold"
-            >Only transfers are allowed</a
-          >
-        </span>
-      </div>
-      <!-- Form description -->
-      <div
-        v-if="event.data?.ticket_form_description"
-        class="my-2 prose prose-sm max-w-none bg-surface-gray-2 rounded-lg px-4 py-3"
-        v-html="markdownToHTML(event.data.ticket_form_description)"
-      ></div>
-
-      <!-- Steps + Sidebar two-column -->
-      <div class="flex flex-col md:flex-row md:items-start md:gap-6">
-        <div class="flex-1 min-w-0 flex flex-col gap-4">
-
-      <!-- Step Progress -->
-      <nav aria-label="Registration steps">
-        <Progress
-          :value="currentStep * 25"
-          :intervals="true"
-          :interval-count="4"
-          size="lg"
-          :label="stepTitle"
-          :hint="true"
+        <div
+          role="note"
+          class="flex items-center gap-2 px-3 py-2 rounded-lg border border-outline-amber-2 bg-surface-amber-1 text-ink-amber-3 text-sm self-center"
         >
-          <template #hint>
-            <span class="text-sm font-medium text-ink-gray-4" aria-live="polite"
-              >{{ currentStep }} / 4</span
+          <IconInfoCircle class="w-5 h-5 shrink-0" aria-hidden="true" />
+          <span
+            >Tickets are non-cancellable.
+            <a
+              href="https://fossunited.org/refund-transfer-policy"
+              target="_blank"
+              class="underline font-semibold"
+              >Only transfers are allowed</a
             >
-          </template>
-        </Progress>
-      </nav>
+          </span>
+        </div>
+        <!-- Form description -->
+        <div
+          v-if="event.data?.ticket_form_description"
+          class="my-2 prose prose-sm max-w-none bg-surface-gray-2 rounded-lg px-4 py-3"
+          v-html="markdownToHTML(event.data.ticket_form_description)"
+        ></div>
 
-      <!-- Step Content -->
-      <transition
-        mode="out-in"
-        :enter-active-class="tClasses.enterActive"
-        :enter-from-class="tClasses.enterFrom"
-        :enter-to-class="tClasses.enterTo"
-        :leave-active-class="tClasses.leaveActive"
-        :leave-from-class="tClasses.leaveFrom"
-        :leave-to-class="tClasses.leaveTo"
-      >
-        <div :key="currentStep">
-          <!-- Select Tiers -->
-          <div
-            v-if="currentStep === 1"
-            class="flex flex-col gap-6 items-center"
-            role="list"
-            aria-label="Available ticket tiers"
-          >
-            <article
-              v-for="tier in sortedTiers"
-              :key="tier.name"
-              role="listitem"
-              class="bg-surface-white border border-outline-gray-2 rounded-2xl flex flex-wrap items-stretch gap-3 p-4 w-full"
-              :class="!isTierActive(tier) ? (isTierComingSoon(tier) ? 'opacity-70' : 'opacity-50') : 'shadow-sm'"
-              :aria-label="`${tier.title} ticket, ₹${tier.price}`"
-              :aria-disabled="!isTierActive(tier)"
+        <!-- Steps + Sidebar two-column -->
+        <div class="flex flex-col md:flex-row md:items-start md:gap-6">
+          <div class="flex-1 min-w-0 flex flex-col gap-4">
+            <!-- Step Progress -->
+            <nav aria-label="Registration steps">
+              <Progress
+                :value="currentStep * 25"
+                :intervals="true"
+                :interval-count="4"
+                size="lg"
+                :label="stepTitle"
+                :hint="true"
+              >
+                <template #hint>
+                  <span class="text-sm font-medium text-ink-gray-4" aria-live="polite"
+                    >{{ currentStep }} / 4</span
+                  >
+                </template>
+              </Progress>
+            </nav>
+
+            <!-- Step Content -->
+            <transition
+              mode="out-in"
+              :enter-active-class="tClasses.enterActive"
+              :enter-from-class="tClasses.enterFrom"
+              :enter-to-class="tClasses.enterTo"
+              :leave-active-class="tClasses.leaveActive"
+              :leave-from-class="tClasses.leaveFrom"
+              :leave-to-class="tClasses.leaveTo"
             >
-              <!-- Image -->
-              <div
-                class="bg-surface-gray-1 border border-outline-gray-2 rounded-lg overflow-hidden w-[58px] h-20 md:w-[78px] md:h-[108px]"
-                aria-hidden="true"
-              >
-                <img
-                  :src="getTierImage(tier)"
-                  :alt="`${tier.title} ticket`"
-                  class="w-full h-full object-contain"
-                />
-              </div>
-
-              <div class="flex-1 min-w-0 flex flex-col justify-evenly">
-                <p class="font-semibold text-base text-ink-gray-9">{{ tier.title }}</p>
-                <p class="font-semibold text-xl text-ink-gray-9">₹{{ tier.price }}</p>
-                <div class="flex flex-wrap gap-1">
-                  <Badge
-                    v-if="tier.tshirt_included"
-                    class="w-fit"
-                    variant="subtle"
-                    theme="green"
-                    title="T-shirt is included with this tier at no extra charge"
-                    >T-shirt Included</Badge
-                  >
-                  <Badge
-                    v-if="isTierSoldOut(tier)"
-                    class="w-fit"
-                    variant="solid"
-                    theme="red"
-                    >Sold Out</Badge
-                  >
-                  <Badge
-                    v-else-if="isTierComingSoon(tier)"
-                    class="w-fit"
-                    variant="subtle"
-                    theme="blue"
-                    >Coming Soon</Badge
-                  >
-                  <Badge v-else-if="!tier.enabled" class="w-fit" variant="outline" theme="red"
-                    >Disabled</Badge
-                  >
-                  <Badge
-                    v-else-if="isTierExpired(tier)"
-                    class="w-fit"
-                    variant="outline"
-                    theme="orange"
-                    >Expired</Badge
-                  >
-                  <Badge
-                    v-if="tier.maximum_tickets > 0 && isTierActive(tier)"
-                    :theme="tierRemainingTheme(tier)"
-                    variant="subtle"
-                    class="w-fit"
-                    :aria-label="`${tierRemainingLabel(tier)} for ${tier.title}`"
-                    >{{ tierRemainingLabel(tier) }}</Badge
-                  >
-                  <Badge
-                    v-if="tier.valid_till && isTierActive(tier)"
-                    class="w-fit"
-                    variant="outline"
-                    theme="green"
-                    >Available till {{ dayjs(tier.valid_till).format('MMM D, YYYY') }}</Badge
-                  >
-                </div>
-              </div>
-
-              <!-- Counter: only shown for active tiers -->
-              <div
-                v-if="isTierActive(tier)"
-                class="order-last md:order-none w-full md:w-auto flex items-center gap-1 justify-center md:justify-end md:self-center md:shrink-0 md:pl-2"
-                :aria-label="`${tier.title} ticket quantity`"
-              >
-                <button
-                  :disabled="!isTierActive(tier) || (tierCounts[tier.name] || 0) <= 0"
-                  :aria-label="`Remove one ${tier.title} ticket`"
-                  class="w-10 h-10 rounded-lg border flex items-center justify-center transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-                  :class="
-                    (tierCounts[tier.name] || 0) > 0
-                      ? 'border-ink-gray-9 bg-ink-gray-9'
-                      : 'border-ink-gray-9 bg-surface-white'
-                  "
-                  @click="decrementTier(tier.name)"
-                >
-                  <IconMinus
-                    aria-hidden="true"
-                    class="w-4 h-4"
-                    :class="(tierCounts[tier.name] || 0) > 0 ? '' : 'text-ink-gray-9'"
-                  />
-                </button>
-                <span
-                  class="w-8 text-center font-semibold text-ink-gray-9"
-                  aria-live="polite"
-                  :aria-label="`${tierCounts[tier.name] || 0} ${tier.title} tickets selected`"
-                  >{{ tierCounts[tier.name] || 0 }}</span
-                >
-                <button
-                  :disabled="!isTierActive(tier) || totalTickets >= MAX_SEATS"
-                  :aria-label="`Add one ${tier.title} ticket`"
-                  class="w-10 h-10 rounded-lg border flex items-center justify-center transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-                  :class="
-                    isTierActive(tier)
-                      ? 'border-ink-gray-9 bg-ink-gray-9'
-                      : 'border-ink-gray-9 bg-surface-white'
-                  "
-                  @click="incrementTier(tier.name)"
-                >
-                  <IconPlus
-                    aria-hidden="true"
-                    class="w-4 h-4"
-                    :class="isTierActive(tier) ? '' : 'text-ink-gray-9'"
-                  />
-                </button>
-              </div>
-
-              <div
-                v-if="tier.description"
-                class="w-full prose prose-sm prose-p:text-xs prose-p:text-ink-gray-5 prose-p:leading-relaxed prose-p:my-0.5 max-w-full"
-                v-html="renderedDescription(tier.description)"
-              />
-            </article>
-          </div>
-
-          <!-- STEP 2: Attendee Details -->
-          <div v-else-if="currentStep === 2" class="flex flex-col gap-6">
-            <AttendeeCard
-              v-for="(attendee, idx) in attendees"
-              :key="idx"
-              :attendee="attendee"
-              :index="idx"
-              :tier-title="getTierTitle(attendee.ticket_type)"
-              :custom-fields="!customFieldsApplyToAll ? event.data.custom_fields : []"
-              :show-tshirt="Boolean(event.data.paid_tshirts_available)"
-              :tshirt-price="event.data.t_shirt_price || 0"
-              :tshirt-included="isTierTshirtIncluded(attendee.ticket_type)"
-              :can-delete="attendees.length > 1"
-              @update:attendee="onUpdateAttendee(idx, $event)"
-              @delete="removeAttendee(idx)"
-            />
-
-            <div
-              v-if="event.data.custom_fields?.length > 0 && attendees.length > 1"
-              class="flex flex-col gap-4"
-            >
-              <Switch
-                v-model="customFieldsApplyToAll"
-                class="w-fit text-xs"
-                label="Apply same answers for all tickets"
-              />
-              <div
-                v-if="customFieldsApplyToAll"
-                class="bg-surface-white border border-outline-gray-2 rounded-lg p-6 grid grid-cols-1 md:grid-cols-2 gap-6"
-              >
-                <FormControl
-                  v-for="field in event.data.custom_fields"
-                  :key="field.name"
-                  v-model="globalCustomFields[field.field_name]"
-                  :type="FIELD_TYPE_MAP[field.field_type]"
-                  :label="field.label"
-                  :options="field.options"
-                  :required="Boolean(field.mandatory)"
-                  size="sm"
-                  variant="subtle"
-                />
-              </div>
-            </div>
-
-            <div class="flex justify-center">
-              <button
-                :disabled="totalTickets >= MAX_SEATS"
-                class="flex items-center gap-2 bg-outline-gray-1 hover:bg-outline-gray-2 border border-outline-gray-2 rounded-lg px-5 py-2.5 font-semibold text-sm uppercase tracking-wider text-ink-gray-9 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-                @click="addAttendee"
-              >
-                <IconPlus class="w-5 h-5" /> Add Another Ticket
-              </button>
-            </div>
-          </div>
-
-          <!-- STEP 3: Verify Details -->
-          <div v-else-if="currentStep === 3" class="flex flex-wrap gap-6 justify-center">
-            <div
-              v-for="(attendee, idx) in attendees"
-              :key="idx"
-              class="bg-surface-white border border-outline-gray-2 rounded-lg p-6 flex flex-col gap-5 w-full max-w-[375px]"
-            >
-              <div class="flex items-center justify-between">
-                <span class="font-semibold text-2xl text-ink-gray-9 tracking-tight"
-                  >#{{ idx + 1 }}</span
-                >
-                <span
-                  class="bg-surface-green-1 text-ink-green-3 text-xs font-semibold tracking-wider uppercase px-3 py-1.5 rounded-lg"
-                  >{{ getTierTitle(attendee.ticket_type) }}</span
-                >
-              </div>
-              <div class="flex flex-col gap-3">
-                <div>
-                  <p class="font-semibold text-ink-gray-8">{{ attendee.full_name || '—' }}</p>
-                  <p class="text-sm text-ink-gray-5">
-                    {{ [attendee.designation, attendee.organization].filter(Boolean).join(' | ') }}
-                  </p>
-                </div>
-                <div class="text-sm text-ink-gray-5 flex flex-col gap-1">
-                  <p>{{ attendee.email }}</p>
-                </div>
-              </div>
-              <div class="flex items-center gap-6 flex-wrap">
+              <div :key="currentStep">
+                <!-- Select Tiers -->
                 <div
-                  v-if="
-                    isTierTshirtIncluded(attendee.ticket_type) || event.data.paid_tshirts_available
-                  "
-                  class="flex items-center gap-1.5 text-sm"
-                  :class="
-                    isTierTshirtIncluded(attendee.ticket_type)
-                      ? 'text-ink-green-3'
-                      : 'text-ink-gray-7'
-                  "
+                  v-if="currentStep === 1"
+                  class="flex flex-col gap-6 items-center"
+                  role="list"
+                  aria-label="Available ticket tiers"
                 >
-                  <IconShirt class="w-5 h-5" aria-hidden="true" />
-                  <span>{{
-                    isTierTshirtIncluded(attendee.ticket_type)
-                      ? 'T-shirt Included'
-                      : attendee.wants_tshirt
-                        ? attendee.tshirt_size
-                        : 'Without T-shirt'
-                  }}</span>
+                  <article
+                    v-for="tier in sortedTiers"
+                    :key="tier.name"
+                    role="listitem"
+                    class="bg-surface-white border border-outline-gray-2 rounded-2xl flex flex-wrap items-stretch gap-3 p-4 w-full"
+                    :class="
+                      !isTierActive(tier)
+                        ? isTierComingSoon(tier)
+                          ? 'opacity-70'
+                          : 'opacity-50'
+                        : 'shadow-sm'
+                    "
+                    :aria-label="`${tier.title} ticket, ₹${tier.price}`"
+                    :aria-disabled="!isTierActive(tier)"
+                  >
+                    <!-- Image -->
+                    <div
+                      class="bg-surface-gray-1 border border-outline-gray-2 rounded-lg overflow-hidden w-[58px] h-20 md:w-[78px] md:h-[108px]"
+                      aria-hidden="true"
+                    >
+                      <img
+                        :src="getTierImage(tier)"
+                        :alt="`${tier.title} ticket`"
+                        class="w-full h-full object-contain"
+                      />
+                    </div>
+
+                    <div class="flex-1 min-w-0 flex flex-col justify-evenly">
+                      <p class="font-semibold text-base text-ink-gray-9">{{ tier.title }}</p>
+                      <p class="font-semibold text-xl text-ink-gray-9">₹{{ tier.price }}</p>
+                      <div class="flex flex-wrap gap-1">
+                        <Badge
+                          v-if="tier.tshirt_included"
+                          class="w-fit"
+                          variant="subtle"
+                          theme="green"
+                          title="T-shirt is included with this tier at no extra charge"
+                          >T-shirt Included</Badge
+                        >
+                        <Badge v-if="isTierSoldOut(tier)" class="w-fit" variant="solid" theme="red"
+                          >Sold Out</Badge
+                        >
+                        <Badge
+                          v-else-if="isTierComingSoon(tier)"
+                          class="w-fit"
+                          variant="subtle"
+                          theme="blue"
+                          >Coming Soon</Badge
+                        >
+                        <Badge
+                          v-else-if="!tier.enabled"
+                          class="w-fit"
+                          variant="outline"
+                          theme="red"
+                          >Disabled</Badge
+                        >
+                        <Badge
+                          v-else-if="isTierExpired(tier)"
+                          class="w-fit"
+                          variant="outline"
+                          theme="orange"
+                          >Expired</Badge
+                        >
+                        <Badge
+                          v-if="tier.maximum_tickets > 0 && isTierActive(tier)"
+                          :theme="tierRemainingTheme(tier)"
+                          variant="subtle"
+                          class="w-fit"
+                          :aria-label="`${tierRemainingLabel(tier)} for ${tier.title}`"
+                          >{{ tierRemainingLabel(tier) }}</Badge
+                        >
+                        <Badge
+                          v-if="tier.valid_till && isTierActive(tier)"
+                          class="w-fit"
+                          variant="outline"
+                          theme="green"
+                          >Available till {{ dayjs(tier.valid_till).format('MMM D, YYYY') }}</Badge
+                        >
+                      </div>
+                    </div>
+
+                    <!-- Counter: only shown for active tiers -->
+                    <div
+                      v-if="isTierActive(tier)"
+                      class="order-last md:order-none w-full md:w-auto flex items-center gap-1 justify-center md:justify-end md:self-center md:shrink-0 md:pl-2"
+                      :aria-label="`${tier.title} ticket quantity`"
+                    >
+                      <button
+                        :disabled="!isTierActive(tier) || (tierCounts[tier.name] || 0) <= 0"
+                        :aria-label="`Remove one ${tier.title} ticket`"
+                        class="w-10 h-10 rounded-lg border flex items-center justify-center transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                        :class="
+                          (tierCounts[tier.name] || 0) > 0
+                            ? 'border-ink-gray-9 bg-ink-gray-9'
+                            : 'border-ink-gray-9 bg-surface-white'
+                        "
+                        @click="decrementTier(tier.name)"
+                      >
+                        <IconMinus
+                          aria-hidden="true"
+                          class="w-4 h-4"
+                          :class="(tierCounts[tier.name] || 0) > 0 ? '' : 'text-ink-gray-9'"
+                        />
+                      </button>
+                      <span
+                        class="w-8 text-center font-semibold text-ink-gray-9"
+                        aria-live="polite"
+                        :aria-label="`${tierCounts[tier.name] || 0} ${tier.title} tickets selected`"
+                        >{{ tierCounts[tier.name] || 0 }}</span
+                      >
+                      <button
+                        :disabled="!isTierActive(tier) || totalTickets >= MAX_SEATS"
+                        :aria-label="`Add one ${tier.title} ticket`"
+                        class="w-10 h-10 rounded-lg border flex items-center justify-center transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                        :class="
+                          isTierActive(tier)
+                            ? 'border-ink-gray-9 bg-ink-gray-9'
+                            : 'border-ink-gray-9 bg-surface-white'
+                        "
+                        @click="incrementTier(tier.name)"
+                      >
+                        <IconPlus
+                          aria-hidden="true"
+                          class="w-4 h-4"
+                          :class="isTierActive(tier) ? '' : 'text-ink-gray-9'"
+                        />
+                      </button>
+                    </div>
+
+                    <div
+                      v-if="tier.description"
+                      class="w-full prose prose-sm prose-p:text-xs prose-p:text-ink-gray-5 prose-p:leading-relaxed prose-p:my-0.5 max-w-full"
+                      v-html="renderedDescription(tier.description)"
+                    />
+                  </article>
                 </div>
-                <div class="flex items-center gap-1.5 text-sm text-ink-gray-7">
-                  <IconSoup class="w-5 h-5" />
-                  <span>Breakfast + Lunch included</span>
+
+                <!-- STEP 2: Attendee Details -->
+                <div v-else-if="currentStep === 2" class="flex flex-col gap-6">
+                  <AttendeeCard
+                    v-for="(attendee, idx) in attendees"
+                    :key="idx"
+                    :attendee="attendee"
+                    :index="idx"
+                    :tier-title="getTierTitle(attendee.ticket_type)"
+                    :custom-fields="!customFieldsApplyToAll ? event.data.custom_fields : []"
+                    :show-tshirt="Boolean(event.data.paid_tshirts_available)"
+                    :tshirt-price="event.data.t_shirt_price || 0"
+                    :tshirt-included="isTierTshirtIncluded(attendee.ticket_type)"
+                    :can-delete="attendees.length > 1"
+                    @update:attendee="attendees[idx] = $event"
+                    @delete="removeAttendee(idx)"
+                  />
+
+                  <div
+                    v-if="event.data.custom_fields?.length > 0 && attendees.length > 1"
+                    class="flex flex-col gap-4"
+                  >
+                    <Switch
+                      v-model="customFieldsApplyToAll"
+                      class="w-fit text-xs"
+                      label="Apply same answers for all tickets"
+                    />
+                    <div
+                      v-if="customFieldsApplyToAll"
+                      class="bg-surface-white border border-outline-gray-2 rounded-lg p-6 grid grid-cols-1 md:grid-cols-2 gap-6"
+                    >
+                      <FormControl
+                        v-for="field in event.data.custom_fields"
+                        :key="field.name"
+                        v-model="globalCustomFields[field.field_name]"
+                        :type="FIELD_TYPE_MAP[field.field_type]"
+                        :label="field.label"
+                        :options="field.options"
+                        :required="Boolean(field.mandatory)"
+                        size="sm"
+                        variant="subtle"
+                      />
+                    </div>
+                  </div>
+
+                  <div class="flex justify-center">
+                    <button
+                      :disabled="totalTickets >= MAX_SEATS"
+                      class="flex items-center gap-2 bg-outline-gray-1 hover:bg-outline-gray-2 border border-outline-gray-2 rounded-lg px-5 py-2.5 font-semibold text-sm uppercase tracking-wider text-ink-gray-9 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                      @click="addAttendee"
+                    >
+                      <IconPlus class="w-5 h-5" /> Add Another Ticket
+                    </button>
+                  </div>
+                </div>
+
+                <!-- STEP 3: Verify Details -->
+                <div v-else-if="currentStep === 3" class="flex flex-wrap gap-6 justify-center">
+                  <div
+                    v-for="(attendee, idx) in attendees"
+                    :key="idx"
+                    class="bg-surface-white border border-outline-gray-2 rounded-lg p-6 flex flex-col gap-5 w-full max-w-[375px]"
+                  >
+                    <div class="flex items-center justify-between">
+                      <span class="font-semibold text-2xl text-ink-gray-9 tracking-tight"
+                        >#{{ idx + 1 }}</span
+                      >
+                      <span
+                        class="bg-surface-green-1 text-ink-green-3 text-xs font-semibold tracking-wider uppercase px-3 py-1.5 rounded-lg"
+                        >{{ getTierTitle(attendee.ticket_type) }}</span
+                      >
+                    </div>
+                    <div class="flex flex-col gap-3">
+                      <div>
+                        <p class="font-semibold text-ink-gray-8">
+                          {{ attendee.full_name || '—' }}
+                        </p>
+                        <p class="text-sm text-ink-gray-5">
+                          {{
+                            [attendee.designation, attendee.organization]
+                              .filter(Boolean)
+                              .join(' | ')
+                          }}
+                        </p>
+                      </div>
+                      <div class="text-sm text-ink-gray-5 flex flex-col gap-1">
+                        <p>{{ attendee.email }}</p>
+                      </div>
+                    </div>
+                    <div class="flex items-center gap-6 flex-wrap">
+                      <div
+                        v-if="
+                          isTierTshirtIncluded(attendee.ticket_type) ||
+                          event.data.paid_tshirts_available
+                        "
+                        class="flex items-center gap-1.5 text-sm"
+                        :class="
+                          isTierTshirtIncluded(attendee.ticket_type)
+                            ? 'text-ink-green-3'
+                            : 'text-ink-gray-7'
+                        "
+                      >
+                        <IconShirt class="w-5 h-5" aria-hidden="true" />
+                        <span>{{
+                          isTierTshirtIncluded(attendee.ticket_type)
+                            ? 'T-shirt Included'
+                            : attendee.wants_tshirt
+                              ? attendee.tshirt_size
+                              : 'Without T-shirt'
+                        }}</span>
+                      </div>
+                      <div class="flex items-center gap-1.5 text-sm text-ink-gray-7">
+                        <IconSoup class="w-5 h-5" />
+                        <span>Breakfast + Lunch included</span>
+                      </div>
+                    </div>
+                    <p
+                      v-if="getTierDescription(attendee.ticket_type)"
+                      class="text-sm text-ink-gray-6"
+                    >
+                      {{ getTierDescription(attendee.ticket_type) }}
+                    </p>
+                  </div>
+                </div>
+
+                <!-- STEP 4: Billing -->
+                <div v-else-if="currentStep === 4">
+                  <BillingForm :billing="billing" :state-options="stateOptions.data" />
                 </div>
               </div>
-              <p v-if="getTierDescription(attendee.ticket_type)" class="text-sm text-ink-gray-6">
-                {{ getTierDescription(attendee.ticket_type) }}
-              </p>
+            </transition>
+
+            <!-- Navigation (Steps 1-3) -->
+            <template v-if="currentStep !== 4">
+              <div class="flex gap-4 items-center justify-end">
+                <Button
+                  v-if="currentStep > 1"
+                  label="Back"
+                  size="lg"
+                  variant="subtle"
+                  icon-left="chevron-left"
+                  class="uppercase !font-medium"
+                  @click="prevStep"
+                />
+                <Button
+                  label="Next"
+                  size="lg"
+                  variant="solid"
+                  icon-right="chevron-right"
+                  class="uppercase !font-medium !px-6"
+                  :disabled="currentStep === 1 && totalTickets === 0"
+                  @click="nextStep"
+                />
+              </div>
+            </template>
+            <div v-else class="flex justify-between">
+              <Button
+                label="Back"
+                size="lg"
+                variant="subtle"
+                icon-left="chevron-left"
+                class="uppercase !font-medium"
+                aria-label="Go back to verify details"
+                @click="prevStep"
+              />
+              <Button
+                label="Proceed to Pay"
+                size="lg"
+                variant="solid"
+                icon-right="chevron-right"
+                class="uppercase !font-medium !px-6"
+                :loading="rzpCheckout?.resource.loading"
+                aria-label="Proceed to payment"
+                @click="createOrder"
+              />
             </div>
+
+            <!-- Error messages -->
+            <ul
+              v-if="errorMessages.length"
+              role="alert"
+              aria-live="assertive"
+              class="flex flex-col gap-1 p-3 rounded-lg bg-surface-red-1 border border-outline-red-2"
+            >
+              <li
+                v-for="msg in errorMessages"
+                :key="msg"
+                class="text-sm text-ink-red-3 flex items-start gap-1.5"
+              >
+                <span class="mt-0.5 shrink-0">•</span>
+                <span>{{ msg }}</span>
+              </li>
+            </ul>
           </div>
 
-          <!-- STEP 4: Billing -->
-          <div v-else-if="currentStep === 4">
-            <BillingForm :billing="billing" :state-options="stateOptions.data" />
-          </div>
+          <aside
+            class="hidden md:block shrink-0 w-[300px] self-start sticky top-6"
+            aria-label="Order summary"
+          >
+            <TicketSummary
+              :active-tier-counts="activeTierCounts"
+              :all-tiers="allTiers"
+              :tshirt-count="numTShirtsAdded"
+              :tshirt-price="event.data.t_shirt_price || 0"
+              :error-message="currentStep === 4 ? errorMessage || '' : ''"
+            />
+          </aside>
         </div>
-      </transition>
-
-      <!-- Navigation (Steps 1-3) -->
-      <template v-if="currentStep !== 4">
-        <div class="flex gap-4 items-center justify-end">
-          <Button
-            v-if="currentStep > 1"
-            label="Back"
-            size="lg"
-            variant="subtle"
-            icon-left="chevron-left"
-            class="uppercase !font-medium"
-            @click="prevStep"
-          />
-          <Button
-            label="Next"
-            size="lg"
-            variant="solid"
-            icon-right="chevron-right"
-            class="uppercase !font-medium !px-6"
-            :disabled="currentStep === 1 && totalTickets === 0"
-            @click="nextStep"
-          />
-        </div>
-      </template>
-      <div v-else class="flex justify-between">
-        <Button
-          label="Back"
-          size="lg"
-          variant="subtle"
-          icon-left="chevron-left"
-          class="uppercase !font-medium"
-          aria-label="Go back to verify details"
-          @click="prevStep"
-        />
-        <Button
-          label="Proceed to Pay"
-          size="lg"
-          variant="solid"
-          icon-right="chevron-right"
-          class="uppercase !font-medium !px-6"
-          :loading="rzpCheckout?.resource.loading"
-          aria-label="Proceed to payment"
-          @click="createOrder"
-        />
-      </div>
-
-      <!-- Error messages -->
-      <ul
-        v-if="errorMessages.length"
-        role="alert"
-        aria-live="assertive"
-        class="flex flex-col gap-1 p-3 rounded-lg bg-surface-red-1 border border-outline-red-2"
-      >
-        <li
-          v-for="msg in errorMessages"
-          :key="msg"
-          class="text-sm text-ink-red-3 flex items-start gap-1.5"
-        >
-          <span class="mt-0.5 shrink-0">•</span>
-          <span>{{ msg }}</span>
-        </li>
-      </ul>
-        </div>
-
-        <aside
-          class="hidden md:block shrink-0 w-[300px] self-start sticky top-6"
-          aria-label="Order summary"
-        >
-          <TicketSummary
-            :active-tier-counts="activeTierCounts"
-            :all-tiers="allTiers"
-            :tshirt-count="numTShirtsAdded"
-            :tshirt-price="event.data.t_shirt_price || 0"
-            :error-message="currentStep === 4 ? (errorMessage || '') : ''"
-          />
-        </aside>
-      </div>
       </main>
     </div>
 
@@ -433,7 +448,7 @@
           :all-tiers="allTiers"
           :tshirt-count="numTShirtsAdded"
           :tshirt-price="event.data.t_shirt_price || 0"
-          :error-message="currentStep === 4 ? (errorMessage || '') : ''"
+          :error-message="currentStep === 4 ? errorMessage || '' : ''"
         />
       </div>
       <!-- Always visible: total toggle row -->
@@ -453,7 +468,11 @@
             ₹{{ summaryTotal }}
           </p>
         </div>
-        <IconChevronUp v-if="mobileBarExpanded" class="w-5 h-5 text-ink-gray-5" aria-hidden="true" />
+        <IconChevronUp
+          v-if="mobileBarExpanded"
+          class="w-5 h-5 text-ink-gray-5"
+          aria-hidden="true"
+        />
         <IconChevronDown v-else class="w-5 h-5 text-ink-gray-5" aria-hidden="true" />
       </button>
     </div>
@@ -595,8 +614,9 @@ const totalTickets = computed(() =>
   Object.values(activeTierCounts.value).reduce((s, c) => s + (c || 0), 0),
 )
 
-const numTShirtsAdded = computed(() =>
-  attendees.value.filter((a) => a.wants_tshirt && !isTierTshirtIncluded(a.ticket_type)).length
+const numTShirtsAdded = computed(
+  () =>
+    attendees.value.filter((a) => a.wants_tshirt && !isTierTshirtIncluded(a.ticket_type)).length,
 )
 
 const summaryTotal = computed(() => {
@@ -766,16 +786,6 @@ function removeAttendee(index) {
   if (removed?.ticket_type && (tierCounts[removed.ticket_type] || 0) > 0) {
     tierCounts[removed.ticket_type]--
   }
-}
-
-function onUpdateAttendee(idx, newAttendee) {
-  const old = attendees.value[idx]
-  if (old.ticket_type !== newAttendee.ticket_type) {
-    if (old.ticket_type && (tierCounts[old.ticket_type] || 0) > 0) tierCounts[old.ticket_type]--
-    if (newAttendee.ticket_type)
-      tierCounts[newAttendee.ticket_type] = (tierCounts[newAttendee.ticket_type] || 0) + 1
-  }
-  attendees.value[idx] = newAttendee
 }
 
 // Navigation

--- a/fossunited/api/dashboard.py
+++ b/fossunited/api/dashboard.py
@@ -1,7 +1,14 @@
 import frappe
 from frappe import _
 
-from fossunited.doctype_ids import CHAPTER, EVENT, RAZORPAY_PAYMENT, TICKET_TIER, USER_PROFILE
+from fossunited.doctype_ids import (
+    CHAPTER,
+    EVENT,
+    EVENT_TICKET,
+    RAZORPAY_PAYMENT,
+    TICKET_TIER,
+    USER_PROFILE,
+)
 from fossunited.utils.payments import (
     get_in_razorpay_money,
     get_razorpay_client,
@@ -28,6 +35,13 @@ def get_event(name: str, by_route: bool = False) -> dict:
 
     if doc.chapter:
         data["chapter_email"] = frappe.db.get_value(CHAPTER, doc.chapter, "email")
+
+    for tier in data.get("tiers", []):
+        if tier.get("maximum_tickets"):
+            tier["sold_count"] = frappe.db.count(
+                EVENT_TICKET,
+                {"event": event_id, "tier": tier.get("title")},
+            )
 
     return data
 


### PR DESCRIPTION

<img width="900" height="475" alt="image" src="https://github.com/user-attachments/assets/2ac3e671-c3f6-4085-8ab9-07f49927e4ed" />


- Extract billing summary into separate component (reduce LOC)
- move ticket billing summary to right aside to progress steps for ease of track
- show the total breakdown in sticky bottom for mobile.
- Make tier and del button compact for mobile
- Badge order are like:

  "Coming soon": if closing is ahead and disabled early
  "Sold Out": if total > max allowed
  "Only X left": if <10% remaining
  "X left": if > 10% and <25% left
  "X available": if >25% left


Note: Most of the LOC diff is due to prettier format indenting the code