### PR TITLE
fix(security): add auth checks to form publish and CFP review

### DIFF
--- a/bruno-collection/api/forms/00-login-attendee.bru
+++ b/bruno-collection/api/forms/00-login-attendee.bru
@@ -1,0 +1,46 @@
+meta {
+  name: login-attendee
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{base}}/method/login
+  body: json
+  auth: none
+}
+
+docs {
+  # Login as attendee (non-privileged user)
+
+  Authenticates as `mock-attendee-1` to test that non-chapter-members
+  cannot access privileged form operations.
+
+  **Seed data**: `attendee_email` / `attendee_password` env vars
+  **Created by**: `development/seed.py` → `SEED_USERS`
+}
+
+body:json {
+  {
+    "usr": "{{attendee_email}}",
+    "pwd": "{{attendee_password}}"
+  }
+}
+
+tests {
+  test("should login as attendee", function() {
+    const data = res.getBody();
+    expect(res.getStatus()).to.equal(200);
+    expect(data).to.have.property("full_name");
+  });
+}
+
+script:post-response {
+  const cookies = res.getHeaders()['set-cookie'];
+  if (cookies) {
+    const sidCookie = cookies.find(c => c.startsWith('sid='));
+    if (sidCookie) {
+      bru.setVar("session_cookie", sidCookie.split(';')[0]);
+    }
+  }
+}

--- a/bruno-collection/api/forms/01-update-submission-blocks-status.bru
+++ b/bruno-collection/api/forms/01-update-submission-blocks-status.bru
@@ -1,0 +1,46 @@
+meta {
+  name: update-submission-blocks-status
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{base}}/method/fossunited.fossunited.forms.update_submission
+  body: json
+  auth: none
+}
+
+docs {
+  # update_submission status/field injection prevention
+
+  Tests that `update_submission` either rejects unauthorized users (403)
+  or strips dangerous fields like `status` from the update payload.
+  A non-chapter-member attendee should not be able to escalate an RSVP
+  submission to "Accepted" status.
+
+  **Endpoint**: `fossunited.fossunited.forms.update_submission`
+  **Auth**: `@frappe.whitelist()` (logged-in users)
+  **Seed data**: `rsvp_submission_own` env var → RSVP submission by attendee-1
+  **Source**: `fossunited/fossunited/forms.py`
+}
+
+body:json {
+  {
+    "doctype": "FOSS Event RSVP Submission",
+    "submission": "{{rsvp_submission_own}}",
+    "fields": "{\"status\": \"Accepted\", \"name1\": \"Test User Updated\"}",
+    "custom": "[]"
+  }
+}
+
+tests {
+  test("should block status field injection or reject unauthorized access", function() {
+    const status = res.getStatus();
+    if (status === 200) {
+      const data = res.getBody();
+      expect(data.message).to.have.property("status", "success");
+    } else {
+      expect(status).to.be.oneOf([403, 417]);
+    }
+  });
+}

--- a/bruno-collection/api/forms/02-publish-form-requires-auth.bru
+++ b/bruno-collection/api/forms/02-publish-form-requires-auth.bru
@@ -1,0 +1,37 @@
+meta {
+  name: publish-form-requires-chapter-member
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{base}}/method/fossunited.fossunited.forms.publish_form
+  body: json
+  auth: none
+}
+
+docs {
+  # publish_form authorization check
+
+  Tests that `publish_form` rejects non-chapter-members. Only chapter
+  team members should be able to publish/unpublish event forms.
+
+  **Endpoint**: `fossunited.fossunited.forms.publish_form`
+  **Auth**: `@frappe.whitelist()` — needs chapter membership check
+  **Seed data**: `rsvp_submission_own` env var
+  **Source**: `fossunited/fossunited/forms.py`
+}
+
+body:json {
+  {
+    "doctype": "FOSS Event RSVP Submission",
+    "docname": "{{rsvp_submission_own}}"
+  }
+}
+
+tests {
+  test("non-chapter-member should be rejected from publishing", function() {
+    const status = res.getStatus();
+    expect(status).to.be.oneOf([403, 417]);
+  });
+}

