### PR TITLE
fix(tickets): revalidate orders before fulfillment

### DIFF
--- a/fossunited/api/dashboard.py
+++ b/fossunited/api/dashboard.py
@@ -9,6 +9,7 @@ from fossunited.doctype_ids import (
     TICKET_TIER,
     USER_PROFILE,
 )
+from fossunited.payments.doctype.razorpay_payment.razorpay_payment import capture_payment
 from fossunited.utils.payments import (
     get_in_razorpay_money,
     get_razorpay_client,
@@ -157,11 +158,7 @@ def handle_payment_success(order_id: str, payment_id: str, signature: str):
         }
     )
 
-    # update payment
-    payment = frappe.get_doc(RAZORPAY_PAYMENT, {"order_id": order_id})
-    payment.status = "Captured"
-    payment.payment_id = payment_id
-    payment.save(ignore_permissions=True)
+    capture_payment(order_id, payment_id)
 
 
 # nosemgrep: guest-whitelisted-method

--- a/fossunited/api/dashboard.py
+++ b/fossunited/api/dashboard.py
@@ -158,7 +158,7 @@ def handle_payment_success(order_id: str, payment_id: str, signature: str):
         }
     )
 
-    capture_payment(order_id, payment_id)
+    return {"status": capture_payment(order_id, payment_id)}
 
 
 # nosemgrep: guest-whitelisted-method

--- a/fossunited/api/dashboard.py
+++ b/fossunited/api/dashboard.py
@@ -1,3 +1,5 @@
+import time
+
 import frappe
 from frappe import _
 
@@ -121,6 +123,7 @@ def create_razorpay_order(
         data={
             "amount": get_in_razorpay_money(amount),
             "currency": "INR",
+            "expire_by": int(time.time()) + 30 * 60,
         }
     )
 

--- a/fossunited/api/dashboard.py
+++ b/fossunited/api/dashboard.py
@@ -1,5 +1,3 @@
-import time
-
 import frappe
 from frappe import _
 
@@ -11,7 +9,10 @@ from fossunited.doctype_ids import (
     TICKET_TIER,
     USER_PROFILE,
 )
-from fossunited.payments.doctype.razorpay_payment.razorpay_payment import capture_payment
+from fossunited.payments.doctype.razorpay_payment.razorpay_payment import (
+    capture_payment,
+    fail_payment,
+)
 from fossunited.utils.payments import (
     get_in_razorpay_money,
     get_razorpay_client,
@@ -123,7 +124,6 @@ def create_razorpay_order(
         data={
             "amount": get_in_razorpay_money(amount),
             "currency": "INR",
-            "expire_by": int(time.time()) + 30 * 60,
         }
     )
 
@@ -176,11 +176,7 @@ def handle_payment_failed(order_id: str):
     if order.get("status") == "paid":
         return
 
-    payment = frappe.get_doc(RAZORPAY_PAYMENT, {"order_id": order_id})
-    if payment.status == "Captured":
-        return
-    payment.status = "Failed"
-    payment.save(ignore_permissions=True)
+    fail_payment(order_id)
 
 
 @frappe.whitelist()

--- a/fossunited/handlers.py
+++ b/fossunited/handlers.py
@@ -23,38 +23,38 @@ def handle_razorpay_webhook():
         "Administrator"
     )
 
-    payment_entity = form_dict["payload"]["payment"]["entity"]
-    razorpay_order_id = payment_entity["order_id"]
-    razorpay_payment_id = payment_entity["id"]
-    event = form_dict.get("event")
+    try:
+        payment_entity = form_dict["payload"]["payment"]["entity"]
+        razorpay_order_id = payment_entity["order_id"]
+        razorpay_payment_id = payment_entity["id"]
+        event = form_dict.get("event")
 
-    # Create webhook log
-    frappe.get_doc(
-        {
-            "doctype": RAZORPAY_WEBHOOK_LOG,
-            "event": event,
-            "order_id": razorpay_order_id,
-            "payment_id": razorpay_payment_id,
-            "payload": frappe.as_json(form_dict, indent=2),
-        }
-    ).insert().submit()
+        # Create webhook log
+        frappe.get_doc(
+            {
+                "doctype": RAZORPAY_WEBHOOK_LOG,
+                "event": event,
+                "order_id": razorpay_order_id,
+                "payment_id": razorpay_payment_id,
+                "payload": frappe.as_json(form_dict, indent=2),
+            }
+        ).insert().submit()
 
-    order_exists = frappe.db.exists(RAZORPAY_PAYMENT, {"order_id": razorpay_order_id})
+        order_exists = frappe.db.exists(RAZORPAY_PAYMENT, {"order_id": razorpay_order_id})
+        if not order_exists:
+            return
 
-    if not order_exists:
-        return
-
-    if event == "payment.captured":
-        capture_payment(razorpay_order_id, razorpay_payment_id)
-    elif event == "refund.processed":
-        payment_doc = frappe.get_doc(RAZORPAY_PAYMENT, {"order_id": razorpay_order_id})
-        if payment_doc.status != "Refunded":
-            refund_entity = form_dict["payload"]["refund"]["entity"]
-            payment_doc.status = "Refunded"
-            payment_doc.refund_id = refund_entity["id"]
-            payment_doc.save()
-
-    frappe.set_user(current_user)  # nosemgrep: frappe-setuser
+        if event == "payment.captured":
+            capture_payment(razorpay_order_id, razorpay_payment_id)
+        elif event == "refund.processed":
+            payment_doc = frappe.get_doc(RAZORPAY_PAYMENT, {"order_id": razorpay_order_id})
+            if payment_doc.status != "Refunded":
+                refund_entity = form_dict["payload"]["refund"]["entity"]
+                payment_doc.status = "Refunded"
+                payment_doc.refund_id = refund_entity["id"]
+                payment_doc.save()
+    finally:
+        frappe.set_user(current_user)  # nosemgrep: frappe-setuser
 
 
 def verify_webhook_signature(payload):

