### PR TITLE
feat(event-cfp): let organizers override session types, categories, and speaker fields per CFP

### DIFF
--- a/dashboard/src/components/cfp-public/PreviewSubmission.vue
+++ b/dashboard/src/components/cfp-public/PreviewSubmission.vue
@@ -65,7 +65,10 @@
               type="checkbox"
               class="rounded-sm mt-[1px] bg-surface-white border-outline-gray-4 text-ink-gray-9 hover:border-outline-gray-5 focus:ring-offset-0 focus:border-outline-gray-8 active:border-outline-gray-6 transition hover:shadow-sm focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3 active:bg-surface-gray-2 w-3.5 h-3.5 shrink-0"
             />
-            <label for="coc-cfp" class="block text-base font-medium text-ink-gray-8 select-none cursor-pointer leading-relaxed">
+            <label
+              for="coc-cfp"
+              class="block text-base font-medium text-ink-gray-8 select-none cursor-pointer leading-relaxed"
+            >
               By registering for this event, you agree to abide by the FOSS United
               <a
                 href="https://fossunited.org/code-of-conduct"
@@ -80,12 +83,10 @@
           </div>
         </template>
         <template v-else>
-          <FormControl
-            v-model="field.value"
-            type="checkbox"
-            :label="field.label"
-            :required="field.required"
-          />
+          <div class="inline-flex items-center gap-1">
+            <FormControl v-model="field.value" type="checkbox" :label="field.label" />
+            <span v-if="field.required" class="text-ink-red-3">*</span>
+          </div>
         </template>
       </div>
     </div>

--- a/dashboard/src/components/cfp-public/SpeakersForm.vue
+++ b/dashboard/src/components/cfp-public/SpeakersForm.vue
@@ -32,10 +32,10 @@
           label="Speaker Image"
           :description="
             index === 0
-              ? 'Pre-filled from your account profile. Uploading a new photo here will also update your profile. Keep a recent 1:1 headshot for best results.'
+              ? 'Pre-filled from your account profile. Uploading a new photo here will ask if you want to update your profile too. Keep a recent 1:1 headshot for best results.'
               : 'Please keep the image ratio as 1:1'
           "
-          :required="true"
+          :required="getFieldRequired(speaker, 'photo')"
           @uploaded="index === 0 && syncProfilePhoto($event)"
         />
         <RenderField
@@ -68,6 +68,24 @@
         for updates on upcoming events and community news.
       </span>
     </div>
+
+    <Dialog
+      v-model="showProfilePhotoDialog"
+      :options="{ title: 'Update your profile picture too?' }"
+    >
+      <template #body-content>
+        <p class="text-sm text-ink-gray-6">
+          You uploaded a new speaker photo. Do you also want to set it as your FOSS United account
+          profile picture?
+        </p>
+      </template>
+      <template #actions>
+        <div class="grid grid-cols-2 gap-3">
+          <Button label="Yes, update profile" variant="solid" @click="confirmProfilePhotoSync" />
+          <Button label="No, just this proposal" @click="showProfilePhotoDialog = false" />
+        </div>
+      </template>
+    </Dialog>
   </section>
 </template>
 <script setup>
@@ -76,8 +94,11 @@ import TextEditor from '@/components/ui/TextEditor.vue'
 import { IconUserCircle } from '@tabler/icons-vue'
 import RenderField from '@/components/form/RenderField.vue'
 import { getSpeakerFields } from '@/helpers/cfp'
-import { createResource, Switch } from 'frappe-ui'
+import { createResource, Switch, Dialog, Button } from 'frappe-ui'
 import { inject, ref } from 'vue'