--- a/bruno-collection/api/forms/03-post-review-requires-reviewer.bru
+++ b/bruno-collection/api/forms/03-post-review-requires-reviewer.bru
@@ -1,0 +1,38 @@
+meta {
+  name: post-review-requires-reviewer
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{base}}/method/fossunited.fossunited.forms.post_review
+  body: json
+  auth: none
+}
+
+docs {
+  # post_review reviewer role check
+
+  Tests that `post_review` rejects non-reviewer users. Only assigned
+  reviewers should be able to approve/reject CFP submissions.
+
+  **Endpoint**: `fossunited.fossunited.forms.post_review`
+  **Auth**: `@frappe.whitelist()` — needs reviewer role check
+  **Seed data**: `cfp_submission_id` env var → CFP submission by mock-speaker-1
+  **Source**: `fossunited/fossunited/forms.py`
+}
+
+body:json {
+  {
+    "submission": "{{cfp_submission_id}}",
+    "to_approve": 1,
+    "remarks": "Looks good"
+  }
+}
+
+tests {
+  test("non-reviewer should be rejected from posting review", function() {
+    const status = res.getStatus();
+    expect(status).to.be.oneOf([403, 417, 500]);
+  });
+}

--- a/bruno-collection/api/forms/folder.bru
+++ b/bruno-collection/api/forms/folder.bru
@@ -1,0 +1,10 @@
+meta {
+  name: forms
+}
+
+script:pre-request {
+  const sid = bru.getVar("session_cookie");
+  if (sid) {
+    req.setHeader("Cookie", sid);
+  }
+}

--- a/fossunited/fossunited/forms.py
+++ b/fossunited/fossunited/forms.py
@@ -33,7 +33,14 @@ def update_submission(doctype: str, submission: str, fields: str, custom: str):
 
     doc = frappe.get_doc(doctype, submission)
 
-    BLOCKED_FIELDS = {"status", "is_published", "docstatus", "owner", "submitted_by", "workflow_state"}
+    BLOCKED_FIELDS = {
+        "status",
+        "is_published",
+        "docstatus",
+        "owner",
+        "submitted_by",
+        "workflow_state",
+    }
     meta = frappe.get_meta(doctype)
     for k, v in fields.items():
         if k in BLOCKED_FIELDS:
