### PR TITLE
build(FC): add frappe deps for FC to install as custom app from GH

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,10 @@ dev = [
 requires = ["flit_core >=3.4,<4"]
 build-backend = "flit_core.buildapi"
 
+# for frappe cloud to install as frappe "App from github"
+[tool.bench.frappe-dependencies]
+frappe = ">=15,<16"
+
 # These dependencies are only installed when developer mode is enabled
 [tool.bench.dev-dependencies]
 # package_name = "~=1.1.0"


### PR DESCRIPTION
- https://docs.frappe.io/cloud/benches/custom-app#note

- Frappe cloud needs this to install as custom app, saw this when creating new bench so...

- Should bump to v16 with #1589