### PR TITLE
docs(macros): add README for macros directory

### DIFF
--- a/fossunited/templates/macros/README.md
+++ b/fossunited/templates/macros/README.md
@@ -1,0 +1,16 @@
+﻿# Macros
+
+Reusable Jinja2 macros used in the server-rendered website templates
+(Frappe web pages, not the Desk/admin UI).
+
+A file can define more than one related macro. For example,
+`breadcrumb.html` also contains `theme_toggle` and `v3_navbar`.
+
+Macros are imported using their full app path:
+
+```jinja
+{% from "fossunited/templates/macros/chapter_branding_block.html" import chapter_branding_block %}
+```
+
+Not everything here is visual - `meta_block.html` just renders page
+`<meta>` tags for SEO/social sharing, rather than page content.


### PR DESCRIPTION
## Status

- [ ] Draft
- [x] Ready for review

---

## Related Issue

Addresses: #1606

---

## Problem

The `templates/macros` directory contains reusable Jinja macros used across the website's server-rendered pages, but there was no README explaining the purpose of the directory or how these macros are organized and used.

---

## Solution

Added a `README.md` for the macros directory explaining what the directory contains, how macros are imported, and that a single file can contain multiple related macros.

This PR only focuses on the `macros` directory to keep the change small and aligned with the approach discussed in the issue.

---

## Progress

- [x] Verified README formatting on GitHub

---

## Changelog

docs(macros): add README for macros directory

---

## Visualization

Not applicable — documentation-only change.

---

## Further Work

More directory READMEs can be added in separate PRs following the same approach.

