### PR TITLE
feat(indiafoss): archive page to aggregate all indiafoss talks

### DIFF
--- a/fossunited/doctype_ids.py
+++ b/fossunited/doctype_ids.py
@@ -30,6 +30,7 @@ CORE_TEAM = "Core Team Member"
 EVENT_VOLUNTEER = "FOSS Chapter Event Member"
 EVENT_SCHEDULE = "FOSS Event Schedule"
 COMMUNITY_PARTNER = "FOSS Event Community Partner"
+EVENT_MEDIA = "Event Media"
 
 # Event proposal-related identifiers
 EVENT_CFP = "FOSS Event CFP"

--- a/fossunited/fossunited/doctype/event_media/event_media.json
+++ b/fossunited/fossunited/doctype/event_media/event_media.json
@@ -25,6 +25,7 @@
    "label": "Title"
   },
   {
+   "fetch_from": "proposal.event",
    "fieldname": "event",
    "fieldtype": "Link",
    "label": "Event",
@@ -66,11 +67,12 @@
    "label": "Video duration"
   },
   {
+   "description": "Youtube URL or direct mp4 media file or other media links (peertube)",
    "fieldname": "video_url",
    "fieldtype": "Data",
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "YouTube ID or Video URL"
+   "label": "Video URL"
   },
   {
    "description": "Only meant for IndiaFOSS 1, 2 3.0 events to map user profile here.",
@@ -87,7 +89,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-07-09 20:45:49.739642",
+ "modified": "2026-07-09 21:50:06.554677",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "Event Media",

--- a/fossunited/fossunited/doctype/event_media/event_media.json
+++ b/fossunited/fossunited/doctype/event_media/event_media.json
@@ -59,7 +59,7 @@
    "fieldtype": "Select",
    "in_standard_filter": 1,
    "label": "Video type",
-   "options": "Talk\nKeynote\nPanel Discussion\nWorkshop\nLive Stream\nLightning Talk\nBirds of Feather(BoF)\nWorkshop\nInvited Talk"
+   "options": "Talk\nKeynote\nPanel Discussion\nWorkshop\nLive Stream\nLightning Talk\nBirds of Feather(BoF)\nInvited Talk"
   },
   {
    "fieldname": "duration",
@@ -89,7 +89,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-07-09 21:50:06.554677",
+ "modified": "2026-07-09 21:54:03.088499",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "Event Media",

--- a/fossunited/fossunited/doctype/event_media/event_media.json
+++ b/fossunited/fossunited/doctype/event_media/event_media.json
@@ -58,7 +58,7 @@
    "fieldtype": "Select",
    "in_standard_filter": 1,
    "label": "Video type",
-   "options": "Talk\nKeynote\nPanel Discussion\nWorkshop\nLightning Talk\nLive Stream"
+   "options": "Talk\nKeynote\nPanel Discussion\nWorkshop\nLive Stream\nLightning Talk\nBirds of Feather(BoF)\nWorkshop\nInvited Talk"
   },
   {
    "fieldname": "duration",
@@ -87,7 +87,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-07-09 20:32:02.400805",
+ "modified": "2026-07-09 20:45:49.739642",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "Event Media",

--- a/fossunited/fossunited/doctype/event_media/event_media.json
+++ b/fossunited/fossunited/doctype/event_media/event_media.json
@@ -1,0 +1,114 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-07-09 13:54:17.442297",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "title",
+  "video_url",
+  "event",
+  "event_name",
+  "proposal",
+  "proposal_route",
+  "video_type",
+  "duration",
+  "section_break_sljw",
+  "speakers"
+ ],
+ "fields": [
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Title"
+  },
+  {
+   "fieldname": "event",
+   "fieldtype": "Link",
+   "label": "Event",
+   "options": "FOSS Chapter Event"
+  },
+  {
+   "fetch_from": "event.event_name",
+   "fieldname": "event_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Event name"
+  },
+  {
+   "fieldname": "proposal",
+   "fieldtype": "Link",
+   "label": "Proposal",
+   "options": "FOSS Event CFP Submission"
+  },
+  {
+   "fetch_from": "proposal.route",
+   "fieldname": "proposal_route",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Proposal URL"
+  },
+  {
+   "fetch_from": "proposal.session_type",
+   "fieldname": "video_type",
+   "fieldtype": "Select",
+   "in_standard_filter": 1,
+   "label": "Video type",
+   "options": "Talk\nKeynote\nPanel Discussion\nWorkshop\nLightning Talk\nLive Stream"
+  },
+  {
+   "fieldname": "duration",
+   "fieldtype": "Duration",
+   "label": "Video duration"
+  },
+  {
+   "fieldname": "video_url",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "YouTube ID or Video URL"
+  },
+  {
+   "description": "Only meant for IndiaFOSS 1, 2 3.0 events to map user profile here.",
+   "fieldname": "speakers",
+   "fieldtype": "Table",
+   "label": "Speakers (optional)",
+   "options": "CFP Submission Speaker"
+  },
+  {
+   "fieldname": "section_break_sljw",
+   "fieldtype": "Section Break"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-07-09 20:32:02.400805",
+ "modified_by": "Administrator",
+ "module": "FOSSUnited",
+ "name": "Event Media",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/fossunited/fossunited/doctype/event_media/event_media.py
+++ b/fossunited/fossunited/doctype/event_media/event_media.py
@@ -26,7 +26,15 @@ class EventMedia(Document):
         speakers: DF.Table[CFPSubmissionSpeaker]
         title: DF.Data | None
         video_type: DF.Literal[
-            "Talk", "Keynote", "Panel Discussion", "Workshop", "Lightning Talk", "Live Stream"
+            "Talk",
+            "Keynote",
+            "Panel Discussion",
+            "Workshop",
+            "Live Stream",
+            "Lightning Talk",
+            "Birds of Feather(BoF)",
+            "Workshop",
+            "Invited Talk",
         ]
         video_url: DF.Data | None
     # end: auto-generated types

--- a/fossunited/fossunited/doctype/event_media/event_media.py
+++ b/fossunited/fossunited/doctype/event_media/event_media.py
@@ -33,7 +33,6 @@ class EventMedia(Document):
             "Live Stream",
             "Lightning Talk",
             "Birds of Feather(BoF)",
-            "Workshop",
             "Invited Talk",
         ]
         video_url: DF.Data | None

--- a/fossunited/fossunited/doctype/event_media/event_media.py
+++ b/fossunited/fossunited/doctype/event_media/event_media.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026, Frappe x FOSSUnited and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class EventMedia(Document):
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        from fossunited.fossunited.doctype.cfp_submission_speaker.cfp_submission_speaker import (
+            CFPSubmissionSpeaker,
+        )
+
+        duration: DF.Duration | None
+        event: DF.Link | None
+        event_name: DF.Data | None
+        proposal: DF.Link | None
+        proposal_route: DF.Data | None
+        speakers: DF.Table[CFPSubmissionSpeaker]
+        title: DF.Data | None
+        video_type: DF.Literal[
+            "Talk", "Keynote", "Panel Discussion", "Workshop", "Lightning Talk", "Live Stream"
+        ]
+        video_url: DF.Data | None
+    # end: auto-generated types
+    pass

--- a/fossunited/fossunited/event_media.py
+++ b/fossunited/fossunited/event_media.py
@@ -1,0 +1,151 @@
+"""Shared helpers for IndiaFOSS Event Media pages (/archive grid + /speakers page).
+
+Keep query/format logic here so `www/indiafoss/archive/index.py` and a later
+`www/indiafoss/speakers/index.py` build their contexts from the same functions.
+"""
+
+import frappe
+
+from fossunited.doctype_ids import EVENT_MEDIA, PROPOSAL, SPEAKER
+from fossunited.fossunited.utils import get_youtube_id
+
+# Chronological order + canonical label per edition. Mirrors _get_indiafoss_years() in
+# www/indiafoss/2026/index.py (cannot import it: the module path contains "2026").
+EDITION_ORDER = {
+    "IndiaOS": 1,
+    "IndiaFOSS 2020": 1,
+    "IndiaFOSS 2.0": 2,
+    "IndiaFOSS 3.0": 3,
+    "IndiaFOSS 2024": 4,
+    "IndiaFOSS 2025": 5,
+    "IndiaFOSS 2026": 6,
+}
+
+
+def get_indiafoss_years():
+    return [
+        {"year": "2026", "url": "/indiafoss/2026", "name": "IndiaFOSS 2026"},
+        {"year": "2025", "url": "/indiafoss/2025", "name": "IndiaFOSS 2025"},
+        {"year": "2024", "url": "/indiafoss/2024", "name": "IndiaFOSS 2024"},
+        {"year": "2023", "url": "/indiafoss/2023", "name": "IndiaFOSS 3.0"},
+        {"year": "2021", "url": "/indiafoss/2022", "name": "IndiaFOSS 2.0"},
+        {"year": "2020", "url": "/indiafoss/2021", "name": "IndiaOS"},
+    ]
+
+
+def edition_label(event_name):
+    """Strip a 'Workshops @ ' prefix so workshop videos fold into their edition."""
+    return (event_name or "").removeprefix("Workshops @ ").strip()
+
+
+def duration_str(seconds):
+    seconds = int(seconds or 0)
+    if not seconds:
+        return ""
+    h, rem = divmod(seconds, 3600)
+    m, s = divmod(rem, 60)
+    return f"{h}:{m:02d}:{s:02d}" if h else f"{m}:{s:02d}"
+
+
+def speaker_map(proposals):
+    """{proposal_name: [{name, photo, user, designation, organization}, ...]} from the linked
+    CFP submissions' speaker rows.
+    """
+    if not proposals:
+        return {}
+    rows = frappe.get_all(
+        SPEAKER,
+        filters={
+            "parent": ["in", list(proposals)],
+            "parentfield": "speakers",
+            "parenttype": PROPOSAL,
+        },
+        fields=[
+            "parent",
+            "full_name",
+            "photo",
+            "linked_user",
+            "designation",
+            "organization",
+        ],
+        order_by="idx asc",
+    )
+    grouped = {}
+    for r in rows:
+        if r.full_name:
+            grouped.setdefault(r.parent, []).append(
+                {
+                    "name": r.full_name,
+                    "photo": r.photo or "",
+                    "user": r.linked_user or "",
+                    "designation": r.designation or "",
+                    "organization": r.organization or "",
+                }
+            )
+    return grouped
+
+
+def get_archive_media():
+    """All Event Media rows that have somewhere to go (playable video or proposal link),
+    enriched for rendering: youtube_id, duration_str, edition (+order), speakers list, link."""
+    media = frappe.get_all(
+        EVENT_MEDIA,
+        # Scope to IndiaFOSS (this is the IndiaFOSS archive; Event Media is a generic doctype
+        # that will also hold other events' media). Covers "IndiaFOSS 2.0/3.0/2024/2025",
+        # "Workshops @ IndiaFOSS 2025", and "IndiaOS" (2020).
+        or_filters=[
+            ["event_name", "like", "%IndiaFOSS%"],
+            ["event_name", "like", "%IndiaOS%"],
+        ],
+        fields=[
+            "name",
+            "title",
+            "video_url",
+            "event_name",
+            "proposal",
+            "proposal_route",
+            "video_type",
+            "duration",
+        ],
+        order_by="title asc",
+    )
+
+    smap = speaker_map({m.proposal for m in media if m.proposal})
+
+    for m in media:
+        m.youtube_id = get_youtube_id(m.video_url)
+        m.duration_str = duration_str(m.duration)
+        m.edition = edition_label(m.event_name)
+        m.edition_order = EDITION_ORDER.get(m.edition, 99)
+        m.speakers = smap.get(m.proposal, [])
+        m.speaker = ", ".join(s["name"] for s in m.speakers)  # single-line + search key
+        # video_type is auto-populated from the proposal via fetch_from (set in Desk);
+        # rendered directly, no fallback needed.
+        # Card destination: proposal page if set (internal route or external IF3 URL),
+        # else the YouTube video. External links open in a new tab.
+        if m.proposal_route:
+            m.external = m.proposal_route.startswith("http")
+            m.link = m.proposal_route if m.external else "/" + m.proposal_route
+        else:
+            m.link = m.video_url
+            m.external = True
+
+    return [m for m in media if m.youtube_id or m.proposal_route]
+
+
+def get_editions(media):
+    """Distinct edition labels present, ordered chronologically."""
+    seen = {m.edition: m.edition_order for m in media if m.edition}
+    return sorted(seen, key=lambda e: (seen[e], e))
+
+
+def get_session_types(media):
+    """Full canonical session-type Select list (so the filter offers the complete variety,
+    not just types present in data). Stray values (e.g. proposal-only types like BoF /
+    Invited Talk not yet in the Event Media Select) are appended, never dropped."""
+    present = {m.video_type for m in media if m.video_type}
+    field = frappe.get_meta(EVENT_MEDIA).get_field("video_type")
+    canonical = (
+        [t.strip() for t in (field.options or "").splitlines() if t.strip()] if field else []
+    )
+    return canonical + sorted(t for t in present if t not in canonical)

