### PR TITLE
feat(freeTicketCode): idempotent function to send free ticket coupon to all approvde speakers from proposals

### DIFF
--- a/dashboard/src/components/event/FreeTicketCodeSection.vue
+++ b/dashboard/src/components/event/FreeTicketCodeSection.vue
@@ -1,74 +1,125 @@
 <template>
   <div>
-  <FreeTicketCodeDialog
-    v-model="showDialog"
-    :event="event"
-    :in-create-mode="inCreateMode"
-    :row="selectedRow"
-    @refresh="freeCodes.fetch()"
-  />
-  <div>
-    <div class="prose w-full mb-4">
-      <h2 class="mb-1">Free Ticket Codes</h2>
-      <p class="text-sm">Manage free ticket codes for this event.</p>
-      <Button variant="solid" label="Create Free Coupon" icon-left="plus" @click="handleCreate" />
-    </div>
-
-    <SearchListView
-      v-if="freeCodes.data && freeCodes.data.length > 0"
-      :rows="groupedRows"
-      class="mt-4 min-h-[300px]"
-      :columns="[
-        { label: 'Full Name', key: 'full_name', icon: 'user' },
-        { label: 'Coupon ID', key: 'name', width: '100px' },
-        { label: 'Email', key: 'mapped_email', icon: 'at-sign' },
-        {
-          label: 'Used / Max',
-          key: 'usage',
-          icon: 'check-circle',
-          width: '100px',
-          exportValue: (row) => `${row.used_count ?? 0} / ${row.max_count ?? 0}`,
-        },
-        { label: 'Tier', key: 'tier', icon: 'award', width: '200px' },
-        { label: 'Organization', key: 'company', icon: 'briefcase' },
-      ]"
-      row-key="name"
-      search-placeholder="Search free coupons…"
-      item-label="free coupons"
-      export-filename="event_coupons"
-      :options="{
-        emptyState: {
-          title: 'No Free Codes',
-          description: 'No free ticket codes have been added yet.',
-        },
-        onRowClick: (row) => handleEdit(row),
-      }"
-    >
-      <template #cell="{ item, row, column }">
-        <div v-if="column.key === 'usage'">
-          <span
-            class="px-2 py-1 rounded text-sm font-medium"
-            :class="
-              row.used_count >= row.max_count
-                ? 'bg-surface-red-2 text-ink-red-3'
-                : 'bg-surface-green-2 text-ink-green-3'
-            "
-          >
-            {{ row.used_count }} / {{ row.max_count }}
-          </span>
+    <FreeTicketCodeDialog
+      v-model="showDialog"
+      :event="event"
+      :in-create-mode="inCreateMode"
+      :row="selectedRow"
+      @refresh="freeCodes.fetch()"
+    />
+    <div>
+      <div class="prose w-full mb-4">
+        <h2 class="mb-1">Free Ticket Codes</h2>
+        <p class="text-sm">Manage free ticket codes for this event.</p>
+        <div class="flex gap-2">
+          <Button
+            variant="solid"
+            label="Create Free Coupon"
+            icon-left="plus"
+            @click="handleCreate"
+          />
+          <Button
+            variant="outline"
+            label="Speaker Coupons"
+            icon-left="users"
+            :disabled="!canCreateSpeakerCoupons"
+            :title="canCreateSpeakerCoupons
+              ? 'Auto-create free ticket coupons for approved CFP speakers who don\'t have one yet'
+              : 'Only available while event is Live and before the event starts'"
+            @click="showSpeakerDialog = true"
+          />
         </div>
