### PR TITLE
fix(cfpEdit): make allow_cfp_edit as master switch to control edits

### DIFF
--- a/fossunited/api/cfp.py
+++ b/fossunited/api/cfp.py
@@ -55,11 +55,10 @@ def can_edit_proposal(cfp_submission: str) -> bool:
     """Whether the proposer may still edit this submission's content.
 
     Server-side because the deadline is naive site-time and the form status may
-    be a stale "Live"; only the server can decide correctly. Read permission on
-    the submission is enforced by frappe.get_doc.
+    be a stale "Live"; only the server can decide correctly.
     """
-    sub = frappe.get_doc(PROPOSAL, cfp_submission)
-    return frappe.get_cached_doc(EVENT_CFP, sub.linked_cfp).can_edit_proposal()
+    linked_cfp = frappe.db.get_value(PROPOSAL, cfp_submission, "linked_cfp")
+    return frappe.get_cached_doc(EVENT_CFP, linked_cfp).can_edit_proposal()
 
 
 # nosemgrep: guest-whitelisted-method

--- a/fossunited/fossunited/doctype/foss_event_cfp/foss_event_cfp.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp/foss_event_cfp.py
@@ -56,13 +56,10 @@ class FOSSEventCFP(Document):
         return False
 
     def can_edit_proposal(self) -> bool:
-        """Whether a proposer may still edit their proposal content.
-
-        allow_cfp_edit is the master switch. status auto-closes once the deadline
-        passes, but we also check the deadline live in case that lazy flip has not
-        run yet.
-        """
-        return bool(self.allow_cfp_edit) and self.status == "Live" and not self.is_past_deadline()
+        """Whether a proposer may still edit their proposal content."""
+        if self.allow_cfp_edit:
+            return True
+        return self.status == "Live" and not self.is_past_deadline()
 
     def before_insert(self):
         self.assign_reviewers()

--- a/fossunited/fossunited/doctype/foss_event_cfp/test_foss_event_cfp.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp/test_foss_event_cfp.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_to_date, now_datetime
@@ -66,31 +68,33 @@ class TestFOSSEventCFP(FrappeTestCase):
 
 
 class TestFOSSEventCFPEditWindow(FrappeTestCase):
+    """can_edit_proposal(): allow_cfp_edit is a standalone master switch (True
+    always wins); when off, falls back to status == Live and not past deadline."""
+
     def tearDown(self):
         frappe.set_user("Administrator")
 
-    def test_editable_when_live_and_before_deadline(self):
-        cfp = FOSSEventCFPFactory.create(
-            allow_cfp_edit=1, status="Live", deadline=add_to_date(now_datetime(), days=3)
-        )
-        self.assertTrue(cfp.can_edit_proposal())
+    # (allow_cfp_edit, status, deadline_days_from_now_or_None, expected)
+    CASES: ClassVar = [
+        (0, "Live", 3, True),  # off, live, before deadline -> open window
+        (0, "Closed", 3, False),  # off, closed -> blocked
+        (0, "Live", -1, False),  # off, past deadline -> blocked
+        (0, "Live", None, True),  # off, no deadline set -> open window
+        (1, "Live", -1, True),  # on overrides past deadline
+        (1, "Closed", 3, True),  # on overrides closed status
+    ]
 
