### PR TITLE
feat(event): add catering option to explicitly mention whats offered to attendees

### DIFF
--- a/dashboard/src/pages/BuyTickets.vue
+++ b/dashboard/src/pages/BuyTickets.vue
@@ -331,9 +331,12 @@
                               : 'Without T-shirt'
                         }}</span>
                       </div>
-                      <div class="flex items-center gap-1.5 text-sm text-ink-gray-7">
+                      <div
+                        v-if="event.data.catering && event.data.catering !== 'None'"
+                        class="flex items-center gap-1.5 text-sm text-ink-gray-7"
+                      >
                         <IconSoup class="w-5 h-5" />
-                        <span>Breakfast + Lunch included</span>
+                        <span>{{ event.data.catering }} included</span>
                       </div>
                     </div>
                     <p

--- a/dashboard/src/pages/EventDetails.vue
+++ b/dashboard/src/pages/EventDetails.vue
@@ -211,6 +211,19 @@
           side="md"
           description="Prefer OpenStreetMap (OSM) links, e.g., https://osmapp.org/"
         />
+        <FormControl
+          v-model="event.doc.catering"
+          :type="'select'"
+          :options="[
+            { label: 'None', value: 'None' },
+            { label: 'Lunch only', value: 'Lunch only' },
+            { label: 'Breakfast + Lunch', value: 'Breakfast + Lunch' },
+            { label: 'Coffee/Tea only', value: 'Coffee/Tea only' },
+          ]"
+          size="md"
+          label="Lunch & Food"
+          description="If event provides any catering for attendees. Shown on the ticket page."
+        />
       </div>
     </div>
 

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
@@ -71,6 +71,7 @@
   "tickets_tab",
   "is_paid_event",
   "tickets_status",
+  "catering",
   "tiers",
   "ticket_form_description",
   "section_break_idyt",
@@ -486,6 +487,13 @@
    "fieldtype": "JSON",
    "label": "Event data",
    "permlevel": 4
+  },
+  {
+   "description": "If event provides any catering for attendees (Coffee, lunch or none)",
+   "fieldname": "catering",
+   "fieldtype": "Select",
+   "label": "Lunch & Food",
+   "options": "None\nLunch only\nBreakfast + Lunch\nCoffee/Tea only"
   }
  ],
  "has_web_view": 1,
@@ -518,7 +526,7 @@
    "link_fieldname": "event"
   }
  ],
- "modified": "2026-06-29 15:58:17.947880",
+ "modified": "2026-08-14 12:53:55.260169",
  "modified_by": "Administrator",
  "module": "Chapters",
  "name": "FOSS Chapter Event",

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -55,6 +55,7 @@ class FOSSChapterEvent(WebsiteGenerator):
         from fossunited.ticketing.doctype.foss_ticket_tier.foss_ticket_tier import FOSSTicketTier
 
         banner_image: DF.AttachImage | None
+        catering: DF.Literal["None", "Lunch only", "Breakfast + Lunch", "Coffee/Tea only"]
         chapter: DF.Link | None
         chapter_name: DF.Data | None
         community_partners: DF.Table[FOSSEventCommunityPartner]

--- a/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
+++ b/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
@@ -349,6 +349,21 @@
               {% else %}
             </div>
             {% endif %}
+
+              {% if doc.catering and doc.catering != 'None' %}
+              <div class="ev-detail-row">
+                <div
+                  class="ev-icon"
+                  tabindex="0"
+                  data-toggle="tooltip"
+                  data-placement="right"
+                  title="{{ doc.catering }} provided for attendees"
+                >
+                  <i class="ti ti-soup" aria-hidden="true"></i>
+                </div>
+                <div class="ev-detail-secondary">{{ doc.catering }}</div>
+              </div>
+              {% endif %}
             </div>
 
             <!-- Do we need to make them repeat same content? -->


### PR DESCRIPTION
## Status

- [x] Ready for review

---

## Related Issue

Closes / Addresses: #1694 

---

## Problem

We had hard coded ticket and breakfast included for all ticket event.
There was no control or organiser need to mention somewhere for what is offered to attendees via email or in event description

For workshops @ indiafoss there won't be any Lunch, ticket only has venue for attending.

---

## Solution

A simple catering field with 4 options can help attendees know whats there and what to not expect.

```
None
Lunch only
Breakfast + Lunch
Coffee/Tea only
```

---

## Progress (All must be checked to merge)

- [x] Tested locally

---

## Changelog

- Added field to doctype
- Added field to be managed via dashboard: https://fossunited.org/dashboard/event/<id>
- Added same text in ticket buying cards to indicate the same
- Added small icon in event page to show the same indication

---

## Visualization

- Option in dashboard to edit
<!-- Add screenshots, diagrams, or screen recordings if applicable -->
<img width="912" height="373" alt="image" src="https://github.com/user-attachments/assets/c3dbccb5-d28b-4223-9535-62745751b867" />

- Icon shown in event page
<img width="642" height="558" alt="image" src="https://github.com/user-attachments/assets/11ed051a-f90e-4a8e-b276-2b4ba7d3ff51" />

- Info shown in verify step while buying ticket
<img width="988" height="478" alt="image" src="https://github.com/user-attachments/assets/73c9008e-5f2a-4629-abdc-7f8ae44ad8cd" />


---

## Further Ahead

<!-- Mention any follow-up work or related PRs planned -->
- Make sure ticket PDF (https://fossunited.org/app/print-format) reflects the same details after its merged

- make sure to check for FC logging out after update before deploying live
