### PR TITLE
a11y(propopal): improve aria-label for proposal page

### DIFF
--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
@@ -149,14 +149,15 @@
 
 {% macro status_badge(status, theme_map) %}
   {% set t = theme_map.get(status, 'gray') %}
+  {% set label = 'Proposal status is ' ~ status ~ '.' %}
   {% if t == 'green' %}
-    <span class="v3-status v3-status--success">{{ status }}</span>
+    <span class="v3-status v3-status--success" aria-label="{{ label }}">{{ status }}</span>
   {% elif t == 'red' %}
-    <span class="v3-status v3-status--error">{{ status }}</span>
+    <span class="v3-status v3-status--error" aria-label="{{ label }}">{{ status }}</span>
   {% elif t in ('orange', 'yellow') %}
-    <span class="v3-status v3-status--warning">{{ status }}</span>
+    <span class="v3-status v3-status--warning" aria-label="{{ label }}">{{ status }}</span>
   {% else %}
-    <span class="v3-tag v3-tag--category">{{ status }}</span>
+    <span class="v3-tag v3-tag--category" aria-label="{{ label }}">{{ status }}</span>
   {% endif %}
 {% endmacro %}
 

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/templates/foss_event_cfp_submission.html
@@ -63,7 +63,7 @@
 
 
 {% macro talk_header() %}
-<div class="d-flex flex-column gap-2">
+<header class="d-flex flex-column gap-2">
   <div class="d-flex align-items-center gap-2 flex-wrap">
     <span class="v3-tag v3-tag--category">{{ doc.session_type }}</span>
     <span class="v3-tag v3-tag--category">
@@ -143,21 +143,21 @@
   {% if submitter_profile %}
     {{ profile_headshot(submitter_profile.full_name, submitter_profile.photo, submitter_profile.url) }}
   {% endif %}
-</div>
+</header>
 {% endmacro %}
 
 
 {% macro status_badge(status, theme_map) %}
   {% set t = theme_map.get(status, 'gray') %}
-  {% set label = 'Proposal status is ' ~ status ~ '.' %}
+  {% set prefix = '<span class="sr-only">Proposal status is </span>' %}
   {% if t == 'green' %}
-    <span class="v3-status v3-status--success" aria-label="{{ label }}">{{ status }}</span>
+    <span class="v3-status v3-status--success">{{ prefix | safe }}{{ status }}</span>
   {% elif t == 'red' %}
-    <span class="v3-status v3-status--error" aria-label="{{ label }}">{{ status }}</span>
+    <span class="v3-status v3-status--error">{{ prefix | safe }}{{ status }}</span>
   {% elif t in ('orange', 'yellow') %}
-    <span class="v3-status v3-status--warning" aria-label="{{ label }}">{{ status }}</span>
+    <span class="v3-status v3-status--warning">{{ prefix | safe }}{{ status }}</span>
   {% else %}
-    <span class="v3-tag v3-tag--category" aria-label="{{ label }}">{{ status }}</span>
+    <span class="v3-tag v3-tag--category">{{ prefix | safe }}{{ status }}</span>
   {% endif %}
 {% endmacro %}
 
@@ -174,11 +174,11 @@
 
 {% macro references() %}
 {% if doc.references %}
-<div>
-  <h2 class="v3-text-tertiary text-base medium mb-2">References</h2>
-  <div class="d-flex flex-column gap-2">
+<section aria-labelledby="cfp-references-heading">
+  <h2 id="cfp-references-heading" class="v3-text-tertiary text-base medium mb-2">References</h2>
+  <div class="d-flex flex-column gap-2" role="list">
     {% for reference in doc.references %}
-      <div class="d-flex align-items-center gap-2">
+      <div class="d-flex align-items-center gap-2" role="listitem">
         <i class="ti ti-link v3-text-secondary text-lg" aria-hidden="true"></i>
         <a
           class="v3-text-secondary"
@@ -189,23 +189,23 @@
       </div>
     {% endfor %}
   </div>
-</div>
+</section>
 {% endif %}
 {% endmacro %}
 
 
 {% macro render_session_categories() %}
 {% if session_categories %}
