### PR TITLE
a11y(if-archive): fix misc accessibility

### DIFF
--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
@@ -40,8 +40,9 @@
     {{ theme_toggle() }}
   </div>
 
+  {% set _video_speaker = doc.speakers[0].full_name if (doc.speakers and not anonymous_cfps) else None %}
   {{ talk_header() }}
-  {% if talk_video %}{{ video_embed(talk_video, doc.talk_title, youtube_id=youtube_embed_id) }}{% endif %}
+  {% if talk_video %}{{ video_embed(talk_video, doc.talk_title, youtube_id=youtube_embed_id, speaker=_video_speaker) }}{% endif %}
   {{ prose_container("Session Description", doc.talk_description) }}
   {{ prose_container("Key Takeaways", doc.key_takeaways) }}
   {{ references() }}

--- a/fossunited/templates/macros/video_embed.html
+++ b/fossunited/templates/macros/video_embed.html
@@ -1,13 +1,16 @@
-{% macro video_embed(url, title, youtube_id=None) %}
+{% macro video_embed(url, title, youtube_id=None, speaker=None, event=None) %}
 {% if url or youtube_id %}
   {% if youtube_id %}
+    {%- set video_label = 'Watch talk: ' ~ title if (speaker or event) else 'Watch ' ~ title -%}
+    {%- if speaker %}{% set video_label = video_label ~ ', given by ' ~ speaker %}{% endif -%}
+    {%- if event %}{% set video_label = video_label ~ ', at ' ~ event %}{% endif -%}
     <link rel="preconnect" href="https://www.youtube-nocookie.com">
     <link rel="preconnect" href="https://i.ytimg.com">
     <div class="m-video-aspect rounded overflow-hidden cursor-pointer"
          id="ve-{{ youtube_id }}"
          role="button"
          tabindex="0"
-         aria-label="Play {{ title | e }}"
+         aria-label="{{ video_label | e }}"
          data-yt="{{ youtube_id }}">
       {# mqdefault = native 16:9 (320x180), no letterbox bars; matches the 16:9
          box exactly. hqdefault is 4:3 with baked-in black bars. #}

--- a/fossunited/www/indiafoss/archive/index.html
+++ b/fossunited/www/indiafoss/archive/index.html
@@ -16,7 +16,7 @@
           <h1 class="v3-page-title v3-text-primary mb-2">IndiaFOSS Archive</h1>
           <p class="v3-text-secondary mb-0">
             Every recorded talk from IndiaFOSS, the annual FOSS & Digital Commons Festival by the
-            FOSS United community. Featuring total of <u>{{ total }}</u> talks.
+            FOSS United community. Featuring total of <strong>{{ total }}</strong> talks.
           </p>
         </header>
 
@@ -98,8 +98,10 @@
                       {% else %}
                         <div
                           class="m-video-aspect rounded d-flex align-items-center justify-content-center v3-bg-subtle"
+                          role="img"
                           data-toggle="tooltip"
                           title="No recording available"
+                          aria-label="No recording available"
                         >
                           <i class="ti ti-video-off v3-text-tertiary" aria-hidden="true"></i>
                         </div>
@@ -350,7 +352,7 @@
           ? grouped
             ? total + ' talk' + (total === 1 ? '' : 's')
             : 'Showing ' + (start + 1) + '–' + Math.min(start + PAGE_SIZE, total) + ' of ' + total
-          : ''
+          : 'No talks match your filters.'
 
         renderPager(pages)
         persist()

--- a/fossunited/www/indiafoss/archive/index.html
+++ b/fossunited/www/indiafoss/archive/index.html
@@ -60,20 +60,24 @@
             <div class="sticky-top" style="top:1rem">
               <p class="text-uppercase semi-bold text-sm v3-text-secondary mb-3">Filters</p>
 
-              <p class="v3-text-secondary mb-2">IndiaFOSS Edition</p>
-              <div class="d-flex flex-column gap-1 mb-4" data-filter="edition" data-mode="single">
-                <button type="button" class="v3-pill w-100 is-active" data-value="">All</button>
-                {% for e in editions %}
-                  <button type="button" class="v3-pill w-100" data-value="{{ e }}">{{ e }}</button>
-                {% endfor %}
-              </div>
+              <fieldset class="mb-4" style="border:0;padding:0;margin:0;">
+                <legend class="v3-text-secondary mb-2" style="font-size:inherit;font-weight:inherit;">IndiaFOSS Edition</legend>
+                <div class="d-flex flex-column gap-1" data-filter="edition" data-mode="single">
+                  <button type="button" class="v3-pill w-100 is-active" data-value="" aria-pressed="true">All</button>
+                  {% for e in editions %}
+                    <button type="button" class="v3-pill w-100" data-value="{{ e }}" aria-pressed="false">{{ e }}</button>
+                  {% endfor %}
+                </div>
+              </fieldset>
 
-              <p class="v3-text-secondary mb-2">Session Type</p>
-              <div class="d-flex flex-wrap gap-1" data-filter="type" data-mode="multi">
-                {% for t in session_types %}
-                  <button type="button" class="v3-pill" data-value="{{ t }}">{{ t }}</button>
-                {% endfor %}
-              </div>
+              <fieldset style="border:0;padding:0;margin:0;">
+                <legend class="v3-text-secondary mb-2" style="font-size:inherit;font-weight:inherit;">Session Type</legend>
+                <div class="d-flex flex-wrap gap-1" data-filter="type" data-mode="multi">
+                  {% for t in session_types %}
+                    <button type="button" class="v3-pill" data-value="{{ t }}" aria-pressed="false">{{ t }}</button>
+                  {% endfor %}
+                </div>
+              </fieldset>
             </div>
           </aside>
 
@@ -94,7 +98,7 @@
                   <div class="v3-hover-shadow rounded h-100 p-2">
                     <div class="position-relative">
                       {% if m.youtube_id %}
-                        {{ video_embed(youtube_id=m.youtube_id, title=m.title) }}
+                        {{ video_embed(youtube_id=m.youtube_id, title=m.title, speaker=m.speaker, event=m.edition) }}
                       {% else %}
                         <div
                           class="m-video-aspect rounded d-flex align-items-center justify-content-center v3-bg-subtle"
@@ -396,18 +400,24 @@
           .scrollIntoView({ behavior: 'smooth', block: 'start' })
       }
 
