### PR TITLE
feat(free-ticket): ask t-shirt size if coupon has t-shirt included

### DIFF
--- a/dashboard/src/components/event/FreeTicketCodeDialog.vue
+++ b/dashboard/src/components/event/FreeTicketCodeDialog.vue
@@ -45,6 +45,12 @@
           :min="1"
           :max="30"
         />
+        <FormControl
+          v-model="code.tshirt_included"
+          type="checkbox"
+          label="T-shirt included"
+          description="Ask for a t-shirt size when this coupon is claimed"
+        />
       </div>
       <ErrorMessage :message="errorMessages" />
     </template>
@@ -105,6 +111,7 @@ const defaultCode = {
   company: '',
   other_tier: '',
   max_count: 1,
+  tshirt_included: false,
 }
 
 const code = reactive({ ...defaultCode })
@@ -127,6 +134,7 @@ watch(
     code.company = row.company || ''
     code.other_tier = row.other_tier || ''
     code.max_count = row.max_count || 1
+    code.tshirt_included = Boolean(row.tshirt_included)
   },
   { immediate: true },
 )
@@ -155,6 +163,7 @@ const createCode = createResource({
         company: code.company,
         other_tier: code.other_tier,
         max_count: code.max_count,
+        tshirt_included: code.tshirt_included ? 1 : 0,
       },
     }
   },
@@ -183,6 +192,7 @@ const updateCode = createResource({
         company: code.company,
         other_tier: code.other_tier,
         max_count: code.max_count,
+        tshirt_included: code.tshirt_included ? 1 : 0,
       },
     }
   },

--- a/dashboard/src/components/event/FreeTicketCodeSection.vue
+++ b/dashboard/src/components/event/FreeTicketCodeSection.vue
@@ -49,6 +49,13 @@
             exportValue: (row) => `${row.used_count ?? 0} / ${row.max_count ?? 0}`,
           },
           { label: 'Tier', key: 'tier', icon: 'award', width: '200px' },
+          {
+            label: 'T-shirt',
+            key: 'tshirt_included',
+            icon: 'gift',
+            width: '90px',
+            exportValue: (row) => (row.tshirt_included ? 'Yes' : 'No'),
+          },
           { label: 'Organization', key: 'company', icon: 'briefcase' },
         ]"
         row-key="name"
@@ -75,6 +82,10 @@
             >
               {{ row.used_count }} / {{ row.max_count }}
             </span>
+          </div>
+          <div v-else-if="column.key === 'tshirt_included'">
+            <IconShirt v-if="row.tshirt_included" class="w-4 h-4 text-ink-green-3" />
+            <span v-else class="text-ink-gray-4">—</span>
           </div>
           <div v-else>
             <span class="text-base truncate text-wrap">{{ item }}</span>
@@ -139,6 +150,7 @@ import { toast } from 'vue-sonner'
 import FreeTicketCodeDialog from '@/components/event/FreeTicketCodeDialog.vue'
 import { useRoute } from 'vue-router'
 import SearchListView from '@/components/ui/SearchListView.vue'