-<div>
-  <h2 class="v3-text-tertiary text-base medium mb-2">Session Categories</h2>
-  <div class="d-flex flex-wrap gap-2">
+<section aria-labelledby="cfp-categories-heading">
+  <h2 id="cfp-categories-heading" class="v3-text-tertiary text-base medium mb-2">Session Categories</h2>
+  <div class="d-flex flex-wrap gap-2" role="list">
     {% for category in session_categories %}
-      <div class="border border-section rounded p-2 d-flex align-items-center gap-2 v3-text-secondary text-sm v3-bg-primary">
+      <div class="border border-section rounded p-2 d-flex align-items-center gap-2 v3-text-secondary text-sm v3-bg-primary" role="listitem">
         {{ category }}
       </div>
     {% endfor %}
   </div>
-</div>
+</section>
 {% endif %}
 {% endmacro %}
 
@@ -222,21 +222,21 @@
 
 
 {% macro render_speakers() %}
-<div>
-  <h2 class="v3-text-tertiary text-base medium mb-2">Speakers</h2>
-  <div class="d-flex flex-column gap-2">
+<section aria-labelledby="cfp-speakers-heading">
+  <h2 id="cfp-speakers-heading" class="v3-text-tertiary text-base medium mb-2">Speakers</h2>
+  <div class="d-flex flex-column gap-2" role="list">
     {% for speaker in doc.speakers %}
       {{ speaker_card(speaker) }}
     {% endfor %}
   </div>
-</div>
+</section>
 {% endmacro %}
 
 
 {% macro speaker_card(speaker) %}
 {% set sp_url = speaker_profile_map.get(speaker.email) %}
-<div class="border border-section rounded p-3 d-flex flex-column gap-2">
-  {% if sp_url %}<a href="{{ sp_url }}" class="d-flex align-items-start justify-content-between gap-6 text-decoration-none">{% else %}<div class="d-flex align-items-start justify-content-between gap-6">{% endif %}
+<div class="border border-section rounded p-3 d-flex flex-column gap-2" role="listitem">
+  {% if sp_url %}<a href="{{ sp_url }}" class="d-flex align-items-start justify-content-between gap-6 text-decoration-none" aria-label="View {{ speaker.full_name }}'s profile">{% else %}<div class="d-flex align-items-start justify-content-between gap-6">{% endif %}
     <div class="d-flex flex-column gap-1 speaker-col">
       <span class="v3-text-primary text-lg semi-bold mb-0">{{ speaker.full_name }}</span>
       {% if speaker.designation or speaker.organization %}
@@ -281,10 +281,10 @@
 {% macro render_custom_responses() %}
 <div class="d-flex flex-column gap-4">
   {% for response in doc.custom_answers %}
-    <div class="d-flex flex-column gap-1">
-      <h2 class="v3-text-tertiary text-base">{{ response.question }}</h2>
+    <section aria-labelledby="cfp-custom-answer-{{ loop.index }}" class="d-flex flex-column gap-1">
+      <h2 id="cfp-custom-answer-{{ loop.index }}" class="v3-text-tertiary text-base">{{ response.question }}</h2>
       <div class="v3-text-primary">{{ response.response }}</div>
-    </div>
+    </section>
   {% endfor %}
 </div>
 {% endmacro %}
@@ -292,8 +292,8 @@
 
 {% macro render_reviews() %}
 {% if not hide_review %}
-<div class="d-flex flex-column gap-3">
-  <h2 class="v3-text-tertiary text-base medium">Reviews</h2>
+<section aria-labelledby="cfp-reviews-heading" class="d-flex flex-column gap-3">
+  <h2 id="cfp-reviews-heading" class="v3-text-tertiary text-base medium">Reviews</h2>
 
   <div class="d-flex flex-column gap-2">
     {% if not doc.reviews %}
@@ -305,7 +305,7 @@
       {% endfor %}
     {% endif %}
   </div>
-</div>
+</section>
 {% endif %}
 {% endmacro %}
 

