### PR TITLE
fix(text): underline href links in paragraphs

### DIFF
--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -238,6 +238,17 @@ a:hover {
   color: inherit;
 }
 
+/* Prose links: color alone doesn't distinguish a link (WCAG 1.4.1) — BS4
+   underlines on :hover only, so underline by default too, in text content. */
+p > a {
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.15em;
+}
+p > a:hover {
+  filter: brightness(1.2);
+}
+
 button {
   display: flex;
   align-items: center;
@@ -1690,17 +1701,6 @@ body:has(.v3-page) {
 
 .v3-page *:not(.no-font-inherit) {
   font-family: inherit;
-}
-
-/* V3 Links - No underline, opacity on hover */
-.v3-page a {
-  text-decoration: none;
-  transition: opacity 0.2s;
-}
-
-.v3-page a:hover {
-  text-decoration: none;
-  opacity: 0.9;
 }
 
 /* V3 Clickable Div - For divs that act as links */


### PR DESCRIPTION
- In proposal no links are underlined and all v3-page had override to show no decoration at all

  which was very bad, underlining helps user to jump link easily

- Although WCAG not mandates this, its a visual distinction for regular users that is required.

Note: Initially while building events redesign page I had override many stuff to suit for how it looks, but someday i want to refactor whole custom.css 