-    def test_not_editable_when_allow_cfp_edit_off(self):
-        cfp = FOSSEventCFPFactory.create(allow_cfp_edit=0, status="Live")
-        self.assertFalse(cfp.can_edit_proposal())
-
-    def test_not_editable_when_past_deadline(self):
-        cfp = FOSSEventCFPFactory.create(
-            allow_cfp_edit=1, status="Live", deadline=add_to_date(now_datetime(), days=-1)
-        )
-        self.assertFalse(cfp.can_edit_proposal())
-
-    def test_not_editable_when_status_closed(self):
-        cfp = FOSSEventCFPFactory.create(
-            allow_cfp_edit=1, status="Closed", deadline=add_to_date(now_datetime(), days=3)
-        )
-        self.assertFalse(cfp.can_edit_proposal())
-
-    def test_editable_when_no_deadline(self):
-        cfp = FOSSEventCFPFactory.create(allow_cfp_edit=1, status="Live", deadline=None)
-        self.assertTrue(cfp.can_edit_proposal())
+    def test_can_edit_proposal_matrix(self):
+        for allow_cfp_edit, status, deadline_days, expected in self.CASES:
+            deadline = (
+                add_to_date(now_datetime(), days=deadline_days)
+                if deadline_days is not None
+                else None
+            )
+            with self.subTest(
+                allow_cfp_edit=allow_cfp_edit, status=status, deadline_days=deadline_days
+            ):
+                cfp = FOSSEventCFPFactory.create(
+                    allow_cfp_edit=allow_cfp_edit, status=status, deadline=deadline
+                )
+                self.assertEqual(cfp.can_edit_proposal(), expected)

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/test_foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/test_foss_event_cfp_submission.py
@@ -136,6 +136,7 @@ class TestFOSSEventCFPSubmission(FrappeTestCase):
     def test_proposer_edit_blocked_when_window_closed(self):
         for allow_cfp_edit, status, deadline_days in self.BLOCKED_CASES:
             with self.subTest(allow_cfp_edit=allow_cfp_edit, status=status):