-        <div v-else>
-          <span class="text-base truncate text-wrap">{{ item }}</span>
+      </div>
+
+      <SearchListView
+        v-if="freeCodes.data && freeCodes.data.length > 0"
+        :rows="groupedRows"
+        class="mt-4 min-h-[300px]"
+        :columns="[
+          { label: 'Full Name', key: 'full_name', icon: 'user' },
+          { label: 'Coupon ID', key: 'name', width: '100px' },
+          { label: 'Email', key: 'mapped_email', icon: 'at-sign' },
+          {
+            label: 'Used / Max',
+            key: 'usage',
+            icon: 'check-circle',
+            width: '100px',
+            exportValue: (row) => `${row.used_count ?? 0} / ${row.max_count ?? 0}`,
+          },
+          { label: 'Tier', key: 'tier', icon: 'award', width: '200px' },
+          { label: 'Organization', key: 'company', icon: 'briefcase' },
+        ]"
+        row-key="name"
+        search-placeholder="Search free coupons…"
+        item-label="free coupons"
+        export-filename="event_coupons"
+        :options="{
+          emptyState: {
+            title: 'No Free Codes',
+            description: 'No free ticket codes have been added yet.',
+          },
+          onRowClick: (row) => handleEdit(row),
+        }"
+      >
+        <template #cell="{ item, row, column }">
+          <div v-if="column.key === 'usage'">
+            <span
+              class="px-2 py-1 rounded text-sm font-medium"
+              :class="
+                row.used_count >= row.max_count
+                  ? 'bg-surface-red-2 text-ink-red-3'
+                  : 'bg-surface-green-2 text-ink-green-3'
+              "
+            >
+              {{ row.used_count }} / {{ row.max_count }}
+            </span>
+          </div>
+          <div v-else>
+            <span class="text-base truncate text-wrap">{{ item }}</span>
+          </div>
+        </template>
+      </SearchListView>
+    </div>
+    <Dialog v-model="showSpeakerDialog" :options="{ title: 'Speaker Coupons' }">
+      <template #body-content>
+        <div class="flex flex-col gap-4">
+          <p v-if="speakerPreview.loading" class="text-sm text-ink-gray-5">Loading…</p>
+          <div v-else-if="speakerPreview.data" class="text-sm text-ink-gray-7">
+            <span class="font-medium">{{ speakerPreview.data.total }}</span> speaker(s) from all approved proposals ·
+            <span class="font-medium">{{ speakerPreview.data.already_has }}</span> already have
+            coupons ·
+            <span class="font-medium text-ink-green-3">{{ speakerPreview.data.will_create }}</span>
+            will be created
+          </div>
+          <FormControl
+            v-model="speakerMaxCount"
+            label="Tickets per speaker"
+            type="number"
+            :min="1"
+            :max="3"
+            description="How many times each coupon can be used (1–3)"
+          />
+          <p v-if="speakerPreviewErr" class="text-sm text-ink-red-3">{{ speakerPreviewErr }}</p>
         </div>
       </template>
-    </SearchListView>
-  </div>
+      <template #actions>
+        <Button label="Cancel" @click="showSpeakerDialog = false" />
+        <Button
+          variant="solid"
+          label="Create Coupons"
+          :loading="bulkCreate.loading"
+          :disabled="!speakerPreview.data || speakerPreview.data.will_create === 0 || bulkCreate.loading"
+          @click="() => { speakerPreviewErr = ''; bulkCreate.fetch() }"
+        />
+      </template>
+    </Dialog>
   </div>
 </template>
 
 <script setup>
-import { defineProps, ref, watchEffect } from 'vue'
-import { createResource, Button } from 'frappe-ui'
+import { defineProps, ref, watchEffect, watch, computed } from 'vue'
+import { createResource, Button, Dialog, FormControl } from 'frappe-ui'
+import { toast } from 'vue-sonner'
 import FreeTicketCodeDialog from '@/components/event/FreeTicketCodeDialog.vue'
 import { useRoute } from 'vue-router'
 import SearchListView from '@/components/ui/SearchListView.vue'
@@ -81,6 +132,13 @@ const props = defineProps({
 })
 
 const route = useRoute()
+
+// Allow Speaker Coupons only while the event is live and hasn't started yet
+const canCreateSpeakerCoupons = computed(() => {
+  const { status, event_start_date } = props.event
+  if (!status || !event_start_date) return false
+  return status === 'Live' && new Date() < new Date(event_start_date)
+})
 const showDialog = ref(false)
 const inCreateMode = ref(false)
 const selectedRow = ref({})
@@ -94,6 +152,39 @@ const freeCodes = createResource({
     }
   },
   auto: true,