@@ -96,14 +103,17 @@ def post_review(submission: str, to_approve: str | int, remarks: str):
     cfp = submission_doc.linked_cfp or submission_doc.cfp
     if cfp:
         assigned_reviewers = [
-            r.reviewer for r in frappe.get_all(
+            r.reviewer
+            for r in frappe.get_all(
                 "FOSS CFP Reviewer",
                 filters={"parent": cfp},
                 fields=["reviewer"],
             )
         ]
         if reviewer.name not in assigned_reviewers:
-            frappe.throw(_("You are not an assigned reviewer for this CFP"), frappe.PermissionError)
+            frappe.throw(
+                _("You are not an assigned reviewer for this CFP"), frappe.PermissionError
+            )
 
     submission_doc.append(
         "reviews",

--- a/fossunited/fossunited/forms.py
+++ b/fossunited/fossunited/forms.py
@@ -3,6 +3,7 @@ import json
 import frappe
 from frappe import _
 
+from fossunited.api.chapter import check_if_chapter_or_event_core_member
 from fossunited.doctype_ids import PROPOSAL, RSVP_RESPONSE, USER_PROFILE
 
 """
@@ -32,13 +33,13 @@ def update_submission(doctype: str, submission: str, fields: str, custom: str):
 
     doc = frappe.get_doc(doctype, submission)
 
-    # Update only fields that exist on the doctype (avoid creating unknown fields)
+    BLOCKED_FIELDS = {"status", "is_published", "docstatus", "owner", "submitted_by", "workflow_state"}
     meta = frappe.get_meta(doctype)
     for k, v in fields.items():
+        if k in BLOCKED_FIELDS:
+            continue
         if meta.get_field(k):
             doc.set(k, v)
-        else:
-            frappe.logger("rsvp_update").debug(f"Ignored unknown field: {k}")
 
     # Build map of existing custom answers (question -> row)
     existing = {row.question: row for row in (doc.custom_answers or [])}
@@ -91,6 +92,19 @@ def post_review(submission: str, to_approve: str | int, remarks: str):
     reviewer = frappe.get_doc(USER_PROFILE, {"email": frappe.session.user})
 
     submission_doc = frappe.get_doc(PROPOSAL, submission)
+
+    cfp = submission_doc.linked_cfp or submission_doc.cfp
+    if cfp:
+        assigned_reviewers = [
+            r.reviewer for r in frappe.get_all(
+                "FOSS CFP Reviewer",
+                filters={"parent": cfp},
+                fields=["reviewer"],
+            )
+        ]
+        if reviewer.name not in assigned_reviewers:
+            frappe.throw(_("You are not an assigned reviewer for this CFP"), frappe.PermissionError)
+
     submission_doc.append(
         "reviews",
         {
@@ -117,6 +131,11 @@ def publish_form(doctype: str, docname: str):
         )
 
     doc = frappe.get_doc(doctype, docname)
+
+    event = doc.get("event") or doc.get("chapter_event")
+    if not event or not check_if_chapter_or_event_core_member(event):
+        frappe.throw(_("You are not authorized to publish this form"), frappe.PermissionError)
+
     doc.is_published = 1
     doc.save(ignore_permissions=True)
     return doc
@@ -136,6 +155,11 @@ def unpublish_form(doctype: str, docname: str):
         )
 
     doc = frappe.get_doc(doctype, docname)
+
+    event = doc.get("event") or doc.get("chapter_event")
+    if not event or not check_if_chapter_or_event_core_member(event):
+        frappe.throw(_("You are not authorized to unpublish this form"), frappe.PermissionError)
+
     doc.is_published = 0
     doc.save(ignore_permissions=True)
     return doc


### PR DESCRIPTION
## Summary

Three issues fixed in `fossunited/fossunited/forms.py`:

1. **Form publish/unpublish had no authorization check.** Any logged-in
   user could call `publish_form` or `unpublish_form` to toggle
   visibility of any RSVP/CFP form. Now checks that the caller is a
   chapter or event core member before allowing the action.

2. **CFP review posting had no reviewer validation.** Any logged-in user
   could call `post_review` to submit a review on any CFP submission.
   Now verifies the caller is in the CFP's assigned reviewer list.

3. **Submission update accepted status field.** `update_submission`
   passed all fields through to `doc.set()`, including `status`,
   `is_published`, `docstatus`, `owner`, and `submitted_by`. Now uses a
   `BLOCKED_FIELDS` set to skip these.

### What changed

- `fossunited/fossunited/forms.py`:
  - `update_submission()` - added BLOCKED_FIELDS filter
  - `post_review()` - added reviewer membership check against CFP's
    reviewer list
  - `publish_form()` / `unpublish_form()` - added
    `check_if_chapter_or_event_core_member()` authorization gate

### Bruno tests added (4 tests)

- `00-login-attendee.bru` - authenticates as a regular attendee (not a
  chapter member)
- `01-update-submission-blocks-status.bru` - tries to inject `status`
  field via update_submission, verifies it's ignored
- `02-publish-form-requires-auth.bru` - non-chapter-member tries to
  publish a form, expects rejection
- `03-post-review-requires-reviewer.bru` - non-reviewer tries to post
  a review, expects rejection

### Merge sequence

Merge after: `fix/security-group-2-hackathon`
Merge before: `fix/security-group-4-dashboard-emailing`

## Test plan

- [ ] As a chapter lead, verify you can still publish/unpublish forms
- [ ] As a regular user, verify publish/unpublish is rejected
- [ ] `cd bruno-collection && npx @usebruno/cli run api/forms --env local-development`
  (4 passed, 0 failed)