--- a/fossunited/public/css/custom.css
+++ b/fossunited/public/css/custom.css
@@ -3221,6 +3221,13 @@ a.m-text-1:hover, a.m-text-2:hover { filter: brightness(1.2); color: inherit; te
 /* --- Video aspect ratio (16:9) --- */
 .m-video-aspect { position: relative; padding-bottom: 56.25%; }
 
+/* Play trigger is a native <button> for free keyboard activation */
+button.m-video-aspect {
+  display: block; width: 100%;
+  padding-top: 0; padding-left: 0; padding-right: 0; margin: 0; border: none; background: none;
+  font: inherit; color: inherit; text-align: inherit;
+}
+
 /* --- Video play button overlay --- */
 .m-play-btn {
   position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);

--- a/fossunited/templates/includes/like/like.html
+++ b/fossunited/templates/includes/like/like.html
@@ -3,8 +3,8 @@
   .like-icon.liked { color: var(--v3-error-text); }
 </style>
 <div id="likes" class="feedback-item d-flex flex-row align-items-center likes">
-  <button type="button" class="like-icon border-0 p-2" aria-pressed="false" aria-label="Like"></button>
-  <span class="like-count"></span>
+  <button type="button" class="like-icon border-0 p-2" aria-pressed="false"></button>
+  <span class="like-count" aria-hidden="true"></span>
 </div>
 
 <script type="text/javascript">
@@ -13,7 +13,12 @@
     let like_count = parseInt('{{ like_count or 0 }}')
     let in_queue = false
 
-    let toggle_like_icon = function (active) {
+    let like_label = function (count, active) {
+      const noun = count === 1 ? 'like' : 'likes'
+      return `${count} ${noun}. ${active ? 'You liked this.' : 'Click to like this.'}`
+    }
+
+    let toggle_like_icon = function (active, count) {
       const $btn = $('.like-icon')
       const $i = $btn.find('i')
       if (active) {
@@ -25,10 +30,11 @@
         $i.removeClass('ti-heart-filled').addClass('ti-heart')
         $btn.attr('aria-pressed', 'false')
       }
+      $btn.attr('aria-label', like_label(count, active))
     }
 
     $('.like-icon').append(`<i class="ti ti-heart" aria-hidden="true"></i>`)
-    toggle_like_icon(like)
+    toggle_like_icon(like, like_count)
 
     $('.like-count').text(like_count)
 
@@ -45,7 +51,7 @@
       const intended_count = intended_like ? like_count + 1 : like_count - 1
 
       // Update UI optimistically
-      toggle_like_icon(intended_like)
+      toggle_like_icon(intended_like, intended_count)
       $('.like-count').text(intended_count)
 
       return frappe
@@ -66,7 +72,7 @@
         })
         .catch((err) => {
           // Revert UI on error
-          toggle_like_icon(like)
+          toggle_like_icon(like, like_count)
           $('.like-count').text(like_count)
           in_queue = false
         })

--- a/fossunited/templates/macros/video_embed.html
+++ b/fossunited/templates/macros/video_embed.html
@@ -6,10 +6,9 @@
     {%- if event %}{% set video_label = video_label ~ ', at ' ~ event %}{% endif -%}
     <link rel="preconnect" href="https://www.youtube-nocookie.com">
     <link rel="preconnect" href="https://i.ytimg.com">
-    <div class="m-video-aspect rounded overflow-hidden cursor-pointer"
+    <button type="button"
+         class="m-video-aspect rounded overflow-hidden cursor-pointer"
          id="ve-{{ youtube_id }}"
-         role="button"
-         tabindex="0"
          aria-label="{{ video_label | e }}"
          data-yt="{{ youtube_id }}">
       {# mqdefault = native 16:9 (320x180), no letterbox bars; matches the 16:9
@@ -20,9 +19,11 @@
       <div class="m-play-btn" aria-hidden="true">
         <i class="ti ti-player-play-filled text-white" style="font-size: 1.5rem;"></i>
       </div>
-    </div>
+    </button>
     <script>
       document.getElementById('ve-{{ youtube_id }}').addEventListener('click', function () {
+        if (this.dataset.playing) return;
+        this.dataset.playing = '1';
         var f = document.createElement('iframe');
         f.src = 'https://www.youtube-nocookie.com/embed/{{ youtube_id }}?autoplay=1&rel=0&modestbranding=1&iv_load_policy=3&color=white';
         f.allow = 'autoplay; encrypted-media';


### PR DESCRIPTION
- Although proposal is all about text give by proposer

some things can be said in context and in single sentence to say what it means

eg: `<a href="/page" aria-label="Read more about the new policy">Read more</a>`

- Instead of just saying status mention it as
  "Proposal status is ..."

- For likes as well announce the purpose and current state in single sentence.

Very minor fix

- replace lot of divs with <section> to adhere to semantics

- Make video_embed (YT video iframe player) to act as button easy function via semantic