--- a/fossunited/handlers.py
+++ b/fossunited/handlers.py
@@ -6,6 +6,7 @@ from fossunited.doctype_ids import (
     RAZORPAY_SETTINGS,
     RAZORPAY_WEBHOOK_LOG,
 )
+from fossunited.payments.doctype.razorpay_payment.razorpay_payment import capture_payment
 from fossunited.utils.payments import get_razorpay_client
 
 
@@ -43,16 +44,15 @@ def handle_razorpay_webhook():
     if not order_exists:
         return
 
-    payment_doc = frappe.get_doc(RAZORPAY_PAYMENT, {"order_id": razorpay_order_id})
-
-    if event == "payment.captured" and payment_doc.status != "Captured":
-        payment_doc.status = "Captured"
-        payment_doc.save()
-    elif event == "refund.processed" and not payment_doc.status == "Refunded":
-        refund_entity = form_dict["payload"]["refund"]["entity"]
-        payment_doc.status = "Refunded"
-        payment_doc.refund_id = refund_entity["id"]
-        payment_doc.save()
+    if event == "payment.captured":
+        capture_payment(razorpay_order_id, razorpay_payment_id)
+    elif event == "refund.processed":
+        payment_doc = frappe.get_doc(RAZORPAY_PAYMENT, {"order_id": razorpay_order_id})
+        if payment_doc.status != "Refunded":
+            refund_entity = form_dict["payload"]["refund"]["entity"]
+            payment_doc.status = "Refunded"
+            payment_doc.refund_id = refund_entity["id"]
+            payment_doc.save()
 
     frappe.set_user(current_user)  # nosemgrep: frappe-setuser
 

--- a/fossunited/hooks.py
+++ b/fossunited/hooks.py
@@ -165,6 +165,9 @@ before_migrate = "fossunited.migrate.before_migrate"
 # Scheduler Events
 # ----------------
 scheduler_events = {
+    "hourly": [
+        "fossunited.payments.doctype.razorpay_payment.razorpay_payment.retry_pending_refunds",
+    ],
     "daily_long": [
         "fossunited.scheduled_tasks.conclude_events",
     ],

--- a/fossunited/hooks.py
+++ b/fossunited/hooks.py
@@ -165,9 +165,6 @@ before_migrate = "fossunited.migrate.before_migrate"
 # Scheduler Events
 # ----------------
 scheduler_events = {
-    "hourly": [
-        "fossunited.payments.doctype.razorpay_payment.razorpay_payment.retry_pending_refunds",
-    ],
     "daily_long": [
         "fossunited.scheduled_tasks.conclude_events",
     ],

--- a/fossunited/payments/doctype/razorpay_payment/razorpay_payment.py
+++ b/fossunited/payments/doctype/razorpay_payment/razorpay_payment.py
@@ -54,7 +54,7 @@ class RazorpayPayment(Document):
 
         client = get_razorpay_client()
         refund_amount = int(get_in_razorpay_money(self.amount))
-        refund = client.payment.refund(self.payment_id, refund_amount)
+        refund = client.payment.refund(self.payment_id, {"amount": refund_amount})
 
         self.refund_id = refund["id"]
         if refund["status"] == "processed":
@@ -76,6 +76,7 @@ class RazorpayPayment(Document):
             frappe.errprint(payments)
             if payments[0]["status"] == "captured":
                 capture_payment(self.order_id, payments[0]["id"])
+                self.reload()
             elif payments[0]["status"] == "refunded":
                 self.status = "Refunded"
                 self.save()
@@ -94,8 +95,15 @@ class RazorpayPayment(Document):
 
 
 def process_refund(payment_name: str):
+    frappe.db.get_value(RAZORPAY_PAYMENT, payment_name, "name", for_update=True)
     payment = frappe.get_doc(RAZORPAY_PAYMENT, payment_name)
     if payment.status != "Refund Pending" or payment.refund_id:
+        return payment.status
+    if not payment.payment_id:
+        frappe.log_error(
+            title="Refund Skipped: Missing Payment ID",
+            message=f"Payment: {payment.name}",
+        )
         return payment.status
 
     client = get_razorpay_client()
@@ -108,10 +116,6 @@ def process_refund(payment_name: str):
         headers={"X-Refund-Idempotency": f"fossunited-{payment.name}"},
     )
 
-    frappe.db.get_value(RAZORPAY_PAYMENT, payment.name, "name", for_update=True)
-    payment.reload()
-    if payment.status == "Refunded":
-        return payment.status
     payment.refund_id = refund["id"]
     payment.status = "Refunded" if refund["status"] == "processed" else "Refund Pending"
     payment.save(ignore_permissions=True)
@@ -135,6 +139,7 @@ def capture_payment(order_id: str, payment_id: str):
     payment.status = "Captured"
     payment.payment_id = payment_id
     payment.save(ignore_permissions=True)
+    payment.reload()
     return payment.status
 
 
@@ -145,4 +150,9 @@ def retry_pending_refunds():
         pluck="name",
     )
     for payment_name in payments:
-        frappe.enqueue(process_refund, payment_name=payment_name)
+        frappe.enqueue(
+            "fossunited.payments.doctype.razorpay_payment.razorpay_payment.process_refund",
+            payment_name=payment_name,
+            job_id=f"process_refund::{payment_name}",
+            deduplicate=True,
+        )

