### PR TITLE
chore: add Bruno API test runner to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,16 @@ repos:
   #       pass_filenames: true
   #       args: [--output=line, --minAlertLevel=error]
 
+  - repo: local
+    hooks:
+      - id: bruno-tests
+        name: Bruno API e2e tests
+        entry: bash development/run_bruno_tests.sh
+        language: system
+        pass_filenames: true
+        files: '(^fossunited/api/.*\.py$|^bruno-collection/.*\.yml$)'
+        stages: [pre-commit]
+
   - repo: https://github.com/semgrep/pre-commit
     rev: 'v1.173.0'
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
         entry: bash development/run_bruno_tests.sh
         language: system
         pass_filenames: true
-        files: '(^fossunited/api/.*\.py$|^bruno-collection/.*\.yml$)'
+        files: '(^fossunited/api/.*\.py$|^bruno-collection/.*\.(bru|yml)$)'
         stages: [pre-commit]
 
   - repo: https://github.com/semgrep/pre-commit

--- a/bruno-collection/README.md
+++ b/bruno-collection/README.md
@@ -1,0 +1,96 @@
+# Bruno API Tests
+
+End-to-end security tests for the fossunited API layer, written in
+[Bruno](https://www.usebruno.com/) `.bru` format.
+
+## Prerequisites
+
+1. **Frappe dev server** running at `http://foss.localhost`
+2. **Seed data** populated via `development/seed.py`:
+   ```bash
+   # Frappe Manager
+   bench execute development.seed.seed
+
+   # Docker / devcontainer
+   docker exec -w /workspace/development/fossu-bench/sites \
+     devcontainer-frappe-1 ../env/bin/python /workspace/development/run_seed.py
+   ```
+3. **Bruno CLI** (`@usebruno/cli`) installed:
+   ```bash
+   npm install -g @usebruno/cli
+   # or use npx (auto-installs)
+   ```
+
+## Running tests
+
+From the `bruno-collection/` directory:
+
+```bash
+# Run a single folder
+npx @usebruno/cli run api/hackathon --env local-development
+
+# Run all test folders
+for folder in api/*/; do
+  npx @usebruno/cli run "$folder" --env local-development
+done
+```
+
+Tests also run automatically via the pre-commit hook when Python API files
+or `.bru` test files are changed (see `development/run_bruno_tests.sh`).
+
+## Environment variables
+
+Edit `environments/local-development.bru` to match your local seed data.
+Key variables:
+
+| Variable | Description | Source |
+|---|---|---|
+| `base` | Frappe API base URL | site config |
+| `hackathon_id` | FOSS Hackathon docname | `MOCK-FOSSIT Hackathon` from seed |
+| `hackathon_permalink` | Hackathon permalink slug | seed `HACKATHON_CFG` |
+| `rsvp_form_id` | FOSS Event RSVP docname | seed `_create_rsvps` |
+| `rsvp_submission_own` | RSVP submission by attendee-1 | seed |
+| `rsvp_submission_other` | RSVP submission by attendee-2 | seed |
+| `cfp_submission_id` | CFP submission docname | seed `_create_cfps` |
+| `newsletter_id` | Newsletter Campaign docname | manual or seed |
+| `attendee_email` | Test attendee login | `mock-attendee-1@example.com` |
+| `attacker_email` | Second user for ownership tests | `mock-attendee-2@example.com` |
+| `chapter_lead_email` | Chapter team member login | `mock-bangalore-lead@example.com` |
+
+All test user passwords default to `password` (set by `development/seed.py`).
+
+### Finding seed data IDs
+
+After running the seed script, look up docnames:
+
+```bash
+bench execute frappe.client.get_list \
+  --args '{"doctype":"FOSS Hackathon","filters":{"hackathon_name":["like","MOCK-%"]},"fields":["name","hackathon_name","permalink"]}'
+```
+
+Or query the database directly:
+
+```sql
+SELECT name, hackathon_name, permalink FROM `tabFOSS Hackathon`
+  WHERE hackathon_name LIKE 'MOCK-%';
+```
+
+## Test folder structure
+
+```
+bruno-collection/
+├── environments/
+│   └── local-development.bru    # env vars for local dev
+├── api/
+│   ├── hackathon/               # Group 2: field exposure
+│   ├── forms/                   # Group 3: auth checks on CFP/forms
+│   ├── dashboard/               # Group 4: dashboard field exposure
+│   ├── emailing/                # Group 4: campaign field whitelist
+│   ├── rsvp/                    # Group 5: mass assignment, ownership
+│   └── profile/                 # Group 5: path traversal
+├── bruno.json                   # Bruno project config
+└── README.md
+```
+
+Each folder has a `folder.bru` for shared config (pre-request scripts for
+session cookies) and numbered test files that run in sequence.

--- a/bruno-collection/environments/local-development.bru
+++ b/bruno-collection/environments/local-development.bru
@@ -1,0 +1,18 @@
+vars {
+  base: http://foss.localhost/api
+  admin_email: administrator
+  admin_password: admin
+  attendee_email: mock-attendee-1@example.com
+  attendee_password: password
+  attacker_email: mock-attendee-2@example.com
+  attacker_password: password
+  chapter_lead_email: mock-bangalore-lead@example.com
+  chapter_lead_password: password
+  hackathon_id: nd21rhrn28
+  hackathon_permalink: mock-fossit-hackathon
+  rsvp_form_id: ncji6bvvos
+  rsvp_submission_own: ncq0qk3842
+  rsvp_submission_other: ncq5qfpgcn
+  cfp_submission_id: nd1ei5lupv
+  newsletter_id: 5zi7mkxcbz
+}

--- a/bruno-collection/environments/local-development.yml
+++ b/bruno-collection/environments/local-development.yml
@@ -1,0 +1,15 @@
+name: local-development
+variables:
+- name: base
+  value: 'http://foss.localhost/api'
+- name: auth_token
+  value: '{{process.env.auth_token}}'
+- name: chapter_lead_email
+  value: 'mock-bangalore-lead@example.com'
+- name: chapter_lead_password
+  value: 'password'
+- name: attendee_email
+  value: 'mock-attendee-1@example.com'
+- name: attendee_password
+  value: 'password'
+color: '#22c55e'

--- a/development/run_bruno_tests.sh
+++ b/development/run_bruno_tests.sh
@@ -49,7 +49,7 @@ fi
 # Check if Frappe server is reachable
 if ! curl -sf --max-time 3 "$BASE_URL/method/frappe.ping" > /dev/null 2>&1; then
   echo "⚠  Frappe server not reachable at $BASE_URL — skipping Bruno tests"
-  echo "   Start the server and run manually: npx bru run bruno-collection/<folder> --env $ENV"
+  echo "   Start the server and run manually: npx @usebruno/cli run bruno-collection/<folder> --env $ENV"
   exit 0
 fi
 
@@ -60,7 +60,7 @@ for folder in "${FOLDERS_TO_RUN[@]}"; do
     continue
   fi
   echo "▶ Running Bruno tests: $folder"
-  if ! npx bru run "$folder_path" --env "$ENV"; then
+  if ! npx @usebruno/cli run "$folder_path" --env "$ENV"; then
     echo "✗ FAILED: $folder"
     FAILED=1
   fi

--- a/development/run_bruno_tests.sh
+++ b/development/run_bruno_tests.sh
@@ -31,7 +31,7 @@ for file in "$@"; do
   fi
 
   # If a Bruno test file changed, queue its parent folder
-  if [[ "$file" == "$BRUNO_DIR/"* && "$file" == *.yml ]]; then
+  if [[ "$file" == "$BRUNO_DIR/"* && ( "$file" == *.bru || "$file" == *.yml ) ]]; then
     folder=$(dirname "$file" | sed "s|^$BRUNO_DIR/||")
     if [[ "$folder" != "environments" && "$folder" != "." ]]; then
       FOLDERS_TO_RUN+=("$folder")

--- a/development/run_bruno_tests.sh
+++ b/development/run_bruno_tests.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Maps changed Python API files and Bruno test files to the Bruno folders
+# that need to run. Skips gracefully if the Frappe server is unreachable.
+
+BRUNO_DIR="bruno-collection"
+ENV="local-development"
+BASE_URL="http://foss.localhost/api"
+
+# Python module → Bruno test folder mapping
+declare -A API_MAP=(
+  ["fossunited/api/tickets.py"]="api/tickets"
+  ["fossunited/api/checkins.py"]="api/checkins"
+  ["fossunited/api/hackathon.py"]="api/hackathon"
+  ["fossunited/api/cfp.py"]="api/cfp"
+  ["fossunited/api/proposal.py"]="api/proposal"
+  ["fossunited/api/rsvp.py"]="api/rsvp"
+  ["fossunited/api/dashboard.py"]="api/dashboard"
+  ["fossunited/api/emailing.py"]="api/emailing"
+  ["fossunited/api/profile.py"]="api/profile"
+  ["fossunited/api/schedule.py"]="api/schedule"
+)
+
+FOLDERS_TO_RUN=()
+
+for file in "$@"; do
+  # If a Python API file changed, queue its Bruno folder
+  if [[ -v "API_MAP[$file]" ]]; then
+    FOLDERS_TO_RUN+=("${API_MAP[$file]}")
+  fi
+
+  # If a Bruno test file changed, queue its parent folder
+  if [[ "$file" == "$BRUNO_DIR/"* && "$file" == *.yml ]]; then
+    folder=$(dirname "$file" | sed "s|^$BRUNO_DIR/||")
+    if [[ "$folder" != "environments" && "$folder" != "." ]]; then
+      FOLDERS_TO_RUN+=("$folder")
+    fi
+  fi
+done
+
+# Deduplicate
+readarray -t FOLDERS_TO_RUN < <(printf '%s\n' "${FOLDERS_TO_RUN[@]}" | sort -u)
+
+if [[ ${#FOLDERS_TO_RUN[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+# Check if Frappe server is reachable
+if ! curl -sf --max-time 3 "$BASE_URL/method/frappe.ping" > /dev/null 2>&1; then
+  echo "⚠  Frappe server not reachable at $BASE_URL — skipping Bruno tests"
+  echo "   Start the server and run manually: npx bru run bruno-collection/<folder> --env $ENV"
+  exit 0
+fi
+
+FAILED=0
+for folder in "${FOLDERS_TO_RUN[@]}"; do
+  folder_path="$BRUNO_DIR/$folder"
+  if [[ ! -d "$folder_path" ]]; then
+    continue
+  fi
+  echo "▶ Running Bruno tests: $folder"
+  if ! npx bru run "$folder_path" --env "$ENV"; then
+    echo "✗ FAILED: $folder"
+    FAILED=1
+  fi
+done
+
+if [[ $FAILED -ne 0 ]]; then
+  echo ""
+  echo "Bruno tests failed. Fix the issues above before committing."
+  exit 1
+fi
+
+echo "✓ All Bruno tests passed"

--- a/development/run_bruno_tests.sh
+++ b/development/run_bruno_tests.sh
@@ -60,7 +60,7 @@ for folder in "${FOLDERS_TO_RUN[@]}"; do
     continue
   fi
   echo "▶ Running Bruno tests: $folder"
-  if ! npx @usebruno/cli run "$folder_path" --env "$ENV"; then
+  if ! (cd "$BRUNO_DIR" && npx @usebruno/cli run "$folder" --env "$ENV"); then
     echo "✗ FAILED: $folder"
     FAILED=1
   fi

--- a/docs/docs/development.md
+++ b/docs/docs/development.md
@@ -284,6 +284,7 @@ To automatically run linters before commits:
 
 - We use [ruff](https://docs.astral.sh/ruff/) for linting python files. It is recommended to use [prettier](https://prettier.io/) for formatting HTML, CSS & Vue files.
 - [Vale](https://vale.sh) is used for spell check and grammar check for docs content.
+- [Bruno CLI](https://docs.usebruno.com/testing/cli) runs API e2e tests when Python API files or `.bru` test files change.
 
 
 ```sh
@@ -292,6 +293,52 @@ pre-commit install
 ```
 
 Or use [uv](https://github.com/astral-sh/uv) as an alternative Python package manager.
+
+---
+
+## Bruno API Tests
+
+The `bruno-collection/` directory contains end-to-end API tests written in
+[Bruno](https://www.usebruno.com/) `.bru` format. These tests verify security
+hardening (field exposure, auth checks, mass assignment prevention, path
+traversal) against a running Frappe instance with seed data.
+
+### Setup
+
+1. Seed your dev site (see [Seed Script](#seed-script) above).
+2. Install Bruno CLI:
+   ```sh
+   npm install -g @usebruno/cli
+   ```
+
+### Running Tests
+
+From the `bruno-collection/` directory:
+
+```sh
+# Run a single test folder
+npx @usebruno/cli run api/hackathon --env local-development
+
+# Run all test folders
+for folder in api/*/; do
+  npx @usebruno/cli run "$folder" --env local-development
+done
+```
+
+Tests also run automatically via the pre-commit hook when you change Python
+API files or `.bru` test files.
+
+### Environment Variables
+
+Edit `bruno-collection/environments/local-development.bru` to match your
+local seed data IDs. After running the seed script, look up docnames:
+
+```sh
+bench execute frappe.client.get_list \
+  --args '{"doctype":"FOSS Hackathon","filters":{"hackathon_name":["like","MOCK-%"]},"fields":["name","hackathon_name","permalink"]}'
+```
+
+See `bruno-collection/README.md` for the full variable reference.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a pre-commit hook that automatically runs Bruno API tests whenever
Python API files or Bruno test files are changed.

### What this adds

- `development/run_bruno_tests.sh` - a test runner script that:
  - Maps Python API files to their corresponding Bruno test folders
    (e.g. `fossunited/api/hackathon.py` triggers `api/hackathon/` tests)
  - Also triggers when `.bru` or `.yml` test files themselves change
  - Skips gracefully with a warning if the Frappe server isn't running
  - Runs from inside `bruno-collection/` to satisfy the CLI's collection root requirement

- Pre-commit config entry that watches `fossunited/api/*.py` and
  `bruno-collection/**/*.{bru,yml}` for changes

- `bruno-collection/environments/local-development.bru` with all the env
  vars the security tests need (user credentials, seed data IDs)

- `bruno-collection/README.md` with setup instructions, env var reference
  table, and folder structure

- New "Bruno API Tests" section in `docs/docs/development.md` with setup
  and usage instructions

### Why .bru over .yml

Bruno CLI v4 supports two collection formats: the legacy `.bru` format
and the newer Open Collection `.yml` format. We tested both and found
that the `.yml` format loads requests but does NOT execute `tests:`
blocks - it always reports 0/0 tests passed. The `.bru` format runs both
requests and test assertions correctly. The pre-commit hook watches both
extensions for forward compatibility, but all new tests use `.bru`.

### Merge sequence

This is part of a security audit remediation split across 5 PRs.
They must be merged in order to avoid conflicts:

1. **This PR** (pre-commit hook + test infra)
2. Group 1 - tickets/checkins (#1704, already merged)
3. Group 2 - hackathon field exposure (`fix/security-group-2-hackathon`)
4. Group 3 - CFP/forms auth (`fix/security-group-3-cfp-forms`)
5. Group 4 - dashboard/emailing fields (`fix/security-group-4-dashboard-emailing`)
6. Group 5 - RSVP/profile (`fix/security-group-5-rsvp-profile`)

### Future work

- Add Bruno tests for the ticket endpoints from group 1 in `.bru` format
  (currently `.yml` only, so assertions don't execute)
- Wire up Bruno tests in CI (GitHub Actions) against a test site
- Expand the `API_MAP` as new API modules get test coverage

## Test plan

- [ ] `pre-commit install` and modify a file in `fossunited/api/` -
  verify the hook triggers and runs the matching Bruno folder
- [ ] Modify a `.bru` file directly - verify the hook picks it up
- [ ] Stop the Frappe server and commit - verify the hook skips
  gracefully with a warning instead of blocking the commit
- [ ] `cd bruno-collection && npx @usebruno/cli run api/hackathon --env local-development` -
  verify tests pass with the env file