-      // Filter pill clicks (single = edition, multi = type). Selected pill = ACTIVE class.
+      // Filter pill clicks (single = edition, multi = type). Selected pill = ACTIVE class
+      // + aria-pressed, so screen readers get the same selected-state signal sighted users see.
       document.querySelectorAll('[data-filter]').forEach((box) => {
         const single = box.dataset.mode === 'single'
         box.addEventListener('click', (e) => {
           const pill = e.target.closest('button[data-value]')
           if (!pill || !box.contains(pill)) return
           if (single) {
-            box.querySelectorAll('button[data-value]').forEach((p) => p.classList.remove(ACTIVE))
+            box.querySelectorAll('button[data-value]').forEach((p) => {
+              p.classList.remove(ACTIVE)
+              p.setAttribute('aria-pressed', 'false')
+            })
             pill.classList.add(ACTIVE)
+            pill.setAttribute('aria-pressed', 'true')
             state.edition = pill.dataset.value
           } else {
             pill.classList.toggle(ACTIVE)
+            pill.setAttribute('aria-pressed', pill.classList.contains(ACTIVE) ? 'true' : 'false')
             state.types.clear()
             box
               .querySelectorAll('button.' + ACTIVE)
@@ -455,12 +465,16 @@
         search.value = state.q
         sortEl.value = state.sort
         groupEl.value = state.group
-        document
-          .querySelectorAll('[data-filter="edition"] button[data-value]')
-          .forEach((p) => p.classList.toggle(ACTIVE, (p.dataset.value || '') === state.edition))
-        document
-          .querySelectorAll('[data-filter="type"] button[data-value]')
-          .forEach((p) => p.classList.toggle(ACTIVE, state.types.has(p.dataset.value)))
+        document.querySelectorAll('[data-filter="edition"] button[data-value]').forEach((p) => {
+          const active = (p.dataset.value || '') === state.edition
+          p.classList.toggle(ACTIVE, active)
+          p.setAttribute('aria-pressed', active ? 'true' : 'false')
+        })
+        document.querySelectorAll('[data-filter="type"] button[data-value]').forEach((p) => {
+          const active = state.types.has(p.dataset.value)
+          p.classList.toggle(ACTIVE, active)
+          p.setAttribute('aria-pressed', active ? 'true' : 'false')
+        })
       }
 
       search.addEventListener(

--- a/fossunited/www/indiafoss/speaker_talks/index.html
+++ b/fossunited/www/indiafoss/speaker_talks/index.html
@@ -95,7 +95,7 @@
                 {% endif %}
                 {% if t.youtube_id %}
                   <div class="col-12 {% if has_side %}col-md-6 order-md-1{% endif %}">
-                    {{ video_embed(youtube_id=t.youtube_id, title=t.title) }}
+                    {{ video_embed(youtube_id=t.youtube_id, title=t.title, speaker=speaker.name, event=t.edition) }}
                   </div>
                 {% endif %}
               </div>

--- a/fossunited/www/indiafoss/speaker_talks/index.html
+++ b/fossunited/www/indiafoss/speaker_talks/index.html
@@ -58,18 +58,21 @@
           {% set body_id = "talk-" ~ loop.index %}
           {% set has_side = t.link or t.references %}
           <article class="v3-card p-3 p-md-4">
-            <div class="v3-clickable d-flex align-items-start gap-2" role="button"
-                 data-toggle="collapse" data-target="#{{ body_id }}"
-                 aria-expanded="true" aria-controls="{{ body_id }}">
-              <i class="ti ti-chevron-down flex-shrink-0 mt-1" aria-hidden="true"></i>
-              <div class="flex-grow-1">
-                <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
-                  {% if t.video_type %}<span class="v3-media-badge" style="background:var(--v3-button-border);color:var(--v3-text-color2);">{{ t.video_type | e }}</span>{% endif %}
-                  {% if t.edition %}<span class="text-xs text-uppercase semi-bold v3-text-tertiary">{{ t.edition | e }}</span>{% endif %}
-                </div>
-                <h2 class="v3-text-primary text-lg mb-0">{{ t.title | e }}</h2>
-              </div>
-            </div>
+            <h2 class="mb-0">
+              <button type="button"
+                      class="v3-clickable d-flex align-items-start gap-2 w-100 border-0 bg-transparent p-0 text-left"
+                      data-toggle="collapse" data-target="#{{ body_id }}"
+                      aria-expanded="true" aria-controls="{{ body_id }}">
+                <i class="ti ti-chevron-down flex-shrink-0 mt-1" aria-hidden="true"></i>
+                <span class="flex-grow-1">
+                  <span class="d-flex flex-wrap align-items-center gap-2 mb-1">
+                    {% if t.video_type %}<span class="v3-media-badge" style="background:var(--v3-button-border);color:var(--v3-text-color2);">{{ t.video_type | e }}</span>{% endif %}
+                    {% if t.edition %}<span class="text-xs text-uppercase semi-bold v3-text-tertiary">{{ t.edition | e }}</span>{% endif %}
+                  </span>
+                  <span class="v3-text-primary text-lg d-block">{{ t.title | e }}</span>
+                </span>
+              </button>
+            </h2>
 
             <div class="collapse show mt-3" id="{{ body_id }}">
               <div class="row">

--- a/fossunited/www/indiafoss/speakers/index.html
+++ b/fossunited/www/indiafoss/speakers/index.html
@@ -14,7 +14,7 @@
         <header>
           <h1 class="v3-page-title v3-text-primary mb-2">IndiaFOSS Speakers</h1>
           <p class="v3-text-secondary mb-0">
-            Everyone who has spoken at IndiaFOSS. <u>{{ total }}</u> speakers across all editions.
+            Everyone who has spoken at IndiaFOSS. <strong>{{ total }}</strong> speakers across all editions.
           </p>
         </header>
 
@@ -125,7 +125,7 @@
         grid.hidden = total === 0
         count.textContent = total
           ? 'Showing ' + (start + 1) + '–' + Math.min(start + PAGE_SIZE, total) + ' of ' + total
-          : ''
+          : 'No speakers match your filters.'
         renderPager(pages)
         persist()
       }

--- a/fossunited/www/indiafoss/speakers/index.html
+++ b/fossunited/www/indiafoss/speakers/index.html
@@ -33,20 +33,24 @@
             <div class="sticky-top" style="top:1rem">
               <p class="text-uppercase semi-bold text-sm v3-text-secondary mb-3">Filters</p>
 
-              <p class="v3-text-secondary mb-2">IndiaFOSS Edition</p>
-              <div class="d-flex flex-column gap-1 mb-4" data-filter="edition" data-mode="single">
-                <button type="button" class="v3-pill w-100 is-active" data-value="">All</button>
-                {% for e in editions %}
-                  <button type="button" class="v3-pill w-100" data-value="{{ e }}">{{ e }}</button>
-                {% endfor %}
-              </div>
+              <fieldset class="mb-4" style="border:0;padding:0;margin:0;">
+                <legend class="v3-text-secondary mb-2" style="font-size:inherit;font-weight:inherit;">IndiaFOSS Edition</legend>
+                <div class="d-flex flex-column gap-1" data-filter="edition" data-mode="single">
+                  <button type="button" class="v3-pill w-100 is-active" data-value="" aria-pressed="true">All</button>
+                  {% for e in editions %}
+                    <button type="button" class="v3-pill w-100" data-value="{{ e }}" aria-pressed="false">{{ e }}</button>
+                  {% endfor %}
+                </div>
+              </fieldset>
 
-              <p class="v3-text-secondary mb-2">Session Type</p>
-              <div class="d-flex flex-wrap gap-1" data-filter="type" data-mode="multi">
-                {% for t in session_types %}
-                  <button type="button" class="v3-pill" data-value="{{ t }}">{{ t }}</button>
-                {% endfor %}
-              </div>
+              <fieldset style="border:0;padding:0;margin:0;">
+                <legend class="v3-text-secondary mb-2" style="font-size:inherit;font-weight:inherit;">Session Type</legend>
+                <div class="d-flex flex-wrap gap-1" data-filter="type" data-mode="multi">
+                  {% for t in session_types %}
+                    <button type="button" class="v3-pill" data-value="{{ t }}" aria-pressed="false">{{ t }}</button>
+                  {% endfor %}
+                </div>
+              </fieldset>
             </div>
           </aside>
 
@@ -168,11 +172,16 @@
           const pill = e.target.closest('button[data-value]')
           if (!pill || !box.contains(pill)) return
           if (single) {
-            box.querySelectorAll('button[data-value]').forEach((p) => p.classList.remove(ACTIVE))
+            box.querySelectorAll('button[data-value]').forEach((p) => {
+              p.classList.remove(ACTIVE)
+              p.setAttribute('aria-pressed', 'false')
+            })
             pill.classList.add(ACTIVE)
+            pill.setAttribute('aria-pressed', 'true')
             state.edition = pill.dataset.value
           } else {
             pill.classList.toggle(ACTIVE)
+            pill.setAttribute('aria-pressed', pill.classList.contains(ACTIVE) ? 'true' : 'false')
             state.types.clear()
             box.querySelectorAll('button.' + ACTIVE).forEach((p) => state.types.add(p.dataset.value))
           }
@@ -198,10 +207,16 @@
       }
       function syncUI() {
         search.value = state.q
-        document.querySelectorAll('[data-filter="edition"] button[data-value]')
-          .forEach((p) => p.classList.toggle(ACTIVE, (p.dataset.value || '') === state.edition))
-        document.querySelectorAll('[data-filter="type"] button[data-value]')
-          .forEach((p) => p.classList.toggle(ACTIVE, state.types.has(p.dataset.value)))
+        document.querySelectorAll('[data-filter="edition"] button[data-value]').forEach((p) => {
+          const active = (p.dataset.value || '') === state.edition
+          p.classList.toggle(ACTIVE, active)
+          p.setAttribute('aria-pressed', active ? 'true' : 'false')
+        })
+        document.querySelectorAll('[data-filter="type"] button[data-value]').forEach((p) => {
+          const active = state.types.has(p.dataset.value)
+          p.classList.toggle(ACTIVE, active)
+          p.setAttribute('aria-pressed', active ? 'true' : 'false')
+        })
       }
 
       search.addEventListener('input', debounce(() => {

--- a/fossunited/www/indiafoss/speakers/index.html
+++ b/fossunited/www/indiafoss/speakers/index.html
@@ -60,7 +60,7 @@
                      data-types="{{ s.types | join('|') }}"
                      data-search="{{ (s.name ~ ' ' ~ s.designation ~ ' ' ~ s.organization) | lower | e }}">
                   <a class="v3-speaker-card" href="/indiafoss/speakers/{{ s.slug }}"
-                     aria-label="{{ s.name | e }} — {{ s.talk_count }} talks">
+                     aria-label="{{ s.name | e }} has given {{ s.talk_count }} talk{{ 's' if s.talk_count != 1 else '' }}">
                     <img class="v3-people-avatar" loading="lazy" alt="{{ s.name | e }}" src="{{ s.avatar }}" />
                     <div class="d-flex flex-column" style="min-width:0;">
                       <div class="v3-people-name semi-bold">{{ s.name | e }}</div>


### PR DESCRIPTION
- Fixes on #1675 

- Speakers listing: inform how many talks speaker gave in a sentence

- Its easier to aria-label to give a sentence/prose form for content to grasp
  rather than leave default SR to setup to read paragraph wise or Line by line

- Fix filters to inform as radio button using html semantics (fieldset and legend) so they belong together

- inform about talk on youtube video embedding

Rather than to leave out reading only title, we can better inform on what
  action the macro card provides

- Speaks as "Watch talk: <title> given by <speakers> at <event>" so its easy to grasp in other pages
