### PR TITLE
doctype(event-volunteer): ask for t-shirt size in form if provided

### DIFF
--- a/fossunited/volunteering/doctype/event_volunteer/event_volunteer.json
+++ b/fossunited/volunteering/doctype/event_volunteer/event_volunteer.json
@@ -21,6 +21,7 @@
     "video_url",
     "column_break_uknn",
     "bio",
+    "tshirt_size",
     "photo",
     "affirmation_for_commitment",
     "past_experience"
@@ -145,10 +146,18 @@
       "in_standard_filter": 1,
       "label": "Volunteer Status",
       "options": "Accepted\nWaitlisted\nRejected"
+    },
+    {
+      "default": "Skip T-shirt",
+      "description": "To get sizes for pre-order if event includes volunteer t-shirts",
+      "fieldname": "tshirt_size",
+      "fieldtype": "Select",
+      "label": "T-shirt size",
+      "options": "XS\nS\nM\nL\nXL\n2XL\n3XL\nSkip T-shirt"
     }
   ],
   "links": [],
-  "modified": "2026-05-19 18:28:34.983497",
+  "modified": "2026-08-24 19:15:39.206291",
   "modified_by": "Administrator",
   "module": "Volunteering",
   "name": "Event Volunteer",

--- a/fossunited/volunteering/doctype/event_volunteer/event_volunteer.py
+++ b/fossunited/volunteering/doctype/event_volunteer/event_volunteer.py
@@ -28,6 +28,7 @@ class EventVolunteer(Document):
         past_experience: DF.LongText | None
         phone_number: DF.Data | None
         photo: DF.AttachImage | None
+        tshirt_size: DF.Literal["XS", "S", "M", "L", "XL", "2XL", "3XL", "Skip T-shirt"]
         video_url: DF.Data | None
         volunteer_as: DF.Literal[
             "Marketing",


### PR DESCRIPTION
* default is kept as "Skip" so nothing filled is anyway considered skipped

* Indiafoss and other events might want to collect sizes for logistics and pre-order thus ask in form filling itself

* now tshirt_size field is in 3 places: Ticket, free-ticket application and volunteer form

Opts remain universal:

```
XS
S
M
L
XL
2XL
3XL
Skip T-shirt
```