### PR TITLE
fix(cfp): normalize speaker social link href on the frontend to include https:// scheme

### DIFF
--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
@@ -261,8 +261,9 @@
     />
   {% if sp_url %}</a>{% else %}</div>{% endif %}
   {% if speaker.social_link %}
+    {% set social_url = speaker.social_link if speaker.social_link.startswith('http://') or speaker.social_link.startswith('https://') else 'https://' + speaker.social_link %}
     <a
-      href="{{ speaker.social_link | e }}"
+      href="{{ social_url | e }}"
       target="_blank"
       rel="noopener noreferrer"
       aria-label="{{ speaker.full_name }}'s social profile"


### PR DESCRIPTION
Speaker social links saved without a URL scheme (e.g. www.linkedin.com/...) were rendered as relative hrefs on the CFP proposal page, resolving against fossunited.org instead of the intended external site.

## Status

- [ ] Draft
- [x] Ready for review

---

## Related Issue

Addresses: #1630 

---

## Problem

Speakers' profile links without https:// would be rendered to relative links, resolving against fossunited.org.

---

## Solution

One fix for [this](https://github.com/fossunited/fossunited/issues/1630#issuecomment-4864456175) was already done on the backend by updating the URLs in db I think. This is another way to handle this which I'd discovered during reporting, where we add handling in how the frontend handles url's, the codebase has a [similar](https://github.com/fossunited/fossunited/blob/0c080d20833c411e8ab749d3c6f7b1d40cc25158/dashboard/src/helpers/utils.js#L43-L46) handling in other places.

This PR was super easy to open since I just had this pushed and lying around and felt might as well get eyes on this for discussions haha. The outcome of closing this in favour of the current fix is totally 🆒 .

---

## Progress (All must be checked to merge)

- [x] Tested locally
- [ ] 