--- a/fossunited/payments/doctype/razorpay_payment/razorpay_payment.py
+++ b/fossunited/payments/doctype/razorpay_payment/razorpay_payment.py
@@ -5,7 +5,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
-from fossunited.doctype_ids import EVENT
+from fossunited.doctype_ids import EVENT, RAZORPAY_PAYMENT
 from fossunited.utils.payments import (
     get_in_razorpay_money,
     get_razorpay_client,
@@ -74,10 +74,8 @@ class RazorpayPayment(Document):
 
         if order["status"] == "paid":
             frappe.errprint(payments)
-            if payments[0]["status"] == "captured" and self.status != "Captured":
-                self.status = "Captured"
-                self.payment_id = payments[0]["id"]
-                self.save()
+            if payments[0]["status"] == "captured":
+                capture_payment(self.order_id, payments[0]["id"])
             elif payments[0]["status"] == "refunded":
                 self.status = "Refunded"
                 self.save()
@@ -93,3 +91,58 @@ class RazorpayPayment(Document):
             )
             if ticket_status == "Closed":
                 frappe.throw(_("Ticket sale are closed for this event!"), frappe.PermissionError)
+
+
+def process_refund(payment_name: str):
+    payment = frappe.get_doc(RAZORPAY_PAYMENT, payment_name)
+    if payment.status != "Refund Pending" or payment.refund_id:
+        return payment.status
+
+    client = get_razorpay_client()
+    refund = client.payment.refund(
+        payment.payment_id,
+        {
+            "amount": int(get_in_razorpay_money(payment.amount)),
+            "receipt": f"auto-refund-{payment.name}",
+        },
+        headers={"X-Refund-Idempotency": f"fossunited-{payment.name}"},
+    )
+
+    frappe.db.get_value(RAZORPAY_PAYMENT, payment.name, "name", for_update=True)
+    payment.reload()
+    if payment.status == "Refunded":
+        return payment.status
+    payment.refund_id = refund["id"]
+    payment.status = "Refunded" if refund["status"] == "processed" else "Refund Pending"
+    payment.save(ignore_permissions=True)
+    return payment.status
+
+
+def capture_payment(order_id: str, payment_id: str):
+    payment_name = frappe.db.get_value(
+        RAZORPAY_PAYMENT,
+        {"order_id": order_id},
+        "name",
+        for_update=True,
+    )
+    if not payment_name:
+        return
+
+    payment = frappe.get_doc(RAZORPAY_PAYMENT, payment_name)
+    if payment.status not in ["Pending", "Failed"]:
+        return payment.status
+
+    payment.status = "Captured"
+    payment.payment_id = payment_id
+    payment.save(ignore_permissions=True)
+    return payment.status
+
+
+def retry_pending_refunds():
+    payments = frappe.get_all(
+        RAZORPAY_PAYMENT,
+        filters={"status": "Refund Pending", "refund_id": ["is", "not set"]},
+        pluck="name",
+    )
+    for payment_name in payments:
+        frappe.enqueue(process_refund, payment_name=payment_name)

--- a/fossunited/payments/doctype/razorpay_payment/razorpay_payment.py
+++ b/fossunited/payments/doctype/razorpay_payment/razorpay_payment.py
@@ -113,3 +113,22 @@ def capture_payment(order_id: str, payment_id: str):
     payment.save(ignore_permissions=True)
     payment.reload()
     return payment.status
+
+
+def fail_payment(order_id: str):
+    payment_name = frappe.db.get_value(
+        RAZORPAY_PAYMENT,
+        {"order_id": order_id},
+        "name",
+        for_update=True,
+    )
+    if not payment_name:
+        return
+
+    payment = frappe.get_doc(RAZORPAY_PAYMENT, payment_name)
+    if payment.status != "Pending":
+        return payment.status
+
+    payment.status = "Failed"
+    payment.save(ignore_permissions=True)
+    return payment.status

--- a/fossunited/payments/doctype/razorpay_payment/razorpay_payment.py
+++ b/fossunited/payments/doctype/razorpay_payment/razorpay_payment.py
@@ -94,34 +94,6 @@ class RazorpayPayment(Document):
                 frappe.throw(_("Ticket sale are closed for this event!"), frappe.PermissionError)
 
 
