### PR TITLE
fix(event): go schedule page with button rather than heading

### DIFF
--- a/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
+++ b/fossunited/chapters/doctype/foss_chapter_event/templates/foss_chapter_event.html
@@ -404,7 +404,7 @@
                       {% endif %}
                     {% elif schedule_data %}
                       <a
-                        href="#schedule-heading"
+                        href="/{{ doc.route }}/schedule"
                         class="v3-btn v3-btn-primary"
                         aria-label="View event schedule"
                       >
@@ -414,7 +414,7 @@
                     {% endif %}
                   {% elif status_concluded and schedule_data %}
                     <a
-                      href="#schedule-heading"
+                      href="/{{ doc.route }}/schedule"
                       class="v3-btn v3-btn-primary"
                       aria-label="View event schedule"
                     >


### PR DESCRIPTION
* schedule button link used go down to agenda section but is better to go to dedicated schedule page itself

Minor change, no effect.