--- a/fossunited/fossunited/event_media.py
+++ b/fossunited/fossunited/event_media.py
@@ -1,36 +1,21 @@
-"""Shared helpers for IndiaFOSS Event Media pages (/archive grid + /speakers page).
+"""Shared helpers for Event Media pages (archive grid + speakers pages).
 
-Keep query/format logic here so `www/indiafoss/archive/index.py` and a later
-`www/indiafoss/speakers/index.py` build their contexts from the same functions.
+The core query/aggregation functions are event-agnostic: pass a `get_all`
+scope (`or_filters`/`filters`) to choose which Event Media rows to operate on,
+and an `edition_order` map for sorting. The IndiaFOSS layer at the bottom is a
+thin wrapper that pins the IndiaFOSS scope + edition order and adds caching;
+other events can add their own wrappers later without touching the core.
 """
 
 import frappe
+from frappe.utils.caching import redis_cache
 
-from fossunited.doctype_ids import EVENT_MEDIA, PROPOSAL, SPEAKER
+from fossunited.doctype_ids import DEFAULT_USER_PHOTO, EVENT_MEDIA, PROPOSAL, SPEAKER, USER_PROFILE
 from fossunited.fossunited.utils import get_youtube_id
 
-# Chronological order + canonical label per edition. Mirrors _get_indiafoss_years() in
-# www/indiafoss/2026/index.py (cannot import it: the module path contains "2026").
-EDITION_ORDER = {
-    "IndiaOS": 1,
-    "IndiaFOSS 2020": 1,
-    "IndiaFOSS 2.0": 2,
-    "IndiaFOSS 3.0": 3,
-    "IndiaFOSS 2024": 4,
-    "IndiaFOSS 2025": 5,
-    "IndiaFOSS 2026": 6,
-}
-
-
-def get_indiafoss_years():
-    return [
-        {"year": "2026", "url": "/indiafoss/2026", "name": "IndiaFOSS 2026"},
-        {"year": "2025", "url": "/indiafoss/2025", "name": "IndiaFOSS 2025"},
-        {"year": "2024", "url": "/indiafoss/2024", "name": "IndiaFOSS 2024"},
-        {"year": "2023", "url": "/indiafoss/2023", "name": "IndiaFOSS 3.0"},
-        {"year": "2021", "url": "/indiafoss/2022", "name": "IndiaFOSS 2.0"},
-        {"year": "2020", "url": "/indiafoss/2021", "name": "IndiaOS"},
-    ]
+# ---------------------------------------------------------------------------
+# Generic core (event-agnostic): operate on any set of Event Media rows.
+# ---------------------------------------------------------------------------
 
 
 def edition_label(event_name):
@@ -47,18 +32,17 @@ def duration_str(seconds):
     return f"{h}:{m:02d}:{s:02d}" if h else f"{m}:{s:02d}"
 
 
-def speaker_map(proposals):
-    """{proposal_name: [{name, photo, user, designation, organization}, ...]} from the linked
-    CFP submissions' speaker rows.
-    """
-    if not proposals:
+def fetch_speaker_rows(parents, parenttype, parentfield="speakers"):
+    """{parent_name: [{name, photo, user, designation, organization, social_link}, ...]}
+    from CFP Submission Speaker rows attached to the given parents."""
+    if not parents:
         return {}
     rows = frappe.get_all(
         SPEAKER,
         filters={
-            "parent": ["in", list(proposals)],
-            "parentfield": "speakers",
-            "parenttype": PROPOSAL,
+            "parent": ["in", list(parents)],
+            "parentfield": parentfield,
+            "parenttype": parenttype,
         },
         fields=[
             "parent",
@@ -67,6 +51,7 @@ def speaker_map(proposals):
             "linked_user",
             "designation",
             "organization",
+            "social_link",
         ],
         order_by="idx asc",
     )
@@ -80,23 +65,27 @@ def speaker_map(proposals):
                     "user": r.linked_user or "",
                     "designation": r.designation or "",
                     "organization": r.organization or "",
+                    "social_link": r.social_link or "",
                 }
             )
     return grouped
 
 
-def get_archive_media():
-    """All Event Media rows that have somewhere to go (playable video or proposal link),
-    enriched for rendering: youtube_id, duration_str, edition (+order), speakers list, link."""
+def get_event_media(or_filters=None, filters=None, edition_order=None):
+    """Event Media rows that have somewhere to go (playable video or proposal link),
+    enriched for rendering: youtube_id, duration_str, edition (+order), merged
+    speakers, link/external.
+
+    Scope the rows with `or_filters`/`filters` (passed straight to frappe.get_all).
+    `edition_order` maps an edition label -> chronological sort index (default 99).
+    Speakers are merged from the linked proposal when present, else from the
+    media's own `speakers` child table -- two bulk queries, no per-row lookups.
+    """
+    edition_order = edition_order or {}
     media = frappe.get_all(
         EVENT_MEDIA,
-        # Scope to IndiaFOSS (this is the IndiaFOSS archive; Event Media is a generic doctype
-        # that will also hold other events' media). Covers "IndiaFOSS 2.0/3.0/2024/2025",
-        # "Workshops @ IndiaFOSS 2025", and "IndiaOS" (2020).
-        or_filters=[
-            ["event_name", "like", "%IndiaFOSS%"],
-            ["event_name", "like", "%IndiaOS%"],
-        ],
+        or_filters=or_filters,
+        filters=filters,
         fields=[
             "name",
             "title",
@@ -110,19 +99,21 @@ def get_archive_media():
         order_by="title asc",
     )
 
-    smap = speaker_map({m.proposal for m in media if m.proposal})
+    prop_speakers = fetch_speaker_rows({m.proposal for m in media if m.proposal}, PROPOSAL)
+    own_speakers = fetch_speaker_rows({m.name for m in media if not m.proposal}, EVENT_MEDIA)
 
     for m in media:
         m.youtube_id = get_youtube_id(m.video_url)
         m.duration_str = duration_str(m.duration)
         m.edition = edition_label(m.event_name)
-        m.edition_order = EDITION_ORDER.get(m.edition, 99)
-        m.speakers = smap.get(m.proposal, [])
+        m.edition_order = edition_order.get(m.edition, 99)
+        # video_type is auto-populated from the proposal via fetch_from (set in Desk).
+        m.speakers = (
+            prop_speakers.get(m.proposal, []) if m.proposal else own_speakers.get(m.name, [])
+        )
         m.speaker = ", ".join(s["name"] for s in m.speakers)  # single-line + search key
-        # video_type is auto-populated from the proposal via fetch_from (set in Desk);
-        # rendered directly, no fallback needed.
-        # Card destination: proposal page if set (internal route or external IF3 URL),
-        # else the YouTube video. External links open in a new tab.
+        # Card destination: proposal page if set (internal route or external URL),
+        # else the video. External links open in a new tab.
         if m.proposal_route:
             m.external = m.proposal_route.startswith("http")
             m.link = m.proposal_route if m.external else "/" + m.proposal_route
@@ -149,3 +140,225 @@ def get_session_types(media):
         [t.strip() for t in (field.options or "").splitlines() if t.strip()] if field else []
     )
     return canonical + sorted(t for t in present if t not in canonical)
+
+
+def _speaker_key(row):
+    # frappe.scrub: lowercase + non-alnum -> "_" (e.g. "Jane Doe" -> "jane_doe").
+    # Speaker names are plain (no punctuation), so scrub is enough for a URL slug.
+    return row["user"] or frappe.scrub(row["name"])
+
+
+def _profiles(user_names):
+    """{profile_name: {profile_photo, route, full_name, linkedin, x, instagram, github, website}}"""
+    if not user_names:
+        return {}
+    rows = frappe.get_all(
+        USER_PROFILE,
+        filters={"name": ["in", list(user_names)]},
+        fields=[
+            "name",
+            "profile_photo",
+            "route",
+            "full_name",
+            "linkedin",
+            "x",
+            "instagram",
+            "github",
+            "website",
+        ],
+    )
+    return {r.name: r for r in rows}
+
+
+def _avatar(row, profile):
+    return row["photo"] or (profile.get("profile_photo") if profile else "") or DEFAULT_USER_PHOTO
+
+
+def build_speakers_index(media, edition_order=None):
+    """Aggregate every speaker across a media set into
+    `{"speakers": [rec, ...], "slugs": {slug: key}}`.
+
+    Aggregation key = `linked_user` if set, else the name slug. The URL slug is
+    always name-based, with `-2`/`-3` suffixes disambiguating distinct speakers
+    whose names slugify identically. One bulk profile query; the rest is pure.
+    """
+    edition_order = edition_order or {}
+    users = {s["user"] for m in media for s in m.speakers if s["user"]}
+    profiles = _profiles(users)
+
+    agg = {}
+    for m in media:
+        for s in m.speakers:
+            key = _speaker_key(s)
+            rec = agg.get(key)
+            if not rec:
+                profile = profiles.get(s["user"]) or {}
+                rec = agg[key] = {
+                    "key": key,
+                    "slug": frappe.scrub(s["name"]),
+                    "name": s["name"],
+                    "designation": s["designation"],
+                    "organization": s["organization"],
+                    "avatar": _avatar(s, profile),
+                    "profile_route": ("/" + profile["route"]) if profile.get("route") else "",
+                    "_media": set(),
+                    "editions": set(),
+                    "types": set(),
+                }
+            rec["_media"].add(m.name)
+            if m.edition:
+                rec["editions"].add(m.edition)
+            if m.video_type:
+                rec["types"].add(m.video_type)
+
+    slugs, taken = {}, {}
+    speakers = []
+    for rec in sorted(agg.values(), key=lambda r: r["name"].lower()):
+        base = rec["slug"]
+        n = taken.get(base, 0) + 1
+        taken[base] = n
+        slug = base if n == 1 else f"{base}-{n}"
+        rec["slug"] = slug
+        slugs[slug] = rec["key"]
+        rec["talk_count"] = len(rec.pop("_media"))
+        rec["editions"] = sorted(rec["editions"], key=lambda e: (edition_order.get(e, 99), e))
+        rec["types"] = sorted(rec["types"])
+        speakers.append(rec)
+
+    return {"speakers": speakers, "slugs": slugs}
+
+
+def build_speaker_talks(media, key):
+    """Speaker meta + their talks (tiered content) for one aggregation key, drawn
+    from `media`. None if the key appears in no media row."""
+    talks = [m for m in media if any(_speaker_key(s) == key for s in m.speakers)]
+    if not talks:
+        return None
+
+    # Speaker meta from the first row that carries this key.
+    row = next(s for m in talks for s in m.speakers if _speaker_key(s) == key)
+    profile = _profiles({row["user"]}).get(row["user"], {}) if row["user"] else {}
+    socials = {}
+    if profile:
+        for f in ("linkedin", "x", "instagram", "github", "website"):
+            if profile.get(f):
+                socials[f] = profile[f]
+    elif row["social_link"]:
+        socials["website"] = row["social_link"]
+    speaker = {
+        "name": row["name"],
+        "designation": row["designation"],
+        "organization": row["organization"],
+        "avatar": _avatar(row, profile),
+        "profile_route": ("/" + profile["route"]) if profile.get("route") else "",
+        "socials": socials,
+    }
+
+    # Proposal description for internal-proposal talks (one bulk query).
+    prop_names = {m.proposal for m in talks if m.proposal}
+    content = {}
+    if prop_names:
+        for p in frappe.get_all(
+            PROPOSAL,
+            filters={"name": ["in", list(prop_names)]},
+            fields=["name", "talk_description"],
+        ):
+            content[p.name] = p
+    refs = fetch_reference_links(prop_names)
+
+    talks = sorted(talks, key=lambda m: (m.edition_order, m.title))
+    for m in talks:
+        if m.proposal:
+            m.description = (content.get(m.proposal) or {}).get("talk_description") or ""
+            m.references = refs.get(m.proposal, [])
+            m.tier = "internal"
+        elif m.proposal_route:  # external proposal (e.g. IF3)
+            m.description = ""
+            m.references = []
+            m.tier = "external"
+        else:  # video-only (e.g. IF1/2)
+            m.description = ""
+            m.references = []
+            m.tier = "video"
+
+    return {"speaker": speaker, "talks": talks}
+
+
+def fetch_reference_links(proposals):
+    """{proposal_name: [url, ...]} from the CFP Submission Reference child rows."""
+    if not proposals:
+        return {}
+    rows = frappe.get_all(
+        "CFP Submission Reference",
+        filters={"parent": ["in", list(proposals)], "parenttype": PROPOSAL},
+        fields=["parent", "link"],
+        order_by="idx asc",
+    )
+    out = {}
+    for r in rows:
+        if r.link:
+            out.setdefault(r.parent, []).append(r.link)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# IndiaFOSS layer: pins the scope + edition order and caches the index.
+# Add a sibling layer per event in future; the core above stays untouched.
+# ---------------------------------------------------------------------------
+
+# Chronological order + canonical label per edition. Mirrors _get_indiafoss_years() in
+# www/indiafoss/2026/index.py (cannot import it: the module path contains "2026").
+EDITION_ORDER = {
+    "IndiaOS": 1,
+    "IndiaFOSS 2020": 1,
+    "IndiaFOSS 2.0": 2,
+    "IndiaFOSS 3.0": 3,
+    "IndiaFOSS 2024": 4,
+    "IndiaFOSS 2025": 5,
+    "IndiaFOSS 2026": 6,
+}
+
+# Event Media rows belonging to IndiaFOSS (any edition, incl. "Workshops @ ..." and IndiaOS).
+INDIAFOSS_MEDIA_SCOPE = [
+    ["event_name", "like", "%IndiaFOSS%"],
+    ["event_name", "like", "%IndiaOS%"],
+]
+
+
+def get_indiafoss_years():
+    return [
+        {"year": "2026", "url": "/indiafoss/2026", "name": "IndiaFOSS 2026"},
+        {"year": "2025", "url": "/indiafoss/2025", "name": "IndiaFOSS 2025"},
+        {"year": "2024", "url": "/indiafoss/2024", "name": "IndiaFOSS 2024"},
+        {"year": "2023", "url": "/indiafoss/2023", "name": "IndiaFOSS 3.0"},
+        {"year": "2021", "url": "/indiafoss/2022", "name": "IndiaFOSS 2.0"},
+        {"year": "2020", "url": "/indiafoss/2021", "name": "IndiaOS"},
+    ]
+
+
+def get_indiafoss_media():
+    """All IndiaFOSS Event Media, enriched (see get_event_media)."""
+    return get_event_media(or_filters=INDIAFOSS_MEDIA_SCOPE, edition_order=EDITION_ORDER)
+
+
+# Back-compat alias: the archive page imports get_archive_media. Same data now,
+# including own-child speakers for pre-proposal editions (IF1/2/3).
+get_archive_media = get_indiafoss_media
+
+
+@redis_cache(ttl=86400)
+def get_speakers_index():
+    """IndiaFOSS speaker index, cached. Invalidated by clear_speakers_cache."""
+    return build_speakers_index(get_indiafoss_media(), edition_order=EDITION_ORDER)
+
+
+def get_speaker_talks(slug):
+    """IndiaFOSS speaker + their talks by URL slug. None if the slug is unknown."""
+    key = get_speakers_index()["slugs"].get(slug)
+    if not key:
+        return None
+    return build_speaker_talks(get_indiafoss_media(), key)
+
+
+def clear_speakers_cache(doc=None, method=None):
+    get_speakers_index.clear_cache()

--- a/fossunited/fossunited/event_media.py
+++ b/fossunited/fossunited/event_media.py
@@ -112,14 +112,24 @@ def get_event_media(or_filters=None, filters=None, edition_order=None):
             prop_speakers.get(m.proposal, []) if m.proposal else own_speakers.get(m.name, [])
         )
         m.speaker = ", ".join(s["name"] for s in m.speakers)  # single-line + search key
-        # Card destination: proposal page if set (internal route or external URL),
-        # else the video. External links open in a new tab.
+        # Proposal/video destination (used by the talks page "View proposal" button):
+        # proposal page if set (internal route or external URL), else the video.
         if m.proposal_route:
             m.external = m.proposal_route.startswith("http")
             m.link = m.proposal_route if m.external else "/" + m.proposal_route
         else:
             m.link = m.video_url
             m.external = True
+
+        # Archive card destination: prefer the speaker page (most talks have a
+        # speaker listed), then fall back to the proposal/video destination above.
+        # "Primary" speaker = first child row (fetch_speaker_rows orders by idx).
+        if m.speakers:
+            m.card_link = "/indiafoss/speakers/" + speaker_slug(m.speakers[0]["name"])
+            m.card_external = False
+        else:
+            m.card_link = m.link
+            m.card_external = m.external
 
     return [m for m in media if m.youtube_id or m.proposal_route]
 
@@ -142,10 +152,14 @@ def get_session_types(media):
     return canonical + sorted(t for t in present if t not in canonical)
 
 
+def speaker_slug(full_name):
+    """URL slug from a speaker name: lowercase, spaces -> "-" (names are plain a-z).
+    A tiny shared helper so _speaker_key and the index slug stay identical."""
+    return (full_name or "").strip().lower().replace(" ", "-")
+
+
 def _speaker_key(row):
-    # frappe.scrub: lowercase + non-alnum -> "_" (e.g. "Jane Doe" -> "jane_doe").
-    # Speaker names are plain (no punctuation), so scrub is enough for a URL slug.
-    return row["user"] or frappe.scrub(row["name"])
+    return row["user"] or speaker_slug(row["name"])
 
 
 def _profiles(user_names):
@@ -195,7 +209,7 @@ def build_speakers_index(media, edition_order=None):
                 profile = profiles.get(s["user"]) or {}
                 rec = agg[key] = {
                     "key": key,
-                    "slug": frappe.scrub(s["name"]),
+                    "slug": speaker_slug(s["name"]),
                     "name": s["name"],
                     "designation": s["designation"],
                     "organization": s["organization"],

--- a/fossunited/hooks.py
+++ b/fossunited/hooks.py
@@ -41,6 +41,10 @@ website_route_rules = [
         "from_route": "/c/<chapter>/rss.xml",
         "to_route": "/c/rss.xml",
     },
+    {
+        "from_route": "/indiafoss/speakers/<slug>",
+        "to_route": "indiafoss/speaker_talks",
+    },
 ]
 
 # add methods and filters to jinja environment
@@ -90,6 +94,14 @@ doc_events = {
     # when a reviewer is assigned to a proposal so we give dashboard link itself to open
     "ToDo": {
         "after_insert": "fossunited.utils.notifications.notify_cfp_reviewer_assignment",
+    },
+    "Event Media": {
+        "on_update": "fossunited.fossunited.event_media.clear_speakers_cache",
+        "on_trash": "fossunited.fossunited.event_media.clear_speakers_cache",
+    },
+    "FOSS Event CFP Submission": {
+        "on_update": "fossunited.fossunited.event_media.clear_speakers_cache",
+        "on_trash": "fossunited.fossunited.event_media.clear_speakers_cache",
     },
 }
 

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -1725,6 +1725,40 @@ body:has(.v3-page) {
   box-shadow: 0 4px 32px 0 rgba(0, 0, 0, 0.7);
 }
 
+/* Reusable hover lift — same shadow as .v3-card, theme-aware, no background change */
+.v3-hover-shadow { transition: box-shadow 0.2s ease; }
+.v3-hover-shadow:hover { box-shadow: 0 4px 32px 0 rgba(0, 0, 0, 0.06); }
+[data-theme='dark'] .v3-hover-shadow:hover { box-shadow: 0 4px 32px 0 rgba(0, 0, 0, 0.7); }
+
+/* Small round avatar (compact people rows) */
+.v3-avatar-xs {
+  width: 1.5rem; height: 1.5rem; border-radius: 50%; object-fit: cover;
+  border: 1px solid var(--v3-button-border); background: var(--v3-button-border); flex-shrink: 0;
+}
+
+/* Filter pill — themeable toggle button. Inactive = bordered/subtle, active = inverse fill.
+   Self-contained so it doesn't inherit .v3-btn's hover-background quirk. */
+.v3-pill {
+  display: inline-flex; align-items: center; justify-content: center;
+  padding: 0.375rem 0.75rem; border: 1px solid var(--v3-button-border); border-radius: 0.375rem;
+  background: var(--v3-card-bg); color: var(--v3-text-color2);
+  font-size: 0.8125rem; line-height: 1.4; cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.v3-pill:hover { background: var(--v3-button-border); color: var(--v3-text-color); }
+.v3-pill.is-active {
+  background: var(--v3-text-color); color: var(--v3-main-bg); border-color: var(--v3-text-color);
+}
+.v3-pill.is-active:hover { filter: brightness(1.1); }
+
+/* Bottom overlay bar + dark pill for media thumbnails (type left, duration right) */
+.v3-media-overlay { position: absolute; left: 0; right: 0; bottom: 0; padding: 8px; z-index: 2; pointer-events: none; }
+.v3-media-badge {
+  background: rgba(0, 0, 0, 0.72); color: #fff; line-height: 1.4;
+  font-size: 10px; font-weight: 600; letter-spacing: 0.4px; text-transform: uppercase;
+  padding: 3px 7px; border-radius: 6px;
+}
+
 /* V3 Grid - 32px gap */
 .v3-grid {
   display: flex;
@@ -3758,3 +3792,19 @@ a.m-text-1:hover, a.m-text-2:hover { filter: brightness(1.2); color: inherit; te
   0%, 100% { filter: drop-shadow(0 0 3px oklch(from var(--badge-glow-color) calc(l * 0.45) calc(c * 4) h)); }
   50%       { filter: drop-shadow(0 0 6px oklch(from var(--badge-glow-color) calc(l * 0.55) calc(c * 5) h)); }
 }
+
+/* ── IndiaFOSS shared header/footer bits (used by the if_header/if_footer macros) ──
+   These were page-local to www/indiafoss/2026; moved here so every IndiaFOSS page
+   (archive, future year pages) that uses the macros renders them correctly. */
+.if-nav-link {
+  display: inline-flex; align-items: center; gap: 4px; padding: 8px 12px; border-radius: 6px;
+  font-size: .6875rem; font-weight: 700; letter-spacing: .08em; text-transform: uppercase;
+  color: var(--v3-text-color2); background: transparent; border: none;
+  white-space: nowrap; text-decoration: none; cursor: pointer; transition: background .15s;
+}
+.if-nav-link:hover { background: var(--v3-button-border); color: var(--v3-text-color2); text-decoration: none; }
+.if-nav-ticket { font-size: .6875rem; letter-spacing: .08em; text-transform: uppercase; padding: 8px 14px; margin-left: 4px; }
+
+.if-tagline { display: inline-flex; align-items: flex-end; gap: 8px; font-size: .6875rem; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; color: var(--v3-text-color); text-decoration: none; }
+.if-tagline svg { width: 40px; height: auto; }
+.if-footer-tagline .if-tagline { color: #fafafa; }

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -2291,6 +2291,26 @@ body:has(.v3-page) {
   white-space: nowrap;
 }
 
+/* Speaker listing card (IndiaFOSS speakers page) */
+.v3-speaker-card {
+  display: flex; align-items: center; gap: 1rem;
+  padding: 0.5rem; border: 1px solid var(--v3-button-border); border-radius: 0.5rem;
+  text-decoration: none; height: 100%;
+  transition: box-shadow 0.15s, border-color 0.15s;
+}
+.v3-speaker-card:hover { box-shadow: 0 2px 12px rgba(0,0,0,0.08); }
+/* 80px framed avatar (Figma) — clip-path for reliable rounding on <img> */
+.v3-speaker-card .v3-people-avatar,
+.v3-avatar-lg {
+  width: 5rem; height: 5rem; border-radius: 0.5rem;
+  clip-path: inset(0 round 0.5rem); object-fit: cover;
+  border: 1px solid var(--v3-button-border); flex-shrink: 0;
+}
+
+/* Talks page: reference-link buttons column + description divider */
+.v3-talk-refs { display: flex; flex-direction: column; gap: 1rem; }
+.v3-talk-divider { border-left: 1px solid var(--v3-button-border); }
+
 /* People Card Expand/Collapse Functionality */
 .v3-people-container {
   position: relative;

--- a/fossunited/public/js/common_functions.js
+++ b/fossunited/public/js/common_functions.js
@@ -9,6 +9,10 @@ $(document).ready(function () {
   // Horizontal Navbar Controls for Profile & Event Pages
   setNavbarControl()
   tab_navigation()
+
+  // Global BS4 tooltip opt-in: any element with data-toggle="tooltip" gets one.
+  // Runs on every page (bundled in website.bundle.js) so pages need no init line.
+  $('[data-toggle="tooltip"]').tooltip()
 })
 
 function makeQuill(
@@ -324,6 +328,43 @@ function toggleSection(id) {
   header?.setAttribute('aria-expanded', !content.classList.contains('hidden'))
 }
 
+// Debounce: delay fn until `wait` ms after the last call. Used by search inputs.
+function debounce(fn, wait = 250) {
+  let t
+  return function (...args) {
+    clearTimeout(t)
+    t = setTimeout(() => fn.apply(this, args), wait)
+  }
+}
+
+// Pagination window: array of page numbers with '…' gaps. First, last, and
+// current +/- `spread` are always shown. e.g. buildPageWindow(5, 20) ->
+// [1,'…',4,5,6,'…',20]. Render each as a button; skip '…'.
+function buildPageWindow(page, totalPages, spread = 1) {
+  const win = []
+  for (let p = 1; p <= totalPages; p++) {
+    if (p === 1 || p === totalPages || Math.abs(p - page) <= spread) win.push(p)
+    else if (win[win.length - 1] !== '…') win.push('…')
+  }
+  return win
+}
+
+// Read the current query string as a plain object. getParams().foo -> "bar".
+function getParams() {
+  return Object.fromEntries(new URLSearchParams(window.location.search))
+}
+
+// Write params to the URL without a reload. Falsy values are dropped.
+// setParams({q: 'x', page: 1}) -> "?q=x&page=1"; setParams({}) clears them.
+function setParams(obj) {
+  const p = new URLSearchParams()
+  Object.entries(obj).forEach(([k, v]) => {
+    if (v !== '' && v != null && v !== false) p.set(k, v)
+  })
+  const qs = p.toString()
+  history.replaceState(null, '', qs ? `${location.pathname}?${qs}` : location.pathname)
+}
+
 // expose all globally via window
 Object.assign(window, {
   makeQuill,
@@ -342,4 +383,8 @@ Object.assign(window, {
   formatShortDate,
   truncateStr,
   toggleSection,
+  debounce,
+  buildPageWindow,
+  getParams,
+  setParams,
 })

--- a/fossunited/templates/macros/indiafoss.html
+++ b/fossunited/templates/macros/indiafoss.html
@@ -10,7 +10,7 @@
 {% endmacro %}
 
 
-{% macro if_header(years=[], current_year=2026, ticket_url="") %}
+{% macro if_header(years=[], current_year=2026, ticket_url="", show_archive=True, show_schedule=False, show_statistics=True) %}
 <header class="v3-event-header" aria-label="IndiaFOSS navigation">
 
   <a href="/indiafoss/{{ current_year }}" class="d-flex align-items-center" aria-label="IndiaFOSS {{ current_year }} home">
@@ -19,12 +19,17 @@
 
   <nav class="d-none d-md-flex align-items-center gap-1" aria-label="Site navigation">
 
-    {# Archive — hidden until ready #}
-    <a href="/indiafoss" class="if-nav-link d-none" aria-label="IndiaFOSS archive">Archive</a>
+    {% if show_archive %}
+      <a href="/indiafoss/archive" class="if-nav-link" aria-label="IndiaFOSS archive">Archive</a>
+    {% endif %}
 
-    <a href="/indiafoss/schedule" class="if-nav-link d-none" aria-label="Event schedule">Schedule</a>
+    {% if show_schedule %}
+      <a href="/indiafoss/schedule" class="if-nav-link" aria-label="Event schedule">Schedule</a>
+    {% endif %}
 
-    <a href="/indiafoss/2026/stats" class="if-nav-link" aria-label="IndiaFOSS 2026 live statistics">Statistics</a>
+    {% if show_statistics %}
+      <a href="/indiafoss/2026/stats" class="if-nav-link" aria-label="IndiaFOSS 2026 live statistics">Statistics</a>
+    {% endif %}
 
     {% if years | length > 1 %}
       <select class="v3-select" aria-label="Select IndiaFOSS year"
@@ -67,8 +72,9 @@
   <div class="collapse d-md-none position-absolute" id="ifMobileMenu"
        style="top: 100%; right: 0; min-width: 200px; z-index: 1050;">
     <div class="v3-card rounded p-3 mt-2 d-flex flex-column gap-2">
-      <a href="/indiafoss/schedule" class="if-nav-link">Schedule</a>
-      <a href="/indiafoss/2026/stats" class="if-nav-link">Statistics</a>
+      {% if show_archive %}<a href="/indiafoss/archive" class="if-nav-link">Archive</a>{% endif %}
+      {% if show_schedule %}<a href="/indiafoss/schedule" class="if-nav-link">Schedule</a>{% endif %}
+      {% if show_statistics %}<a href="/indiafoss/2026/stats" class="if-nav-link">Statistics</a>{% endif %}
       {% if years | length > 1 %}
         <select class="v3-select" style="width: 100%;"
                 onchange="window.location=this.value;">

--- a/fossunited/templates/macros/indiafoss.html
+++ b/fossunited/templates/macros/indiafoss.html
@@ -10,7 +10,7 @@
 {% endmacro %}
 
 
-{% macro if_header(years=[], current_year=2026, ticket_url="", show_archive=True, show_schedule=False, show_statistics=True) %}
+{% macro if_header(years=[], current_year=2026, ticket_url="", show_archive=True, show_schedule=False, show_statistics=True, show_speakers=False) %}
 <header class="v3-event-header" aria-label="IndiaFOSS navigation">
 
   <a href="/indiafoss/{{ current_year }}" class="d-flex align-items-center" aria-label="IndiaFOSS {{ current_year }} home">
@@ -21,6 +21,10 @@
 
     {% if show_archive %}
       <a href="/indiafoss/archive" class="if-nav-link" aria-label="IndiaFOSS archive">Archive</a>
+    {% endif %}
+
+    {% if show_speakers %}
+      <a href="/indiafoss/speakers" class="if-nav-link" aria-label="IndiaFOSS speakers">Speakers</a>
     {% endif %}
 
     {% if show_schedule %}
@@ -73,6 +77,7 @@
        style="top: 100%; right: 0; min-width: 200px; z-index: 1050;">
     <div class="v3-card rounded p-3 mt-2 d-flex flex-column gap-2">
       {% if show_archive %}<a href="/indiafoss/archive" class="if-nav-link">Archive</a>{% endif %}
+      {% if show_speakers %}<a href="/indiafoss/speakers" class="if-nav-link">Speakers</a>{% endif %}
       {% if show_schedule %}<a href="/indiafoss/schedule" class="if-nav-link">Schedule</a>{% endif %}
       {% if show_statistics %}<a href="/indiafoss/2026/stats" class="if-nav-link">Statistics</a>{% endif %}
       {% if years | length > 1 %}

--- a/fossunited/templates/macros/indiafoss.html
+++ b/fossunited/templates/macros/indiafoss.html
@@ -98,6 +98,28 @@
 
 
 {% macro if_footer(footer_links={}) %}
+{# Shared default footer sections; a page can override by passing its own footer_links. #}
+{% set footer_links = footer_links or {
+  "Info": [
+    {"label": "Code of Conduct", "url": "/code-of-conduct"},
+    {"label": "Ticket Transfer", "url": "/refund-transfer-policy"},
+    {"label": "Sponsorship Deck", "url": "https://fossunited.org/files/Sponsorship-Deck-IF26.pdf"},
+    {"label": "Community Deck", "url": "https://fossunited.org/files/Community-deck-V2.pdf"}
+  ],
+  "Archive": [
+    {"label": "IndiaFOSS 2025", "url": "/indiafoss/2025"},
+    {"label": "IndiaFOSS 2024", "url": "/indiafoss/2024"},
+    {"label": "IndiaFOSS 3.0", "url": "/indiafoss/2023"},
+    {"label": "IndiaFOSS 2.0", "url": "/indiafoss/2022"},
+    {"label": "IndiaOS", "url": "/indiafoss/2020"}
+  ],
+  "Explore": [
+    {"label": "IndiaFOSS 2026", "url": "/indiafoss/2026"},
+    {"label": "Schedule", "url": "/indiafoss/schedule"},
+    {"label": "All Events", "url": "/events/timeline"},
+    {"label": "Grants", "url": "/grants"}
+  ]
+} %}
 <footer class="foss-footer" aria-label="Site footer">
   <div class="if-footer-inner">
 

--- a/fossunited/templates/macros/video_embed.html
+++ b/fossunited/templates/macros/video_embed.html
@@ -9,7 +9,9 @@
          tabindex="0"
          aria-label="Play {{ title | e }}"
          data-yt="{{ youtube_id }}">
-      <img src="https://img.youtube.com/vi/{{ youtube_id }}/hqdefault.jpg"
+      {# mqdefault = native 16:9 (320x180), no letterbox bars; matches the 16:9
+         box exactly. hqdefault is 4:3 with baked-in black bars. #}
+      <img src="https://img.youtube.com/vi/{{ youtube_id }}/mqdefault.jpg"
            alt="{{ title | e }}"
            class="position-absolute w-100 h-100 object-cover" />
       <div class="m-play-btn" aria-hidden="true">

--- a/fossunited/templates/macros/volunteers_card.html
+++ b/fossunited/templates/macros/volunteers_card.html
@@ -1,4 +1,4 @@
-{% macro profile_headshot(name, photo=None, url=None, info=None) %}
+{% macro profile_headshot(name, photo=None, url=None, info=None, badge=None) %}
   {# Single avatar+name chip. Extracted from people_card. url optional — wraps in anchor if provided. #}
   {% set default_photo = "/assets/fossunited/images/defaults/user_profile_image.png" %}
   {% if url %}
@@ -15,6 +15,9 @@
         <div class="v3-people-name">{{ name }}</div>
         {% if info %}
           <small class="v3-text-tertiary">{{ info }}</small>
+        {% endif %}
+        {% if badge %}
+          <span class="v3-tag mt-1" style="align-self:flex-start;">{{ badge }}</span>
         {% endif %}
       </div>
   {% if url %}</a>{% else %}</div>{% endif %}

--- a/fossunited/www/indiafoss/2026/index.css
+++ b/fossunited/www/indiafoss/2026/index.css
@@ -6,15 +6,7 @@
 }
 .skip-link:focus { top: 0; }
 
-/* ── IndiaFOSS nav link style ───────────────── */
-.if-nav-link {
-  display: inline-flex; align-items: center; gap: 4px; padding: 8px 12px; border-radius: 6px;
-  font-size: .6875rem; font-weight: 700; letter-spacing: .08em; text-transform: uppercase;
-  color: var(--v3-text-color2); background: transparent; border: none;
-  white-space: nowrap; text-decoration: none; cursor: pointer; transition: background .15s;
-}
-.if-nav-link:hover { background: var(--v3-button-border); color: var(--v3-text-color2); text-decoration: none; }
-.if-nav-ticket { font-size: .6875rem; letter-spacing: .08em; text-transform: uppercase; padding: 8px 14px; margin-left: 4px; }
+/* .if-nav-link / .if-nav-ticket moved to custom.css (shared across IndiaFOSS pages) */
 
 /* ── Hero (IndiaFOSS-specific sizing) ───────── */
 /* Full-bleed bg image, natural 1200x438. >=1200 fits exactly; narrower crops
@@ -56,10 +48,7 @@
 /* Tagline white on dark image regardless of theme */
 .if-hero .if-tagline { color: #fff; }
 
-/* ── Community tagline ──────────────────────── */
-.if-tagline { display: inline-flex; align-items: flex-end; gap: 8px; font-size: .6875rem; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; color: var(--v3-text-color); text-decoration: none; }
-.if-tagline svg { width: 40px; height: auto; }
-.if-footer-tagline .if-tagline { color: #fafafa; }
+/* .if-tagline moved to custom.css (shared). Hero-specific override kept below. */
 
 
 /* ── Toggle icon rotation ───────────────────── */

--- a/fossunited/www/indiafoss/archive/index.html
+++ b/fossunited/www/indiafoss/archive/index.html
@@ -122,40 +122,44 @@
                       {% endif %}
                     </div>
 
+                    {# Whole body (title + speakers + edition) links to the card destination;
+                       the video block above stays a separate play/thumbnail area. #}
                     <a
-                      class="line-clamp-2 semi-bold v3-text-primary d-block mt-2"
+                      class="d-block text-decoration-none"
                       href="{{ m.card_link }}"
                       {% if m.card_external %}target="_blank" rel="noopener noreferrer"{% endif %}
                     >
-                      {{ m.title | e }}
+                      <span class="line-clamp-2 semi-bold v3-text-primary d-block mt-2">
+                        {{ m.title | e }}
+                      </span>
+
+                      {% if m.speakers %}
+                        {# compact single row: small avatars + truncated names #}
+                        <span class="d-flex align-items-center gap-2 mt-2">
+                          <span class="d-flex gap-1 flex-shrink-0">
+                            {% for s in m.speakers[:3] %}
+                              <img
+                                class="v3-avatar-xs"
+                                loading="lazy"
+                                alt="{{ s.name | e }}"
+                                data-toggle="tooltip"
+                                title="{{ s.name | e }}{% if s.organization %}· {{ s.organization | e }}{% endif %}"
+                                src="{{ s.photo or '/assets/fossunited/images/defaults/user_profile_image.png' }}"
+                              />
+                            {% endfor %}
+                          </span>
+                          <span
+                            class="text-truncate v3-text-secondary text-sm"
+                            title="{{ m.speaker | e }}"
+                            >{{ m.speaker | e }}</span
+                          >
+                        </span>
+                      {% endif %}
+
+                      {% if m.edition %}<span class="d-block text-xs v3-text-tertiary mt-2">
+                        {{ m.edition | e }}
+                      </span>{% endif %}
                     </a>
-
-                    {% if m.speakers %}
-                      {# compact single row: small avatars + truncated names #}
-                      <div class="d-flex align-items-center gap-2 mt-2">
-                        <div class="d-flex gap-1 flex-shrink-0">
-                          {% for s in m.speakers[:3] %}
-                            <img
-                              class="v3-avatar-xs"
-                              loading="lazy"
-                              alt="{{ s.name | e }}"
-                              data-toggle="tooltip"
-                              title="{{ s.name | e }}{% if s.organization %}· {{ s.organization | e }}{% endif %}"
-                              src="{{ s.photo or '/assets/fossunited/images/defaults/user_profile_image.png' }}"
-                            />
-                          {% endfor %}
-                        </div>
-                        <span
-                          class="text-truncate v3-text-secondary text-sm"
-                          title="{{ m.speaker | e }}"
-                          >{{ m.speaker | e }}</span
-                        >
-                      </div>
-                    {% endif %}
-
-                    {% if m.edition %}<div class="text-xs v3-text-tertiary mt-2">
-                      {{ m.edition | e }}
-                    </div>{% endif %}
                   </div>
                 </article>
               {% endfor %}

--- a/fossunited/www/indiafoss/archive/index.html
+++ b/fossunited/www/indiafoss/archive/index.html
@@ -9,7 +9,7 @@
 {% block page_content %}
   <div class="v3-page">
     <div class="v3-page-wide">
-      {{ if_header(years, current_year, show_statistics=False, show_archive=False) }}
+      {{ if_header(years, current_year, show_statistics=False, show_archive=False, show_speakers=True) }}
 
       <main id="main-content" role="main" class="d-flex flex-column gap-6 mt-4 pb-section">
         <header>
@@ -89,7 +89,7 @@
                   data-eorder="{{ m.edition_order }}"
                   data-type="{{ m.video_type }}"
                   data-duration="{{ m.duration | int }}"
-                  data-search="{{ (m.title ~ ' ' ~ m.speaker) | lower }}"
+                  data-search="{{ (m.title ~ ' ' ~ m.speaker) | lower | e }}"
                 >
                   <div class="v3-hover-shadow rounded h-100 p-2">
                     <div class="position-relative">
@@ -110,7 +110,7 @@
                             class="v3-media-badge"
                             data-toggle="tooltip"
                             title="Session type"
-                            >{{ m.video_type }}</span
+                            >{{ m.video_type | e }}</span
                           >{% endif %}
                           {% if m.duration_str %}<span
                             class="v3-media-badge ml-auto"
@@ -127,7 +127,7 @@
                       href="{{ m.link }}"
                       {% if m.external %}target="_blank" rel="noopener noreferrer"{% endif %}
                     >
-                      {{ m.title }}
+                      {{ m.title | e }}
                     </a>
 
                     {% if m.speakers %}
@@ -138,23 +138,23 @@
                             <img
                               class="v3-avatar-xs"
                               loading="lazy"
-                              alt="{{ s.name }}"
+                              alt="{{ s.name | e }}"
                               data-toggle="tooltip"
-                              title="{{ s.name }}{% if s.organization %}· {{ s.organization }}{% endif %}"
+                              title="{{ s.name | e }}{% if s.organization %}· {{ s.organization | e }}{% endif %}"
                               src="{{ s.photo or '/assets/fossunited/images/defaults/user_profile_image.png' }}"
                             />
                           {% endfor %}
                         </div>
                         <span
                           class="text-truncate v3-text-secondary text-sm"
-                          title="{{ m.speaker }}"
-                          >{{ m.speaker }}</span
+                          title="{{ m.speaker | e }}"
+                          >{{ m.speaker | e }}</span
                         >
                       </div>
                     {% endif %}
 
                     {% if m.edition %}<div class="text-xs v3-text-tertiary mt-2">
-                      {{ m.edition }}
+                      {{ m.edition | e }}
                     </div>{% endif %}
                   </div>
                 </article>

--- a/fossunited/www/indiafoss/archive/index.html
+++ b/fossunited/www/indiafoss/archive/index.html
@@ -124,8 +124,8 @@
 
                     <a
                       class="line-clamp-2 semi-bold v3-text-primary d-block mt-2"
-                      href="{{ m.link }}"
-                      {% if m.external %}target="_blank" rel="noopener noreferrer"{% endif %}
+                      href="{{ m.card_link }}"
+                      {% if m.card_external %}target="_blank" rel="noopener noreferrer"{% endif %}
                     >
                       {{ m.title | e }}
                     </a>

--- a/fossunited/www/indiafoss/archive/index.html
+++ b/fossunited/www/indiafoss/archive/index.html
@@ -1,0 +1,481 @@
+{% extends "templates/foss_base.html" %}
+{% from "fossunited/templates/macros/indiafoss.html" import if_header, if_footer %}
+{% from "fossunited/templates/macros/video_embed.html" import video_embed %}
+{% from "fossunited/templates/macros/meta_block.html" import meta_tags %}
+
+{% block meta_block %}{{ meta_tags(pagetitle, description, image) }}{% endblock %}
+{% block title %}{{ pagetitle }} | FOSS United{% endblock %}
+
+{% block page_content %}
+  <div class="v3-page">
+    <div class="v3-page-wide">
+      {{ if_header(years, current_year, show_statistics=False, show_archive=False) }}
+
+      <main id="main-content" role="main" class="d-flex flex-column gap-6 mt-4 pb-section">
+        <header>
+          <h1 class="v3-text-primary mb-2">IndiaFOSS Archive</h1>
+          <p class="v3-text-secondary mb-0">
+            Every recorded talk from IndiaFOSS, the annual FOSS & Digital Commons Festival by the
+            FOSS United community. Featuring total of <u>{{ total }}</u> talks.
+          </p>
+        </header>
+
+        {# Toolbar: search + sort + group + mobile filter toggle #}
+        <div class="d-flex flex-wrap align-items-center gap-2">
+          <input
+            type="search"
+            id="arcSearch"
+            class="form-control flex-grow-1"
+            style="max-width:420px"
+            placeholder="Search talks or speakers"
+            aria-label="Search talks or speakers"
+          />
+          <select id="arcSort" class="v3-select" aria-label="Sort talks">
+            <option value="az">Sort: A&ndash;Z</option>
+            <option value="za">Sort: Z&ndash;A</option>
+            <option value="short">Sort: Shortest</option>
+            <option value="long">Sort: Longest</option>
+          </select>
+          <select id="arcGroup" class="v3-select" aria-label="Group talks">
+            <option value="none">No grouping</option>
+            <option value="edition">Group: Event</option>
+            <option value="type">Group: Session type</option>
+            <option value="duration">Group: Duration</option>
+          </select>
+          <button
+            class="v3-btn v3-btn-secondary v3-btn--sm d-md-none"
+            type="button"
+            data-toggle="collapse"
+            data-target="#arcFilters"
+            aria-controls="arcFilters"
+            aria-expanded="false"
+          >
+            <i class="ti ti-filter"></i> Filters
+          </button>
+        </div>
+
+        <div class="row">
+          {# Filters sidebar #}
+          <aside class="col-md-3 mb-3 collapse d-md-block" id="arcFilters" aria-label="Filters">
+            <div class="sticky-top" style="top:1rem">
+              <p class="text-uppercase semi-bold text-sm v3-text-secondary mb-3">Filters</p>
+
+              <p class="v3-text-secondary mb-2">IndiaFOSS Edition</p>
+              <div class="d-flex flex-column gap-1 mb-4" data-filter="edition" data-mode="single">
+                <button type="button" class="v3-pill w-100 is-active" data-value="">All</button>
+                {% for e in editions %}
+                  <button type="button" class="v3-pill w-100" data-value="{{ e }}">{{ e }}</button>
+                {% endfor %}
+              </div>
+
+              <p class="v3-text-secondary mb-2">Session Type</p>
+              <div class="d-flex flex-wrap gap-1" data-filter="type" data-mode="multi">
+                {% for t in session_types %}
+                  <button type="button" class="v3-pill" data-value="{{ t }}">{{ t }}</button>
+                {% endfor %}
+              </div>
+            </div>
+          </aside>
+
+          {# Results #}
+          <section class="col-md-9" aria-label="Talks">
+            <p id="arcCount" class="v3-text-tertiary text-sm mb-3" aria-live="polite"></p>
+
+            <div class="row" id="arcGrid">
+              {% for m in media %}
+                <article
+                  class="if-arc-card col-6 col-md-4 mb-4"
+                  data-edition="{{ m.edition }}"
+                  data-eorder="{{ m.edition_order }}"
+                  data-type="{{ m.video_type }}"
+                  data-duration="{{ m.duration | int }}"
+                  data-search="{{ (m.title ~ ' ' ~ m.speaker) | lower }}"
+                >
+                  <div class="v3-hover-shadow rounded h-100 p-2">
+                    <div class="position-relative">
+                      {% if m.youtube_id %}
+                        {{ video_embed(youtube_id=m.youtube_id, title=m.title) }}
+                      {% else %}
+                        <div
+                          class="m-video-aspect rounded d-flex align-items-center justify-content-center v3-bg-subtle"
+                          data-toggle="tooltip"
+                          title="No recording available"
+                        >
+                          <i class="ti ti-video-off v3-text-tertiary" aria-hidden="true"></i>
+                        </div>
+                      {% endif %}
+                      {% if m.video_type or m.duration_str %}
+                        <div class="v3-media-overlay d-flex align-items-end">
+                          {% if m.video_type %}<span
+                            class="v3-media-badge"
+                            data-toggle="tooltip"
+                            title="Session type"
+                            >{{ m.video_type }}</span
+                          >{% endif %}
+                          {% if m.duration_str %}<span
+                            class="v3-media-badge ml-auto"
+                            data-toggle="tooltip"
+                            title="Talk length"
+                            >{{ m.duration_str }}</span
+                          >{% endif %}
+                        </div>
+                      {% endif %}
+                    </div>
+
+                    <a
+                      class="line-clamp-2 semi-bold v3-text-primary d-block mt-2"
+                      href="{{ m.link }}"
+                      {% if m.external %}target="_blank" rel="noopener noreferrer"{% endif %}
+                    >
+                      {{ m.title }}
+                    </a>
+
+                    {% if m.speakers %}
+                      {# compact single row: small avatars + truncated names #}
+                      <div class="d-flex align-items-center gap-2 mt-2">
+                        <div class="d-flex gap-1 flex-shrink-0">
+                          {% for s in m.speakers[:3] %}
+                            <img
+                              class="v3-avatar-xs"
+                              loading="lazy"
+                              alt="{{ s.name }}"
+                              data-toggle="tooltip"
+                              title="{{ s.name }}{% if s.organization %}· {{ s.organization }}{% endif %}"
+                              src="{{ s.photo or '/assets/fossunited/images/defaults/user_profile_image.png' }}"
+                            />
+                          {% endfor %}
+                        </div>
+                        <span
+                          class="text-truncate v3-text-secondary text-sm"
+                          title="{{ m.speaker }}"
+                          >{{ m.speaker }}</span
+                        >
+                      </div>
+                    {% endif %}
+
+                    {% if m.edition %}<div class="text-xs v3-text-tertiary mt-2">
+                      {{ m.edition }}
+                    </div>{% endif %}
+                  </div>
+                </article>
+              {% endfor %}
+            </div>
+
+            <div id="arcEmpty" class="text-center py-5 v3-text-tertiary" hidden>
+              <i
+                class="ti ti-mood-empty d-block mb-2"
+                style="font-size:2rem"
+                aria-hidden="true"
+              ></i>
+              No talks match your filters.
+            </div>
+
+            <nav class="v3-pagination" id="arcPager" aria-label="Pagination"></nav>
+          </section>
+        </div>
+      </main>
+    </div>
+    {{ if_footer() }}
+  </div>
+{% endblock %}
+
+{% block page_script %}
+  <script>
+    ;(function () {
+      const PAGE_SIZE = 24
+      const grid = document.getElementById('arcGrid') // a .row
+      const search = document.getElementById('arcSearch')
+      const sortEl = document.getElementById('arcSort')
+      const groupEl = document.getElementById('arcGroup')
+      const pager = document.getElementById('arcPager')
+      const count = document.getElementById('arcCount')
+      const empty = document.getElementById('arcEmpty')
+      if (!grid) return
+
+      const cards = Array.from(grid.querySelectorAll('.if-arc-card'))
+      const state = { edition: '', types: new Set(), q: '', sort: 'az', group: 'none', page: 1 }
+      const ACTIVE = 'is-active' // selected filter pill (styled by .v3-pill.is-active)
+
+      // Snapshot each embed's thumbnail; restore on re-render to stop playback (no background
+      // audio / no autoplay on return). Only embeds the user played are tracked.
+      const embeds = new Map()
+      grid.querySelectorAll('[data-yt]').forEach((el) => embeds.set(el, el.innerHTML))
+      const playing = new Set()
+      grid.addEventListener('click', (e) => {
+        const el = e.target.closest('[data-yt]')
+        if (el) playing.add(el)
+      })
+      function stopVideos() {
+        playing.forEach((el) => {
+          if (embeds.has(el)) el.innerHTML = embeds.get(el)
+        })
+        playing.clear()
+      }
+
+      const matches = (c) =>
+        (!state.edition || c.dataset.edition === state.edition) &&
+        (state.types.size === 0 || state.types.has(c.dataset.type)) &&
+        (!state.q || (c.dataset.search || '').includes(state.q.toLowerCase()))
+
+      const DUR_BUCKETS = [
+        { max: 600, label: 'Under 10 min' },
+        { max: 1200, label: '10–20 min' },
+        { max: 1800, label: '20–30 min' },
+        { max: 3600, label: '30–60 min' },
+        { max: Infinity, label: '1 hr+' },
+      ]
+      function durBucket(sec) {
+        if (!sec) return { i: 99, label: 'Unknown length' }
+        const i = DUR_BUCKETS.findIndex((b) => sec < b.max)
+        return { i: i, label: DUR_BUCKETS[i].label }
+      }
+
+      function groupOf(c) {
+        if (state.group === 'edition')
+          return { key: c.dataset.edition || 'Other', order: +c.dataset.eorder }
+        if (state.group === 'type') return { key: c.dataset.type || 'Other', order: 0 }
+        if (state.group === 'duration') {
+          const b = durBucket(+c.dataset.duration)
+          return { key: b.label, order: b.i }
+        }
+        return null
+      }
+
+      function sortCmp(a, b) {
+        if (state.sort === 'short' || state.sort === 'long') {
+          const d = (+a.dataset.duration || 0) - (+b.dataset.duration || 0)
+          if (d) return state.sort === 'short' ? d : -d
+          return a.dataset.search.localeCompare(b.dataset.search)
+        }
+        const c = a.dataset.search.localeCompare(b.dataset.search)
+        return state.sort === 'za' ? -c : c
+      }
+
+      function fullCmp(a, b) {
+        if (state.group !== 'none') {
+          const ga = groupOf(a),
+            gb = groupOf(b)
+          if (state.group === 'type') {
+            const k = ga.key.localeCompare(gb.key)
+            if (k) return k
+          } else if (ga.order !== gb.order) return ga.order - gb.order
+        }
+        return sortCmp(a, b)
+      }
+
+      // Move cards back to the root row, then drop group scaffolding (so cards survive).
+      function resetContainer() {
+        cards.forEach((c) => grid.appendChild(c))
+        grid.querySelectorAll('.if-arc-ghead, .if-arc-group').forEach((n) => n.remove())
+      }
+
+      function groupHeading(key, targetId, n) {
+        const h = document.createElement('h2')
+        h.className =
+          'if-arc-ghead v3-clickable col-12 d-flex align-items-center gap-2 ' +
+          'border-bottom pb-2 mt-3 mb-3 v3-text-secondary text-uppercase text-sm'
+        h.setAttribute('role', 'button')
+        h.setAttribute('data-toggle', 'collapse')
+        h.setAttribute('data-target', '#' + targetId)
+        h.setAttribute('aria-expanded', 'true')
+        h.setAttribute('aria-controls', targetId)
+        const chev = document.createElement('i')
+        chev.className = 'ti ti-chevron-down'
+        chev.setAttribute('aria-hidden', 'true')
+        const span = document.createElement('span')
+        span.textContent = key + ' (' + n + ')'
+        h.append(chev, span)
+        return h
+      }
+
+      function render() {
+        stopVideos()
+        resetContainer()
+        const list = cards.filter(matches).sort(fullCmp)
+        const grouped = state.group !== 'none'
+        const total = list.length
+        const pages = grouped ? 1 : Math.max(1, Math.ceil(total / PAGE_SIZE))
+        if (state.page > pages) state.page = pages
+        const start = grouped ? 0 : (state.page - 1) * PAGE_SIZE
+        const slice = grouped ? list : list.slice(start, start + PAGE_SIZE)
+
+        cards.forEach((c) => (c.style.display = 'none'))
+
+        if (grouped) {
+          // Each group = a BS4 collapsible section: clickable heading (col-12) + a `collapse show`
+          // wrapper (col-12) holding that group's own card row.
+          const counts = {}
+          slice.forEach((c) => {
+            const k = groupOf(c).key
+            counts[k] = (counts[k] || 0) + 1
+          })
+          let key = null,
+            inner = null,
+            i = 0
+          slice.forEach((c) => {
+            const k = groupOf(c).key
+            if (k !== key) {
+              key = k
+              i += 1
+              const id = 'arc-grp-' + i
+              grid.appendChild(groupHeading(k, id, counts[k]))
+              const wrap = document.createElement('div')
+              wrap.className = 'collapse show if-arc-group col-12'
+              wrap.id = id
+              inner = document.createElement('div')
+              inner.className = 'row'
+              wrap.appendChild(inner)
+              grid.appendChild(wrap)
+            }
+            c.style.display = ''
+            inner.appendChild(c)
+          })
+        } else {
+          slice.forEach((c) => {
+            c.style.display = ''
+            grid.appendChild(c)
+          })
+        }
+
+        empty.hidden = total !== 0
+        grid.hidden = total === 0
+        count.textContent = total
+          ? grouped
+            ? total + ' talk' + (total === 1 ? '' : 's')
+            : 'Showing ' + (start + 1) + '–' + Math.min(start + PAGE_SIZE, total) + ' of ' + total
+          : ''
+
+        renderPager(pages)
+        persist()
+      }
+
+      function renderPager(pages) {
+        pager.innerHTML = ''
+        if (pages <= 1) return
+        const btn = (label, page, opts = {}) => {
+          const b = document.createElement('button')
+          b.type = 'button'
+          b.className = 'v3-pagination__btn' + (opts.active ? ' v3-pagination__btn--active' : '')
+          b.textContent = label
+          if (opts.disabled) b.disabled = true
+          else
+            b.addEventListener('click', () => {
+              state.page = page
+              render()
+              scrollUp()
+            })
+          return b
+        }
+        pager.appendChild(btn('← Prev', state.page - 1, { disabled: state.page === 1 }))
+        buildPageWindow(state.page, pages).forEach((p) => {
+          if (p === '…') {
+            const s = document.createElement('span')
+            s.className = 'v3-pagination__btn'
+            s.style.pointerEvents = 'none'
+            s.textContent = '…'
+            pager.appendChild(s)
+          } else {
+            pager.appendChild(btn(String(p), p, { active: p === state.page }))
+          }
+        })
+        pager.appendChild(btn('Next →', state.page + 1, { disabled: state.page === pages }))
+      }
+
+      function scrollUp() {
+        document
+          .getElementById('main-content')
+          .scrollIntoView({ behavior: 'smooth', block: 'start' })
+      }
+
+      // Filter pill clicks (single = edition, multi = type). Selected pill = ACTIVE class.
+      document.querySelectorAll('[data-filter]').forEach((box) => {
+        const single = box.dataset.mode === 'single'
+        box.addEventListener('click', (e) => {
+          const pill = e.target.closest('button[data-value]')
+          if (!pill || !box.contains(pill)) return
+          if (single) {
+            box.querySelectorAll('button[data-value]').forEach((p) => p.classList.remove(ACTIVE))
+            pill.classList.add(ACTIVE)
+            state.edition = pill.dataset.value
+          } else {
+            pill.classList.toggle(ACTIVE)
+            state.types.clear()
+            box
+              .querySelectorAll('button.' + ACTIVE)
+              .forEach((p) => state.types.add(p.dataset.value))
+          }
+          state.page = 1
+          render()
+        })
+      })
+
+      // ── URL <-> state sync (shareable, survives reload/return; no page reload) ──
+      function persist() {
+        setParams({
+          edition: state.edition,
+          type: state.types.size ? [...state.types].join(',') : '',
+          q: state.q,
+          sort: state.sort !== 'az' ? state.sort : '',
+          group: state.group !== 'none' ? state.group : '',
+          page: state.page > 1 ? state.page : '',
+        })
+        try {
+          sessionStorage.setItem('arcFilters', location.search.replace(/^\?/, ''))
+        } catch (e) {}
+      }
+
+      function restore() {
+        let qs = location.search.replace(/^\?/, '')
+        if (!qs) {
+          try {
+            qs = sessionStorage.getItem('arcFilters') || ''
+          } catch (e) {}
+        }
+        const p = new URLSearchParams(qs)
+        state.edition = p.get('edition') || ''
+        state.types = new Set((p.get('type') || '').split(',').filter(Boolean))
+        state.q = p.get('q') || ''
+        const s = p.get('sort')
+        state.sort = ['za', 'short', 'long'].includes(s) ? s : 'az'
+        const g = p.get('group')
+        state.group = ['edition', 'type', 'duration'].includes(g) ? g : 'none'
+        state.page = Math.max(1, parseInt(p.get('page'), 10) || 1)
+      }
+
+      function syncUI() {
+        search.value = state.q
+        sortEl.value = state.sort
+        groupEl.value = state.group
+        document
+          .querySelectorAll('[data-filter="edition"] button[data-value]')
+          .forEach((p) => p.classList.toggle(ACTIVE, (p.dataset.value || '') === state.edition))
+        document
+          .querySelectorAll('[data-filter="type"] button[data-value]')
+          .forEach((p) => p.classList.toggle(ACTIVE, state.types.has(p.dataset.value)))
+      }
+
+      search.addEventListener(
+        'input',
+        debounce(() => {
+          state.q = search.value.trim()
+          state.page = 1
+          render()
+        }, 150),
+      )
+      sortEl.addEventListener('change', () => {
+        state.sort = sortEl.value
+        state.page = 1
+        render()
+      })
+      groupEl.addEventListener('change', () => {
+        state.group = groupEl.value
+        state.page = 1
+        render()
+      })
+
+      restore()
+      syncUI()
+      render()
+    })()
+  </script>
+{% endblock %}

--- a/fossunited/www/indiafoss/archive/index.py
+++ b/fossunited/www/indiafoss/archive/index.py
@@ -1,0 +1,28 @@
+from fossunited.fossunited.event_media import (
+    get_archive_media,
+    get_editions,
+    get_indiafoss_years,
+    get_session_types,
+)
+
+
+def get_context(context):
+    context.no_cache = 1
+    # Custom IndiaFOSS header + footer (if_header/if_footer); suppress the site defaults.
+    context.hide_nav, context.hide_footer = True, True
+
+    media = get_archive_media()
+    context.media = media
+    context.total = len(media)
+    context.editions = get_editions(media)
+    context.session_types = get_session_types(media)
+
+    context.years = get_indiafoss_years()
+    context.current_year = 2026
+
+    context.pagetitle = "IndiaFOSS Archive"
+    context.description = (
+        "Browse every talk from IndiaFOSS, the annual Free and Open Source Software "
+        "conference by the FOSS United community."
+    )
+    context.image = "https://fossunited.org/files/indiafoss-2026-og.png"

--- a/fossunited/www/indiafoss/archive/index.py
+++ b/fossunited/www/indiafoss/archive/index.py
@@ -25,4 +25,4 @@ def get_context(context):
         "Browse every talk from IndiaFOSS, the annual Free and Open Source Software "
         "conference by the FOSS United community."
     )
-    context.image = "https://fossunited.org/files/indiafoss-2026-og.png"
+    # context.image = "https://fossunited.org/files/indiafoss-2026-og.png"

--- a/fossunited/www/indiafoss/speaker_talks/index.html
+++ b/fossunited/www/indiafoss/speaker_talks/index.html
@@ -1,0 +1,104 @@
+{% extends "templates/foss_base.html" %}
+{% from "fossunited/templates/macros/indiafoss.html" import if_header, if_footer %}
+{% from "fossunited/templates/macros/video_embed.html" import video_embed %}
+{% from "fossunited/templates/macros/meta_block.html" import meta_tags %}
+
+{% set SOCIAL_ICONS = {
+  "linkedin": "brand-linkedin", "x": "brand-x", "instagram": "brand-instagram",
+  "github": "brand-github", "website": "world"
+} %}
+
+{% block meta_block %}{{ meta_tags(pagetitle, description, image) }}{% endblock %}
+{% block title %}{{ pagetitle }} | FOSS United{% endblock %}
+
+{% block page_content %}
+  <div class="v3-page">
+    <div class="v3-page-wide">
+      {{ if_header(years, current_year, show_statistics=False, show_archive=True, show_speakers=True) }}
+
+      <main id="main-content" role="main" class="d-flex flex-column gap-6 mt-4 pb-section">
+        <nav aria-label="Breadcrumb" class="text-sm v3-text-tertiary">
+          <a class="v3-text-secondary" href="/indiafoss/speakers">Speakers</a>
+          <span class="mx-1">›</span>
+          <span>{{ speaker.name | e }}</span>
+        </nav>
+
+        {# Speaker header card #}
+        <div class="v3-card d-flex align-items-center gap-3 p-3">
+          <img class="v3-avatar-lg" alt="{{ speaker.name | e }}" src="{{ speaker.avatar }}" />
+          <div class="d-flex flex-column">
+            <h1 class="v3-text-primary text-xl mb-1">{{ speaker.name | e }}</h1>
+            {% if speaker.designation %}<span class="v3-text-secondary">{{ speaker.designation | e }}{% if speaker.organization %}, {{ speaker.organization | e }}{% endif %}</span>{% endif %}
+            {% if speaker.socials %}
+              <div class="d-flex align-items-center gap-3 mt-2">
+                {% for k, url in speaker.socials.items() %}
+                  <a href="{{ url }}" target="_blank" rel="noopener noreferrer"
+                     class="v3-text-secondary" aria-label="{{ k }}">
+                    <i class="ti ti-{{ SOCIAL_ICONS.get(k, 'link') }}" style="font-size:1.25rem;"></i>
+                  </a>
+                {% endfor %}
+              </div>
+            {% endif %}
+          </div>
+        </div>
+
+        {# Talk cards: each is a BS4 collapsible section. Header (title + badges) toggles the body.
+           Body row = video (left on desktop) + refs/proposal (right on desktop, ABOVE video on mobile
+           via order utilities); description spans full width below. Key takeaways intentionally omitted. #}
+        {% for t in talks %}
+          {% set body_id = "talk-" ~ loop.index %}
+          {% set has_side = t.link or t.references %}
+          <article class="v3-card p-3 p-md-4">
+            <div class="v3-clickable d-flex align-items-start gap-2" role="button"
+                 data-toggle="collapse" data-target="#{{ body_id }}"
+                 aria-expanded="true" aria-controls="{{ body_id }}">
+              <i class="ti ti-chevron-down flex-shrink-0 mt-1" aria-hidden="true"></i>
+              <div class="flex-grow-1">
+                <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
+                  {% if t.video_type %}<span class="v3-media-badge" style="background:var(--v3-button-border);color:var(--v3-text-color2);">{{ t.video_type | e }}</span>{% endif %}
+                  {% if t.edition %}<span class="text-xs text-uppercase semi-bold v3-text-tertiary">{{ t.edition | e }}</span>{% endif %}
+                </div>
+                <h2 class="v3-text-primary text-lg mb-0">{{ t.title | e }}</h2>
+              </div>
+            </div>
+
+            <div class="collapse show mt-3" id="{{ body_id }}">
+              <div class="row">
+                {% if has_side %}
+                  <div class="col-12 col-md-6 order-md-2 mb-3 mb-md-0">
+                    <div class="v3-talk-refs">
+                      {% if t.link %}
+                        <a class="v3-btn v3-btn-secondary v3-btn--sm" href="{{ t.link }}"
+                           {% if t.external %}target="_blank" rel="noopener noreferrer"{% endif %}>
+                          <i class="ti ti-external-link"></i> View proposal
+                        </a>
+                      {% endif %}
+                      {% for ref in t.references %}
+                        <a class="v3-btn v3-btn-secondary v3-btn--sm" href="{{ ref }}" target="_blank" rel="noopener noreferrer">
+                          <i class="ti ti-link"></i> Reference link
+                        </a>
+                      {% endfor %}
+                    </div>
+                  </div>
+                {% endif %}
+                {% if t.youtube_id %}
+                  <div class="col-12 {% if has_side %}col-md-6 order-md-1{% endif %}">
+                    {{ video_embed(youtube_id=t.youtube_id, title=t.title) }}
+                  </div>
+                {% endif %}
+              </div>
+
+              {% if t.tier == 'internal' and t.description %}
+                <div class="mt-3">
+                  <p class="semi-bold v3-text-secondary mb-2">Session Description</p>
+                  <div class="v3-text-primary from-markdown">{{ t.description | safe }}</div>
+                </div>
+              {% endif %}
+            </div>
+          </article>
+        {% endfor %}
+      </main>
+    </div>
+    {{ if_footer() }}
+  </div>
+{% endblock %}

--- a/fossunited/www/indiafoss/speaker_talks/index.py
+++ b/fossunited/www/indiafoss/speaker_talks/index.py
@@ -1,0 +1,25 @@
+import frappe
+
+from fossunited.fossunited.event_media import get_indiafoss_years, get_speaker_talks
+
+
+def get_context(context):
+    context.no_cache = 1
+    context.hide_nav, context.hide_footer = True, True
+
+    slug = frappe.form_dict.slug
+    data = get_speaker_talks(slug) if slug else None
+    if not data:
+        raise frappe.DoesNotExistError
+
+    context.speaker = data["speaker"]
+    context.talks = data["talks"]
+    context.years = get_indiafoss_years()
+    context.current_year = 2026
+
+    context.pagetitle = context.speaker["name"] + " — IndiaFOSS talks"
+    context.description = (
+        context.speaker["name"]
+        + " has spoken at IndiaFOSS. Watch their talks and read the details."
+    )
+    # context.image = "https://fossunited.org/files/indiafoss-2026-og.png"

--- a/fossunited/www/indiafoss/speakers/index.html
+++ b/fossunited/www/indiafoss/speakers/index.html
@@ -1,0 +1,218 @@
+{% extends "templates/foss_base.html" %}
+{% from "fossunited/templates/macros/indiafoss.html" import if_header, if_footer %}
+{% from "fossunited/templates/macros/meta_block.html" import meta_tags %}
+
+{% block meta_block %}{{ meta_tags(pagetitle, description, image) }}{% endblock %}
+{% block title %}{{ pagetitle }} | FOSS United{% endblock %}
+
+{% block page_content %}
+  <div class="v3-page">
+    <div class="v3-page-wide">
+      {{ if_header(years, current_year, show_statistics=False, show_archive=True, show_speakers=True) }}
+
+      <main id="main-content" role="main" class="d-flex flex-column gap-6 mt-4 pb-section">
+        <header>
+          <h1 class="v3-text-primary mb-2">IndiaFOSS Speakers</h1>
+          <p class="v3-text-secondary mb-0">
+            Everyone who has spoken at IndiaFOSS. <u>{{ total }}</u> speakers across all editions.
+          </p>
+        </header>
+
+        <div class="d-flex flex-wrap align-items-center gap-2">
+          <input type="search" id="spkSearch" class="form-control flex-grow-1" style="max-width:420px"
+                 placeholder="Search speakers" aria-label="Search speakers" />
+          <button class="v3-btn v3-btn-secondary v3-btn--sm d-md-none" type="button"
+                  data-toggle="collapse" data-target="#spkFilters"
+                  aria-controls="spkFilters" aria-expanded="false">
+            <i class="ti ti-filter"></i> Filters
+          </button>
+        </div>
+
+        <div class="row">
+          <aside class="col-md-3 mb-3 collapse d-md-block" id="spkFilters" aria-label="Filters">
+            <div class="sticky-top" style="top:1rem">
+              <p class="text-uppercase semi-bold text-sm v3-text-secondary mb-3">Filters</p>
+
+              <p class="v3-text-secondary mb-2">IndiaFOSS Edition</p>
+              <div class="d-flex flex-column gap-1 mb-4" data-filter="edition" data-mode="single">
+                <button type="button" class="v3-pill w-100 is-active" data-value="">All</button>
+                {% for e in editions %}
+                  <button type="button" class="v3-pill w-100" data-value="{{ e }}">{{ e }}</button>
+                {% endfor %}
+              </div>
+
+              <p class="v3-text-secondary mb-2">Session Type</p>
+              <div class="d-flex flex-wrap gap-1" data-filter="type" data-mode="multi">
+                {% for t in session_types %}
+                  <button type="button" class="v3-pill" data-value="{{ t }}">{{ t }}</button>
+                {% endfor %}
+              </div>
+            </div>
+          </aside>
+
+          <section class="col-md-9" aria-label="Speakers">
+            <p id="spkCount" class="v3-text-tertiary text-sm mb-3" aria-live="polite"></p>
+
+            <div class="row" id="spkGrid">
+              {% for s in speakers %}
+                <div class="spk-card-col col-6 mb-3"
+                     data-editions="{{ s.editions | join('|') }}"
+                     data-types="{{ s.types | join('|') }}"
+                     data-search="{{ (s.name ~ ' ' ~ s.designation ~ ' ' ~ s.organization) | lower | e }}">
+                  <a class="v3-speaker-card" href="/indiafoss/speakers/{{ s.slug }}"
+                     aria-label="{{ s.name | e }} — {{ s.talk_count }} talks">
+                    <img class="v3-people-avatar" loading="lazy" alt="{{ s.name | e }}" src="{{ s.avatar }}" />
+                    <div class="d-flex flex-column" style="min-width:0;">
+                      <div class="v3-people-name semi-bold">{{ s.name | e }}</div>
+                      {% if s.designation %}<small class="v3-text-tertiary text-truncate">{{ s.designation | e }}</small>{% endif %}
+                      <span class="v3-tag mt-1" style="align-self:flex-start;">Talks: {{ s.talk_count }}</span>
+                    </div>
+                  </a>
+                </div>
+              {% endfor %}
+            </div>
+
+            <div id="spkEmpty" class="text-center py-5 v3-text-tertiary" hidden>
+              <i class="ti ti-mood-empty d-block mb-2" style="font-size:2rem" aria-hidden="true"></i>
+              No speakers match your filters.
+            </div>
+
+            <nav class="v3-pagination" id="spkPager" aria-label="Pagination"></nav>
+          </section>
+        </div>
+      </main>
+    </div>
+    {{ if_footer() }}
+  </div>
+{% endblock %}
+
+{% block page_script %}
+  <script>
+    ;(function () {
+      const PAGE_SIZE = 24
+      const grid = document.getElementById('spkGrid')
+      const search = document.getElementById('spkSearch')
+      const pager = document.getElementById('spkPager')
+      const count = document.getElementById('spkCount')
+      const empty = document.getElementById('spkEmpty')
+      if (!grid) return
+
+      const cards = Array.from(grid.querySelectorAll('.spk-card-col'))
+      const state = { edition: '', types: new Set(), q: '', page: 1 }
+      const ACTIVE = 'is-active'
+      const has = (csv, v) => (csv || '').split('|').filter(Boolean).includes(v)
+
+      const matches = (c) =>
+        (!state.edition || has(c.dataset.editions, state.edition)) &&
+        (state.types.size === 0 || [...state.types].some((t) => has(c.dataset.types, t))) &&
+        (!state.q || (c.dataset.search || '').includes(state.q.toLowerCase()))
+
+      function render() {
+        const list = cards.filter(matches)
+        const total = list.length
+        const pages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+        if (state.page > pages) state.page = pages
+        const start = (state.page - 1) * PAGE_SIZE
+        const slice = list.slice(start, start + PAGE_SIZE)
+
+        cards.forEach((c) => (c.style.display = 'none'))
+        slice.forEach((c) => {
+          c.style.display = ''
+          grid.appendChild(c)
+        })
+
+        empty.hidden = total !== 0
+        grid.hidden = total === 0
+        count.textContent = total
+          ? 'Showing ' + (start + 1) + '–' + Math.min(start + PAGE_SIZE, total) + ' of ' + total
+          : ''
+        renderPager(pages)
+        persist()
+      }
+
+      function renderPager(pages) {
+        pager.innerHTML = ''
+        if (pages <= 1) return
+        const btn = (label, page, opts = {}) => {
+          const b = document.createElement('button')
+          b.type = 'button'
+          b.className = 'v3-pagination__btn' + (opts.active ? ' v3-pagination__btn--active' : '')
+          b.textContent = label
+          if (opts.disabled) b.disabled = true
+          else
+            b.addEventListener('click', () => {
+              state.page = page
+              render()
+              document.getElementById('main-content').scrollIntoView({ behavior: 'smooth', block: 'start' })
+            })
+          return b
+        }
+        pager.appendChild(btn('← Prev', state.page - 1, { disabled: state.page === 1 }))
+        buildPageWindow(state.page, pages).forEach((p) => {
+          if (p === '…') {
+            const s = document.createElement('span')
+            s.className = 'v3-pagination__btn'
+            s.style.pointerEvents = 'none'
+            s.textContent = '…'
+            pager.appendChild(s)
+          } else {
+            pager.appendChild(btn(String(p), p, { active: p === state.page }))
+          }
+        })
+        pager.appendChild(btn('Next →', state.page + 1, { disabled: state.page === pages }))
+      }
+
+      document.querySelectorAll('[data-filter]').forEach((box) => {
+        const single = box.dataset.mode === 'single'
+        box.addEventListener('click', (e) => {
+          const pill = e.target.closest('button[data-value]')
+          if (!pill || !box.contains(pill)) return
+          if (single) {
+            box.querySelectorAll('button[data-value]').forEach((p) => p.classList.remove(ACTIVE))
+            pill.classList.add(ACTIVE)
+            state.edition = pill.dataset.value
+          } else {
+            pill.classList.toggle(ACTIVE)
+            state.types.clear()
+            box.querySelectorAll('button.' + ACTIVE).forEach((p) => state.types.add(p.dataset.value))
+          }
+          state.page = 1
+          render()
+        })
+      })
+
+      function persist() {
+        setParams({
+          edition: state.edition,
+          type: state.types.size ? [...state.types].join(',') : '',
+          q: state.q,
+          page: state.page > 1 ? state.page : '',
+        })
+      }
+      function restore() {
+        const p = new URLSearchParams(location.search.replace(/^\?/, ''))
+        state.edition = p.get('edition') || ''
+        state.types = new Set((p.get('type') || '').split(',').filter(Boolean))
+        state.q = p.get('q') || ''
+        state.page = Math.max(1, parseInt(p.get('page'), 10) || 1)
+      }
+      function syncUI() {
+        search.value = state.q
+        document.querySelectorAll('[data-filter="edition"] button[data-value]')
+          .forEach((p) => p.classList.toggle(ACTIVE, (p.dataset.value || '') === state.edition))
+        document.querySelectorAll('[data-filter="type"] button[data-value]')
+          .forEach((p) => p.classList.toggle(ACTIVE, state.types.has(p.dataset.value)))
+      }
+
+      search.addEventListener('input', debounce(() => {
+        state.q = search.value.trim()
+        state.page = 1
+        render()
+      }, 150))
+
+      restore()
+      syncUI()
+      render()
+    })()
+  </script>
+{% endblock %}

--- a/fossunited/www/indiafoss/speakers/index.py
+++ b/fossunited/www/indiafoss/speakers/index.py
@@ -26,4 +26,4 @@ def get_context(context):
         "Every speaker who has taken the stage at IndiaFOSS, the annual FOSS & Digital "
         "Commons Festival by the FOSS United community."
     )
-    context.image = "https://fossunited.org/files/indiafoss-2026-og.png"
+    # context.image = "https://fossunited.org/files/indiafoss-2026-og.png"

--- a/fossunited/www/indiafoss/speakers/index.py
+++ b/fossunited/www/indiafoss/speakers/index.py
@@ -1,0 +1,29 @@
+from fossunited.fossunited.event_media import (
+    get_editions,
+    get_indiafoss_media,
+    get_indiafoss_years,
+    get_session_types,
+    get_speakers_index,
+)
+
+
+def get_context(context):
+    context.no_cache = 1
+    context.hide_nav, context.hide_footer = True, True
+
+    context.speakers = get_speakers_index()["speakers"]
+    context.total = len(context.speakers)
+
+    media = get_indiafoss_media()
+    context.editions = get_editions(media)
+    context.session_types = get_session_types(media)
+
+    context.years = get_indiafoss_years()
+    context.current_year = 2026
+
+    context.pagetitle = "IndiaFOSS Speakers"
+    context.description = (
+        "Every speaker who has taken the stage at IndiaFOSS, the annual FOSS & Digital "
+        "Commons Festival by the FOSS United community."
+    )
+    context.image = "https://fossunited.org/files/indiafoss-2026-og.png"


### PR DESCRIPTION
IndiaFOSS Archive will kinda mimic "Mini Youtube"
Basically we are showing youtube videos itself, just that with speaker names and proposal page link. Aggregation is the main focus!

- `/indiafoss/archive` page acts as aggregate to all previous Talks to show
  - Click on thumbnail plays the video in-page
  - Click on title takes to proposal page (for IndiaOS (1), 2.0 it takes to YT link itself, since there is no CFP page in archive platform)

- Doctype :: `Event Media` which collects YT URL and links each to an proposal (so auto fetch other details)
  - Helps to also map older events and is generic to expand for other events to show in some page like `/videos` or `/media`

- Data migration is hard and will be incomplete, and we might miss the taste and state of how platform was that time, so IMHO it better stay legacy on its own page.

- Further additions `/indiafoss/speakers` to show all aggregate of speakers who spoke in IndiaFOSS and each speaker page shows talks list as well.

TBH IMO its not required for platform, since it does reinvent the wheel and added new way to show. But I thought it can stay generic to collect for all events (Mumbai, MangaloreFOSS and etc) so we group and once place rules them all.

<img width="1232" height="1090" alt="image" src="https://github.com/user-attachments/assets/fb3b77b0-a6e0-4ae3-b99a-0b9324ffc24e" />