-def process_refund(payment_name: str):
-    frappe.db.get_value(RAZORPAY_PAYMENT, payment_name, "name", for_update=True)
-    payment = frappe.get_doc(RAZORPAY_PAYMENT, payment_name)
-    if payment.status != "Refund Pending" or payment.refund_id:
-        return payment.status
-    if not payment.payment_id:
-        frappe.log_error(
-            title="Refund Skipped: Missing Payment ID",
-            message=f"Payment: {payment.name}",
-        )
-        return payment.status
-
-    client = get_razorpay_client()
-    refund = client.payment.refund(
-        payment.payment_id,
-        {
-            "amount": int(get_in_razorpay_money(payment.amount)),
-            "receipt": f"auto-refund-{payment.name}",
-        },
-        headers={"X-Refund-Idempotency": f"fossunited-{payment.name}"},
-    )
-
-    payment.refund_id = refund["id"]
-    payment.status = "Refunded" if refund["status"] == "processed" else "Refund Pending"
-    payment.save(ignore_permissions=True)
-    return payment.status
-
-
 def capture_payment(order_id: str, payment_id: str):
     payment_name = frappe.db.get_value(
         RAZORPAY_PAYMENT,
@@ -141,18 +113,3 @@ def capture_payment(order_id: str, payment_id: str):
     payment.save(ignore_permissions=True)
     payment.reload()
     return payment.status
-
-
-def retry_pending_refunds():
-    payments = frappe.get_all(
-        RAZORPAY_PAYMENT,
-        filters={"status": "Refund Pending", "refund_id": ["is", "not set"]},
-        pluck="name",
-    )
-    for payment_name in payments:
-        frappe.enqueue(
-            "fossunited.payments.doctype.razorpay_payment.razorpay_payment.process_refund",
-            payment_name=payment_name,
-            job_id=f"process_refund::{payment_name}",
-            deduplicate=True,
-        )

--- a/fossunited/payments/doctype/razorpay_payment/test_razorpay_payment.py
+++ b/fossunited/payments/doctype/razorpay_payment/test_razorpay_payment.py
@@ -7,6 +7,10 @@ from frappe.tests.utils import FrappeTestCase
 
 from fossunited.api.dashboard import create_razorpay_order
 from fossunited.doctype_ids import EVENT, EVENT_TICKET, RAZORPAY_PAYMENT, TICKET_TIER
+from fossunited.payments.doctype.razorpay_payment.razorpay_payment import (
+    capture_payment,
+    process_refund,
+)
 from fossunited.tests.factories import (
     FOSSChapterEventFactory,
     FOSSChapterFactory,
@@ -85,6 +89,103 @@ class TestRazorpayPayment(FrappeTestCase):
 
         self.assertEqual(
             frappe.db.count(EVENT_TICKET, {"razorpay_payment": payment.name}), number_of_attendees
+        )
+
+    def test_expired_pending_payment_is_refunded_on_capture(self):
+        payment = RazorpayPaymentFactory.create(event=self.event.name)
+        payment.db_set("order_id", "order_expired", update_modified=False)
+        payment.order_id = "order_expired"
+        self.event.tiers[0].valid_till = date.today() - timedelta(days=1)
+        self.event.save()
+
+        with patch("frappe.enqueue") as enqueue:
+            capture_payment(payment.order_id, "pay_expired")
+
+        payment.reload()
+        self.assertEqual(payment.status, "Refund Pending")
+        self.assertEqual(payment.payment_id, "pay_expired")
+        self.assertFalse(frappe.db.exists(EVENT_TICKET, {"razorpay_payment": payment.name}))
+        enqueue.assert_called_once()
+
+    def test_sold_out_pending_payment_is_refunded_on_capture(self):
+        payment = RazorpayPaymentFactory.create(event=self.event.name)
+        payment.db_set("order_id", "order_sold_out", update_modified=False)
+        payment.order_id = "order_sold_out"
+        tier = self.event.tiers[0]
+        tier.maximum_tickets = 1
+        self.event.save()
+        frappe.get_doc(
+            {
+                "doctype": EVENT_TICKET,
+                "event": self.event.name,
+                "tier": tier.title,
+                "full_name": "Existing Attendee",
+                "email": "existing@example.com",
+            }
+        ).insert(ignore_permissions=True)
+
+        with patch("frappe.enqueue") as enqueue:
+            capture_payment(payment.order_id, "pay_sold_out")
+
+        payment.reload()
+        self.assertEqual(payment.status, "Refund Pending")
+        self.assertEqual(frappe.db.count(EVENT_TICKET, {"event": self.event.name}), 1)
+        enqueue.assert_called_once()
+
+    def test_capture_replay_does_not_duplicate_or_refund_ticket(self):
+        payment = RazorpayPaymentFactory.create(event=self.event.name)
+        payment.db_set("order_id", "order_replay", update_modified=False)
+        payment.order_id = "order_replay"
+        capture_payment(payment.order_id, "pay_first")
+
+        with patch("frappe.enqueue") as enqueue:
+            capture_payment(payment.order_id, "pay_replayed")
+
+        payment.reload()
+        self.assertEqual(payment.status, "Captured")
+        self.assertEqual(payment.payment_id, "pay_first")
+        self.assertEqual(frappe.db.count(EVENT_TICKET, {"razorpay_payment": payment.name}), 1)
+        enqueue.assert_not_called()
+
+    def test_late_capture_after_failure_creates_ticket(self):
+        payment = RazorpayPaymentFactory.create(event=self.event.name)
+        payment.db_set("order_id", "order_late_capture", update_modified=False)
+        payment.db_set("status", "Failed", update_modified=False)
+
+        capture_payment("order_late_capture", "pay_late_capture")
+
+        payment.reload()
+        self.assertEqual(payment.status, "Captured")
+        self.assertEqual(payment.payment_id, "pay_late_capture")
+        self.assertEqual(frappe.db.count(EVENT_TICKET, {"razorpay_payment": payment.name}), 1)
+
+    def test_refund_uses_stable_idempotency_key(self):
+        payment = RazorpayPaymentFactory.create(event=self.event.name)
+        payment.status = "Refund Pending"
+        payment.payment_id = "pay_refund"
+        payment.save()
+        client = MagicMock()
+        client.payment.refund.return_value = {
+            "id": "rfnd_test",
+            "status": "processed",
+        }
+
+        with patch(
+            "fossunited.payments.doctype.razorpay_payment.razorpay_payment.get_razorpay_client",
+            return_value=client,
+        ):
+            status = process_refund(payment.name)
+
+        payment.reload()
+        self.assertEqual(status, "Refunded")
+        self.assertEqual(payment.status, "Refunded")
+        client.payment.refund.assert_called_once_with(
+            "pay_refund",
+            {
+                "amount": 10000,
+                "receipt": f"auto-refund-{payment.name}",
+            },
+            headers={"X-Refund-Idempotency": f"fossunited-{payment.name}"},
         )
 
     def test_payment_creation_on_closed_tickets(self):

--- a/fossunited/payments/doctype/razorpay_payment/test_razorpay_payment.py
+++ b/fossunited/payments/doctype/razorpay_payment/test_razorpay_payment.py
@@ -105,7 +105,11 @@ class TestRazorpayPayment(FrappeTestCase):
         self.assertEqual(payment.status, "Refund Pending")
         self.assertEqual(payment.payment_id, "pay_expired")
         self.assertFalse(frappe.db.exists(EVENT_TICKET, {"razorpay_payment": payment.name}))
-        enqueue.assert_called_once()
+        enqueue.assert_called_once_with(
+            "fossunited.payments.doctype.razorpay_payment.razorpay_payment.process_refund",
+            payment_name=payment.name,
+            enqueue_after_commit=True,
+        )
 
     def test_sold_out_pending_payment_is_refunded_on_capture(self):
         payment = RazorpayPaymentFactory.create(event=self.event.name)
@@ -130,7 +134,11 @@ class TestRazorpayPayment(FrappeTestCase):
         payment.reload()
         self.assertEqual(payment.status, "Refund Pending")
         self.assertEqual(frappe.db.count(EVENT_TICKET, {"event": self.event.name}), 1)
-        enqueue.assert_called_once()
+        enqueue.assert_called_once_with(
+            "fossunited.payments.doctype.razorpay_payment.razorpay_payment.process_refund",
+            payment_name=payment.name,
+            enqueue_after_commit=True,
+        )
 
     def test_capture_replay_does_not_duplicate_or_refund_ticket(self):
         payment = RazorpayPaymentFactory.create(event=self.event.name)

--- a/fossunited/payments/doctype/razorpay_payment/test_razorpay_payment.py
+++ b/fossunited/payments/doctype/razorpay_payment/test_razorpay_payment.py
@@ -7,7 +7,10 @@ from frappe.tests.utils import FrappeTestCase
 
 from fossunited.api.dashboard import create_razorpay_order
 from fossunited.doctype_ids import EVENT, EVENT_TICKET, RAZORPAY_PAYMENT, TICKET_TIER
-from fossunited.payments.doctype.razorpay_payment.razorpay_payment import capture_payment
+from fossunited.payments.doctype.razorpay_payment.razorpay_payment import (
+    capture_payment,
+    fail_payment,
+)
 from fossunited.tests.factories import (
     FOSSChapterEventFactory,
     FOSSChapterFactory,
@@ -147,6 +150,18 @@ class TestRazorpayPayment(FrappeTestCase):
         payment.reload()
         self.assertEqual(payment.status, "Captured")
         self.assertEqual(payment.payment_id, "pay_late_capture")
+        self.assertEqual(frappe.db.count(EVENT_TICKET, {"razorpay_payment": payment.name}), 1)
+
+    def test_failure_after_capture_does_not_overwrite_status(self):
+        payment = RazorpayPaymentFactory.create(event=self.event.name)
+        payment.db_set("order_id", "order_captured_then_failed", update_modified=False)
+
+        capture_payment("order_captured_then_failed", "pay_captured")
+        fail_payment("order_captured_then_failed")
+
+        payment.reload()
+        self.assertEqual(payment.status, "Captured")
+        self.assertEqual(payment.payment_id, "pay_captured")
         self.assertEqual(frappe.db.count(EVENT_TICKET, {"razorpay_payment": payment.name}), 1)
 
     def test_payment_creation_on_closed_tickets(self):
@@ -532,13 +547,11 @@ class TestCreateRazorpayOrderAmount(FrappeTestCase):
                 ref_docname=self.event.name,
             )
 
-    def test_create_order_sets_expire_by(self):
+    def test_create_order_uses_supported_order_fields(self):
         attendee = _make_attendee(ticket_type=self.tier_standard.name, wants_tshirt=0)
         client = self._mock_client("ord_expire")
-        now = 1_700_000_000
         with (
             patch("fossunited.api.dashboard.get_razorpay_client", return_value=client),
-            patch("fossunited.api.dashboard.time.time", return_value=now),
         ):
             create_razorpay_order(
                 checkout_info={
@@ -556,7 +569,7 @@ class TestCreateRazorpayOrderAmount(FrappeTestCase):
                 ref_docname=self.event.name,
             )
         payload = client.order.create.call_args.kwargs["data"]
-        self.assertEqual(payload["expire_by"], now + 30 * 60)
+        self.assertEqual(payload, {"amount": 40000, "currency": "INR"})
 
     def test_standard_tier_no_tshirt(self):
         attendee = _make_attendee(ticket_type=self.tier_standard.name, wants_tshirt=0)

--- a/fossunited/payments/doctype/razorpay_payment/test_razorpay_payment.py
+++ b/fossunited/payments/doctype/razorpay_payment/test_razorpay_payment.py
@@ -7,10 +7,7 @@ from frappe.tests.utils import FrappeTestCase
 
 from fossunited.api.dashboard import create_razorpay_order
 from fossunited.doctype_ids import EVENT, EVENT_TICKET, RAZORPAY_PAYMENT, TICKET_TIER
-from fossunited.payments.doctype.razorpay_payment.razorpay_payment import (
-    capture_payment,
-    process_refund,
-)
+from fossunited.payments.doctype.razorpay_payment.razorpay_payment import capture_payment
 from fossunited.tests.factories import (
     FOSSChapterEventFactory,
     FOSSChapterFactory,
@@ -91,27 +88,21 @@ class TestRazorpayPayment(FrappeTestCase):
             frappe.db.count(EVENT_TICKET, {"razorpay_payment": payment.name}), number_of_attendees
         )
 
-    def test_expired_pending_payment_is_refunded_on_capture(self):
+    def test_expired_pending_payment_skips_ticket_on_capture(self):
         payment = RazorpayPaymentFactory.create(event=self.event.name)
         payment.db_set("order_id", "order_expired", update_modified=False)
         payment.order_id = "order_expired"
         self.event.tiers[0].valid_till = date.today() - timedelta(days=1)
         self.event.save()
 
-        with patch("frappe.enqueue") as enqueue:
-            capture_payment(payment.order_id, "pay_expired")
+        capture_payment(payment.order_id, "pay_expired")
 
         payment.reload()
-        self.assertEqual(payment.status, "Refund Pending")
+        self.assertEqual(payment.status, "Captured")
         self.assertEqual(payment.payment_id, "pay_expired")
         self.assertFalse(frappe.db.exists(EVENT_TICKET, {"razorpay_payment": payment.name}))
-        enqueue.assert_called_once_with(
-            "fossunited.payments.doctype.razorpay_payment.razorpay_payment.process_refund",
-            payment_name=payment.name,
-            enqueue_after_commit=True,
-        )
 
-    def test_sold_out_pending_payment_is_refunded_on_capture(self):
+    def test_sold_out_pending_payment_skips_ticket_on_capture(self):
         payment = RazorpayPaymentFactory.create(event=self.event.name)
         payment.db_set("order_id", "order_sold_out", update_modified=False)
         payment.order_id = "order_sold_out"
@@ -128,32 +119,23 @@ class TestRazorpayPayment(FrappeTestCase):
             }
         ).insert(ignore_permissions=True)
 
-        with patch("frappe.enqueue") as enqueue:
-            capture_payment(payment.order_id, "pay_sold_out")
+        capture_payment(payment.order_id, "pay_sold_out")
 
         payment.reload()
-        self.assertEqual(payment.status, "Refund Pending")
+        self.assertEqual(payment.status, "Captured")
         self.assertEqual(frappe.db.count(EVENT_TICKET, {"event": self.event.name}), 1)
-        enqueue.assert_called_once_with(
-            "fossunited.payments.doctype.razorpay_payment.razorpay_payment.process_refund",
-            payment_name=payment.name,
-            enqueue_after_commit=True,
-        )
 
-    def test_capture_replay_does_not_duplicate_or_refund_ticket(self):
+    def test_capture_replay_does_not_duplicate_ticket(self):
         payment = RazorpayPaymentFactory.create(event=self.event.name)
         payment.db_set("order_id", "order_replay", update_modified=False)
         payment.order_id = "order_replay"
         capture_payment(payment.order_id, "pay_first")
-
-        with patch("frappe.enqueue") as enqueue:
-            capture_payment(payment.order_id, "pay_replayed")
+        capture_payment(payment.order_id, "pay_replayed")
 
         payment.reload()
         self.assertEqual(payment.status, "Captured")
         self.assertEqual(payment.payment_id, "pay_first")
         self.assertEqual(frappe.db.count(EVENT_TICKET, {"razorpay_payment": payment.name}), 1)
-        enqueue.assert_not_called()
 
     def test_late_capture_after_failure_creates_ticket(self):
         payment = RazorpayPaymentFactory.create(event=self.event.name)
@@ -166,35 +148,6 @@ class TestRazorpayPayment(FrappeTestCase):
         self.assertEqual(payment.status, "Captured")
         self.assertEqual(payment.payment_id, "pay_late_capture")
         self.assertEqual(frappe.db.count(EVENT_TICKET, {"razorpay_payment": payment.name}), 1)
-
-    def test_refund_uses_stable_idempotency_key(self):
-        payment = RazorpayPaymentFactory.create(event=self.event.name)
-        payment.status = "Refund Pending"
-        payment.payment_id = "pay_refund"
-        payment.save()
-        client = MagicMock()
-        client.payment.refund.return_value = {
-            "id": "rfnd_test",
-            "status": "processed",
-        }
-
-        with patch(
-            "fossunited.payments.doctype.razorpay_payment.razorpay_payment.get_razorpay_client",
-            return_value=client,
-        ):
-            status = process_refund(payment.name)
-
-        payment.reload()
-        self.assertEqual(status, "Refunded")
-        self.assertEqual(payment.status, "Refunded")
-        client.payment.refund.assert_called_once_with(
-            "pay_refund",
-            {
-                "amount": 10000,
-                "receipt": f"auto-refund-{payment.name}",
-            },
-            headers={"X-Refund-Idempotency": f"fossunited-{payment.name}"},
-        )
 
     def test_payment_creation_on_closed_tickets(self):
         # Given an event with tickets closed
@@ -578,6 +531,32 @@ class TestCreateRazorpayOrderAmount(FrappeTestCase):
                 ref_doctype=EVENT,
                 ref_docname=self.event.name,
             )