+import { IconShirt } from '@tabler/icons-vue'
 
 const props = defineProps({
   event: {

--- a/dashboard/src/components/event/FreeTicketCodeSection.vue
+++ b/dashboard/src/components/event/FreeTicketCodeSection.vue
@@ -102,6 +102,12 @@
             :max="3"
             description="How many times each coupon can be used (1–3)"
           />
+          <FormControl
+            v-model="speakerTshirtIncluded"
+            type="checkbox"
+            label="T-shirt included"
+            description="Speakers will be asked for a t-shirt size when claiming"
+          />
           <p v-if="speakerPreviewErr" class="text-sm text-ink-red-3">{{ speakerPreviewErr }}</p>
         </div>
       </template>
@@ -166,6 +172,7 @@ const freeCodes = createResource({
 
 const showSpeakerDialog = ref(false)
 const speakerMaxCount = ref(1)
+const speakerTshirtIncluded = ref(false)
 const speakerPreviewErr = ref('')
 
 const speakerPreview = createResource({
@@ -178,11 +185,13 @@ const bulkCreate = createResource({
   makeParams: () => ({
     event: props.event.data?.name || route.params.id,
     max_count: speakerMaxCount.value,
+    tshirt_included: speakerTshirtIncluded.value ? 1 : 0,
   }),
   onSuccess(r) {
     toast.success(`Created ${r.created} coupon(s), skipped ${r.skipped}`)
     showSpeakerDialog.value = false
     speakerMaxCount.value = 1
+    speakerTshirtIncluded.value = false
     freeCodes.fetch()
   },
   onError(e) {

--- a/fossunited/api/checkins.py
+++ b/fossunited/api/checkins.py
@@ -19,7 +19,14 @@ def get_attendee_with_checkin_data(event_id: str, filters: dict | None = None) -
     Returns:
         dict: The attendees of the event with their checkin details
     """
-    ALLOWED_FILTER_KEYS = {"name", "full_name", "designation", "organization", "tier", "tshirt_size"}
+    ALLOWED_FILTER_KEYS = {
+        "name",
+        "full_name",
+        "designation",
+        "organization",
+        "tier",
+        "tshirt_size",
+    }
     _filters = {"event": event_id}
     if filters:
         for key, value in filters.items():

--- a/fossunited/api/tickets.py
+++ b/fossunited/api/tickets.py
@@ -494,14 +494,27 @@ def get_event_free_codes(event: str):
 
 # nosemgrep: guest-whitelisted-method
 @frappe.whitelist(allow_guest=True)
-@rate_limit(limit=30, seconds=60 * 60)
-def free_coupon_has_tshirt(coupon_id: str) -> bool:
+@rate_limit(limit=10, seconds=60 * 60)
+def get_free_coupon_info(coupon_id: str) -> dict:
     """
-    Tell the free ticket web form whether it has to collect a t-shirt size.
+    Tell the free ticket web form what it needs to know about a coupon:
+    whether it has to collect a t-shirt size, and which event's custom
+    fields to ask for. An unknown coupon returns an empty dict, same shape
+    as a coupon without a t-shirt or event, so the form cannot be looped
+    over to discover valid coupon IDs.
 
-    Rate limit: 20 requests per hour per IP
+    Rate limit: 10 requests per hour per IP
     """
-    return bool(frappe.db.get_value(FREE_TICKET_CODE, coupon_id, "tshirt_included"))
+    coupon = frappe.db.get_value(
+        FREE_TICKET_CODE, coupon_id, ["event", "tshirt_included"], as_dict=True
+    )
+    if not coupon:
+        return {}
+
+    return {
+        "event": coupon.event,
+        "tshirt_included": bool(coupon.tshirt_included),
+    }
 
 
 def _get_approved_speaker_emails_for_event(event: str) -> dict[str, tuple[str, int]]:

--- a/fossunited/api/tickets.py
+++ b/fossunited/api/tickets.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 import frappe
 from frappe import _
 from frappe.rate_limiter import rate_limit
-from frappe.utils import add_days, now_datetime
+from frappe.utils import add_days, cint, now_datetime
 
 from fossunited.doctype_ids import (
     EVENT,
@@ -484,11 +484,24 @@ def get_event_free_codes(event: str):
             "used_count",
             "max_count",
             "is_used",
+            "tshirt_included",
         ],
         order_by="tier asc, creation desc",
     )
 
     return codes
+
+
+# nosemgrep: guest-whitelisted-method
+@frappe.whitelist(allow_guest=True)
+@rate_limit(limit=30, seconds=60 * 60)
+def free_coupon_has_tshirt(coupon_id: str) -> bool:
+    """
+    Tell the free ticket web form whether it has to collect a t-shirt size.
+
+    Rate limit: 20 requests per hour per IP
+    """
+    return bool(frappe.db.get_value(FREE_TICKET_CODE, coupon_id, "tshirt_included"))
 
 
 def _get_approved_speaker_emails_for_event(event: str) -> dict[str, tuple[str, int]]:
@@ -560,7 +573,7 @@ def get_speaker_coupon_preview(event: str) -> dict:
 
 @frappe.whitelist()
 @require_chapter_or_event_member(event_id="event")
-def bulk_create_speaker_coupons(event: str, max_count: int = 1) -> dict:
+def bulk_create_speaker_coupons(event: str, max_count: int = 1, tshirt_included: int = 0) -> dict:
     """
     Idempotently create EventFreeTicketCode docs for approved CFP speakers.
 
@@ -568,6 +581,7 @@ def bulk_create_speaker_coupons(event: str, max_count: int = 1) -> dict:
     """
 
     max_count = int(max_count)
+    tshirt_included = cint(tshirt_included)
     if not 1 <= max_count <= 3:
         frappe.throw(_("max_count must be between 1 and 3"))
 
@@ -584,6 +598,7 @@ def bulk_create_speaker_coupons(event: str, max_count: int = 1) -> dict:
                 "full_name": full_name,
                 "tier": "Speaker/Workshop Host",
                 "max_count": max_count * talk_count,
+                "tshirt_included": tshirt_included,
             }
         ).insert(ignore_permissions=True)
 

--- a/fossunited/fossunited/doctype/event_free_ticket_applications/event_free_ticket_applications.json
+++ b/fossunited/fossunited/doctype/event_free_ticket_applications/event_free_ticket_applications.json
@@ -16,7 +16,8 @@
   "column_break_qzhw",
   "tshirt_size",
   "section_break_kdwt",
-  "event"
+  "event",
+  "custom_fields"
  ],
  "fields": [
   {
@@ -84,11 +85,17 @@
    "fieldtype": "Select",
    "label": "T-shirt Size",
    "options": "\nXS\nS\nM\nL\nXL\n2XL\n3XL\nSkip T-shirt"
+  },
+  {
+   "fieldname": "custom_fields",
+   "fieldtype": "Table",
+   "label": "Custom Field for Ticket",
+   "options": "FOSS Ticket Custom Field"
   }
  ],
  "grid_page_length": 50,
  "links": [],
- "modified": "2026-08-21 12:19:34.429564",
+ "modified": "2026-08-24 12:46:13.722991",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "Event Free Ticket Applications",

--- a/fossunited/fossunited/doctype/event_free_ticket_applications/event_free_ticket_applications.json
+++ b/fossunited/fossunited/doctype/event_free_ticket_applications/event_free_ticket_applications.json
@@ -83,12 +83,12 @@
    "fieldname": "tshirt_size",
    "fieldtype": "Select",
    "label": "T-shirt Size",
-   "options": "\nXS\nS\nM\nL\nXL\n2XL\n3XL"
+   "options": "\nXS\nS\nM\nL\nXL\n2XL\n3XL\nSkip T-shirt"
   }
  ],
  "grid_page_length": 50,
  "links": [],
- "modified": "2026-08-21 10:31:08.944546",
+ "modified": "2026-08-21 12:19:34.429564",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "Event Free Ticket Applications",

--- a/fossunited/fossunited/doctype/event_free_ticket_applications/event_free_ticket_applications.json
+++ b/fossunited/fossunited/doctype/event_free_ticket_applications/event_free_ticket_applications.json
@@ -83,12 +83,12 @@
    "fieldname": "tshirt_size",
    "fieldtype": "Select",
    "label": "T-shirt Size",
-   "options": "XS\nS\nM\nL\nXL\n2XL\n3XL"
+   "options": "\nXS\nS\nM\nL\nXL\n2XL\n3XL"
   }
  ],
  "grid_page_length": 50,
  "links": [],
- "modified": "2026-08-20 20:14:39.706394",
+ "modified": "2026-08-21 10:31:08.944546",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "Event Free Ticket Applications",

--- a/fossunited/fossunited/doctype/event_free_ticket_applications/event_free_ticket_applications.json
+++ b/fossunited/fossunited/doctype/event_free_ticket_applications/event_free_ticket_applications.json
@@ -14,6 +14,7 @@
   "section_break_amhv",
   "coupon_id",
   "column_break_qzhw",
+  "tshirt_size",
   "section_break_kdwt",
   "event"
  ],
@@ -77,11 +78,17 @@
    "fieldtype": "Link",
    "label": "Event",
    "options": "FOSS Chapter Event"
+  },
+  {
+   "fieldname": "tshirt_size",
+   "fieldtype": "Select",
+   "label": "T-shirt Size",
+   "options": "XS\nS\nM\nL\nXL\n2XL\n3XL"
   }
  ],
  "grid_page_length": 50,
  "links": [],
- "modified": "2025-11-04 13:59:27.389137",
+ "modified": "2026-08-20 20:14:39.706394",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "Event Free Ticket Applications",

--- a/fossunited/fossunited/doctype/event_free_ticket_applications/event_free_ticket_applications.py
+++ b/fossunited/fossunited/doctype/event_free_ticket_applications/event_free_ticket_applications.py
@@ -37,7 +37,7 @@ class EventFreeTicketApplications(Document):
         self.validate_email_not_used()
         coupon_data = self.validate_coupon()
         ticket_tier = self.get_ticket_tier(coupon_data)
-        self.create_free_ticket(ticket_tier)
+        self.create_free_ticket(ticket_tier, coupon_data)
         self.update_coupon_usage(coupon_data)
 
     def validate_coupon(self):
@@ -51,7 +51,7 @@ class EventFreeTicketApplications(Document):
         coupon_data = frappe.db.get_value(
             FREE_TICKET_CODE,
             self.coupon_id,
-            ["max_count", "used_count", "tier", "other_tier", "is_used"],
+            ["max_count", "used_count", "tier", "other_tier", "is_used", "tshirt_included"],
             as_dict=True,
         )
 
@@ -61,7 +61,22 @@ class EventFreeTicketApplications(Document):
         if coupon_data.is_used or (coupon_data.used_count >= coupon_data.max_count):
             frappe.throw(_("Reached max count of coupon usage."))
 
+        self.validate_tshirt_size(coupon_data)
+
         return coupon_data
+
+    def validate_tshirt_size(self, coupon_data):
+        """Require a t-shirt size only when the coupon includes a t-shirt.
+
+        The web form hides the field for coupons without a t-shirt, so a size
+        sent for such a coupon is discarded here instead of reaching the ticket.
+        """
+        if not coupon_data.tshirt_included:
+            self.tshirt_size = None
+            return
+
+        if not self.tshirt_size:
+            frappe.throw(_("T-shirt size is required for this coupon."))
 
     def get_ticket_tier(self, coupon_data):
         """Derive ticket tier name from coupon info."""
@@ -69,8 +84,9 @@ class EventFreeTicketApplications(Document):
             return f"{coupon_data.other_tier} Free Pass"
         return f"{coupon_data.tier} Free Pass"
 
-    def create_free_ticket(self, ticket_tier):
+    def create_free_ticket(self, ticket_tier, coupon_data):
         """Create a FOSS Event Ticket for the user."""
+        wants_tshirt = int(coupon_data.tshirt_included or 0)
         try:
             ticket = frappe.get_doc(
                 {
@@ -81,6 +97,8 @@ class EventFreeTicketApplications(Document):
                     "tier": ticket_tier,
                     "designation": self.designation,
                     "organization": self.organization,
+                    "wants_tshirt": wants_tshirt,
+                    "tshirt_size": self.tshirt_size if wants_tshirt else None,
                     "subscribe_chapter_mailing": 1,
                 }
             )

--- a/fossunited/fossunited/doctype/event_free_ticket_applications/event_free_ticket_applications.py
+++ b/fossunited/fossunited/doctype/event_free_ticket_applications/event_free_ticket_applications.py
@@ -7,6 +7,8 @@ from frappe.model.document import Document
 
 from fossunited.doctype_ids import EVENT_TICKET, FREE_TICKET_CODE
 
+TSHIRT_SKIPPED = "Skip T-shirt"
+
 
 class EventFreeTicketApplications(Document):
     # begin: auto-generated types
@@ -23,7 +25,7 @@ class EventFreeTicketApplications(Document):
         event: DF.Link | None
         full_name: DF.Data
         organization: DF.Data | None
-        tshirt_size: DF.Literal["", "XS", "S", "M", "L", "XL", "2XL", "3XL"]
+        tshirt_size: DF.Literal["", "XS", "S", "M", "L", "XL", "2XL", "3XL", "Skip T-shirt"]
     # end: auto-generated types
 
     def before_insert(self):
@@ -66,17 +68,23 @@ class EventFreeTicketApplications(Document):
         return coupon_data
 
     def validate_tshirt_size(self, coupon_data):
-        """Require a t-shirt size only when the coupon includes a t-shirt.
+        """Require a t-shirt choice only when the coupon includes a t-shirt.
 
         The web form hides the field for coupons without a t-shirt, so a size
         sent for such a coupon is discarded here instead of reaching the ticket.
+        Claimants who do not want one pick "Skip T-shirt", which stays on the
+        application as a deliberate choice but leaves the ticket without a size.
         """
         if not coupon_data.tshirt_included:
             self.tshirt_size = None
             return
 
         if not self.tshirt_size:
-            frappe.throw(_("T-shirt size is required for this coupon."))
+            frappe.throw(
+                _("Select a t-shirt size, or choose {0} if you do not want one.").format(
+                    _(TSHIRT_SKIPPED)
+                )
+            )
 
     def get_ticket_tier(self, coupon_data):
         """Derive ticket tier name from coupon info."""
@@ -86,7 +94,9 @@ class EventFreeTicketApplications(Document):
 
     def create_free_ticket(self, ticket_tier, coupon_data):
         """Create a FOSS Event Ticket for the user."""
-        wants_tshirt = int(coupon_data.tshirt_included or 0)
+        wants_tshirt = int(
+            bool(coupon_data.tshirt_included) and self.tshirt_size != TSHIRT_SKIPPED
+        )
         try:
             ticket = frappe.get_doc(
                 {

--- a/fossunited/fossunited/doctype/event_free_ticket_applications/event_free_ticket_applications.py
+++ b/fossunited/fossunited/doctype/event_free_ticket_applications/event_free_ticket_applications.py
@@ -5,7 +5,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
-from fossunited.doctype_ids import EVENT, EVENT_TICKET, FREE_TICKET_CODE
+from fossunited.doctype_ids import EVENT_TICKET, FREE_TICKET_CODE
 
 TSHIRT_SKIPPED = "Skip T-shirt"
 
@@ -43,7 +43,6 @@ class EventFreeTicketApplications(Document):
 
         self.validate_email_not_used()
         coupon_data = self.validate_coupon()
-        self.validate_custom_fields()
         ticket_tier = self.get_ticket_tier(coupon_data)
         self.create_free_ticket(ticket_tier, coupon_data)
         self.update_coupon_usage(coupon_data)
@@ -91,26 +90,6 @@ class EventFreeTicketApplications(Document):
                     _(TSHIRT_SKIPPED)
                 )
             )
-
-    def validate_custom_fields(self):
-        """Ensure every mandatory custom field defined on the event is answered.
-
-        The web form prefills one row per event custom field into
-        `custom_fields`, mirroring how tickets store answers, so a missing
-        mandatory field means the guest cleared it or bypassed the form.
-        """
-        mandatory_fields = frappe.get_all(
-            "FOSS Event Field",
-            filters={"parent": self.event, "parenttype": EVENT, "mandatory": 1},
-            pluck="field_name",
-        )
-        if not mandatory_fields:
-            return
-
-        answered = {row.field_name for row in self.custom_fields if row.field_name and row.data}
-        missing = [f for f in mandatory_fields if f not in answered]
-        if missing:
-            frappe.throw(_("Please fill the required field(s): {0}").format(", ".join(missing)))
 
     def get_ticket_tier(self, coupon_data):
         """Derive ticket tier name from coupon info."""

--- a/fossunited/fossunited/doctype/event_free_ticket_applications/event_free_ticket_applications.py
+++ b/fossunited/fossunited/doctype/event_free_ticket_applications/event_free_ticket_applications.py
@@ -5,7 +5,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
-from fossunited.doctype_ids import EVENT_TICKET, FREE_TICKET_CODE
+from fossunited.doctype_ids import EVENT, EVENT_TICKET, FREE_TICKET_CODE
 
 TSHIRT_SKIPPED = "Skip T-shirt"
 
@@ -19,7 +19,12 @@ class EventFreeTicketApplications(Document):
     if TYPE_CHECKING:
         from frappe.types import DF
 
+        from fossunited.ticketing.doctype.foss_ticket_custom_field.foss_ticket_custom_field import (
+            FOSSTicketCustomField,
+        )
+
         coupon_id: DF.Link
+        custom_fields: DF.Table[FOSSTicketCustomField]
         designation: DF.Data | None
         email: DF.Data
         event: DF.Link | None
@@ -38,6 +43,7 @@ class EventFreeTicketApplications(Document):
 
         self.validate_email_not_used()
         coupon_data = self.validate_coupon()
+        self.validate_custom_fields()
         ticket_tier = self.get_ticket_tier(coupon_data)
         self.create_free_ticket(ticket_tier, coupon_data)
         self.update_coupon_usage(coupon_data)
@@ -86,6 +92,26 @@ class EventFreeTicketApplications(Document):
                 )
             )
 
+    def validate_custom_fields(self):
+        """Ensure every mandatory custom field defined on the event is answered.
+
+        The web form prefills one row per event custom field into
+        `custom_fields`, mirroring how tickets store answers, so a missing
+        mandatory field means the guest cleared it or bypassed the form.
+        """
+        mandatory_fields = frappe.get_all(
+            "FOSS Event Field",
+            filters={"parent": self.event, "parenttype": EVENT, "mandatory": 1},
+            pluck="field_name",
+        )
+        if not mandatory_fields:
+            return
+
+        answered = {row.field_name for row in self.custom_fields if row.field_name and row.data}
+        missing = [f for f in mandatory_fields if f not in answered]
+        if missing:
+            frappe.throw(_("Please fill the required field(s): {0}").format(", ".join(missing)))
+
     def get_ticket_tier(self, coupon_data):
         """Derive ticket tier name from coupon info."""
         if coupon_data.tier == "Other":
@@ -110,6 +136,11 @@ class EventFreeTicketApplications(Document):
                     "wants_tshirt": wants_tshirt,
                     "tshirt_size": self.tshirt_size if wants_tshirt else None,
                     "subscribe_chapter_mailing": 1,
+                    "custom_fields": [
+                        {"field_name": row.field_name, "data": row.data}
+                        for row in self.custom_fields
+                        if row.field_name and row.data
+                    ],
                 }
             )
             ticket.insert(ignore_permissions=True)

--- a/fossunited/fossunited/doctype/event_free_ticket_applications/event_free_ticket_applications.py
+++ b/fossunited/fossunited/doctype/event_free_ticket_applications/event_free_ticket_applications.py
@@ -23,6 +23,7 @@ class EventFreeTicketApplications(Document):
         event: DF.Link | None
         full_name: DF.Data
         organization: DF.Data | None
+        tshirt_size: DF.Literal["XS", "S", "M", "L", "XL", "2XL", "3XL"]
     # end: auto-generated types
 
     def before_insert(self):

--- a/fossunited/fossunited/doctype/event_free_ticket_applications/event_free_ticket_applications.py
+++ b/fossunited/fossunited/doctype/event_free_ticket_applications/event_free_ticket_applications.py
@@ -23,7 +23,7 @@ class EventFreeTicketApplications(Document):
         event: DF.Link | None
         full_name: DF.Data
         organization: DF.Data | None
-        tshirt_size: DF.Literal["XS", "S", "M", "L", "XL", "2XL", "3XL"]
+        tshirt_size: DF.Literal["", "XS", "S", "M", "L", "XL", "2XL", "3XL"]
     # end: auto-generated types
 
     def before_insert(self):

--- a/fossunited/fossunited/doctype/event_free_ticket_applications/test_event_free_ticket_applications.py
+++ b/fossunited/fossunited/doctype/event_free_ticket_applications/test_event_free_ticket_applications.py
@@ -196,20 +196,6 @@ class TestEventFreeTicketApplications(FrappeTestCase):
         self.assertEqual(ticket.custom_fields[0].data, "octocat")
         frappe.delete_doc(EVENT, event.name, force=True)
 
-    def test_missing_mandatory_custom_field_throws_error(self):
-        event = FOSSChapterEventFactory.create(
-            chapter=self.chapter.name,
-            custom_fields=[
-                {"field_name": "github_handle", "label": "GitHub Handle", "mandatory": 1}
-            ],
-        )
-        coupon = FreeTicketCodeFactory.create(event=event.name)
-        with self.assertRaises(frappe.ValidationError):
-            FreeTicketApplicationFactory.create(coupon_id=coupon.name, event=event.name)
-
-        self.assertFalse(frappe.db.exists(EVENT_TICKET, {"event": event.name}))
-        frappe.delete_doc(EVENT, event.name, force=True)
-
     def test_second_application_after_max_count(self):
         coupon = FreeTicketCodeFactory.create(event=self.event.name, max_count=1, used_count=0)
         FreeTicketApplicationFactory.create(coupon_id=coupon.name, event=self.event.name)

--- a/fossunited/fossunited/doctype/event_free_ticket_applications/test_event_free_ticket_applications.py
+++ b/fossunited/fossunited/doctype/event_free_ticket_applications/test_event_free_ticket_applications.py
@@ -180,6 +180,7 @@ class TestEventFreeTicketApplications(FrappeTestCase):
 
     def test_custom_field_answer_passed_to_ticket(self):
         event = FOSSChapterEventFactory.create(
+            "with_paid_tickets",
             chapter=self.chapter.name,
             custom_fields=[{"field_name": "github_handle", "label": "GitHub Handle"}],
         )

--- a/fossunited/fossunited/doctype/event_free_ticket_applications/test_event_free_ticket_applications.py
+++ b/fossunited/fossunited/doctype/event_free_ticket_applications/test_event_free_ticket_applications.py
@@ -66,6 +66,22 @@ class TestEventFreeTicketApplications(FrappeTestCase):
         self.assertEqual(ticket.wants_tshirt, 1)
         self.assertEqual(ticket.tshirt_size, "L")
 
+    def test_skip_tshirt_leaves_ticket_without_size(self):
+        coupon = FreeTicketCodeFactory.create(event=self.event.name, tshirt_included=1)
+        application = FreeTicketApplicationFactory.create(
+            coupon_id=coupon.name, event=self.event.name, tshirt_size="Skip T-shirt"
+        )
+
+        # the choice stays on the application, but the ticket gets no t-shirt
+        application.reload()
+        self.assertEqual(application.tshirt_size, "Skip T-shirt")
+
+        ticket = frappe.get_doc(
+            EVENT_TICKET, {"event": self.event.name, "email": application.email}
+        )
+        self.assertEqual(ticket.wants_tshirt, 0)
+        self.assertIsNone(ticket.tshirt_size)
+
     def test_tshirt_coupon_without_size_throws_error(self):
         coupon = FreeTicketCodeFactory.create(event=self.event.name, tshirt_included=1)
         with self.assertRaises(frappe.ValidationError):

--- a/fossunited/fossunited/doctype/event_free_ticket_applications/test_event_free_ticket_applications.py
+++ b/fossunited/fossunited/doctype/event_free_ticket_applications/test_event_free_ticket_applications.py
@@ -51,6 +51,44 @@ class TestEventFreeTicketApplications(FrappeTestCase):
         self.assertIsNone(ticket.designation)
         self.assertIsNone(ticket.organization)
         self.assertEqual(ticket.subscribe_chapter_mailing, 1)
+        self.assertEqual(ticket.wants_tshirt, 0)
+        self.assertIsNone(ticket.tshirt_size)
+
+    def test_tshirt_coupon_passes_size_to_ticket(self):
+        coupon = FreeTicketCodeFactory.create(event=self.event.name, tshirt_included=1)
+        application = FreeTicketApplicationFactory.create(
+            coupon_id=coupon.name, event=self.event.name, tshirt_size="L"
+        )
+
+        ticket = frappe.get_doc(
+            EVENT_TICKET, {"event": self.event.name, "email": application.email}
+        )
+        self.assertEqual(ticket.wants_tshirt, 1)
+        self.assertEqual(ticket.tshirt_size, "L")
+
+    def test_tshirt_coupon_without_size_throws_error(self):
+        coupon = FreeTicketCodeFactory.create(event=self.event.name, tshirt_included=1)
+        with self.assertRaises(frappe.ValidationError):
+            FreeTicketApplicationFactory.create(coupon_id=coupon.name, event=self.event.name)
+
+        self.assertFalse(frappe.db.exists(EVENT_TICKET, {"event": self.event.name}))
+        coupon.reload()
+        self.assertEqual(coupon.used_count, 0)
+
+    def test_size_is_dropped_when_coupon_has_no_tshirt(self):
+        coupon = FreeTicketCodeFactory.create(event=self.event.name, tshirt_included=0)
+        application = FreeTicketApplicationFactory.create(
+            coupon_id=coupon.name, event=self.event.name, tshirt_size="XL"
+        )
+
+        application.reload()
+        self.assertIsNone(application.tshirt_size)
+
+        ticket = frappe.get_doc(
+            EVENT_TICKET, {"event": self.event.name, "email": application.email}
+        )
+        self.assertEqual(ticket.wants_tshirt, 0)
+        self.assertIsNone(ticket.tshirt_size)
 
     def test_coupon_usage_increments(self):
         coupon = FreeTicketCodeFactory.create(event=self.event.name, max_count=5, used_count=0)

--- a/fossunited/fossunited/doctype/event_free_ticket_applications/test_event_free_ticket_applications.py
+++ b/fossunited/fossunited/doctype/event_free_ticket_applications/test_event_free_ticket_applications.py
@@ -178,6 +178,38 @@ class TestEventFreeTicketApplications(FrappeTestCase):
                 ticket = frappe.get_last_doc(EVENT_TICKET)
                 self.assertEqual(ticket.tier, f"{tier} Free Pass")
 
+    def test_custom_field_answer_passed_to_ticket(self):
+        event = FOSSChapterEventFactory.create(
+            chapter=self.chapter.name,
+            custom_fields=[{"field_name": "github_handle", "label": "GitHub Handle"}],
+        )
+        coupon = FreeTicketCodeFactory.create(event=event.name)
+        application = FreeTicketApplicationFactory.create(
+            coupon_id=coupon.name,
+            event=event.name,
+            custom_fields=[{"field_name": "github_handle", "data": "octocat"}],
+        )
+
+        ticket = frappe.get_doc(EVENT_TICKET, {"event": event.name, "email": application.email})
+        self.assertEqual(len(ticket.custom_fields), 1)
+        self.assertEqual(ticket.custom_fields[0].field_name, "github_handle")
+        self.assertEqual(ticket.custom_fields[0].data, "octocat")
+        frappe.delete_doc(EVENT, event.name, force=True)
+
+    def test_missing_mandatory_custom_field_throws_error(self):
+        event = FOSSChapterEventFactory.create(
+            chapter=self.chapter.name,
+            custom_fields=[
+                {"field_name": "github_handle", "label": "GitHub Handle", "mandatory": 1}
+            ],
+        )
+        coupon = FreeTicketCodeFactory.create(event=event.name)
+        with self.assertRaises(frappe.ValidationError):
+            FreeTicketApplicationFactory.create(coupon_id=coupon.name, event=event.name)
+
+        self.assertFalse(frappe.db.exists(EVENT_TICKET, {"event": event.name}))
+        frappe.delete_doc(EVENT, event.name, force=True)
+
     def test_second_application_after_max_count(self):
         coupon = FreeTicketCodeFactory.create(event=self.event.name, max_count=1, used_count=0)
         FreeTicketApplicationFactory.create(coupon_id=coupon.name, event=self.event.name)

--- a/fossunited/fossunited/doctype/event_free_ticket_code/event_free_ticket_code.json
+++ b/fossunited/fossunited/doctype/event_free_ticket_code/event_free_ticket_code.json
@@ -11,6 +11,7 @@
   "mapped_email",
   "full_name",
   "max_count",
+  "tshirt_included",
   "used_count",
   "tier",
   "company",
@@ -79,11 +80,18 @@
    "fieldtype": "Data",
    "label": "Other Tier",
    "mandatory_depends_on": "eval:doc.tier=='Other'"
+  },
+  {
+   "default": "0",
+   "description": "If free pass has t-shirt included to give. Mostly to collect t-shirt size while claiming.",
+   "fieldname": "tshirt_included",
+   "fieldtype": "Check",
+   "label": "T-shirt Included?"
   }
  ],
  "grid_page_length": 50,
  "links": [],
- "modified": "2025-11-04 23:05:04.412179",
+ "modified": "2026-08-20 20:11:59.723532",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "Event Free Ticket Code",

--- a/fossunited/fossunited/doctype/event_free_ticket_code/event_free_ticket_code.py
+++ b/fossunited/fossunited/doctype/event_free_ticket_code/event_free_ticket_code.py
@@ -33,6 +33,7 @@ class EventFreeTicketCode(Document):
             "Booth Manager",
             "Other",
         ]
+        tshirt_included: DF.Check
         used_count: DF.Int
     # end: auto-generated types
 

--- a/fossunited/tests/test_speaker_coupons.py
+++ b/fossunited/tests/test_speaker_coupons.py
@@ -3,6 +3,7 @@ from frappe.tests.utils import FrappeTestCase
 
 from fossunited.api.tickets import (
     bulk_create_speaker_coupons,
+    free_coupon_has_tshirt,
     get_speaker_coupon_preview,
 )
 from fossunited.doctype_ids import CHAPTER, EVENT, FREE_TICKET_CODE, PROPOSAL
@@ -90,6 +91,43 @@ class TestSpeakerCoupons(FrappeTestCase):
             "max_count",
         )
         self.assertEqual(int(max_count), 4)  # 2 per talk * 2 talks
+
+    def test_tshirt_included_flag_is_stored_on_coupon(self):
+        self._approved([_speaker("frank@test.com")])
+        frappe.set_user(self.team_member.name)
+
+        bulk_create_speaker_coupons(event=self.event.name, max_count=1, tshirt_included=1)
+
+        tshirt_included = frappe.db.get_value(
+            FREE_TICKET_CODE,
+            {"event": self.event.name, "mapped_email": "frank@test.com"},
+            "tshirt_included",
+        )
+        self.assertEqual(int(tshirt_included), 1)
+
+    def test_tshirt_included_defaults_to_off(self):
+        self._approved([_speaker("grace@test.com")])
+        frappe.set_user(self.team_member.name)
+
+        bulk_create_speaker_coupons(event=self.event.name, max_count=1)
+
+        tshirt_included = frappe.db.get_value(
+            FREE_TICKET_CODE,
+            {"event": self.event.name, "mapped_email": "grace@test.com"},
+            "tshirt_included",
+        )
+        self.assertEqual(int(tshirt_included), 0)
+
+    def test_coupon_lookup_reports_tshirt_requirement(self):
+        coupon = FreeTicketCodeFactory.create(event=self.event.name, tshirt_included=1)
+        self.assertTrue(free_coupon_has_tshirt(coupon_id=coupon.name))
+
+    def test_coupon_lookup_false_without_tshirt(self):
+        coupon = FreeTicketCodeFactory.create(event=self.event.name, tshirt_included=0)
+        self.assertFalse(free_coupon_has_tshirt(coupon_id=coupon.name))
+
+    def test_coupon_lookup_false_for_unknown_coupon(self):
+        self.assertFalse(free_coupon_has_tshirt(coupon_id="NOT-A-COUPON"))
 
     def test_idempotent_skips_existing(self):
         self._approved([_speaker("carol@test.com")])

--- a/fossunited/tests/test_speaker_coupons.py
+++ b/fossunited/tests/test_speaker_coupons.py
@@ -3,7 +3,7 @@ from frappe.tests.utils import FrappeTestCase
 
 from fossunited.api.tickets import (
     bulk_create_speaker_coupons,
-    free_coupon_has_tshirt,
+    get_free_coupon_info,
     get_speaker_coupon_preview,
 )
 from fossunited.doctype_ids import CHAPTER, EVENT, FREE_TICKET_CODE, PROPOSAL
@@ -120,14 +120,16 @@ class TestSpeakerCoupons(FrappeTestCase):
 
     def test_coupon_lookup_reports_tshirt_requirement(self):
         coupon = FreeTicketCodeFactory.create(event=self.event.name, tshirt_included=1)
-        self.assertTrue(free_coupon_has_tshirt(coupon_id=coupon.name))
+        info = get_free_coupon_info(coupon_id=coupon.name)
+        self.assertEqual(info["event"], self.event.name)
+        self.assertTrue(info["tshirt_included"])
 
     def test_coupon_lookup_false_without_tshirt(self):
         coupon = FreeTicketCodeFactory.create(event=self.event.name, tshirt_included=0)
-        self.assertFalse(free_coupon_has_tshirt(coupon_id=coupon.name))
+        self.assertFalse(get_free_coupon_info(coupon_id=coupon.name)["tshirt_included"])
 
-    def test_coupon_lookup_false_for_unknown_coupon(self):
-        self.assertFalse(free_coupon_has_tshirt(coupon_id="NOT-A-COUPON"))
+    def test_coupon_lookup_empty_for_unknown_coupon(self):
+        self.assertEqual(get_free_coupon_info(coupon_id="NOT-A-COUPON"), {})
 
     def test_idempotent_skips_existing(self):
         self._approved([_speaker("carol@test.com")])


### PR DESCRIPTION
- Fix #1706 

- Most paid events might give out t-shirts to Speakers and volunteers.

When we give free coupon we fail to collect t-shirt size from them to order properly.
So coupon gets checkbox if t-shirt included and application ask with select option

- Web form will only show this option if coupon includes t-shirt. Thus had to introduce an api which simply says true or false for t-shirt

- We've controller to avoid anyone entering t-shirt even if coupon does not have.

- Dashboard create coupon showing t-shirt checkbox
<img width="330" height="325" alt="image" src="https://github.com/user-attachments/assets/b4550179-9ce4-4ae5-a182-ba8ced2405d3" />
