### PR TITLE
fix(indiafoss): format card deadline date for improved readability

### DIFF
--- a/fossunited/www/indiafoss/2026/index.html
+++ b/fossunited/www/indiafoss/2026/index.html
@@ -243,7 +243,7 @@
                       {% endif %}
                     </div>
                     {% if card.deadline %}
-                      <span class="v3-action-card-sub">Due {{ card.deadline }}</span>
+                      <span class="v3-action-card-sub">Due {{ frappe.utils.format_date(card.deadline, format_string='dd MMM yyyy') }}</span>
                     {% elif card.get('description', '') %}
                       <span class="v3-action-card-sub">{{ card.description }}</span>
                     {% elif card.badge and badge_lower != 'live' %}


### PR DESCRIPTION
| before | after |
| ------ | ------ |
| <img width="774" height="450" alt="telegram-cloud-photo-size-5-6113698359324380952-x" src="https://github.com/user-attachments/assets/7dcaf5bc-2ce9-45ad-8f13-13ec292b8ba6" /> | <img width="755" height="431" alt="image" src="https://github.com/user-attachments/assets/321b8741-202d-4618-8544-89286e8258f9" /> |

## Summary
- Format action card deadline dates using `frappe.utils.format_date` with `dd MMM yyyy` format for better readability (e.g., "01 Jun 2026" instead of raw date string)