### PR TITLE
fix(grants): fix currency option to get sum on number card

### DIFF
--- a/fossunited/fossunited/doctype/foss_event_grant/foss_event_grant.json
+++ b/fossunited/fossunited/doctype/foss_event_grant/foss_event_grant.json
@@ -299,7 +299,7 @@
       "fieldname": "grant_amount",
       "fieldtype": "Currency",
       "label": "Approved Grant Amount",
-      "options": "INR"
+      "options": "Company:company:default_currency"
     },
     {
       "default": "0",
@@ -345,7 +345,7 @@
     }
   ],
   "links": [],
-  "modified": "2026-06-11 14:17:43.049441",
+  "modified": "2026-08-07 11:50:18.972766",
   "modified_by": "Administrator",
   "module": "FOSSUnited",
   "name": "FOSS Event Grant",

--- a/fossunited/fossunited/doctype/foss_project_grant/foss_project_grant.json
+++ b/fossunited/fossunited/doctype/foss_project_grant/foss_project_grant.json
@@ -69,7 +69,7 @@
    "fieldtype": "Currency",
    "in_list_view": 1,
    "label": "Grant amount",
-   "options": "INR"
+   "options": "Company:company:default_currency"
   },
   {
    "fieldname": "co_sponsor",
@@ -95,7 +95,7 @@
   }
  ],
  "links": [],
- "modified": "2026-04-27 11:30:20.479327",
+ "modified": "2026-08-07 11:55:08.151388",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "FOSS Project Grant",


### PR DESCRIPTION
replaced option field: `INR` -> `Company:company:default_currency`

- Issue in upstream repo that does not allow using sum on number card for currency

- this fix should resolve it: https://github.com/frappe/frappe/issues/18611#issuecomment-3761068367

- also will not be required & can revert back to INR in frappe version-16

- [X] Test locally to have number card and it shows fine in INR itself.

Siddharth wants it to show on workspace (/app) so its easy to get total disbursed in timeframe.