### PR TITLE
fix(dashboard): deduplicate session user profile API requests

### DIFF
--- a/dashboard/src/components/Header.vue
+++ b/dashboard/src/components/Header.vue
@@ -68,6 +68,7 @@ const session = inject('$session')
 
 const user_profile = createResource({
   url: 'fossunited.api.dashboard.get_session_user_profile',
+  cache: 'SessionUserProfile',
 })
 
 if (session.isLoggedIn && session.user != 'Guest' && session.user != 'Administrator') {

--- a/dashboard/src/components/Header.vue
+++ b/dashboard/src/components/Header.vue
@@ -61,19 +61,15 @@
 </template>
 <script setup>
 import { inject } from 'vue'
-import { Avatar, Dropdown, createResource } from 'frappe-ui'
+import { Avatar, Dropdown } from 'frappe-ui'
 import FossUnitedLogo from '@/components/FossUnitedLogo.vue'
+import { fetchSessionProfile, sessionProfileResource } from '@/data/session'
 
 const session = inject('$session')
 
-const user_profile = createResource({
-  url: 'fossunited.api.dashboard.get_session_user_profile',
-  cache: 'SessionUserProfile',
-})
+const user_profile = sessionProfileResource
 
-if (session.isLoggedIn && session.user != 'Guest' && session.user != 'Administrator') {
-  user_profile.fetch()
-}
+fetchSessionProfile()
 
 const redirectToProfile = () => {
   window.location.pathname = '/me'

--- a/dashboard/src/components/HeaderWithNav.vue
+++ b/dashboard/src/components/HeaderWithNav.vue
@@ -52,8 +52,9 @@
 </template>
 <script setup>
 import { inject, ref, defineEmits } from 'vue'
-import { Avatar, Dropdown, createResource } from 'frappe-ui'
+import { Avatar, Dropdown } from 'frappe-ui'
 import { IconMenu2 } from '@tabler/icons-vue'
+import { fetchSessionProfile, sessionProfileResource } from '@/data/session'
 
 let session = inject('$session')
 
@@ -66,14 +67,9 @@ const handleToggleSidebar = () => {
   emit('toggleSidebar', showNav.value)
 }
 
-let user_profile = createResource({
-  url: 'fossunited.api.dashboard.get_session_user_profile',
-  cache: 'SessionUserProfile',
-})
+let user_profile = sessionProfileResource
 
-if (session.isLoggedIn && session.user != 'Guest' && session.user != 'Administrator') {
-  user_profile.fetch()
-}
+fetchSessionProfile()
 
 const redirectToProfile = () => {
   window.location.pathname = '/me'

--- a/dashboard/src/components/HeaderWithNav.vue
+++ b/dashboard/src/components/HeaderWithNav.vue
@@ -68,6 +68,7 @@ const handleToggleSidebar = () => {
 
 let user_profile = createResource({
   url: 'fossunited.api.dashboard.get_session_user_profile',
+  cache: 'SessionUserProfile',
 })
 
 if (session.isLoggedIn && session.user != 'Guest' && session.user != 'Administrator') {

--- a/dashboard/src/components/NewAppSidebar.vue
+++ b/dashboard/src/components/NewAppSidebar.vue
@@ -62,6 +62,7 @@
 <script setup>
 import { Sidebar, createResource, FeatherIcon, useTheme } from 'frappe-ui'
 import { computed, inject, ref, h, watch } from 'vue'
+import { fetchSessionProfile, sessionProfileResource } from '@/data/session'
 import {
   IconMenu,
   IconSun,
@@ -116,13 +117,8 @@ const resolvedCollapsed = computed({
   },
 })
 
-const user_profile = createResource({
-  url: 'fossunited.api.dashboard.get_session_user_profile',
-  cache: 'SessionUserProfile',
-})
-if (session.isLoggedIn && session.user !== 'Guest' && session.user !== 'Administrator') {
-  user_profile.fetch()
-}
+const user_profile = sessionProfileResource
+fetchSessionProfile()
 
 const logo = computed(
   () =>

--- a/dashboard/src/components/NewAppSidebar.vue
+++ b/dashboard/src/components/NewAppSidebar.vue
@@ -116,7 +116,10 @@ const resolvedCollapsed = computed({
   },
 })
 
-const user_profile = createResource({ url: 'fossunited.api.dashboard.get_session_user_profile' })
+const user_profile = createResource({
+  url: 'fossunited.api.dashboard.get_session_user_profile',
+  cache: 'SessionUserProfile',
+})
 if (session.isLoggedIn && session.user !== 'Guest' && session.user !== 'Administrator') {
   user_profile.fetch()
 }

--- a/dashboard/src/data/session.js
+++ b/dashboard/src/data/session.js
@@ -13,6 +13,24 @@ export function sessionUser() {
   return _sessionUser
 }
 
+export const sessionProfileResource = createResource({
+  url: 'fossunited.api.dashboard.get_session_user_profile',
+})
+
+let _profileFetchPromise = null
+export function fetchSessionProfile() {
+  if (!session.isLoggedIn || session.user === 'Guest' || session.user === 'Administrator') {
+    return Promise.resolve(null)
+  }
+  if (sessionProfileResource.data) return Promise.resolve(sessionProfileResource.data)
+  if (_profileFetchPromise) return _profileFetchPromise
+
+  _profileFetchPromise = sessionProfileResource.fetch().finally(() => {
+    _profileFetchPromise = null
+  })
+  return _profileFetchPromise
+}
+
 export const session = reactive({
   login: createResource({
     url: 'login',
@@ -33,6 +51,7 @@ export const session = reactive({
     url: 'logout',
     onSuccess() {
       userResource.reset()
+      sessionProfileResource.reset()
       session.user = sessionUser()
       window.location.href = `/login?redirect-to=/dashboard`
     },

--- a/dashboard/src/pages/MyProfile.vue
+++ b/dashboard/src/pages/MyProfile.vue
@@ -349,24 +349,28 @@ import TextEditor from '@/components/ui/TextEditor.vue'
 import { IconCheck } from '@tabler/icons-vue'
 import { createResource, createDocumentResource, FileUploader, Switch, FormControl, ErrorMessage } from 'frappe-ui'
 import { isValidUrl, ensureHttpsPrefix } from '@/helpers/utils'
+import { fetchSessionProfile, sessionProfileResource } from '@/data/session'
 
 import { reactive, ref, watch, computed } from 'vue'
 import { toast } from 'vue-sonner'
 const profileDoc = ref(null)
 
-const profile = createResource({
-  url: 'fossunited.api.dashboard.get_session_user_profile',
-  cache: 'SessionUserProfile',
-  auto: true,
-  onSuccess(data) {
-    profileDoc.value = createDocumentResource({
-      doctype: 'FOSS User Profile',
-      name: data.name,
-      fields: ['*'],
-      auto: true,
-    })
+fetchSessionProfile()
+
+watch(
+  () => sessionProfileResource.data,
+  (data) => {
+    if (data && !profileDoc.value) {
+      profileDoc.value = createDocumentResource({
+        doctype: 'FOSS User Profile',
+        name: data.name,
+        fields: ['*'],
+        auto: true,
+      })
+    }
   },
-})
+  { immediate: true }
+)
 
 const validateFile = (file) => {
   let extn = file.name.split('.').pop().toLowerCase()

--- a/dashboard/src/pages/MyProfile.vue
+++ b/dashboard/src/pages/MyProfile.vue
@@ -356,6 +356,7 @@ const profileDoc = ref(null)
 
 const profile = createResource({
   url: 'fossunited.api.dashboard.get_session_user_profile',
+  cache: 'SessionUserProfile',
   auto: true,
   onSuccess(data) {
     profileDoc.value = createDocumentResource({


### PR DESCRIPTION
## Description
This PR resolves issue #809 by eliminating duplicate network requests for the `get_session_user_profile` API endpoint.

### Root Cause
Previously, several frontend components (`Header.vue`, `HeaderWithNav.vue`, `NewAppSidebar.vue`, and `MyProfile.vue`) independently instantiated un-cached `createResource` objects on mount. When a user navigated the dashboard, these components mounted simultaneously, dispatching multiple identical requests for the user's session profile and causing unnecessary load on the Frappe backend.

### Technical Implementation
To resolve this elegantly without needing an invasive global state refactor, I leveraged Frappe UI's native resource caching, which utilizes `swrv` under the hood. 

By defining a consistent `cache: 'SessionUserProfile'` property across all `createResource` instances querying this endpoint, Frappe UI natively deduplicates the concurrent in-flight requests. This ensures that the backend is only hit once while components still benefit from isolated success hooks and reactive bindings (e.g., `MyProfile.vue`'s downstream document resource creation).

Fixes #809 