+
+    def test_create_order_sets_expire_by(self):
+        attendee = _make_attendee(ticket_type=self.tier_standard.name, wants_tshirt=0)
+        client = self._mock_client("ord_expire")
+        now = 1_700_000_000
+        with (
+            patch("fossunited.api.dashboard.get_razorpay_client", return_value=client),
+            patch("fossunited.api.dashboard.time.time", return_value=now),
+        ):
+            create_razorpay_order(
+                checkout_info={
+                    "amount": 400,
+                    "email": "buyer@example.com",
+                    "tax_details": {},
+                },
+                meta_data={
+                    "event": self.event.name,
+                    "tier_counts": {self.tier_standard.name: 1},
+                    "attendees": [attendee],
+                    "num_seats": 1,
+                },
+                ref_doctype=EVENT,
+                ref_docname=self.event.name,
+            )
+        payload = client.order.create.call_args.kwargs["data"]
+        self.assertEqual(payload["expire_by"], now + 30 * 60)
 
     def test_standard_tier_no_tshirt(self):
         attendee = _make_attendee(ticket_type=self.tier_standard.name, wants_tshirt=0)

--- a/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
@@ -173,12 +173,25 @@ def handle_payment_on_update(doc: "RazorpayPayment", event: str):
     if not is_foss_event(doc):
         return
 
