### PR TITLE
docs(doctype): add README for doctype directory

### DIFF
--- a/fossunited/fossunited/doctype/README.md
+++ b/fossunited/fossunited/doctype/README.md
@@ -10,5 +10,6 @@ Some doctypes also have:
 - a `test_*.py`, for unit tests
 - a `templates/` folder, for doctypes rendered on the website
 
-New doctypes should be added via `bench`, not created by hand, so the
-generated files stay consistent with the rest here.
+New doctypes should be created via the Desk UI (with developer mode
+enabled), not written by hand, so Frappe generates the standard file set
+consistently.

--- a/fossunited/fossunited/doctype/README.md
+++ b/fossunited/fossunited/doctype/README.md
@@ -1,0 +1,14 @@
+﻿# doctype
+
+DocTypes for the `fossunited` app, following standard Frappe conventions.
+Each subfolder is one DocType - its schema/permissions live in the `.json`,
+and its logic lives in the `.py` controller (plus `__init__.py`, which
+Frappe needs to treat it as a module).
+
+Some doctypes also have:
+- a `.js` file, for client-side form behaviour
+- a `test_*.py`, for unit tests
+- a `templates/` folder, for doctypes rendered on the website
+
+New doctypes should be added via `bench`, not created by hand, so the
+generated files stay consistent with the rest here.


### PR DESCRIPTION
## Status

- [ ] Draft
- [x] Ready for review

---

## Related Issue

Addresses: #1606

---

## Problem

Some major directories, such as `doctype`, currently do not have README files. This makes it harder for contributors to quickly understand the purpose and structure of these directories.

---

## Solution

Added a `README.md` inside `fossunited/doctype` explaining the purpose of the directory and the general structure of a DocType folder.

It covers the commonly used files such as the `.json` definition, `.py` controller, and optional files like `.js`, `test_*.py`, and `templates/`.

This PR only focuses on one directory to keep the change small, as suggested by the maintainer.

---

## Progress

- [x] Verified README formatting on GitHub

---

## Changelog

docs: add README for doctype directory

---

## Visualization

Not applicable — documentation-only change.

---

## Further Work

More directory READMEs can be added in separate PRs following the same approach.