### PR TITLE
feat: send reminder email to RSVP attendees one day before event

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
@@ -45,6 +45,7 @@
   "column_break_ae9v",
   "event_end_date",
   "feedback_sent",
+  "reminder_sent",
   "livestreaming_section",
   "livestream_link",
   "livestream_embed_link",
@@ -492,6 +493,13 @@
    "fieldname": "feedback_sent",
    "fieldtype": "Check",
    "label": "Feedback sent?",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "reminder_sent",
+   "fieldtype": "Check",
+   "label": "Reminder sent?",
    "read_only": 1
   },
   {

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -83,6 +83,7 @@ class FOSSChapterEvent(WebsiteGenerator):
         external_event_url: DF.Data | None
         feedback_sent: DF.Check
         hall_options: DF.SmallText | None
+        reminder_sent: DF.Check
         has_external_webpage: DF.Check
         is_external_event: DF.Check
         is_paid_event: DF.Check

--- a/fossunited/hooks.py
+++ b/fossunited/hooks.py
@@ -149,6 +149,7 @@ before_migrate = "fossunited.migrate.before_migrate"
 scheduler_events = {
     "daily_long": [
         "fossunited.scheduled_tasks.conclude_events",
+        "fossunited.scheduled_tasks.send_rsvp_event_reminders",
     ],
     "monthly": [
         "fossunited.scheduled_tasks.update_past_job_status",

--- a/fossunited/scheduled_tasks.py
+++ b/fossunited/scheduled_tasks.py
@@ -8,6 +8,7 @@ from fossunited.doctype_ids import (
     JOB_STATUS_APPROVED,
     JOB_STATUS_EXPIRED,
 )
+from fossunited.utils.notifications import send_event_rsvp_reminder
 
 
 def conclude_events():
@@ -42,6 +43,33 @@ def conclude_events():
         except Exception:
             frappe.log_error(
                 title=f"Error concluding event: {event.name}",
+                message=frappe.get_traceback(),
+            )
+
+
+def send_rsvp_event_reminders():
+    tomorrow = add_days(frappe.utils.today(), 1)
+    day_after = add_days(frappe.utils.today(), 2)
+
+    events = frappe.db.get_all(
+        EVENT,
+        filters=[
+            ["status", "=", "Live"],
+            ["is_paid_event", "=", 0],
+            ["reminder_sent", "=", 0],
+            ["event_start_date", ">=", tomorrow],
+            ["event_start_date", "<", day_after],
+        ],
+        pluck="name",
+        page_length=999,
+    )
+
+    for event_id in events:
+        try:
+            send_event_rsvp_reminder(event_id)
+        except Exception:
+            frappe.log_error(
+                title=f"Error sending RSVP reminder: {event_id}",
                 message=frappe.get_traceback(),
             )
 

--- a/fossunited/tests/test_scheduled_tasks.py
+++ b/fossunited/tests/test_scheduled_tasks.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from frappe.tests.utils import FrappeTestCase
 
-from fossunited.scheduled_tasks import conclude_events
+from fossunited.scheduled_tasks import conclude_events, send_rsvp_event_reminders
 from fossunited.tests.factories.foss_chapter_event_factory import FOSSChapterEventFactory
 from fossunited.tests.factories.foss_chapter_factory import FOSSChapterFactory
 from fossunited.tests.factories.foss_event_cfp_submission_factory import FOSSEventCFPFactory
@@ -69,3 +69,43 @@ class TestScheduledTasks(FrappeTestCase):
         self.assertEqual(self.event3.status, "Live")
         self.assertEqual(self.event3_cfp.status, "Live")
         self.assertEqual(self.event3_rsvp.is_published, 1)
+
+    @patch("fossunited.scheduled_tasks.send_event_rsvp_reminder")
+    @patch("frappe.utils.today")
+    def test_send_rsvp_event_reminders(self, mock_today, mock_send_reminder):
+        mock_today.return_value = datetime.today().strftime("%Y-%m-%d")
+
+        send_rsvp_event_reminders()
+
+        reminder_event_ids = [call[0][0] for call in mock_send_reminder.call_args_list]
+        self.assertIn(self.event3.name, reminder_event_ids)
+        self.assertNotIn(self.event1.name, reminder_event_ids)
+        self.assertNotIn(self.event2.name, reminder_event_ids)
+
+    @patch("fossunited.scheduled_tasks.send_event_rsvp_reminder")
+    @patch("frappe.utils.today")
+    def test_rsvp_reminder_not_sent_twice(self, mock_today, mock_send_reminder):
+        mock_today.return_value = datetime.today().strftime("%Y-%m-%d")
+
+        self.event3.reload()
+        self.event3.reminder_sent = 1
+        self.event3.save(ignore_permissions=True)
+
+        send_rsvp_event_reminders()
+
+        reminder_event_ids = [call[0][0] for call in mock_send_reminder.call_args_list]
+        self.assertNotIn(self.event3.name, reminder_event_ids)
+
+    @patch("fossunited.scheduled_tasks.send_event_rsvp_reminder")
+    @patch("frappe.utils.today")
+    def test_rsvp_reminder_not_sent_for_paid_events(self, mock_today, mock_send_reminder):
+        mock_today.return_value = datetime.today().strftime("%Y-%m-%d")
+
+        self.event3.reload()
+        self.event3.is_paid_event = 1
+        self.event3.save(ignore_permissions=True)
+
+        send_rsvp_event_reminders()
+
+        reminder_event_ids = [call[0][0] for call in mock_send_reminder.call_args_list]
+        self.assertNotIn(self.event3.name, reminder_event_ids)

--- a/fossunited/utils/notifications.py
+++ b/fossunited/utils/notifications.py
@@ -77,6 +77,8 @@ for the broader community.</p><br/>
 
 
 def send_event_rsvp_reminder(event_id):
+    from frappe.utils import escape_html
+
     doc = frappe.get_doc(EVENT, event_id)
 
     email_groups = frappe.db.get_all(
@@ -84,7 +86,7 @@ def send_event_rsvp_reminder(event_id):
         filters={
             "reference_document": event_id,
             "document_type": EVENT,
-            "group_type": "Event Participants",
+            "group_type": ["in", ["Event Participants", "Accepted Proposers"]],
             "total_subscribers": [">", 0],
         },
         pluck="name",
@@ -98,22 +100,24 @@ def send_event_rsvp_reminder(event_id):
     )
     chapter_email = chapter_email or "noreply@fossunited.org"
 
+    event_name = escape_html(doc.event_name)
     event_url = f"https://fossunited.org/{doc.route}"
     start_date_display = doc.event_start_date.strftime("%A, %-d %B %Y")
     start_time_display = doc.event_start_date.strftime("%-I:%M %p")
 
     location_html = ""
     if doc.event_location:
-        if doc.map_link:
+        location = escape_html(doc.event_location)
+        if doc.map_link and doc.map_link.startswith(("https://", "http://")):
             location_html = (
-                f'<li><span>Location: </span><a href="{doc.map_link}">'
-                f"{doc.event_location}</a></li>"
+                f'<li><span>Location: </span><a href="{escape_html(doc.map_link)}">'
+                f"{location}</a></li>"
             )
         else:
-            location_html = f"<li><span>Location: </span>{doc.event_location}</li>"
+            location_html = f"<li><span>Location: </span>{location}</li>"
 
     subject = f"Reminder: {doc.event_name} is tomorrow!"
-    message = f"""<p>This is a friendly reminder that <a href="{event_url}"><strong>{doc.event_name}</strong></a> is happening tomorrow!</p>
+    message = f"""<p>This is a friendly reminder that <a href="{event_url}"><strong>{event_name}</strong></a> is happening tomorrow!</p>
 
 <ul>
   <li><span>Date: </span>{start_date_display}</li>
@@ -124,7 +128,7 @@ def send_event_rsvp_reminder(event_id):
 <p>We look forward to seeing you there. Check the
 <a href="{event_url}">event page</a> for the latest schedule and updates.</p>
 
-<p>Regards,<br>Team {doc.event_name}</p>"""
+<p>Regards,<br>Team {event_name}</p>"""
 
     newsletter = frappe.get_doc(
         {

--- a/fossunited/utils/notifications.py
+++ b/fossunited/utils/notifications.py
@@ -101,7 +101,7 @@ def send_event_rsvp_reminder(event_id):
     chapter_email = chapter_email or "noreply@fossunited.org"
 
     event_name = escape_html(doc.event_name)
-    event_url = f"https://fossunited.org/{doc.route}"
+    event_url = f"{frappe.utils.get_url()}/{doc.route}"
     start_date_display = doc.event_start_date.strftime("%A, %-d %B %Y")
     start_time_display = doc.event_start_date.strftime("%-I:%M %p")
 

--- a/fossunited/utils/notifications.py
+++ b/fossunited/utils/notifications.py
@@ -76,6 +76,77 @@ for the broader community.</p><br/>
     )
 
 
+def send_event_rsvp_reminder(event_id):
+    doc = frappe.get_doc(EVENT, event_id)
+
+    email_groups = frappe.db.get_all(
+        EMAIL_GROUP,
+        filters={
+            "reference_document": event_id,
+            "document_type": EVENT,
+            "group_type": "Event Participants",
+            "total_subscribers": [">", 0],
+        },
+        pluck="name",
+    )
+
+    if not email_groups:
+        return
+
+    chapter_name, chapter_email = frappe.db.get_value(
+        CHAPTER, doc.chapter, ["chapter_name", "email"]
+    )
+    chapter_email = chapter_email or "noreply@fossunited.org"
+
+    event_url = f"https://fossunited.org/{doc.route}"
+    start_date_display = doc.event_start_date.strftime("%A, %-d %B %Y")
+    start_time_display = doc.event_start_date.strftime("%-I:%M %p")
+
+    location_html = ""
+    if doc.event_location:
+        if doc.map_link:
+            location_html = (
+                f'<li><span>Location: </span><a href="{doc.map_link}">'
+                f"{doc.event_location}</a></li>"
+            )
+        else:
+            location_html = f"<li><span>Location: </span>{doc.event_location}</li>"
+
+    subject = f"Reminder: {doc.event_name} is tomorrow!"
+    message = f"""<p>This is a friendly reminder that <a href="{event_url}"><strong>{doc.event_name}</strong></a> is happening tomorrow!</p>
+
+<ul>
+  <li><span>Date: </span>{start_date_display}</li>
+  <li><span>Time: </span>{start_time_display}</li>
+  {location_html}
+</ul>
+
+<p>We look forward to seeing you there. Check the
+<a href="{event_url}">event page</a> for the latest schedule and updates.</p>
+
+<p>Regards,<br>Team {doc.event_name}</p>"""
+
+    newsletter = frappe.get_doc(
+        {
+            "doctype": CAMPAIGN,
+            "reference_document": event_id,
+            "document_type": EVENT,
+            "chapter": doc.chapter,
+            "sender_name": chapter_name,
+            "sender_email": chapter_email,
+            "email_group": [{"email_group": g} for g in email_groups],
+            "subject": subject,
+            "content_type": "Rich Text",
+            "message": message,
+        }
+    )
+    newsletter.flags.ignore_permissions = True
+    newsletter.insert(ignore_permissions=True)
+    newsletter.send_emails()
+
+    frappe.db.set_value(EVENT, event_id, "reminder_sent", 1)
+
+
 def notify_cfp_reviewer_assignment(doc, method=None) -> None:
     """
     doc_events hook: ToDo → after_insert.


### PR DESCRIPTION
  ## Status

  - [] Draft
  - [x] Ready for review

  ---

  ## Related Issue

Closes / Addresses: #1614

  ---

  ## Problem

RSVP attendees have no reminder before an event
  ---

  ## Solution

Added a daily scheduled task that sends a reminder email to all RSVP subscribers one day before a free event starts. A `reminder_sent` flag on the event prevents duplicate sends. The email includes event name, date, time, and location with a
  link to the event page

  ---

  ## Progress (All must be checked to merge)

  - [x] Tested locally
  - [ ]

  ---

  ## Changelog

  feat: send reminder email to RSVP attendees one day before event

  ---

  ## Visualization

  N/A

  ---

  ## Further Ahead