+
+// Provided by CfpForm.vue (new submission) and ProposalEdit.vue
+const cfpData = inject('$cfpData', null)
 
 const speakers = defineModel('speakers', {
   type: Array,
@@ -96,10 +117,12 @@ const props = defineProps({
   },
 })
 
-const fields = getSpeakerFields().filter((field) => !['photo', 'bio'].includes(field.fieldname))
+const fields = getSpeakerFields(cfpData?.data).filter(
+  (field) => !['photo', 'bio'].includes(field.fieldname),
+)
 
 const addSpeaker = () => {
-  speakers.value.push(getSpeakerFields())
+  speakers.value.push(getSpeakerFields(cfpData?.data))
 }
 
 const deleteSpeaker = (index) => {
@@ -108,6 +131,10 @@ const deleteSpeaker = (index) => {
 
 const getFieldIndex = (speaker, fieldname) => {
   return speaker.findIndex((field) => field.fieldname === fieldname)
+}
+
+const getFieldRequired = (speaker, fieldname) => {
+  return Boolean(speaker[getFieldIndex(speaker, fieldname)]?.required)
 }
 
 const session = inject('$session')
@@ -181,13 +208,22 @@ function mergeAndPrefill() {
 
 const updateProfilePhoto = createResource({ url: 'frappe.client.set_value' })
 
+const showProfilePhotoDialog = ref(false)
+const pendingPhotoUrl = ref(null)
+
 function syncProfilePhoto(url) {
   if (!profileData.value?.name) return
+  pendingPhotoUrl.value = url
+  showProfilePhotoDialog.value = true
+}
+
+function confirmProfilePhotoSync() {
   updateProfilePhoto.fetch({
     doctype: 'FOSS User Profile',
     name: profileData.value.name,
     fieldname: 'profile_photo',
-    value: url,
+    value: pendingPhotoUrl.value,
   })
+  showProfilePhotoDialog.value = false
 }
 </script>

--- a/dashboard/src/helpers/cfp.js
+++ b/dashboard/src/helpers/cfp.js
@@ -131,6 +131,7 @@ const parseAllowedSessionTypes = (allowedSessionTypes) => {
 export const getUpdatedAllowedSessionTypes = (currentValue, type, checked) => {
   let selected = parseAllowedSessionTypes(currentValue) || [...SESSION_TYPES]
   selected = checked ? [...new Set([...selected, type])] : selected.filter((t) => t !== type)
+  if (!selected.length) return null
   return selected.length === SESSION_TYPES.length ? '' : selected.join('\n')
 }
 

--- a/dashboard/src/helpers/cfp.js
+++ b/dashboard/src/helpers/cfp.js
@@ -15,7 +15,7 @@ export const getProposalFormFields = (cfpData) => {
       label: 'Session Type',
       fieldname: 'session_type',
       fieldtype: 'radio_group',
-      options: getSessionTypeOptions(cfpData.only_workshops, cfpData.only_talk_proposals),
+      options: getSessionTypeOptions(cfpData.allowed_session_types),
       required: true,
       value: '',
     },
@@ -23,7 +23,7 @@ export const getProposalFormFields = (cfpData) => {
       label: 'Session Category',
       fieldname: 'session_categories',
       fieldtype: 'multiselect',
-      options: getSessionCategoryOptions(),
+      options: getSessionCategoryOptions(cfpData.override_session_categories),
       required: true,
       value: [],
     },
@@ -76,6 +76,7 @@ export const getProposalFormFields = (cfpData) => {
       label: 'License',
       fieldname: 'talk_license',
       fieldtype: 'text',
+      required: true,
       value: '',
       description:
         'Specify the license(s) under which your project/talk is distributed. Examples: MIT License (software), CC BY-SA 4.0 (open data/documentation), CERN OHL-W (open hardware). Refer: https://opensource.org/licenses',
@@ -102,30 +103,57 @@ export const getProposalFormFields = (cfpData) => {
   return baseFields
 }
 
-const getSessionTypeOptions = (only_workshops, only_talk_proposals) => {
-  let options = [
-    { label: 'Talk', value: 'Talk', description: '25-30 mins' },
-    { label: 'Lightning Talk', value: 'Lightning Talk', description: 'Upto 15 mins' },
-    {
-      label: 'Birds of Feather(BoF)',
-      value: 'Birds of Feather(BoF)',
-      help: 'Birds of a Feather sessions (or BoFs) are informal gatherings of like-minded individuals who wish to discuss a certain topic without a pre-planned agenda',
-    },
-    { label: 'Panel Discussion', value: 'Panel Discussion' },
-    { label: 'Workshop', value: 'Workshop' },
-  ]
-  if (only_workshops) {
-    return [{ label: 'Workshop', value: 'Workshop' }]
-  }
+const SESSION_TYPE_OPTION_DEFS = [
+  { label: 'Talk', value: 'Talk', description: '25-30 mins' },
+  { label: 'Lightning Talk', value: 'Lightning Talk', description: 'Upto 15 mins' },
+  {
+    label: 'Birds of Feather(BoF)',
+    value: 'Birds of Feather(BoF)',
+    help: 'Birds of a Feather sessions (or BoFs) are informal gatherings of like-minded individuals who wish to discuss a certain topic without a pre-planned agenda',
+  },
+  { label: 'Panel Discussion', value: 'Panel Discussion' },
+  { label: 'Workshop', value: 'Workshop' },
+]
 
-  if (only_talk_proposals) {
-    return options.filter((option) => option.value !== 'Workshop')
-  }
+export const SESSION_TYPES = SESSION_TYPE_OPTION_DEFS.map((option) => option.value)
 
-  return options
+const parseAllowedSessionTypes = (allowedSessionTypes) => {
+  if (!allowedSessionTypes) return null
+  const allowed = allowedSessionTypes
+    .split('\n')
+    .map((t) => t.trim())
+    .filter(Boolean)
+  return allowed.length ? allowed : null
 }
 
-const getSessionCategoryOptions = () => {
+// Returns the updated `allowed_session_types` newline list after toggling one
+// type. An empty string means "no restriction, all types allowed".
+export const getUpdatedAllowedSessionTypes = (currentValue, type, checked) => {
+  let selected = parseAllowedSessionTypes(currentValue) || [...SESSION_TYPES]
+  selected = checked ? [...new Set([...selected, type])] : selected.filter((t) => t !== type)
+  return selected.length === SESSION_TYPES.length ? '' : selected.join('\n')
+}
+
+export const isSessionTypeAllowed = (allowedSessionTypes, type) => {
+  const allowed = parseAllowedSessionTypes(allowedSessionTypes)
+  return !allowed || allowed.includes(type)
+}
+
+const getSessionTypeOptions = (allowedSessionTypes) => {
+  const allowed = parseAllowedSessionTypes(allowedSessionTypes)
+  if (!allowed) return SESSION_TYPE_OPTION_DEFS
+  return SESSION_TYPE_OPTION_DEFS.filter((option) => allowed.includes(option.value))
+}
+
+const getSessionCategoryOptions = (overrideCategories) => {
+  const override = (overrideCategories || '')
+    .split('\n')
+    .map((c) => c.trim())
+    .filter(Boolean)
+  if (override.length) {
+    return override.map((value) => ({ value, label: value }))
+  }
+
   return [
     {
       value: 'Introducing a FOSS project or a new version of a popular project',
@@ -152,9 +180,15 @@ const getSessionCategoryOptions = () => {
   ]
 }
 
+// Custom questions of type "Check" are treated as confirmation checkboxes
+// (see getCustomConfirmationFields) and rendered on the Preview step instead
+// of here. fieldname keeps the original table index regardless of which
+// bucket a question lands in, so custom_answers stay unambiguous.
 const getCustomQuestions = (questions) => {
-  return questions.map((question, index) => {
-    return {
+  return questions
+    .map((question, index) => ({ question, index }))
+    .filter(({ question }) => question.type !== 'Check')
+    .map(({ question, index }) => ({
       label: question.question,
       fieldname: 'custom_question_' + index,
       fieldtype: getQuestionType(question.type),
@@ -162,8 +196,21 @@ const getCustomQuestions = (questions) => {
       required: question.is_mandatory,
       value: '',
       description: question.description,
-    }
-  })
+    }))
+}
+
+const getCustomConfirmationFields = (questions) => {
+  return questions
+    .map((question, index) => ({ question, index }))
+    .filter(({ question }) => question.type === 'Check')
+    .map(({ question, index }) => ({
+      label: question.question,
+      fieldname: 'custom_question_' + index,
+      fieldtype: 'checkbox',
+      required: question.is_mandatory,
+      value: false,
+      description: question.description,
+    }))
 }
 
 const getQuestionType = (type) => {
@@ -199,18 +246,19 @@ export const getSpeakerSchema = () => {
     designation: '',
     organization: '',
     social_link: '',
+    contact_info: '',
     bio: '',
   }
 }
 
-export const getSpeakerFields = () => {
-  return [
+export const getSpeakerFields = (cfpData = {}) => {
+  const fields = [
     {
       label: 'Speaker Image',
       fieldname: 'photo',
       value: '',
       fieldtype: 'attach_image',
-      required: true,
+      required: Boolean(cfpData.require_speaker_photo ?? 1),
     },
     {
       label: 'Full Name',
@@ -260,46 +308,64 @@ export const getSpeakerFields = () => {
       required: true,
     },
   ]
+
+  if (cfpData.hide_contact_info) {
+    return fields.filter((field) => field.fieldname !== 'contact_info')
+  }
+  return fields
 }
 
-export const getSubmissionConfirmationFields = () => {
+// FOSS United's default acks, used unless the organizer has added their own
+// "Check"-type custom questions (same override-only-when-set convention as
+// allowed_session_types/override_session_categories).
+const DEFAULT_CONFIRMATION_ACKS = [
+  {
+    label: 'I have gone through the proposal guidelines before submitting the proposal',
+    fieldname: 'proposal_guidelines_ack',
+    fieldtype: 'checkbox',
+    required: true,
+    value: false,
+  },
+  {
+    label: 'I wrote this myself, it was NOT generated primarily by AI',
+    fieldname: 'authorship_ack',
+    fieldtype: 'checkbox',
+    required: true,
+    value: false,
+  },
+  {
+    label: 'I have included relevant references to provide as much context as possible',
+    fieldname: 'references_ack',
+    fieldtype: 'checkbox',
+    required: true,
+    value: false,
+  },
+  {
+    label: 'I can do a mock presentation of this talk if required',
+    fieldname: 'mock_presentation_ack',
+    fieldtype: 'checkbox',
+    required: true,
+    value: false,
+  },
+  {
+    label:
+      'I agree that my talk, slides, and related materials will be published under a Creative Commons (CC BY-SA 4.0) license if my proposal is accepted.',
+    fieldname: 'license_ack',
+    fieldtype: 'checkbox',
+    required: true,
+    value: false,
+  },
+]
+
+// Organizer-defined confirmation checkboxes from cfp_custom_questions check type
+export const getSubmissionConfirmationFields = (cfpData = {}) => {
+  const customAcks = getCustomConfirmationFields(cfpData.cfp_custom_questions || [])
+  const acks = customAcks.length
+    ? customAcks
+    : DEFAULT_CONFIRMATION_ACKS.map((field) => ({ ...field }))
+
   return [
-    {
-      label: 'I have gone through the proposal guidelines before submitting the proposal',
-      fieldname: 'proposal_guidelines_ack',
-      fieldtype: 'checkbox',
-      required: true,
-      value: false,
-    },
-    {
-      label: 'I wrote this myself, it was NOT generated primarily by AI',
-      fieldname: 'authorship_ack',
-      fieldtype: 'checkbox',
-      required: true,
-      value: false,
-    },
-    {
-      label: 'I have included relevant references to provide as much context as possible',
-      fieldname: 'references_ack',
-      fieldtype: 'checkbox',
-      required: true,
-      value: false,
-    },
-    {
-      label: 'I can do a mock presentation of this talk if required',
-      fieldname: 'mock_presentation_ack',
-      fieldtype: 'checkbox',
-      required: true,
-      value: false,
-    },
-    {
-      label:
-        'I agree that my talk, slides, and related materials will be published under a Creative Commons (CC BY-SA 4.0) license if my proposal is accepted.',
-      fieldname: 'license_ack',
-      fieldtype: 'checkbox',
-      required: true,
-      value: false,
-    },
+    ...acks,
     {
       label: 'Accepting Code of Conduct',
       fieldname: 'accept_coc',

--- a/dashboard/src/pages/EventCfpCreate.vue
+++ b/dashboard/src/pages/EventCfpCreate.vue
@@ -1,11 +1,11 @@
 <template>
-  <div v-if="event.doc" class="px-4 py-8 md:p-8 flex flex-col gap-4">
+  <div v-if="event.doc" class="px-4 py-8 md:p-8 flex flex-col gap-8">
     <div class="flex flex-col md:flex-row justify-between gap-2">
       <div class="text-xl font-medium">Create CFP</div>
       <Button size="md" label="Create" variant="solid" @click="createCfpForm" />
     </div>
     <div>
-      <div class="grid sm:grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
+      <div class="grid sm:grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-8">
         <div class="flex flex-col gap-2">
           <FormControl
             v-model="cfp_doc.allow_cfp_edit"
@@ -44,25 +44,27 @@
         </div>
         <div class="flex flex-col gap-2">
           <FormControl
-            v-model="cfp_doc.only_workshops"
+            v-model="cfp_doc.hide_contact_info"
             type="checkbox"
-            label="Only Workshops"
+            label="Hide Contact Info Field"
             description=""
             size="md"
-            @change="validateOnlyOneType"
           />
-          <span class="text-sm text-ink-gray-5">Only accept workshop proposals.</span>
+          <span class="text-sm text-ink-gray-5"
+            >Removes the optional "Contact Info" field from the speaker form.</span
+          >
         </div>
         <div class="flex flex-col gap-2">
           <FormControl
-            v-model="cfp_doc.only_talk_proposals"
+            v-model="cfp_doc.require_speaker_photo"
             type="checkbox"
-            label="Only Talk Proposals"
+            label="Require Speaker Photo"
             description=""
             size="md"
-            @change="validateOnlyOneType"
           />
-          <span class="text-sm text-ink-gray-5">Only accept talk proposals.</span>
+          <span class="text-sm text-ink-gray-5"
+            >If unchecked, speakers can submit without uploading a photo.</span
+          >
         </div>
         <div class="flex flex-col gap-2">
           <FormControl
@@ -86,9 +88,36 @@
           />
           <span class="text-sm text-ink-gray-5"
             >Shown as the guideline step for applicants. Leave empty to show the foundation's
-            default guidelines instead.</span
+            default guidelines instead. If filled, this replaces the default entirely — include
+            everything applicants need, not just an addition to it.</span
           >
         </div>
+        <div class="col-span-1 md:col-span-2 flex flex-col gap-2">
+          <span class="text-base text-ink-gray-5">Allowed Session Types</span>
+          <div class="grid grid-cols-2 gap-2">
+            <FormControl
+              v-for="type in SESSION_TYPES"
+              :key="type"
+              type="checkbox"
+              :label="type"
+              :model-value="isSessionTypeAllowed(cfp_doc.allowed_session_types, type)"
+              @update:model-value="(val) => toggleSessionType(type, val)"
+              size="md"
+            />
+          </div>
+          <span class="text-sm text-ink-gray-5"
+            >Restrict which session types applicants can choose from. Leave all checked to allow
+            every type.</span
+          >
+        </div>
+        <FormControl
+          class="col-span-1 md:col-span-2"
+          v-model="cfp_doc.override_session_categories"
+          type="textarea"
+          label="Override Session Categories"
+          description='One category per line. Leave empty to use FOSS United&#39;s default category list. Include "Other" as one of the lines to let proposers type in their own custom category.'
+          size="md"
+        />
       </div>
     </div>
     <div>
@@ -107,7 +136,7 @@
     </div>
     <div>
       <div class="font-semibold text-ink-gray-8 border-b-2 pb-2">Custom Fields</div>
-      <div class="flex flex-col gap-2 mt-4">
+      <div class="flex flex-col gap-3 mt-4">
         <FormControl
           v-model="cfp_doc.has_public_custom_responses"
           type="checkbox"
@@ -118,6 +147,10 @@
           >Show answers to these custom questions publicly on the proposal page. Be careful: do not
           make responses public if any question collects sensitive data such as phone numbers or
           email addresses.</span
+        >
+        <span class="text-sm text-ink-gray-5"
+          >Fields of type "Check" appear as confirmation checkboxes on the final review step,
+          instead of on the submission form.</span
         >
       </div>
       <Button
@@ -223,6 +256,7 @@ import { reactive, ref, defineEmits } from 'vue'
 import { useRoute } from 'vue-router'
 import { toast } from 'vue-sonner'
 import TextEditor from '@/components/ui/TextEditor.vue'
+import { SESSION_TYPES, isSessionTypeAllowed, getUpdatedAllowedSessionTypes } from '@/helpers/cfp'
 
 const route = useRoute()
 const emit = defineEmits(['cfpCreated'])
@@ -296,8 +330,10 @@ let cfp_doc = reactive({
   event: route.params.id,
   anonymise_proposals: 1,
   allow_cfp_edit: 0,
-  only_workshops: 0,
-  only_talk_proposals: 0,
+  allowed_session_types: '',
+  override_session_categories: '',
+  hide_contact_info: 0,
+  require_speaker_photo: 1,
   deadline: '',
   hide_review: 1,
   has_public_custom_responses: 0,
@@ -305,14 +341,12 @@ let cfp_doc = reactive({
   cfp_custom_questions: [],
 })
 
-const validateOnlyOneType = () => {
-  if (cfp_doc.only_workshops && cfp_doc.only_talk_proposals) {
-    toast.error('Invalid Selection.', {
-      description: 'If you wish to accept all type of proposals, uncheck both options.',
-    })
-    cfp_doc.only_workshops = 0
-    cfp_doc.only_talk_proposals = 0
-  }
+const toggleSessionType = (type, checked) => {
+  cfp_doc.allowed_session_types = getUpdatedAllowedSessionTypes(
+    cfp_doc.allowed_session_types,
+    type,
+    checked,
+  )
 }
 
 let custom_field = reactive({

--- a/dashboard/src/pages/EventCfpCreate.vue
+++ b/dashboard/src/pages/EventCfpCreate.vue
@@ -342,11 +342,14 @@ let cfp_doc = reactive({
 })
 
 const toggleSessionType = (type, checked) => {
-  cfp_doc.allowed_session_types = getUpdatedAllowedSessionTypes(
-    cfp_doc.allowed_session_types,
-    type,
-    checked,
-  )
+  const updated = getUpdatedAllowedSessionTypes(cfp_doc.allowed_session_types, type, checked)
+  if (updated === null) {
+    toast.error('Invalid Selection.', {
+      description: 'At least one session type must remain allowed.',
+    })
+    return
+  }
+  cfp_doc.allowed_session_types = updated
 }
 
 let custom_field = reactive({

--- a/dashboard/src/pages/EventCfpEdit.vue
+++ b/dashboard/src/pages/EventCfpEdit.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="cfp_form.data && cfp.doc" class="px-4 py-8 md:p-8 flex flex-col gap-4">
+  <div v-if="cfp_form.data && cfp.doc" class="px-4 py-8 md:p-8 flex flex-col gap-8">
     <div class="flex flex-row justify-end gap-2">
       <Button
         class="w-fit"
@@ -21,7 +21,7 @@
     </div>
     <div class="flex flex-col my-4 gap-6">
       <div class="font-semibold text-ink-gray-8 border-b-2 pb-2">Edit Details</div>
-      <div class="grid sm:grid-cols-1 md:grid-cols-2 gap-4">
+      <div class="grid sm:grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-8">
         <div class="flex flex-col gap-2">
           <FormControl
             v-model="cfp.doc.allow_cfp_edit"
@@ -58,23 +58,25 @@
         </div>
         <div class="flex flex-col gap-2">
           <FormControl
-            v-model="cfp.doc.only_workshops"
+            v-model="cfp.doc.hide_contact_info"
             type="checkbox"
-            label="Only Workshops"
+            label="Hide Contact Info Field"
             size="md"
-            @change="validateOnlyOneType"
           />
-          <span class="text-sm text-ink-gray-5">Only accept workshop proposals.</span>
+          <span class="text-sm text-ink-gray-5"
+            >Removes the optional "Contact Info" field from the speaker form.</span
+          >
         </div>
         <div class="flex flex-col gap-2">
           <FormControl
-            v-model="cfp.doc.only_talk_proposals"
+            v-model="cfp.doc.require_speaker_photo"
             type="checkbox"
-            label="Only Talk Proposals"
+            label="Require Speaker Photo"
             size="md"
-            @change="validateOnlyOneType"
           />
-          <span class="text-sm text-ink-gray-5">Only accept talk proposals.</span>
+          <span class="text-sm text-ink-gray-5"
+            >If unchecked, speakers can submit without uploading a photo.</span
+          >
         </div>
         <div class="flex flex-col gap-2">
           <FormControl
@@ -98,9 +100,36 @@
           />
           <span class="text-sm text-ink-gray-5"
             >Shown as the guideline step for applicants. Leave empty to show the foundation's
-            default guidelines instead.</span
+            default guidelines instead. If filled, this replaces the default entirely — include
+            everything applicants need, not just an addition to it.</span
           >
         </div>
+        <div class="col-span-1 md:col-span-2 flex flex-col gap-2">
+          <span class="text-base text-ink-gray-5">Allowed Session Types</span>
+          <div class="grid grid-cols-2 gap-2">
+            <FormControl
+              v-for="type in SESSION_TYPES"
+              :key="type"
+              type="checkbox"
+              :label="type"
+              :model-value="isSessionTypeAllowed(cfp.doc.allowed_session_types, type)"
+              size="md"
+              @update:model-value="(val) => toggleSessionType(type, val)"
+            />
+          </div>
+          <span class="text-sm text-ink-gray-5"
+            >Restrict which session types applicants can choose from. Leave all checked to allow
+            every type.</span
+          >
+        </div>
+        <FormControl
+          v-model="cfp.doc.override_session_categories"
+          class="col-span-1 md:col-span-2"
+          type="textarea"
+          label="Override Session Categories"
+          description='One category per line. Leave empty to use default category list. Include "Other" as one of the lines to let proposers type in their own custom category.'
+          size="md"
+        />
       </div>
     </div>
     <div>
@@ -119,7 +148,7 @@
     </div>
     <div>
       <div class="font-semibold text-ink-gray-8 border-b-2 pb-2">Custom Fields</div>
-      <div class="flex flex-col gap-2 mt-4">
+      <div class="flex flex-col gap-3 mt-4">
         <FormControl
           v-model="cfp.doc.has_public_custom_responses"
           type="checkbox"
@@ -130,6 +159,10 @@
           >Show answers to these custom questions publicly on the proposal page. Be careful: do not
           make responses public if any question collects sensitive data such as phone numbers or
           email addresses.</span
+        >
+        <span class="text-sm text-ink-gray-5"
+          >Fields of type "Check" appear as confirmation checkboxes on the final review step,
+          instead of on the submission form.</span
         >
       </div>
       <Button
@@ -252,6 +285,7 @@ import { toast } from 'vue-sonner'
 import CopyToClipboardComponent from '@/components/CopyToClipboardComponent.vue'
 import TextEditor from '@/components/ui/TextEditor.vue'
 import FormActionBar from '@/components/FormActionBar.vue'
+import { SESSION_TYPES, isSessionTypeAllowed, getUpdatedAllowedSessionTypes } from '@/helpers/cfp'
 
 const route = useRoute()
 
@@ -329,14 +363,12 @@ const standard_fields = [
   },
 ]
 
-const validateOnlyOneType = () => {
-  if (cfp.doc.only_workshops && cfp.doc.only_talk_proposals) {
-    toast.error('Invalid Selection.', {
-      description: 'If you wish to accept all type of proposals, uncheck both options.',
-    })
-    cfp.doc.only_workshops = 0
-    cfp.doc.only_talk_proposals = 0
-  }
+const toggleSessionType = (type, checked) => {
+  cfp.doc.allowed_session_types = getUpdatedAllowedSessionTypes(
+    cfp.doc.allowed_session_types,
+    type,
+    checked,
+  )
 }
 
 let cfp = reactive({})
@@ -363,13 +395,7 @@ watch(cfp_form, (newForm) => {
 
 const emit = defineEmits(['reloadDoc'])
 const togglePublishForm = () => {
-  let to_set_status = ''
-
-  if (cfp.doc.status == 'Live') {
-    to_set_status = 'Closed'
-  } else {
-    to_set_status = 'Live'
-  }
+  const to_set_status = cfp.doc.status == 'Live' ? 'Closed' : 'Live'
 
   cfp.setValue.submit({
     status: to_set_status,

--- a/dashboard/src/pages/EventCfpEdit.vue
+++ b/dashboard/src/pages/EventCfpEdit.vue
@@ -364,11 +364,14 @@ const standard_fields = [
 ]
 
 const toggleSessionType = (type, checked) => {
-  cfp.doc.allowed_session_types = getUpdatedAllowedSessionTypes(
-    cfp.doc.allowed_session_types,
-    type,
-    checked,
-  )
+  const updated = getUpdatedAllowedSessionTypes(cfp.doc.allowed_session_types, type, checked)
+  if (updated === null) {
+    toast.error('Invalid Selection.', {
+      description: 'At least one session type must remain allowed.',
+    })
+    return
+  }
+  cfp.doc.allowed_session_types = updated
 }
 
 let cfp = reactive({})

--- a/dashboard/src/pages/cfp/CfpForm.vue
+++ b/dashboard/src/pages/cfp/CfpForm.vue
@@ -142,8 +142,6 @@ const proposalConfirmationFields = ref([])
 const subscribeNewsletter = ref(false)
 
 proposalReferences.value.push(getReferenceItemSchema())
-proposalSpeakers.value.push(getSpeakerFields())
-proposalConfirmationFields.value = getSubmissionConfirmationFields()
 
 const errorMessages = ref('')
 
@@ -159,6 +157,8 @@ const cfpData = createResource({
   onSuccess(data) {
     if (data) {
       proposalFormFields.value = getProposalFormFields(data).value
+      proposalSpeakers.value = [getSpeakerFields(data)]
+      proposalConfirmationFields.value = getSubmissionConfirmationFields(data)
     }
   },
 })
@@ -277,7 +277,11 @@ const insertProposal = createResource({
           ? 1
           : 0,
         ...getTransformedSubmissionFields(
-          proposalFormFields.value,
+          [
+            ...proposalFormFields.value,
+            // Custom "Check"-type confirmation checkboxes; accept_coc is handled above.
+            ...proposalConfirmationFields.value.filter((f) => f.fieldname !== 'accept_coc'),
+          ],
           proposalReferences.value,
           proposalSpeakers.value,
         ),

--- a/dashboard/src/pages/cfp/ProposalEdit.vue
+++ b/dashboard/src/pages/cfp/ProposalEdit.vue
@@ -164,6 +164,7 @@ const submission = createDocumentResource({
 })
 
 provide('submission', submission)
+provide('$cfpData', cfpForm)
 
 // createDocumentResource is globally cached; on remount it may return a cached
 // instance whose onSuccess closure is bound to a destroyed component. Drive the
@@ -200,7 +201,7 @@ const mapTalkFields = () => {
 const mapToSpeakerFields = () => {
   speakerFields.value = []
   submission.doc.speakers.forEach((speaker) => {
-    let fields = getSpeakerFields()
+    let fields = getSpeakerFields(cfpForm.data)
     fields.forEach((field) => {
       if (Object.prototype.hasOwnProperty.call(speaker, field.fieldname)) {
         field.value = speaker[field.fieldname]

--- a/fossunited/fossunited/doctype/foss_event_cfp/foss_event_cfp.json
+++ b/fossunited/fossunited/doctype/foss_event_cfp/foss_event_cfp.json
@@ -10,12 +10,14 @@
   "field_order": [
     "meta_section",
     "status",
-    "only_workshops",
-    "only_talk_proposals",
+    "allowed_session_types",
+    "override_session_categories",
     "column_break_puww",
     "allow_cfp_edit",
     "anonymise_proposals",
     "hide_review",
+    "hide_contact_info",
+    "require_speaker_photo",
     "event_information_section",
     "event",
     "event_name",
@@ -110,20 +112,6 @@
       "label": "Anonymise Proposals?"
     },
     {
-      "default": "0",
-      "description": "Only accept workshop proposals.",
-      "fieldname": "only_workshops",
-      "fieldtype": "Check",
-      "label": "Only Workshop Proposals"
-    },
-    {
-      "default": "0",
-      "description": "Only accept Talk proposals.",
-      "fieldname": "only_talk_proposals",
-      "fieldtype": "Check",
-      "label": "Only Talk Proposals"
-    },
-    {
       "fieldname": "deadline",
       "fieldtype": "Datetime",
       "label": "Deadline"
@@ -151,6 +139,32 @@
       "fieldname": "hide_review",
       "fieldtype": "Check",
       "label": "Hide Reviews from Public Page"
+    },
+    {
+      "description": "Limit session they can choose for submission.",
+      "fieldname": "allowed_session_types",
+      "fieldtype": "Small Text",
+      "label": "Allowed Session Type"
+    },
+    {
+      "description": "Show personalized categories to pick or choose for submitters",
+      "fieldname": "override_session_categories",
+      "fieldtype": "Small Text",
+      "label": "Override Session category"
+    },
+    {
+      "default": "0",
+      "description": "If optional field need to be shown in UI for speakers",
+      "fieldname": "hide_contact_info",
+      "fieldtype": "Check",
+      "label": "Ask Contact Info"
+    },
+    {
+      "default": "1",
+      "description": "If mandate speaker to add photo",
+      "fieldname": "require_speaker_photo",
+      "fieldtype": "Check",
+      "label": "Ask speaker photo"
     }
   ],
   "links": [
@@ -160,7 +174,7 @@
       "link_fieldname": "linked_cfp"
     }
   ],
-  "modified": "2026-07-02 19:38:36.773556",
+  "modified": "2026-08-28 13:42:04.167204",
   "modified_by": "Administrator",
   "module": "FOSSUnited",
   "name": "FOSS Event CFP",

--- a/fossunited/fossunited/doctype/foss_event_cfp/foss_event_cfp.json
+++ b/fossunited/fossunited/doctype/foss_event_cfp/foss_event_cfp.json
@@ -154,10 +154,10 @@
     },
     {
       "default": "0",
-      "description": "If optional field need to be shown in UI for speakers",
+      "description": "If optional contact field need to be shown in UI for speakers",
       "fieldname": "hide_contact_info",
       "fieldtype": "Check",
-      "label": "Ask Contact Info"
+      "label": "Hide speaker contact field"
     },
     {
       "default": "1",
@@ -174,7 +174,7 @@
       "link_fieldname": "linked_cfp"
     }
   ],
-  "modified": "2026-08-28 13:42:04.167204",
+  "modified": "2026-08-28 17:29:30.216781",
   "modified_by": "Administrator",
   "module": "FOSSUnited",
   "name": "FOSS Event CFP",

--- a/fossunited/fossunited/doctype/foss_event_cfp/foss_event_cfp.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp/foss_event_cfp.py
@@ -2,10 +2,14 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 from frappe.utils import get_datetime, now_datetime
 
 from fossunited.doctype_ids import GLOBAL_CFP_SETTINGS
+from fossunited.fossunited.doctype.foss_event_cfp_submission.foss_event_cfp_submission import (
+    ALLOWED_SESSION_TYPES,
+)
 
 
 class FOSSEventCFP(Document):
@@ -62,6 +66,26 @@ class FOSSEventCFP(Document):
         if self.allow_cfp_edit:
             return True
         return self.status == "Live" and not self.is_past_deadline()
+
+    def validate(self):
+        self.validate_allowed_session_types()
+
+    def validate_allowed_session_types(self) -> None:
+        """Catch a bad Desk edit to allowed_session_types at save time."""
+        if not self.allowed_session_types:
+            return
+        invalid = [
+            t
+            for t in (line.strip() for line in self.allowed_session_types.splitlines())
+            if t and t not in ALLOWED_SESSION_TYPES
+        ]
+        if invalid:
+            frappe.throw(
+                _("Invalid session type(s) in Allowed Session Types: {0}").format(
+                    ", ".join(invalid)
+                ),
+                frappe.ValidationError,
+            )
 
     def before_insert(self):
         self.assign_reviewers()

--- a/fossunited/fossunited/doctype/foss_event_cfp/foss_event_cfp.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp/foss_event_cfp.py
@@ -25,6 +25,7 @@ class FOSSEventCFP(Document):
         )
 
         allow_cfp_edit: DF.Check
+        allowed_session_types: DF.SmallText | None
         anonymise_proposals: DF.Check
         cfp_custom_questions: DF.Table[FOSSCustomQuestion]
         cfp_form_description: DF.TextEditor | None
@@ -34,9 +35,10 @@ class FOSSEventCFP(Document):
         event: DF.Link
         event_name: DF.Data | None
         has_public_custom_responses: DF.Check
+        hide_contact_info: DF.Check
         hide_review: DF.Check
-        only_talk_proposals: DF.Check
-        only_workshops: DF.Check
+        override_session_categories: DF.SmallText | None
+        require_speaker_photo: DF.Check
         status: DF.Literal["Closed", "Live"]
     # end: auto-generated types
 

--- a/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
+++ b/fossunited/fossunited/doctype/foss_event_cfp_submission/foss_event_cfp_submission.py
@@ -22,6 +22,15 @@ from fossunited.doctype_ids import (
 )
 from fossunited.fossunited.utils import get_youtube_id, sanitize_text_content
 
+# session_type Select options, minus 'Invited Talk'.
+ALLOWED_SESSION_TYPES = {
+    "Talk",
+    "Lightning Talk",
+    "Panel Discussion",
+    "Birds of Feather(BoF)",
+    "Workshop",
+}
+
 # Proposer-editable content fields. A change to any of these after the CFP
 # edit window closes is blocked for non-System-Manager users. Reviewer/status
 # edits and withdrawal touch none of these, so they pass through.

--- a/fossunited/patches.txt
+++ b/fossunited/patches.txt
@@ -1,6 +1,7 @@
 [pre_model_sync]
 # Patches added in this section will be executed before doctypes are migrated
 # Read docs to understand patches: https://frappeframework.com/docs/v14/user/en/database-migrations
+fossunited.patches.v1_0.migrate_only_flags_to_allowed_session_types
 
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated

--- a/fossunited/patches/v1_0/migrate_only_flags_to_allowed_session_types.py
+++ b/fossunited/patches/v1_0/migrate_only_flags_to_allowed_session_types.py
@@ -1,0 +1,48 @@
+import frappe
+
+from fossunited.doctype_ids import EVENT_CFP
+
+# Mirrors the "no Workshop" filter dashboard/src/helpers/cfp.js used to apply
+# for only_talk_proposals, before allowed_session_types replaced both flags.
+NON_WORKSHOP_TYPES = "Talk\nLightning Talk\nBirds of Feather(BoF)\nPanel Discussion"
+
+
+def execute():
+    """Backfill allowed_session_types from only_workshops/only_talk_proposals
+    before those two Check fields are removed from FOSS Event CFP.
+
+    Must run pre_model_sync: it reads the old columns, which this same
+    deploy's schema sync would otherwise drop before this patch gets a chance
+    to run.
+    """
+    cfps = frappe.get_all(
+        EVENT_CFP,
+        or_filters={"only_workshops": 1, "only_talk_proposals": 1},
+        fields=[
+            "name",
+            "only_workshops",
+            "only_talk_proposals",
+            "allowed_session_types",
+        ],
+        page_length=999,
+    )
+
+    for cfp in cfps:
+        if cfp.allowed_session_types:
+            continue
+
+        allowed = "Workshop" if cfp.only_workshops else NON_WORKSHOP_TYPES
+
+        try:
+            frappe.db.set_value(
+                EVENT_CFP,
+                cfp.name,
+                "allowed_session_types",
+                allowed,
+                update_modified=False,
+            )
+        except Exception:
+            frappe.log_error(
+                title="migrate_only_flags_to_allowed_session_types:failed",
+                message=f"CFP: {cfp.name}\n{frappe.get_traceback()}",
+            )


### PR DESCRIPTION
## Status

- [x] Ready for review

---

## Related Issue

Closes / Addresses: #1673 

---

## Problem

<!-- Briefly describe the problem or motivation for this PR -->

Many fields in CFP form is catered for Indiafoss and generic FOSS events happening with fossunited.

We fail to provide customization for any event hosts to come and conduct an event in capable manner.

Firstly if cfp form can be extended from base default

---

## Solution

<!-- Describe your solution and what you changed -->

Keep default from fossunited as it is, but provide option to override and replace as they wish.

---

## Progress (All must be checked to merge)

- [x] Tested locally
- [ ] Not adding much tests since these are just frontend UI helpers

---

## Changelog

<commit>: <!-- e.g., feat: add user login endpoint -->
- doctype(event-cfp): add fields to override the cfpForm as per event
- helper(cfp): override session type and category as per event form
- add override helper to respective cfp edit, manage and proposal edit page
- doctype(event-cfp): validate session type match correctly to allowed fields

---

## Visualization

- Override limiting session type to 2 and category with only one and "other" for more manual
<img width="1213" height="1482" alt="2026-08-28-155837_hyprshot" src="https://github.com/user-attachments/assets/6fa43123-317b-4918-87ea-1c38f822b5a9" />

- final step showing only replaced checkbox from custom questions to agree
<img width="1242" height="394" alt="2026-08-28-155930_hyprshot" src="https://github.com/user-attachments/assets/e0a20be5-3658-4397-ad29-f458ab94835d" />

- Edit proposal page reflecting as per event CFP options to not expose others.
<img width="3700" height="1285" alt="2026-08-28-160041_hyprshot" src="https://github.com/user-attachments/assets/3d633da0-eff6-4156-ae6d-c0213996fe99" />