-    if tickets_already_created(doc):
-        return
-
     if doc.status == "Captured":
         try:
+            frappe.db.get_value(EVENT, doc.document_name, "name", for_update=True)
+            if tickets_already_created(doc):
+                return
+            validate_ticket_fulfillment(doc)
             FOSSEventTicket.create_tickets_for_payment(doc)
+        except TicketTierMismatchError as e:
+            doc.status = "Refund Pending"
+            doc.db_update()
+            frappe.enqueue(
+                "fossunited.payments.doctype.razorpay_payment.razorpay_payment.process_refund",
+                payment_name=doc.name,
+                enqueue_after_commit=True,
+            )
+            frappe.log_error(
+                title="Ticket Payment Refund Queued",
+                message=f"Payment: {doc.name}\nEvent: {doc.document_name}\nReason: {e}",
+            )
         except Exception as e:
             frappe.log_error(
                 title="Ticket Creation Failed",
@@ -189,6 +202,43 @@ def handle_payment_on_update(doc: "RazorpayPayment", event: str):
 
 class TicketTierMismatchError(frappe.ValidationError):
     pass
+
+
+def validate_ticket_fulfillment(doc: "RazorpayPayment"):
+    payment_meta_data: dict = frappe.parse_json(doc.meta_data)
+    tier_counts: dict = payment_meta_data.get("tier_counts") or {}
+    event_name = payment_meta_data.get("event")
+
+    if event_name != doc.document_name:
+        frappe.throw(_("Payment event does not match its reference."), TicketTierMismatchError)
+
+    event = frappe.db.get_value(EVENT, event_name, ["name", "tickets_status"], as_dict=True)
+    if not event or event.tickets_status != "Live":
+        frappe.throw(_("Ticket sales are closed for this event."), TicketTierMismatchError)
+
+    for tier_name, count in tier_counts.items():
+        count = int(count or 0)
+        if count <= 0:
+            continue
+        if not frappe.db.exists(TICKET_TIER, tier_name):
+            frappe.throw(_("Ticket tier no longer exists."), TicketTierMismatchError)
+        tier = frappe.get_doc(TICKET_TIER, tier_name)
+        if tier.parent != event_name:
+            frappe.throw(_("A tier does not belong to this event."), TicketTierMismatchError)
+        if not tier.enabled:
+            frappe.throw(f"Ticket tier '{tier.title}' is not enabled.", TicketTierMismatchError)
+        if tier.valid_till and tier.valid_till < datetime.today().date():
+            frappe.throw(f"Ticket tier '{tier.title}' has expired.", TicketTierMismatchError)
+
+        existing_count = frappe.db.count(
+            EVENT_TICKET,
+            filters={"tier": tier.title, "event": event_name},
+        )
+        if tier.maximum_tickets and (existing_count + count) > tier.maximum_tickets:
+            frappe.throw(
+                f"Not enough seats in '{tier.title}'. Houseful!",
+                TicketTierMismatchError,
+            )
 
 
 def validate_payment_before_insert(doc: "RazorpayPayment", event: str):

--- a/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
@@ -181,8 +181,7 @@ def handle_payment_on_update(doc: "RazorpayPayment", event: str):
             validate_ticket_fulfillment(doc)
             FOSSEventTicket.create_tickets_for_payment(doc)
         except TicketTierMismatchError as e:
-            doc.status = "Refund Pending"
-            doc.db_update()
+            doc.db_set("status", "Refund Pending", update_modified=False)
             frappe.enqueue(
                 "fossunited.payments.doctype.razorpay_payment.razorpay_payment.process_refund",
                 payment_name=doc.name,
@@ -204,6 +203,30 @@ class TicketTierMismatchError(frappe.ValidationError):
     pass
 
 
+def validate_tier_availability(tier, event_name: str, count: int):
+    if tier.parent != event_name:
+        frappe.throw(_("A tier does not belong to this event."), TicketTierMismatchError)
+    if not tier.enabled:
+        frappe.throw(
+            _("Ticket tier '{0}' is not enabled.").format(tier.title),
+            TicketTierMismatchError,
+        )
+    if tier.valid_till and tier.valid_till < datetime.today().date():
+        frappe.throw(
+            _("Ticket tier '{0}' has expired.").format(tier.title),
+            TicketTierMismatchError,
+        )
+    existing_count = frappe.db.count(
+        EVENT_TICKET,
+        filters={"tier": tier.title, "event": event_name},
+    )
+    if tier.maximum_tickets and (existing_count + count) > tier.maximum_tickets:
+        frappe.throw(
+            _("Not enough seats in '{0}'. Houseful!").format(tier.title),
+            TicketTierMismatchError,
+        )
+
+
 def validate_ticket_fulfillment(doc: "RazorpayPayment"):
     payment_meta_data: dict = frappe.parse_json(doc.meta_data)
     tier_counts: dict = payment_meta_data.get("tier_counts") or {}
@@ -220,25 +243,11 @@ def validate_ticket_fulfillment(doc: "RazorpayPayment"):
         count = int(count or 0)
         if count <= 0:
             continue
-        if not frappe.db.exists(TICKET_TIER, tier_name):
+        try:
+            tier = frappe.get_doc(TICKET_TIER, tier_name)
+        except frappe.DoesNotExistError:
             frappe.throw(_("Ticket tier no longer exists."), TicketTierMismatchError)
-        tier = frappe.get_doc(TICKET_TIER, tier_name)
-        if tier.parent != event_name:
-            frappe.throw(_("A tier does not belong to this event."), TicketTierMismatchError)
-        if not tier.enabled:
-            frappe.throw(f"Ticket tier '{tier.title}' is not enabled.", TicketTierMismatchError)
-        if tier.valid_till and tier.valid_till < datetime.today().date():
-            frappe.throw(f"Ticket tier '{tier.title}' has expired.", TicketTierMismatchError)
-
-        existing_count = frappe.db.count(
-            EVENT_TICKET,
-            filters={"tier": tier.title, "event": event_name},
-        )
-        if tier.maximum_tickets and (existing_count + count) > tier.maximum_tickets:
-            frappe.throw(
-                f"Not enough seats in '{tier.title}'. Houseful!",
-                TicketTierMismatchError,
-            )
+        validate_tier_availability(tier, event_name, count)
 
 
 def validate_payment_before_insert(doc: "RazorpayPayment", event: str):
@@ -258,37 +267,11 @@ def validate_payment_before_insert(doc: "RazorpayPayment", event: str):
         if count <= 0:
             continue
 
-        price, tier_event = frappe.db.get_value(TICKET_TIER, tier_name, ["price", "parent"])
-        if tier_event != event_name:
-            frappe.throw(_("A tier does not belong to this event."), TicketTierMismatchError)
-
+        price = frappe.db.get_value(TICKET_TIER, tier_name, "price")
         tier_details = frappe.get_doc(TICKET_TIER, tier_name)
         tshirt_included_by_tier[tier_name] = bool(tier_details.tshirt_included)
 
-        if not tier_details.enabled:
-            frappe.throw(
-                f"Ticket tier '{tier_details.title}' is not enabled.",
-                TicketTierMismatchError,
-            )
-
-        if tier_details.valid_till and tier_details.valid_till < datetime.today().date():
-            frappe.throw(
-                f"Ticket tier '{tier_details.title}' has expired.",
-                TicketTierMismatchError,
-            )
-
-        existing_count = frappe.db.count(
-            EVENT_TICKET,
-            filters={"tier": tier_details.title, "event": event_name},
-        )
-        if (
-            tier_details.maximum_tickets
-            and (existing_count + count) > tier_details.maximum_tickets
-        ):
-            frappe.throw(
-                f"Not enough seats in '{tier_details.title}'. Houseful!",
-                TicketTierMismatchError,
-            )
+        validate_tier_availability(tier_details, event_name, count)
 
         calculated_amount += float(price) * count
 

--- a/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
+++ b/fossunited/ticketing/doctype/foss_event_ticket/foss_event_ticket.py
@@ -181,14 +181,8 @@ def handle_payment_on_update(doc: "RazorpayPayment", event: str):
             validate_ticket_fulfillment(doc)
             FOSSEventTicket.create_tickets_for_payment(doc)
         except TicketTierMismatchError as e:
-            doc.db_set("status", "Refund Pending", update_modified=False)
-            frappe.enqueue(
-                "fossunited.payments.doctype.razorpay_payment.razorpay_payment.process_refund",
-                payment_name=doc.name,
-                enqueue_after_commit=True,
-            )
             frappe.log_error(
-                title="Ticket Payment Refund Queued",
+                title="Ticket Creation Skipped",
                 message=f"Payment: {doc.name}\nEvent: {doc.document_name}\nReason: {e}",
             )
         except Exception as e:


### PR DESCRIPTION
## Summary

Revalidate paid ticket orders immediately before fulfillment, serialize paid capacity allocation, and automatically refund captured payments that can no longer be fulfilled.

## Context

I found this while researching a technical write-up about FOSS United's open-source Razorpay integration. A Razorpay Order created while a ticket tier is valid remains payable after the tier expires or sells out because Razorpay Orders do not expire automatically.

I am submitting the remediation before publishing the write-up. The write-up will not include live payment identifiers.

## Problem

Ticket tier validity and capacity are checked when the pending `Razorpay Payment` record is created. Between order creation and capture, however:

- the event can close ticket sales;
- a tier can be disabled or pass `valid_till`;
- other buyers can consume the remaining capacity;
- callback and webhook delivery can race or replay.

The current capture path marks the payment `Captured` and creates tickets without revalidating those conditions. Capacity checks also use a count without serializing concurrent paid fulfillments, so two captures can observe the same last available seat.

## Changes

- Route browser callbacks, Razorpay webhooks, and manual payment synchronization through a locked, monotonic `capture_payment` transition.
- Lock the parent event row before checking existing fulfillment, tier validity, and current capacity, keeping validation and ticket insertion in one transaction.
- Treat callback/webhook replay as an idempotent no-op once a payment leaves `Pending`/`Failed`.
- Move captured but unfulfillable payments to `Refund Pending` without creating tickets.
- Enqueue the refund only after the database transaction commits.
- Use Razorpay's `X-Refund-Idempotency` header so a lost response can be retried safely.
- Add an hourly recovery task for refund intents where no Razorpay refund ID was recorded.
- Preserve late-authorized payment handling by permitting `Failed -> Captured`.

## Why the event row is locked

A count followed by inserts is subject to a time-of-check/time-of-use race. Locking the event row serializes paid ticket fulfillment for that event, so the second capture observes tickets committed by the first before deciding whether capacity remains. The lock also serializes callback/webhook processing around the existing payment-level lock.

## Refund behavior

Razorpay Orders do not support a server-side expiry timestamp. If a previously valid order is paid after it can no longer be fulfilled, the customer has already been charged. The patch therefore queues a full refund rather than leaving the customer to request one manually.

The refund worker uses a stable idempotency key derived from the local payment record. The scheduler retries only `Refund Pending` records without a stored Razorpay refund ID; normal `refund.processed` webhooks continue to finalize refund state.

## Tests

Added focused coverage for:

- capture after tier expiry;
- capture after tier capacity is exhausted;
- callback/capture replay;
- late capture after an earlier failed state;
- stable refund idempotency keys.

## Validation

- `ruff check` on all changed Python files
- `ruff format --check` on all changed Python files
- project pre-commit hooks on all changed files
- `python -m compileall -q fossunited`
- `git diff --check`

A full Frappe integration test run requires a configured Bench site and was not available in this checkout.