+                frappe.set_user("Administrator")
                 _, sub = self._closed_submission(
                     allow_cfp_edit=allow_cfp_edit,
                     status=status,
@@ -155,6 +156,7 @@ class TestFOSSEventCFPSubmission(FrappeTestCase):
     def test_proposer_edit_allowed_when_window_open(self):
         for allow_cfp_edit, status, deadline_days in self.OPEN_CASES:
             with self.subTest(allow_cfp_edit=allow_cfp_edit, status=status):
+                frappe.set_user("Administrator")
                 _, sub = self._closed_submission(
                     allow_cfp_edit=allow_cfp_edit,
                     status=status,

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/test_foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/test_foss_event_cfp_submission.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_to_date, now_datetime
@@ -125,56 +127,47 @@ class TestFOSSEventCFPSubmission(FrappeTestCase):
         )
         return cfp, sub
 
-    def test_proposer_edit_blocked_when_allow_cfp_edit_off(self):
-        _, sub = self._closed_submission(allow_cfp_edit=0, status="Live")
-        frappe.set_user(Submitter)
-        sub.talk_title = "Edited after lock"
-        with self.assertRaises(frappe.PermissionError):
-            sub.save()
+    # (allow_cfp_edit, status, deadline_days_from_now) -> window closed, save must raise
+    BLOCKED_CASES: ClassVar = [
+        (0, "Closed", 3),  # switch off, status closed
+        (0, "Live", -1),  # switch off, past deadline
+    ]
 
-    def test_proposer_edit_blocked_past_deadline(self):
-        _, sub = self._closed_submission(
-            allow_cfp_edit=1,
-            status="Live",
-            deadline=add_to_date(now_datetime(), days=-1),
-        )
-        frappe.set_user(Submitter)
-        sub.talk_description = "Edited after deadline"
-        with self.assertRaises(frappe.PermissionError):
-            sub.save()
+    def test_proposer_edit_blocked_when_window_closed(self):
+        for allow_cfp_edit, status, deadline_days in self.BLOCKED_CASES:
+            with self.subTest(allow_cfp_edit=allow_cfp_edit, status=status):
+                _, sub = self._closed_submission(
+                    allow_cfp_edit=allow_cfp_edit,
+                    status=status,
+                    deadline=add_to_date(now_datetime(), days=deadline_days),
+                )
+                frappe.set_user(Submitter)
+                sub.talk_title = "Edited after lock"
+                with self.assertRaises(frappe.PermissionError):
+                    sub.save()
 
-    def test_proposer_edit_blocked_when_status_closed(self):
-        _, sub = self._closed_submission(
-            allow_cfp_edit=1,
-            status="Closed",
-            deadline=add_to_date(now_datetime(), days=3),
-        )
-        frappe.set_user(Submitter)
-        sub.talk_title = "Edited while closed"
-        with self.assertRaises(frappe.PermissionError):
-            sub.save()
+    # (allow_cfp_edit, status, deadline_days_from_now) -> window open, save must succeed
+    OPEN_CASES: ClassVar = [
+        (1, "Closed", 3),  # switch on overrides closed status
+        (1, "Live", 3),  # naturally open window
+    ]
 
     def test_proposer_edit_allowed_when_window_open(self):
-        cfp = FOSSEventCFPFactory.create(
-            event=self.event.name,
-            allow_cfp_edit=1,
-            status="Live",
-            deadline=add_to_date(now_datetime(), days=3),
-        )
-        sub = FOSSEventCFPSubmissionFactory.create(
-            linked_cfp=cfp.name,
-            event=self.event.name,
-            submitted_by=Submitter,
-            email=Submitter,
-        )
-        frappe.set_user(Submitter)
-        sub.talk_title = "Edited within window"
-        sub.save()  # must not raise
-        sub.reload()
-        self.assertEqual(sub.talk_title, "Edited within window")
+        for allow_cfp_edit, status, deadline_days in self.OPEN_CASES:
+            with self.subTest(allow_cfp_edit=allow_cfp_edit, status=status):
+                _, sub = self._closed_submission(
+                    allow_cfp_edit=allow_cfp_edit,
+                    status=status,
+                    deadline=add_to_date(now_datetime(), days=deadline_days),
+                )
+                frappe.set_user(Submitter)
+                sub.talk_title = "Edited within window"
+                sub.save()  # must not raise
+                sub.reload()
+                self.assertEqual(sub.talk_title, "Edited within window")
 
     def test_proposer_can_withdraw_after_close(self):
-        _, sub = self._closed_submission(allow_cfp_edit=0, status="Live")
+        _, sub = self._closed_submission(allow_cfp_edit=0, status="Closed")
         frappe.set_user(Submitter)
         sub.is_withdrawn = 1
         sub.save()  # withdraw is not a content change -> allowed
@@ -183,7 +176,7 @@ class TestFOSSEventCFPSubmission(FrappeTestCase):
 
     def test_reviewer_can_review_after_close(self):
         _, sub = self._closed_submission(
-            allow_cfp_edit=1,
+            allow_cfp_edit=0,
             status="Live",
             deadline=add_to_date(now_datetime(), days=-1),
         )
@@ -199,7 +192,7 @@ class TestFOSSEventCFPSubmission(FrappeTestCase):
         # CFP. validate() sanitises talk_description before before_save, so the
         # naive before/after compare would otherwise see a phantom content change.
         _, sub = self._closed_submission(
-            allow_cfp_edit=1,
+            allow_cfp_edit=0,
             status="Live",
             deadline=add_to_date(now_datetime(), days=-1),
         )
@@ -218,7 +211,7 @@ class TestFOSSEventCFPSubmission(FrappeTestCase):
         self.assertEqual(len(sub.reviews), 1)
 
     def test_system_manager_can_edit_after_close(self):
-        _, sub = self._closed_submission(allow_cfp_edit=0, status="Live")
+        _, sub = self._closed_submission(allow_cfp_edit=0, status="Closed")
         frappe.set_user("Administrator")
         sub.talk_title = "Edited by admin"
         sub.save()  # System Manager bypass


### PR DESCRIPTION
- In commit: 589066e4 -> I had made switch to be only available when status is live and not after deadline
- But team needs this switch to control even after closure.

- So now CFP submissions will be allowed to be edit via this checkbox alone
- If checkbox disabled, then check if status is live and not past deadline.

- Simplified testst to be simple loop based on condition, many funcs were duplicates & served same person

TLDR:

- `allow_cfp_edit`: Enabled -> Proposer can edit
- `allow_cfp_edit`: Disabled -> Proposer can edit only if cfp status is `Live` and not ahead of given deadline. If either is not true, no edit allowed.