### PR TITLE
feat: add list view toggle to events timeline

### DIFF
--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -3696,35 +3696,14 @@ a.m-text-1:hover, a.m-text-2:hover { filter: brightness(1.2); color: inherit; te
 .v3-view-toggle .btn {
   width: 36px;
   height: 36px;
-  padding: 0;
-  border: none;
-  border-radius: 0;
   background: var(--v3-card-bg);
   color: var(--v3-text-color2);
   font-size: 1.1rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
 }
-.v3-view-toggle .btn:hover {
-  background: var(--v3-button-border);
-}
-.v3-view-toggle .btn:focus-visible {
-  outline: 2px solid var(--v3-text-color2);
-  outline-offset: -2px;
-  z-index: 1;
-}
-.v3-view-toggle .btn.active {
-  background: var(--v3-text-color2);
-  color: var(--v3-main-bg);
-}
-.v3-view-toggle .btn.active:hover {
-  background: var(--v3-text-color2);
-}
-summary:focus-visible {
-  outline: 2px solid var(--v3-text-color2);
-  outline-offset: 2px;
-}
+.v3-view-toggle .btn:hover { background: var(--v3-button-border); }
+.v3-view-toggle .btn:focus-visible { outline: 2px solid var(--v3-text-color2); outline-offset: -2px; z-index: 1; }
+.v3-view-toggle .btn.active { background: var(--v3-text-color2); color: var(--v3-main-bg); }
+summary:focus-visible { outline: 2px solid var(--v3-text-color2); outline-offset: 2px; }
 
 /* List view */
 .v3-timeline-list {
@@ -3764,27 +3743,9 @@ summary:focus-visible {
   color: var(--v3-text-color);
 }
 
-.v3-event-list-row__name {
-  font-weight: 500;
-  font-size: 0.9375rem;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.v3-event-list-row__date {
-  font-size: 0.8125rem;
-  color: var(--v3-text-color2);
-  white-space: nowrap;
-}
-
-.v3-event-list-row__location {
-  font-size: 0.8125rem;
-  color: var(--v3-text-color2);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
+.v3-event-list-row__name { font-weight: 500; font-size: 0.9375rem; }
+.v3-event-list-row__date,
+.v3-event-list-row__location { font-size: 0.8125rem; color: var(--v3-text-color2); }
 
 @media (max-width: 768px) {
   .v3-timeline-list__header {

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -3687,6 +3687,122 @@ a.m-text-1:hover, a.m-text-2:hover { filter: brightness(1.2); color: inherit; te
   .illust-img, .illust-photo, .faq-chevron, .v3-toggle-icon, .v3-action-card, .vol-item { transition: none; }
 }
 
+/* View toggle */
+.v3-view-toggle {
+  display: inline-flex;
+  border: 1px solid var(--v3-button-border);
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+.v3-view-toggle__btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: none;
+  background: var(--v3-card-bg);
+  color: var(--v3-text-color2);
+  cursor: pointer;
+  transition: all 0.15s;
+  font-size: 1.1rem;
+}
+
+.v3-view-toggle__btn:hover {
+  background: var(--v3-button-border);
+}
+
+.v3-view-toggle__btn--active {
+  background: var(--v3-text-color2);
+  color: var(--v3-main-bg);
+}
+
+.v3-view-toggle__btn--active:hover {
+  background: var(--v3-text-color2);
+}
+
+/* List view */
+.v3-timeline-list {
+  border-left: 1px solid var(--v3-text-color2);
+  padding-left: 0.8rem;
+  margin-left: 0.4rem;
+}
+
+.v3-timeline-list__header {
+  display: grid;
+  grid-template-columns: 1fr 160px 200px;
+  gap: 1rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--v3-text-color2);
+  border-bottom: 1px solid var(--v3-button-border);
+}
+
+.v3-event-list-row {
+  display: grid;
+  grid-template-columns: 1fr 160px 200px;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  text-decoration: none;
+  color: var(--v3-text-color);
+  border-bottom: 1px solid var(--v3-button-border);
+  transition: background 0.1s;
+  align-items: center;
+}
+
+.v3-event-list-row:hover {
+  background: var(--v3-button-border);
+  text-decoration: none;
+  color: var(--v3-text-color);
+}
+
+.v3-event-list-row__name {
+  font-weight: 500;
+  font-size: 0.9375rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.v3-event-list-row__date {
+  font-size: 0.8125rem;
+  color: var(--v3-text-color2);
+  white-space: nowrap;
+}
+
+.v3-event-list-row__location {
+  font-size: 0.8125rem;
+  color: var(--v3-text-color2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@media (max-width: 768px) {
+  .v3-timeline-list__header {
+    display: none;
+  }
+
+  .v3-event-list-row {
+    grid-template-columns: 1fr;
+    gap: 0.25rem;
+    padding: 0.75rem 0.75rem;
+  }
+
+  .v3-event-list-row__name {
+    white-space: normal;
+  }
+
+  .v3-event-list-row__date,
+  .v3-event-list-row__location {
+    font-size: 0.75rem;
+  }
+}
+
 /* ===== Tablet ===== */
 @media (min-width: 768px) {
   .v3-btn-group {

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -3703,6 +3703,7 @@ a.m-text-1:hover, a.m-text-2:hover { filter: brightness(1.2); color: inherit; te
 .v3-view-toggle .btn:hover { background: var(--v3-button-border); }
 .v3-view-toggle .btn:focus-visible { outline: 2px solid var(--v3-text-color2); outline-offset: -2px; z-index: 1; }
 .v3-view-toggle .btn.active { background: var(--v3-text-color2); color: var(--v3-main-bg); }
+.timeline-month-header:focus-visible,
 summary:focus-visible { outline: 2px solid var(--v3-text-color2); outline-offset: 2px; }
 
 /* List view */
@@ -3714,7 +3715,7 @@ summary:focus-visible { outline: 2px solid var(--v3-text-color2); outline-offset
 
 .v3-timeline-list__header {
   display: grid;
-  grid-template-columns: 1fr 160px 200px;
+  grid-template-columns: 1fr 180px 140px 180px;
   gap: 1rem;
   padding: 0.5rem 1rem;
   font-size: 0.75rem;
@@ -3727,7 +3728,7 @@ summary:focus-visible { outline: 2px solid var(--v3-text-color2); outline-offset
 
 .v3-event-list-row {
   display: grid;
-  grid-template-columns: 1fr 160px 200px;
+  grid-template-columns: 1fr 180px 140px 180px;
   gap: 1rem;
   padding: 0.75rem 1rem;
   text-decoration: none;
@@ -3743,7 +3744,9 @@ summary:focus-visible { outline: 2px solid var(--v3-text-color2); outline-offset
   color: var(--v3-text-color);
 }
 
-.v3-event-list-row__name { font-weight: 500; font-size: 0.9375rem; }
+.v3-event-list-row__name { font-weight: 500; font-size: 0.9375rem; display: flex; align-items: center; gap: 0.5rem; }
+.v3-event-list-row__name .v3-tag { flex-shrink: 0; }
+.v3-event-list-row__chapter,
 .v3-event-list-row__date,
 .v3-event-list-row__location { font-size: 0.8125rem; color: var(--v3-text-color2); }
 
@@ -3761,6 +3764,8 @@ summary:focus-visible { outline: 2px solid var(--v3-text-color2); outline-offset
   .v3-event-list-row__name {
     white-space: normal;
   }
+
+  .v3-event-list-row__chapter { display: none; }
 
   .v3-event-list-row__date,
   .v3-event-list-row__location {

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -3743,9 +3743,15 @@ summary:focus-visible { outline: 2px solid var(--v3-text-color2); outline-offset
   text-decoration: none;
   color: var(--v3-text-color);
 }
+.v3-event-list-row:focus-visible {
+  outline: 2px solid var(--v3-text-color2);
+  outline-offset: -2px;
+  z-index: 1;
+}
 
-.v3-event-list-row__name { font-weight: 500; font-size: 0.9375rem; display: flex; align-items: center; gap: 0.5rem; }
+.v3-event-list-row__name { font-weight: 500; font-size: 0.9375rem; display: flex; align-items: center; gap: 0.5rem; min-width: 0; }
 .v3-event-list-row__name .v3-tag { flex-shrink: 0; }
+.v3-event-list-row__name .truncate { min-width: 0; flex: 1; }
 .v3-event-list-row__chapter,
 .v3-event-list-row__date,
 .v3-event-list-row__location { font-size: 0.8125rem; color: var(--v3-text-color2); }

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -3689,37 +3689,41 @@ a.m-text-1:hover, a.m-text-2:hover { filter: brightness(1.2); color: inherit; te
 
 /* View toggle */
 .v3-view-toggle {
-  display: inline-flex;
   border: 1px solid var(--v3-button-border);
   border-radius: 0.5rem;
   overflow: hidden;
 }
-
-.v3-view-toggle__btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+.v3-view-toggle .btn {
   width: 36px;
   height: 36px;
+  padding: 0;
   border: none;
+  border-radius: 0;
   background: var(--v3-card-bg);
   color: var(--v3-text-color2);
-  cursor: pointer;
-  transition: all 0.15s;
   font-size: 1.1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
-
-.v3-view-toggle__btn:hover {
+.v3-view-toggle .btn:hover {
   background: var(--v3-button-border);
 }
-
-.v3-view-toggle__btn--active {
+.v3-view-toggle .btn:focus-visible {
+  outline: 2px solid var(--v3-text-color2);
+  outline-offset: -2px;
+  z-index: 1;
+}
+.v3-view-toggle .btn.active {
   background: var(--v3-text-color2);
   color: var(--v3-main-bg);
 }
-
-.v3-view-toggle__btn--active:hover {
+.v3-view-toggle .btn.active:hover {
   background: var(--v3-text-color2);
+}
+summary:focus-visible {
+  outline: 2px solid var(--v3-text-color2);
+  outline-offset: 2px;
 }
 
 /* List view */

--- a/fossunited/public/js/common_functions.js
+++ b/fossunited/public/js/common_functions.js
@@ -322,11 +322,18 @@ function truncateStr(title, len) {
 var VIEW_MODE_KEY = 'fossunited-view-mode'
 
 function getViewMode() {
-  return localStorage.getItem(VIEW_MODE_KEY) || 'grid'
+  try {
+    var v = localStorage.getItem(VIEW_MODE_KEY)
+    return v === 'list' ? 'list' : 'grid'
+  } catch (e) {
+    return 'grid'
+  }
 }
 
 function saveViewMode(mode) {
-  localStorage.setItem(VIEW_MODE_KEY, mode)
+  try {
+    localStorage.setItem(VIEW_MODE_KEY, mode === 'list' ? 'list' : 'grid')
+  } catch (e) {}
 }
 
 function toggleSection(id) {

--- a/fossunited/public/js/common_functions.js
+++ b/fossunited/public/js/common_functions.js
@@ -319,6 +319,16 @@ function truncateStr(title, len) {
   return title.length > len ? title.substring(0, len) + '...' : title
 }
 
+var VIEW_MODE_KEY = 'fossunited-view-mode'
+
+function getViewMode() {
+  return localStorage.getItem(VIEW_MODE_KEY) || 'grid'
+}
+
+function saveViewMode(mode) {
+  localStorage.setItem(VIEW_MODE_KEY, mode)
+}
+
 function toggleSection(id) {
   const content = document.getElementById(id)
   if (!content) return
@@ -382,6 +392,9 @@ Object.assign(window, {
   formatTimeOnly,
   formatShortDate,
   truncateStr,
+  VIEW_MODE_KEY,
+  getViewMode,
+  saveViewMode,
   toggleSection,
   debounce,
   buildPageWindow,

--- a/fossunited/templates/macros/event_card.html
+++ b/fossunited/templates/macros/event_card.html
@@ -129,8 +129,8 @@
       target="_blank" rel="noopener noreferrer"
     {% endif %}
   >
-    <div class="v3-event-list-row__name">{{ event_name }}</div>
-    <div class="v3-event-list-row__date">
+    <div class="v3-event-list-row__name truncate">{{ event_name }}</div>
+    <div class="v3-event-list-row__date text-nowrap">
       {% set sd = frappe.utils.get_datetime(start_date) %}
       {% set ed = frappe.utils.get_datetime(end_date or start_date) %}
       {% set same_day = sd.date() == ed.date() %}
@@ -147,6 +147,6 @@
         {{ frappe.utils.formatdate(sd, "d MMM yyyy") }} – {{ frappe.utils.formatdate(ed, "d MMM yyyy") }}
       {% endif %}
     </div>
-    <div class="v3-event-list-row__location">{{ location }}</div>
+    <div class="v3-event-list-row__location truncate">{{ location }}</div>
   </a>
 {% endmacro %}

--- a/fossunited/templates/macros/event_card.html
+++ b/fossunited/templates/macros/event_card.html
@@ -121,6 +121,7 @@
   {% set start_date = event.event_start_date or event.start_date %}
   {% set end_date = event.event_end_date or event.end_date or start_date %}
   {% set location = event.event_location or event.location or event.hackathon_type or "TBA" %}
+  {% set chapter_name = event._chapter_name or '' %}
 
   <a
     href="{{ event.external_event_url or '/' ~ (event.route or '').lstrip('/') }}"
@@ -129,7 +130,11 @@
       target="_blank" rel="noopener noreferrer"
     {% endif %}
   >
-    <div class="v3-event-list-row__name truncate">{{ event_name }}</div>
+    <div class="v3-event-list-row__name truncate">
+      {{ event_name }}
+      {% if event.must_attend %}{{ event_must_attend_tag() }}{% endif %}
+    </div>
+    <div class="v3-event-list-row__chapter truncate">{{ chapter_name }}</div>
     <div class="v3-event-list-row__date text-nowrap">
       {% set sd = frappe.utils.get_datetime(start_date) %}
       {% set ed = frappe.utils.get_datetime(end_date or start_date) %}

--- a/fossunited/templates/macros/event_card.html
+++ b/fossunited/templates/macros/event_card.html
@@ -123,35 +123,42 @@
   {% set location = event.event_location or event.location or event.hackathon_type or "TBA" %}
   {% set chapter_name = event._chapter_name or '' %}
 
+  {% set sd = frappe.utils.get_datetime(start_date) %}
+  {% set ed = frappe.utils.get_datetime(end_date or start_date) %}
+  {% set same_day = sd.date() == ed.date() %}
+  {% set same_month = sd.strftime("%Y-%m") == ed.strftime("%Y-%m") %}
+  {% set same_year = sd.year == ed.year %}
+
+  {% if same_day %}
+    {% set date_str = frappe.utils.formatdate(sd, "d MMM yyyy") %}
+  {% elif same_month %}
+    {% set date_str = frappe.utils.formatdate(sd, "d") ~ " – " ~ frappe.utils.formatdate(ed, "d MMM yyyy") %}
+  {% elif same_year %}
+    {% set date_str = frappe.utils.formatdate(sd, "d MMM") ~ " – " ~ frappe.utils.formatdate(ed, "d MMM yyyy") %}
+  {% else %}
+    {% set date_str = frappe.utils.formatdate(sd, "d MMM yyyy") ~ " – " ~ frappe.utils.formatdate(ed, "d MMM yyyy") %}
+  {% endif %}
+
+  {% set aria_parts = [event_name] %}
+  {% if event.must_attend %}{% set _ = aria_parts.append("Must Attend") %}{% endif %}
+  {% if chapter_name %}{% set _ = aria_parts.append("by " ~ chapter_name) %}{% endif %}
+  {% set _ = aria_parts.append(date_str) %}
+  {% set _ = aria_parts.append(location) %}
+
   <a
     href="{{ event.external_event_url or '/' ~ (event.route or '').lstrip('/') }}"
     class="v3-event-list-row"
+    aria-label="{{ aria_parts | join(', ') }}"
     {% if event.is_external_event %}
       target="_blank" rel="noopener noreferrer"
     {% endif %}
   >
-    <div class="v3-event-list-row__name truncate">
-      {{ event_name }}
+    <div class="v3-event-list-row__name" aria-hidden="true">
+      <span class="truncate">{{ event_name }}</span>
       {% if event.must_attend %}{{ event_must_attend_tag() }}{% endif %}
     </div>
-    <div class="v3-event-list-row__chapter truncate">{{ chapter_name }}</div>
-    <div class="v3-event-list-row__date text-nowrap">
-      {% set sd = frappe.utils.get_datetime(start_date) %}
-      {% set ed = frappe.utils.get_datetime(end_date or start_date) %}
-      {% set same_day = sd.date() == ed.date() %}
-      {% set same_month = sd.strftime("%Y-%m") == ed.strftime("%Y-%m") %}
-      {% set same_year = sd.year == ed.year %}
-
-      {% if same_day %}
-        {{ frappe.utils.formatdate(sd, "d MMM yyyy") }}
-      {% elif same_month %}
-        {{ frappe.utils.formatdate(sd, "d") }} – {{ frappe.utils.formatdate(ed, "d MMM yyyy") }}
-      {% elif same_year %}
-        {{ frappe.utils.formatdate(sd, "d MMM") }} – {{ frappe.utils.formatdate(ed, "d MMM yyyy") }}
-      {% else %}
-        {{ frappe.utils.formatdate(sd, "d MMM yyyy") }} – {{ frappe.utils.formatdate(ed, "d MMM yyyy") }}
-      {% endif %}
-    </div>
-    <div class="v3-event-list-row__location truncate">{{ location }}</div>
+    <div class="v3-event-list-row__chapter truncate" aria-hidden="true">{{ chapter_name }}</div>
+    <div class="v3-event-list-row__date text-nowrap" aria-hidden="true">{{ date_str }}</div>
+    <div class="v3-event-list-row__location truncate" aria-hidden="true">{{ location }}</div>
   </a>
 {% endmacro %}

--- a/fossunited/templates/macros/event_card.html
+++ b/fossunited/templates/macros/event_card.html
@@ -115,3 +115,38 @@
     </div>
   </a>
 {% endmacro %}
+
+{% macro event_list_row(event) %}
+  {% set event_name = event.event_name or event.hackathon_name %}
+  {% set start_date = event.event_start_date or event.start_date %}
+  {% set end_date = event.event_end_date or event.end_date or start_date %}
+  {% set location = event.event_location or event.location or event.hackathon_type or "TBA" %}
+
+  <a
+    href="{{ event.external_event_url or '/' ~ (event.route or '').lstrip('/') }}"
+    class="v3-event-list-row"
+    {% if event.is_external_event %}
+      target="_blank" rel="noopener noreferrer"
+    {% endif %}
+  >
+    <div class="v3-event-list-row__name">{{ event_name }}</div>
+    <div class="v3-event-list-row__date">
+      {% set sd = frappe.utils.get_datetime(start_date) %}
+      {% set ed = frappe.utils.get_datetime(end_date or start_date) %}
+      {% set same_day = sd.date() == ed.date() %}
+      {% set same_month = sd.strftime("%Y-%m") == ed.strftime("%Y-%m") %}
+      {% set same_year = sd.year == ed.year %}
+
+      {% if same_day %}
+        {{ frappe.utils.formatdate(sd, "d MMM yyyy") }}
+      {% elif same_month %}
+        {{ frappe.utils.formatdate(sd, "d") }} – {{ frappe.utils.formatdate(ed, "d MMM yyyy") }}
+      {% elif same_year %}
+        {{ frappe.utils.formatdate(sd, "d MMM") }} – {{ frappe.utils.formatdate(ed, "d MMM yyyy") }}
+      {% else %}
+        {{ frappe.utils.formatdate(sd, "d MMM yyyy") }} – {{ frappe.utils.formatdate(ed, "d MMM yyyy") }}
+      {% endif %}
+    </div>
+    <div class="v3-event-list-row__location">{{ location }}</div>
+  </a>
+{% endmacro %}

--- a/fossunited/templates/pages/timeline_base.html
+++ b/fossunited/templates/pages/timeline_base.html
@@ -281,6 +281,9 @@
     </div>
   </div>
 
+{% endblock %}
+
+{% block page_script %}
   <script>
     ;(function () {
       'use strict'

--- a/fossunited/templates/pages/timeline_base.html
+++ b/fossunited/templates/pages/timeline_base.html
@@ -135,10 +135,10 @@
           {% endif %}
 
           <div class="btn-group v3-view-toggle" role="group" aria-label="View mode">
-            <button id="view-grid" class="btn active" type="button" aria-pressed="true" title="Card view">
+            <button id="view-grid" class="btn d-inline-flex align-items-center justify-content-center p-0 border-0 rounded-0 active" type="button" aria-pressed="true" title="Card view">
               <i class="ti ti-layout-grid" aria-hidden="true"></i>
             </button>
-            <button id="view-list" class="btn" type="button" aria-pressed="false" title="List view">
+            <button id="view-list" class="btn d-inline-flex align-items-center justify-content-center p-0 border-0 rounded-0" type="button" aria-pressed="false" title="List view">
               <i class="ti ti-list" aria-hidden="true"></i>
             </button>
           </div>

--- a/fossunited/templates/pages/timeline_base.html
+++ b/fossunited/templates/pages/timeline_base.html
@@ -291,7 +291,7 @@
       // State
       const state = {
         category: 'city',
-        viewMode: localStorage.getItem('fossunited-view-mode') || 'grid',
+        viewMode: getViewMode(),
         filters: {
           search: '',
           city: '',
@@ -540,7 +540,7 @@
 
            <div id="${sectionId}" class="collapse show">
              <div class="${containerClass}">
-               ${isList ? '<div class="v3-timeline-list__header"><span>Name</span><span>Date</span><span>Location</span></div>' : ''}
+               ${isList ? '<div class="v3-timeline-list__header"><span>Name</span><span>Chapter</span><span>Date</span><span>Location</span></div>' : ''}
              </div>
            </div>
          `
@@ -723,7 +723,7 @@
 
       function setViewMode(mode) {
         state.viewMode = mode
-        localStorage.setItem('fossunited-view-mode', mode)
+        saveViewMode(mode)
         dom.viewGrid.classList.toggle('active', mode === 'grid')
         dom.viewList.classList.toggle('active', mode === 'list')
         dom.viewGrid.setAttribute('aria-pressed', mode === 'grid')

--- a/fossunited/templates/pages/timeline_base.html
+++ b/fossunited/templates/pages/timeline_base.html
@@ -134,11 +134,11 @@
             </div>
           {% endif %}
 
-          <div class="v3-view-toggle" role="group" aria-label="View mode">
-            <button id="view-grid" class="v3-view-toggle__btn v3-view-toggle__btn--active" type="button" aria-pressed="true" title="Card view">
+          <div class="btn-group v3-view-toggle" role="group" aria-label="View mode">
+            <button id="view-grid" class="btn active" type="button" aria-pressed="true" title="Card view">
               <i class="ti ti-layout-grid" aria-hidden="true"></i>
             </button>
-            <button id="view-list" class="v3-view-toggle__btn" type="button" aria-pressed="false" title="List view">
+            <button id="view-list" class="btn" type="button" aria-pressed="false" title="List view">
               <i class="ti ti-list" aria-hidden="true"></i>
             </button>
           </div>
@@ -724,8 +724,8 @@
       function setViewMode(mode) {
         state.viewMode = mode
         localStorage.setItem('fossunited-view-mode', mode)
-        dom.viewGrid.classList.toggle('v3-view-toggle__btn--active', mode === 'grid')
-        dom.viewList.classList.toggle('v3-view-toggle__btn--active', mode === 'list')
+        dom.viewGrid.classList.toggle('active', mode === 'grid')
+        dom.viewList.classList.toggle('active', mode === 'list')
         dom.viewGrid.setAttribute('aria-pressed', mode === 'grid')
         dom.viewList.setAttribute('aria-pressed', mode === 'list')
         render()
@@ -771,8 +771,8 @@
 
       // Initialize
       if (state.viewMode === 'list') {
-        dom.viewGrid.classList.remove('v3-view-toggle__btn--active')
-        dom.viewList.classList.add('v3-view-toggle__btn--active')
+        dom.viewGrid.classList.remove('active')
+        dom.viewList.classList.add('active')
         dom.viewGrid.setAttribute('aria-pressed', 'false')
         dom.viewList.setAttribute('aria-pressed', 'true')
       }

--- a/fossunited/templates/pages/timeline_base.html
+++ b/fossunited/templates/pages/timeline_base.html
@@ -1,6 +1,6 @@
 {% extends "templates/foss_base.html" %}
 {% from "fossunited/templates/macros/breadcrumb.html" import v3_navbar %}
-{% from "fossunited/templates/macros/event_card.html" import event_card %}
+{% from "fossunited/templates/macros/event_card.html" import event_card, event_list_row %}
 
 {% block head %}
   {{ super() }}
@@ -134,6 +134,15 @@
             </div>
           {% endif %}
 
+          <div class="v3-view-toggle" role="group" aria-label="View mode">
+            <button id="view-grid" class="v3-view-toggle__btn v3-view-toggle__btn--active" type="button" aria-pressed="true" title="Card view">
+              <i class="ti ti-layout-grid" aria-hidden="true"></i>
+            </button>
+            <button id="view-list" class="v3-view-toggle__btn" type="button" aria-pressed="false" title="List view">
+              <i class="ti ti-list" aria-hidden="true"></i>
+            </button>
+          </div>
+
           <button
             id="filter-toggle"
             class="v3-btn v3-btn-secondary"
@@ -249,6 +258,26 @@
           </div>
         {% endfor %}
       </div>
+
+      <!-- Event list rows (hidden) -->
+      <div id="event-rows-template" class="d-none">
+        {% for event in all_events %}
+          <div
+            class="timeline-row-wrapper"
+            data-event-id="{{ event.name }}"
+            data-name="{{ event.event_name }}"
+            data-location="{{ event.event_location }}"
+            data-city="{{ event._chapter_city or '' }}"
+            data-start="{{ event._start }}"
+            data-end="{{ event._end }}"
+            data-is-past="{{ 'true' if event._is_past else 'false' }}"
+            data-must-attend="{{ 'true' if event.must_attend else 'false' }}"
+            data-chapter-type="{{ event._chapter_type }}"
+          >
+            {{ event_list_row(event) }}
+          </div>
+        {% endfor %}
+      </div>
     </div>
   </div>
 
@@ -262,6 +291,7 @@
       // State
       const state = {
         category: 'city',
+        viewMode: localStorage.getItem('fossunited-view-mode') || 'grid',
         filters: {
           search: '',
           city: '',
@@ -293,9 +323,15 @@
         downloadIcsToggle: document.getElementById('download-ics-toggle'),
         icsDropdown: document.getElementById('ics-dropdown-menu'),
         yearPagination: document.getElementById('year-pagination'),
+        viewGrid: document.getElementById('view-grid'),
+        viewList: document.getElementById('view-list'),
       }
 
       const wrappers = Array.from(document.querySelectorAll('.timeline-event-wrapper'))
+      const rowWrappers = Array.from(document.querySelectorAll('.timeline-row-wrapper'))
+
+      const rowsByEventId = {}
+      rowWrappers.forEach(rw => { rowsByEventId[rw.dataset.eventId] = rw })
 
       // Lazy loading observer
       const lazyImageObserver = new IntersectionObserver(
@@ -478,6 +514,7 @@
         const sortedKeys = Object.keys(groups).sort((a, b) =>
           reverse ? b.localeCompare(a) : a.localeCompare(b),
         )
+        const isList = state.viewMode === 'list'
 
         return sortedKeys.map((key) => {
           const { display: month, items: list } = groups[key]
@@ -486,6 +523,8 @@
 
           const sectionId = `month-${key}`
           const statusClass = isUpcoming ? 'v3-text-success' : 'v3-text-tertiary'
+          const containerClass = isList ? 'v3-timeline-list' : 'row v3-timeline-grid'
+
           group.innerHTML = `
            <div
              class="d-flex align-items-center mb-3 timeline-month-header"
@@ -500,18 +539,25 @@
            </div>
 
            <div id="${sectionId}" class="collapse show">
-             <div class="row v3-timeline-grid"></div>
+             <div class="${containerClass}">
+               ${isList ? '<div class="v3-timeline-list__header"><span>Name</span><span>Date</span><span>Location</span></div>' : ''}
+             </div>
            </div>
          `
 
-          const row = group.querySelector('.v3-timeline-grid')
+          const container = group.querySelector(isList ? '.v3-timeline-list' : '.v3-timeline-grid')
           list
             .sort((a, b) => (reverse ? b.d - a.d : a.d - b.d))
             .forEach(({ w }) => {
-              const col = document.createElement('div')
-              col.className = 'mb-4'
-              col.appendChild(w.cloneNode(true))
-              row.appendChild(col)
+              if (isList) {
+                const rw = rowsByEventId[w.dataset.eventId]
+                if (rw) container.appendChild(rw.cloneNode(true))
+              } else {
+                const col = document.createElement('div')
+                col.className = 'mb-4'
+                col.appendChild(w.cloneNode(true))
+                container.appendChild(col)
+              }
             })
 
           return group
@@ -675,6 +721,19 @@
         dom.endDate.value = _parsed.end
       }
 
+      function setViewMode(mode) {
+        state.viewMode = mode
+        localStorage.setItem('fossunited-view-mode', mode)
+        dom.viewGrid.classList.toggle('v3-view-toggle__btn--active', mode === 'grid')
+        dom.viewList.classList.toggle('v3-view-toggle__btn--active', mode === 'list')
+        dom.viewGrid.setAttribute('aria-pressed', mode === 'grid')
+        dom.viewList.setAttribute('aria-pressed', mode === 'list')
+        render()
+      }
+
+      dom.viewGrid.onclick = () => setViewMode('grid')
+      dom.viewList.onclick = () => setViewMode('list')
+
       if (dom.downloadIcsToggle && dom.icsDropdown) {
         function openIcsDropdown() {
           dom.icsDropdown.style.opacity = '1'
@@ -711,6 +770,12 @@
       }
 
       // Initialize
+      if (state.viewMode === 'list') {
+        dom.viewGrid.classList.remove('v3-view-toggle__btn--active')
+        dom.viewList.classList.add('v3-view-toggle__btn--active')
+        dom.viewGrid.setAttribute('aria-pressed', 'false')
+        dom.viewList.setAttribute('aria-pressed', 'true')
+      }
       setupPagination()
       render()
     })()

--- a/fossunited/templates/pages/timeline_base.html
+++ b/fossunited/templates/pages/timeline_base.html
@@ -204,7 +204,7 @@
         </div>
       </div>
 
-      <div class="v3-card btn-group w-100 mb-4 p-2" role="group" aria-label="Event category filter">
+      <div class="v3-card d-flex gap-2 w-100 mb-4 p-2" role="group" aria-label="Event category filter">
         <button id="toggle-city" class="v3-btn v3-text-primary v3-btn-secondary w-50" aria-pressed="true">
           City Events
         </button>

--- a/fossunited/www/events/timeline/index.py
+++ b/fossunited/www/events/timeline/index.py
@@ -44,6 +44,7 @@ def get_foss_timeline_items(is_upcoming=True):
             "event_type",
             "modified",
             "chapter.chapter_type as _chapter_type",
+            "chapter.chapter_name as _chapter_name",
             "chapter.city as _chapter_city",
         ],
     )
@@ -63,6 +64,7 @@ def get_foss_timeline_items(is_upcoming=True):
             "hackathon_description as event_description",
             "modified",
             "chapter.chapter_type as _chapter_type",
+            "chapter.chapter_name as _chapter_name",
             "chapter.city as _chapter_city",
         ],
     )
@@ -102,6 +104,7 @@ def get_foss_timeline_items(is_upcoming=True):
                 "banner_image": None,
                 "chapter": frappe._dict({**_GRANTS_CHAPTER, "city": city}),
                 "_chapter_type": "City Community",
+                "_chapter_name": "FOSS Event Grants",
                 "_chapter_city": city,
                 "event_location": location,
                 "must_attend": (g.get("grant_amount") or 0) > 10000,


### PR DESCRIPTION
## Status

- [ ] Draft
- [X] Ready for review

---

## Related Issue

Closes / Addresses: #1643 

---

## Summary
- Adds a grid/list view toggle to the events timeline page
- List view shows compact rows (name, date, location) - no images, much faster to scan through completed events
- View preference persists in localStorage
- Responsive on mobile

---

## Visualization

[Screencast From 2026-08-11 13-16-03.webm](https://github.com/user-attachments/assets/74ee0b66-54d7-457c-b7cd-7d4d1dce19ce)


---

## Further Ahead

## Other pages that could benefit
- `/grants` - stacked grant cards with images
- `/hackathon/projects` - grid of project cards
- `/clubs` - club listing that could grow