+})
+
+const showSpeakerDialog = ref(false)
+const speakerMaxCount = ref(1)
+const speakerPreviewErr = ref('')
+
+const speakerPreview = createResource({
+  url: 'fossunited.api.tickets.get_speaker_coupon_preview',
+  makeParams: () => ({ event: props.event.name || route.params.id }),
+})
+
+const bulkCreate = createResource({
+  url: 'fossunited.api.tickets.bulk_create_speaker_coupons',
+  makeParams: () => ({
+    event: props.event.name || route.params.id,
+    max_count: speakerMaxCount.value,
+  }),
+  onSuccess(r) {
+    toast.success(`Created ${r.created} coupon(s), skipped ${r.skipped}`)
+    showSpeakerDialog.value = false
+    speakerMaxCount.value = 1
+    freeCodes.fetch()
+  },
+  onError(e) {
+    speakerPreviewErr.value = e.message
+  },
+})
+
+watch(showSpeakerDialog, (open) => {
+  if (open) {
+    speakerPreviewErr.value = ''
+    speakerPreview.fetch()
+  }
 })
 
 watchEffect(() => {

--- a/fossunited/api/checkins.py
+++ b/fossunited/api/checkins.py
@@ -2,11 +2,12 @@ import frappe
 from frappe import _
 from frappe.utils import getdate, now_datetime, today
 
-from fossunited.api.tickets import has_valid_permission
 from fossunited.doctype_ids import EVENT_TICKET
+from fossunited.utils.decorators import require_chapter_or_event_member
 
 
 @frappe.whitelist()
+@require_chapter_or_event_member(event_id="event_id")
 def get_attendee_with_checkin_data(event_id: str, filters: dict | None = None) -> dict:
     """
     Get the attendees of the event with their checkin details
@@ -18,11 +19,6 @@ def get_attendee_with_checkin_data(event_id: str, filters: dict | None = None) -
     Returns:
         dict: The attendees of the event with their checkin details
     """
-    if not has_valid_permission(event_id):
-        frappe.throw(
-            _("You do not have permission to access this resource"), frappe.PermissionError
-        )
-
     _filters = {"event": event_id}
     # Map the items in filters to be like "key": ["like", value]
     _filters.update({key: ["like", f"%{value}%"] for key, value in filters.items()})
@@ -69,6 +65,7 @@ def get_checkin_data(attendee_id: str) -> dict:
 
 
 @frappe.whitelist()
+@require_chapter_or_event_member(event_id="event_id")
 def checkin_attendee(event_id: str, attendee: dict, assign_tshirt: bool = False):
     """
     Check-in the attendee for the event.
@@ -78,11 +75,6 @@ def checkin_attendee(event_id: str, attendee: dict, assign_tshirt: bool = False)
         attendee (dict): The attendee details / ticket details
         assign_tshirt (bool): Whether to assign a T-shirt to the attendee
     """
-    if not has_valid_permission(event_id):
-        frappe.throw(
-            _("You do not have permission to access this resource"), frappe.PermissionError
-        )
-
     ticket = frappe.get_doc(EVENT_TICKET, attendee["name"])
 
     already_checked_in = check_if_already_checked_in(attendee["name"])
@@ -131,6 +123,7 @@ def check_if_already_checked_in(attendee_id: str) -> bool:
 
 
 @frappe.whitelist()
+@require_chapter_or_event_member(event_id="event_id")
 def undo_attendee_checkin(event_id: str, attendee: dict):
     """
     Undo the check-in for the attendee
@@ -139,17 +132,13 @@ def undo_attendee_checkin(event_id: str, attendee: dict):
         attendee (dict): The attendee details / ticket details
         user (str): The user who is undoing the check-in
     """
-    if not has_valid_permission(event_id):
-        frappe.throw(
-            _("You do not have permission to access this resource"), frappe.PermissionError
-        )
-
     ticket = frappe.get_doc(EVENT_TICKET, attendee["name"])
     ticket.check_ins.pop()
     ticket.save(ignore_permissions=True)
 
 
 @frappe.whitelist()
+@require_chapter_or_event_member(event_id="event_id")
 def assign_tshirt(event_id: str, attendee: dict):
     """
     Assign Tshirt to the attendee
@@ -159,11 +148,6 @@ def assign_tshirt(event_id: str, attendee: dict):
         attendee (dict): The attendee details / ticket details
         user (str): The user who is assigning the Tshirt
     """
-    if not has_valid_permission(event_id):
-        frappe.throw(
-            _("You do not have permission to access this resource"), frappe.PermissionError
-        )
-
     ticket = frappe.get_doc(EVENT_TICKET, attendee["name"])
     ticket.tshirt_delivered = True
     ticket.save(ignore_permissions=True)

--- a/fossunited/api/tickets.py
+++ b/fossunited/api/tickets.py
@@ -482,25 +482,39 @@ def get_event_free_codes(event: str):
 
 
 def _get_approved_speaker_emails_for_event(event: str) -> dict[str, str]:
-    """Return {email: full_name} for unique speakers across approved proposals."""
-    proposal_names = frappe.get_all(
+    """Return {email: full_name} for unique speakers across approved proposals.
+
+    Unions two sources: CFP Submission Speaker child rows + proposal-level email field.
+    Speaker child rows take priority for full_name when the same email appears in both.
+    """
+    proposals = frappe.get_all(
         PROPOSAL,
         filters={"event": event, "status": "Approved"},
-        pluck="name",
+        fields=["name", "email", "full_name"],
     )
-    if not proposal_names:
+    if not proposals:
         return {}
 
-    rows = frappe.get_all(
+    proposal_names = [p.name for p in proposals]
+
+    # Source 1: speaker child table (higher priority — more specific per-event entry)
+    speaker_rows = frappe.get_all(
         SPEAKER,
         filters={"parent": ["in", proposal_names], "parenttype": PROPOSAL},
         fields=["email", "full_name"],
     )
     result = {}
-    for r in rows:
+    for r in speaker_rows:
         if r.email:
             key = r.email.strip().lower()
             result.setdefault(key, r.full_name or "")
+
+    # Source 2: proposal-level email field (fallback for single-speaker submissions)
+    for p in proposals:
+        if p.email:
+            key = p.email.strip().lower()
+            result.setdefault(key, p.full_name or "")
+
     return result
 
 

--- a/fossunited/api/tickets.py
+++ b/fossunited/api/tickets.py
@@ -9,7 +9,6 @@ from frappe import _
 from frappe.rate_limiter import rate_limit
 from frappe.utils import add_days, now_datetime
 
-from fossunited.api.chapter import check_if_chapter_member
 from fossunited.doctype_ids import (
     EVENT,
     EVENT_CHECKIN,
@@ -19,6 +18,7 @@ from fossunited.doctype_ids import (
     RAZORPAY_PAYMENT,
     TICKET_TRANSFER,
 )
+from fossunited.utils.decorators import require_chapter_or_event_member
 
 
 # nosemgrep: guest-whitelisted-method
@@ -297,6 +297,7 @@ def get_percentage_change(today: float, yesterday: float) -> float:
 
 
 @frappe.whitelist()
+@require_chapter_or_event_member(event_id="event_id")
 def get_tickets_with_custom_fields(event_id: str) -> list:
     """
     Get all tickets with their custom field answers merged as dynamic fields.
@@ -308,8 +309,6 @@ def get_tickets_with_custom_fields(event_id: str) -> list:
     Returns:
         dict: Dictionary containing tickets list and custom field names
     """
-    if not has_valid_permission(event_id):
-        frappe.throw(_("You are not authorized to view the tickets for this event"))
 
     from frappe.query_builder import DocType
     from frappe.query_builder.functions import Coalesce
@@ -360,38 +359,6 @@ def get_tickets_with_custom_fields(event_id: str) -> list:
             tickets_map[ticket_id][row["question"]] = row["response"] or ""
 
     return list(tickets_map.values())
-
-
-def has_valid_permission(event_id: str) -> bool:
-    """
-    Check if the user has valid permission to view the tickets for the event
-
-    Args:
-        event_id (str): Event ID
-
-    Returns:
-        bool: True if the user has valid permission, False otherwise
-    """
-    session_user = frappe.session.user
-
-    # Allow if user has "Chapter Team Member" role AND is a member of the chapter
-    if frappe.db.exists("Has Role", {"role": "Chapter Team Member", "parent": session_user}):
-        chapter_id = frappe.db.get_value(EVENT, event_id, "chapter")
-        if chapter_id and check_if_chapter_member(chapter_id, session_user):
-            return True
-
-    # Allow if user is listed as an event member
-    if frappe.db.exists(
-        "FOSS Chapter Event Member",
-        {
-            "parent": event_id,
-            "parenttype": EVENT,
-            "email": session_user,
-        },
-    ):
-        return True
-
-    return False
 
 
 @frappe.whitelist()
@@ -488,11 +455,9 @@ def get_free_pass_insights(event_id: str) -> dict:
 
 
 @frappe.whitelist()
+@require_chapter_or_event_member(event_id="event")
 def get_event_free_codes(event: str):
     """Get all free ticket codes for an event"""
-
-    if not has_valid_permission(event):
-        frappe.throw(_("You are not authorized to view the tickets for this event"))
 
     codes = frappe.get_all(
         FREE_TICKET_CODE,

--- a/fossunited/api/tickets.py
+++ b/fossunited/api/tickets.py
@@ -481,11 +481,11 @@ def get_event_free_codes(event: str):
     return codes
 
 
-def _get_approved_speaker_emails_for_event(event: str) -> dict[str, str]:
-    """Return {email: full_name} for unique speakers across approved proposals.
+def _get_approved_speaker_emails_for_event(event: str) -> dict[str, tuple[str, int]]:
+    """Return {email: (full_name, talk_count)} for unique speakers across approved proposals.
 
-    Unions two sources: CFP Submission Speaker child rows + proposal-level email field.
-    Speaker child rows take priority for full_name when the same email appears in both.
+    talk_count is the number of approved proposals this speaker appears in.
+    Speaker child rows take priority; proposal-level email is a fallback when no child rows exist.
     """
     proposals = frappe.get_all(
         PROPOSAL,
@@ -496,26 +496,37 @@ def _get_approved_speaker_emails_for_event(event: str) -> dict[str, str]:
         return {}
 
     proposal_names = [p.name for p in proposals]
-
-    # Source 1: speaker child table (higher priority — more specific per-event entry)
     speaker_rows = frappe.get_all(
         SPEAKER,
         filters={"parent": ["in", proposal_names], "parenttype": PROPOSAL},
-        fields=["email", "full_name"],
+        fields=["email", "full_name", "parent"],
     )
-    result = {}
+
+    rows_by_proposal = {}
     for r in speaker_rows:
-        if r.email:
-            key = r.email.strip().lower()
-            result.setdefault(key, r.full_name or "")
+        rows_by_proposal.setdefault(r.parent, []).append(r)
 
-    # Source 2: proposal-level email field (fallback for single-speaker submissions)
+    email_data = {}  # email → [full_name, talk_count]
+
     for p in proposals:
-        if p.email:
-            key = p.email.strip().lower()
-            result.setdefault(key, p.full_name or "")
+        p_emails = set()
 
-    return result
+        for r in rows_by_proposal.get(p.name, []):
+            if r.email:
+                key = r.email.strip().lower()
+                p_emails.add(key)
+                email_data.setdefault(key, [r.full_name or "", 0])
+
+        # Fallback: proposal-level email if no speaker child rows on this proposal
+        if not p_emails and p.email:
+            key = p.email.strip().lower()
+            p_emails.add(key)
+            email_data.setdefault(key, [p.full_name or "", 0])
+
+        for key in p_emails:
+            email_data[key][1] += 1
+
+    return {email: (name, count) for email, (name, count) in email_data.items()}
 
 
 def _get_existing_coupon_emails_for_event(event: str) -> set[str]:
@@ -552,9 +563,9 @@ def bulk_create_speaker_coupons(event: str, max_count: int = 1) -> dict:
 
     info = _get_approved_speaker_emails_for_event(event)
     existing = _get_existing_coupon_emails_for_event(event)
-    to_create = {e: n for e, n in info.items() if e not in existing}
+    to_create = {e: v for e, v in info.items() if e not in existing}
 
-    for email, full_name in to_create.items():
+    for email, (full_name, talk_count) in to_create.items():
         frappe.get_doc(
             {
                 "doctype": FREE_TICKET_CODE,
@@ -562,7 +573,7 @@ def bulk_create_speaker_coupons(event: str, max_count: int = 1) -> dict:
                 "mapped_email": email,
                 "full_name": full_name,
                 "tier": "Speaker/Workshop Host",
-                "max_count": max_count,
+                "max_count": max_count * talk_count,
             }
         ).insert(ignore_permissions=True)
 

--- a/fossunited/api/tickets.py
+++ b/fossunited/api/tickets.py
@@ -15,7 +15,9 @@ from fossunited.doctype_ids import (
     EVENT_TICKET,
     FREE_TICKET_APPLY,
     FREE_TICKET_CODE,
+    PROPOSAL,
     RAZORPAY_PAYMENT,
+    SPEAKER,
     TICKET_TRANSFER,
 )
 from fossunited.utils.decorators import require_chapter_or_event_member
@@ -477,6 +479,80 @@ def get_event_free_codes(event: str):
     )
 
     return codes
+
+
+def _get_approved_speaker_emails_for_event(event: str) -> dict[str, str]:
+    """Return {email: full_name} for unique speakers across approved proposals."""
+    proposal_names = frappe.get_all(
+        PROPOSAL,
+        filters={"event": event, "status": "Approved"},
+        pluck="name",
+    )
+    if not proposal_names:
+        return {}
+
+    rows = frappe.get_all(
+        SPEAKER,
+        filters={"parent": ["in", proposal_names], "parenttype": PROPOSAL},
+        fields=["email", "full_name"],
+    )
+    result = {}
+    for r in rows:
+        if r.email:
+            key = r.email.strip().lower()
+            result.setdefault(key, r.full_name or "")
+    return result
+
+
+def _get_existing_coupon_emails_for_event(event: str) -> set[str]:
+    existing = frappe.get_all(FREE_TICKET_CODE, filters={"event": event}, pluck="mapped_email")
+    return {e.strip().lower() for e in existing if e}
+
+
+@frappe.whitelist()
+@require_chapter_or_event_member(event_id="event")
+def get_speaker_coupon_preview(event: str) -> dict:
+    """Return stats on how many speaker coupons would be created."""
+    info = _get_approved_speaker_emails_for_event(event)
+    existing = _get_existing_coupon_emails_for_event(event)
+    already_has = len(set(info) & existing)
+    return {
+        "total": len(info),
+        "already_has": already_has,
+        "will_create": len(info) - already_has,
+    }
+
+
+@frappe.whitelist()
+@require_chapter_or_event_member(event_id="event")
+def bulk_create_speaker_coupons(event: str, max_count: int = 1) -> dict:
+    """
+    Idempotently create EventFreeTicketCode docs for approved CFP speakers.
+
+    Skips speakers who already have a coupon for this event.
+    """
+
+    max_count = int(max_count)
+    if not 1 <= max_count <= 3:
+        frappe.throw(_("max_count must be between 1 and 3"))
+
+    info = _get_approved_speaker_emails_for_event(event)
+    existing = _get_existing_coupon_emails_for_event(event)
+    to_create = {e: n for e, n in info.items() if e not in existing}
+
+    for email, full_name in to_create.items():
+        frappe.get_doc(
+            {
+                "doctype": FREE_TICKET_CODE,
+                "event": event,
+                "mapped_email": email,
+                "full_name": full_name,
+                "tier": "Speaker/Workshop Host",
+                "max_count": max_count,
+            }
+        ).insert(ignore_permissions=True)
+
+    return {"created": len(to_create), "skipped": len(info) - len(to_create)}
 
 
 # nosemgrep: guest-whitelisted-method

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -186,7 +186,10 @@ class FOSSEventCFPSubmission(WebsiteGenerator):
 
     def check_status(self) -> None:
         if self.status != "Review Pending":
-            frappe.throw(_("Illegal status change"), frappe.ValidationError)
+            frappe.throw(
+                _("New CFP submissions must start with status 'Review Pending'"),
+                frappe.ValidationError,
+            )
 
     def validate_linked_cfp_exists(self) -> None:
         if not frappe.db.exists(EVENT_CFP, self.linked_cfp):

--- a/fossunited/tests/test_speaker_coupons.py
+++ b/fossunited/tests/test_speaker_coupons.py
@@ -54,12 +54,13 @@ class TestSpeakerCoupons(FrappeTestCase):
             frappe.delete_doc(PROPOSAL, name, force=True, ignore_missing=True)
 
     def _approved(self, speakers):
-        return FOSSEventCFPSubmissionFactory.create(
-            "with_approved_status",
+        sub = FOSSEventCFPSubmissionFactory.create(
             linked_cfp=self.cfp.name,
             event=self.event.name,
             speakers=speakers,
         )
+        frappe.db.set_value(PROPOSAL, sub.name, "status", "Approved")
+        return sub
 
     def test_creates_coupon_for_approved_speaker(self):
         self._approved([_speaker("alice@test.com")])

--- a/fossunited/tests/test_speaker_coupons.py
+++ b/fossunited/tests/test_speaker_coupons.py
@@ -1,0 +1,130 @@
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from fossunited.api.tickets import (
+    bulk_create_speaker_coupons,
+    get_speaker_coupon_preview,
+)
+from fossunited.doctype_ids import CHAPTER, EVENT, FREE_TICKET_CODE, PROPOSAL
+from fossunited.tests.factories import (
+    FOSSChapterEventFactory,
+    FOSSChapterFactory,
+    FOSSEventCFPFactory,
+    FOSSEventCFPSubmissionFactory,
+    FreeTicketCodeFactory,
+    UserFactory,
+)
+
+
+def _speaker(email, name="Speaker"):
+    return {
+        "full_name": name,
+        "email": email,
+        "designation": "Speaker",
+        "organization": "alwaysFOSS",
+        "bio": "Touch Grass and watch OnePiece",
+    }
+
+
+class TestSpeakerCoupons(FrappeTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        frappe.set_user("Administrator")
+        cls.team_member = UserFactory.create("with_foss_website_user_role")
+        cls.chapter = FOSSChapterFactory.create("with_members", members=[cls.team_member.name])
+        cls.event = FOSSChapterEventFactory.create(chapter=cls.chapter.name)
+        cls.cfp = FOSSEventCFPFactory.create(event=cls.event.name)
+
+    @classmethod
+    def tearDownClass(cls):
+        frappe.set_user("Administrator")
+        frappe.db.delete(FREE_TICKET_CODE, {"event": cls.event.name})
+        for name in frappe.get_all(PROPOSAL, filters={"event": cls.event.name}, pluck="name"):
+            frappe.delete_doc(PROPOSAL, name, force=True, ignore_missing=True)
+        cls.cfp.delete(force=True)
+        frappe.delete_doc(EVENT, cls.event.name, force=True)
+        frappe.delete_doc(CHAPTER, cls.chapter.name, force=True)
+        super().tearDownClass()
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+        frappe.db.delete(FREE_TICKET_CODE, {"event": self.event.name})
+        for name in frappe.get_all(PROPOSAL, filters={"event": self.event.name}, pluck="name"):
+            frappe.delete_doc(PROPOSAL, name, force=True, ignore_missing=True)
+
+    def _approved(self, speakers):
+        return FOSSEventCFPSubmissionFactory.create(
+            "with_approved_status",
+            linked_cfp=self.cfp.name,
+            event=self.event.name,
+            speakers=speakers,
+        )
+
+    def test_creates_coupon_for_approved_speaker(self):
+        self._approved([_speaker("alice@test.com")])
+        frappe.set_user(self.team_member.name)
+
+        result = bulk_create_speaker_coupons(event=self.event.name, max_count=1)
+
+        self.assertEqual(result["created"], 1)
+        self.assertTrue(
+            frappe.db.exists(
+                FREE_TICKET_CODE,
+                {"event": self.event.name, "mapped_email": "alice@test.com"},
+            )
+        )
+
+    def test_multi_talk_speaker_gets_multiplied_max_count(self):
+        # Same speaker, two approved proposals
+        self._approved([_speaker("bob@test.com")])
+        self._approved([_speaker("bob@test.com")])
+        frappe.set_user(self.team_member.name)
+
+        bulk_create_speaker_coupons(event=self.event.name, max_count=2)
+
+        max_count = frappe.db.get_value(
+            FREE_TICKET_CODE,
+            {"event": self.event.name, "mapped_email": "bob@test.com"},
+            "max_count",
+        )
+        self.assertEqual(int(max_count), 4)  # 2 per talk * 2 talks
+
+    def test_idempotent_skips_existing(self):
+        self._approved([_speaker("carol@test.com")])
+        frappe.set_user(self.team_member.name)
+
+        bulk_create_speaker_coupons(event=self.event.name, max_count=1)
+        result = bulk_create_speaker_coupons(event=self.event.name, max_count=1)
+
+        self.assertEqual(result["created"], 0)
+        self.assertEqual(result["skipped"], 1)
+
+    def test_non_approved_proposals_excluded(self):
+        # Status defaults to "Review Pending" — no approved proposals
+        FOSSEventCFPSubmissionFactory.create(
+            linked_cfp=self.cfp.name,
+            event=self.event.name,
+            speakers=[_speaker("pending@test.com")],
+        )
+        frappe.set_user(self.team_member.name)
+
+        result = bulk_create_speaker_coupons(event=self.event.name, max_count=1)
+
+        self.assertEqual(result["created"], 0)
+
+    def test_preview_reflects_state(self):
+        self._approved([_speaker("diana@test.com")])
+        self._approved([_speaker("eve@test.com")])
+        FreeTicketCodeFactory.create(
+            event=self.event.name,
+            mapped_email="diana@test.com",
+            tier="Speaker/Workshop Host",
+        )
+        frappe.set_user(self.team_member.name)
+
+        preview = get_speaker_coupon_preview(event=self.event.name)
+
+        self.assertEqual(preview["total"], 2)
+        self.assertEqual(preview["already_has"], 1)
+        self.assertEqual(preview["will_create"], 1)

--- a/fossunited/utils/decorators.py
+++ b/fossunited/utils/decorators.py
@@ -2,6 +2,7 @@
 Permission check decorators for hackathon and chapter operations
 """
 
+import inspect
 from functools import wraps
 
 import frappe
@@ -149,6 +150,14 @@ def require_chapter_member(chapter_id="chapter"):
 
             chapter = kwargs.get(chapter_id)
             if not chapter:
+                sig = inspect.signature(func)
+                param_names = list(sig.parameters.keys())
+                if chapter_id in param_names:
+                    idx = param_names.index(chapter_id)
+                    if idx < len(args):
+                        chapter = args[idx]
+
+            if not chapter:
                 frappe.throw(_("Chapter data is required"), frappe.ValidationError)
 
             if not check_if_chapter_member(chapter, frappe.session.user):
@@ -177,6 +186,14 @@ def require_event_member(event_id="event"):
 
             event = kwargs.get(event_id)
             if not event:
+                sig = inspect.signature(func)
+                param_names = list(sig.parameters.keys())
+                if event_id in param_names:
+                    idx = param_names.index(event_id)
+                    if idx < len(args):
+                        event = args[idx]
+
+            if not event:
                 frappe.throw(_("Event data is required"), frappe.ValidationError)
 
             if not check_if_event_member(event):
@@ -204,6 +221,15 @@ def require_chapter_or_event_member(event_id="event"):
                 frappe.throw(_("Authentication required"), frappe.PermissionError)
 
             event = kwargs.get(event_id)
+            if not event:
+                # Resolve positional args by inspecting the wrapped function's signature
+                sig = inspect.signature(func)
+                param_names = list(sig.parameters.keys())
+                if event_id in param_names:
+                    idx = param_names.index(event_id)
+                    if idx < len(args):
+                        event = args[idx]
+
             if not event:
                 frappe.throw(_("Event ID is not provided"), frappe.ValidationError)
 


### PR DESCRIPTION
fixes #1554

TLDR: helper button to send ticket coupons to all approved speakers (since we can batch send)
Rest of it (sponsors, volunteer) need to be manually managed.

- Users can click anytime on the button which sends free ticket coupon to speakers who haven't received it yet.

- My rationale too add this feature is that I saw the pain work in
chennaiFOSS of volunteer who had to track everyone in excel
and send each one coupon code.
  - this welcome more big FOSS events/festivals in every city!
  - or we should give out desk access slowly by sorting our role/permissions

- since i used script in console, it'd be great to bake into dashboard itself since its simple

- LOC changes are due to prettier format

- **Security** - made sure function can be only run by chapter team member for the event.

<img width="721" height="410" alt="image" src="https://github.com/user-attachments/assets/80e09284-6abe-4b08-953f-7628d375475d" />
