### PR TITLE
fix: ambiguous link text (here/apply/Read More) across docs and web pages

### DIFF
--- a/docs/docs/clubs-contribution-ideas.md
+++ b/docs/docs/clubs-contribution-ideas.md
@@ -74,6 +74,6 @@ If you have other ideas, feel free to book a call to discuss with the foundation
 
 
 
-> Have other ideas to suggest? Send us a PR [here](https://github.com/fossunited/fossunited/tree/develop/docs/docs).
+> Have other ideas to suggest? Send us a [PR with your idea](https://github.com/fossunited/fossunited/tree/develop/docs/docs).
 
 ---

--- a/docs/docs/grants.md
+++ b/docs/docs/grants.md
@@ -24,4 +24,4 @@ FOSS United has provided grants to various projects, including Rethink DNS, Fire
 
 By offering these grants, FOSS United aims to foster the growth and development of the FOSS community in India, supporting projects that align with its mission and values.
 
-Apply [here](https://fossunited.org/grants)
+[Apply for a FOSS United grant](https://fossunited.org/grants)

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -20,7 +20,7 @@ Together, we're building a culture of openness, collaboration, and innovation th
 - **Grants and Initiatives**
   Track and apply for community grants, explore ongoing initiatives.
 
-See more on what we do [here](initiative.md).
+See more on [our initiatives](initiative.md).
 
 ## Tech Stack
 
@@ -29,7 +29,7 @@ See more on what we do [here](initiative.md).
 - **Database**: MariaDB
 - **Caching**: Redis
 
-FOSS United relies on a variety of self-hosted services, which you can find listed [here](https://fossunited.org/stack)
+FOSS United relies on a variety of self-hosted services, which you can find listed [in our tech stack](https://fossunited.org/stack)
 
 ## Getting Involved
 

--- a/docs/docs/people.md
+++ b/docs/docs/people.md
@@ -7,7 +7,7 @@ The people behind FOSS United include a mix of dedicated individuals, volunteers
 
 2. **Volunteers:**
    A vibrant and diverse group of volunteers actively contributes to FOSS United projects, events, and community-building efforts. They bring a wide range of skills and perspectives, enriching the foundation's impact across India.
-  Active Volunteers workforce can be seen [here](https://fossunited.org/volunteers)
+  Active Volunteers workforce can be seen [on our volunteers page](https://fossunited.org/volunteers)
 
 3. **Governing Board:**
    FOSS United is guided by a board of experienced professionals and leaders from the FOSS ecosystem. They provide strategic direction, governance, and support to the foundation's leadership.

--- a/fossunited/www/grants/directory/index.html
+++ b/fossunited/www/grants/directory/index.html
@@ -17,8 +17,8 @@
             <p class="v3-text-secondary mb-0">
               Explore projects from Funding JSON manifests. Inspired by
               <a href="https://dir.floss.fund" class="text-decoration-underline">floss.fund</a>.
-              To add your project apply
-              <a href="/grants/apply" class="text-decoration-underline">here</a>.
+              To add your project,
+              <a href="/grants/apply" class="text-decoration-underline">submit an application</a>.
             </p>
           </div>
 

--- a/fossunited/www/grants/index.html
+++ b/fossunited/www/grants/index.html
@@ -114,7 +114,7 @@
             The FOSS United grants program aims to provide financial support to FOSS creators,
             maintainers, projects and events all over India. To date, we have disbursed over INR 3
             crores towards Indian FOSS projects and maintainers. All FOSS United grantees are
-            listed <a class="underline" href="/grants/grantees">here</a>.
+            listed <a class="underline" href="/grants/grantees">on the grantees page</a>.
             <br />
             We fund FOSS projects by raising funds from the tech industry, either through our
             Industry Partnership Program, individual donations, or by reaching out to companies
@@ -127,7 +127,7 @@
           </p>
           <p>
             If you're a FOSS project or developer in need of financial support, please
-            <a class="underline" href="https://fossunited.org/grants/apply/new">apply</a>. For any
+            <a class="underline" href="https://fossunited.org/grants/apply/new">apply for a grant</a>. For any
             questions, please reach out to us at
             <a class="underline" href="mailto:events@fossunited.org">events@fossunited.org</a> (for Events) or
             <a class="underline" href="mailto:grants@fossunited.org">grants@fossunited.org</a> (for Projects) respectively.

--- a/fossunited/www/maintainers-may/index.html
+++ b/fossunited/www/maintainers-may/index.html
@@ -103,7 +103,7 @@
             {% endif %}
 
             <div class="d-flex flex-wrap gap-3">
-              <a href="{{ links.thesis }}" class="v3-btn m-btn m-btn-p">Read More</a>
+              <a href="{{ links.thesis }}" class="v3-btn m-btn m-btn-p">Read the Thesis</a>
               <a href="{{ links.view_deck }}" target="_blank" rel="noopener noreferrer" class="v3-btn m-btn m-btn-s">
                 View Deck <span class="sr-only">(opens in new tab)</span>
               </a>
@@ -289,7 +289,7 @@
         </div>
         {% if blogs | length > 5 %}
         <div class="mt-4 text-center">
-          <a href="https://fossunited.org/blog/maintainers" class="m-text-1 semi-bold">Read More</a>
+          <a href="https://fossunited.org/blog/maintainers" class="m-text-1 semi-bold">Read More Posts</a>
         </div>
         {% endif %}
       </section>

--- a/fossunited/www/maintainers-may/index.html
+++ b/fossunited/www/maintainers-may/index.html
@@ -103,7 +103,7 @@
             {% endif %}
 
             <div class="d-flex flex-wrap gap-3">
-              <a href="{{ links.thesis }}" class="v3-btn m-btn m-btn-p">Read the Thesis</a>
+              <a href="{{ links.thesis }}" class="v3-btn m-btn m-btn-p">Read the Maintainers Program thesis</a>
               <a href="{{ links.view_deck }}" target="_blank" rel="noopener noreferrer" class="v3-btn m-btn m-btn-s">
                 View Deck <span class="sr-only">(opens in new tab)</span>
               </a>
@@ -289,7 +289,7 @@
         </div>
         {% if blogs | length > 5 %}
         <div class="mt-4 text-center">
-          <a href="https://fossunited.org/blog/maintainers" class="m-text-1 semi-bold">Read More Posts</a>
+          <a href="https://fossunited.org/blog/maintainers" class="m-text-1 semi-bold">Read more posts from FOSS United maintainers</a>
         </div>
         {% endif %}
       </section>


### PR DESCRIPTION
Closes #1689

Problem
The platform used ambiguous link text like "here", "apply", and "Read More" in several docs and web pages. Screen reader users tabbing through links or using a links-list view can't tell where these links go without reading the surrounding paragraph.

Solution

Audited the repo for ambiguous link text ("here", "click here", "read more", "apply", generic verbs used as link text) across HTML, Vue, and Markdown files. Replaced 10 instances with descriptive link text so each link's purpose is clear out of context. No new ARIA attributes added — fixed via visible link text per the issue's guidance.