### PR TITLE
feat: My-Tickets page to show tickets bought by session.user as owner or email that match

### DIFF
--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -146,6 +146,7 @@ declare module 'vue' {
     TextEditor: typeof import('./src/components/ui/TextEditor.vue')['default']
     ThemedSelectBlack: typeof import('./src/components/common/ThemedSelectBlack.vue')['default']
     ThemeToggle: typeof import('./src/components/ui/ThemeToggle.vue')['default']
+    TicketCard: typeof import('./src/components/tickets/TicketCard.vue')['default']
     TicketCustomFieldDialog: typeof import('./src/components/event/TicketCustomFieldDialog.vue')['default']
     TicketCustomFieldsSection: typeof import('./src/components/event/TicketCustomFieldsSection.vue')['default']
     TicketList: typeof import('./src/components/event/TicketList.vue')['default']

--- a/dashboard/src/components/animation/LivePing.vue
+++ b/dashboard/src/components/animation/LivePing.vue
@@ -1,7 +1,7 @@
 <template>
-  <span class="relative flex h-3 w-3">
+  <span class="relative flex h-3 w-3" aria-hidden="true">
     <span
-      class="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"
+      class="motion-safe:animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"
     ></span>
     <span class="relative inline-flex rounded-full h-3 w-3 bg-surface-green-3"></span>
   </span>

--- a/dashboard/src/components/tickets/TicketCard.vue
+++ b/dashboard/src/components/tickets/TicketCard.vue
@@ -1,10 +1,10 @@
 <template>
   <div
-    class="bg-surface-white border border-outline-gray-2 rounded-lg flex items-start hover:border-outline-gray-4 transition-colors"
+    class="bg-surface-white border border-outline-gray-2 rounded-lg flex items-start hover:border-outline-gray-4 hover:bg-surface-gray-1 transition-colors"
   >
     <button
       type="button"
-      class="flex-1 min-w-0 flex gap-4 items-start p-5 text-left rounded-l-lg hover:bg-surface-gray-1 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-outline-gray-4"
+      class="flex-1 min-w-0 flex gap-4 items-start p-5 text-left rounded-l-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-outline-gray-4"
       @click="$emit('select', ticket)"
     >
       <img
@@ -66,7 +66,7 @@
 
     <button
       type="button"
-      class="w-9 h-9 flex items-center justify-center rounded-md hover:bg-surface-gray-1 transition-colors flex-shrink-0 mt-5 mr-5 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-outline-gray-4"
+      class="w-9 h-9 flex items-center justify-center rounded-md hover:bg-surface-gray-2 transition-colors flex-shrink-0 mt-5 mr-5 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-outline-gray-4"
       title="Download ticket"
       aria-label="Download ticket"
       :disabled="downloading"

--- a/dashboard/src/components/tickets/TicketCard.vue
+++ b/dashboard/src/components/tickets/TicketCard.vue
@@ -1,0 +1,101 @@
+<template>
+  <div
+    role="button"
+    tabindex="0"
+    class="bg-surface-white border border-outline-gray-2 rounded-lg p-5 flex gap-4 items-start hover:border-outline-gray-4 transition-colors hover:cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-outline-gray-4"
+    :aria-label="`View ticket details for ${ticket.event_name}`"
+    @click="$emit('select', ticket)"
+    @keydown.enter="$emit('select', ticket)"
+    @keydown.space.prevent="$emit('select', ticket)"
+  >
+    <img
+      :src="qrUrl"
+      :alt="`QR code for ticket ${ticket.name}`"
+      class="w-28 h-28 flex-shrink-0 rounded-md bg-surface-gray-1 p-1.5 object-contain"
+    />
+
+    <div class="min-w-0 flex-1 flex flex-col gap-1.5">
+      <div class="flex items-center gap-1.5">
+        <LivePing v-if="!ticket.is_concluded" />
+        <span v-else class="w-2 h-2 rounded-full bg-surface-gray-4 flex-shrink-0" />
+        <p class="text-base font-medium text-ink-gray-9 truncate">{{ ticket.event_name }}</p>
+      </div>
+
+      <div class="flex items-center gap-1.5 text-sm text-ink-gray-5 truncate">
+        <IconTicket class="w-5 h-5 flex-shrink-0" aria-hidden="true" />
+        <span class="truncate">{{ ticket.tier }}</span>
+      </div>
+      <div class="flex items-center gap-1.5 text-sm text-ink-gray-5 truncate">
+        <IconCalendar class="w-5 h-5 flex-shrink-0" aria-hidden="true" />
+        <span class="truncate">{{
+          getFormattedEventDate(ticket.event_start_date, ticket.event_end_date)
+        }}</span>
+      </div>
+      <div
+        v-if="ticket.event_location"
+        class="flex items-center gap-1.5 text-sm text-ink-gray-5 truncate"
+      >
+        <IconMapPin class="w-5 h-5 flex-shrink-0" aria-hidden="true" />
+        <span class="truncate">{{ ticket.event_location }}</span>
+      </div>
+      <span
+        v-if="ticket.wants_tshirt"
+        class="inline-flex items-center gap-1.5 text-sm px-2 py-0.5 rounded-md border w-fit"
+        :class="tshirtState.class"
+        :title="tshirtState.tooltip"
+      >
+        <IconShirt class="w-5 h-5 flex-shrink-0" aria-hidden="true" />
+        {{ ticket.tshirt_size }}
+      </span>
+
+      <Badge
+        v-if="ticket.is_transfer_ticket"
+        class="w-fit"
+        variant="subtle"
+        theme="blue"
+        label="Transferred"
+      />
+    </div>
+
+    <button
+      type="button"
+      class="w-9 h-9 flex items-center justify-center rounded-md hover:bg-surface-gray-2 flex-shrink-0 disabled:cursor-not-allowed disabled:opacity-60"
+      title="Download ticket"
+      aria-label="Download ticket"
+      :disabled="downloading"
+      @click.stop="onDownloadClick"
+    >
+      <LoadingIndicator v-if="downloading" class="w-5 h-5 text-ink-gray-6" />
+      <IconDownload v-else class="w-5 h-5 text-ink-gray-6" />
+    </button>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { Badge, LoadingIndicator } from 'frappe-ui'
+import { IconDownload, IconTicket, IconCalendar, IconMapPin, IconShirt } from '@tabler/icons-vue'
+import LivePing from '@/components/animation/LivePing.vue'
+import { getTicketQrUrl, getTicketDownloadUrl, getTshirtState } from '@/helpers/tickets'
+import { getFormattedEventDate } from '@/helpers/date'
+import { fetchAndDownload } from '@/helpers/utils'
+import { useDownloadAction } from '@/composables/useDownloadAction'
+
+const props = defineProps({
+  ticket: { type: Object, required: true },
+})
+defineEmits(['select'])
+
+const qrUrl = computed(() => getTicketQrUrl(props.ticket.name))
+const tshirtState = computed(() => getTshirtState(props.ticket))
+
+const { loading: downloading, run: downloadTicket } = useDownloadAction(
+  'Could not download ticket',
+)
+
+function onDownloadClick() {
+  downloadTicket(() =>
+    fetchAndDownload(getTicketDownloadUrl(props.ticket.name), `${props.ticket.name}.pdf`),
+  )
+}
+</script>

--- a/dashboard/src/components/tickets/TicketCard.vue
+++ b/dashboard/src/components/tickets/TicketCard.vue
@@ -1,69 +1,77 @@
 <template>
   <div
-    role="button"
-    tabindex="0"
-    class="bg-surface-white border border-outline-gray-2 rounded-lg p-5 flex gap-4 items-start hover:border-outline-gray-4 transition-colors hover:cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-outline-gray-4"
-    :aria-label="`View ticket details for ${ticket.event_name}`"
-    @click="$emit('select', ticket)"
-    @keydown.enter="$emit('select', ticket)"
-    @keydown.space.prevent="$emit('select', ticket)"
+    class="bg-surface-white border border-outline-gray-2 rounded-lg flex items-start hover:border-outline-gray-4 transition-colors"
   >
-    <img
-      :src="qrUrl"
-      :alt="`QR code for ticket ${ticket.name}`"
-      class="w-28 h-28 flex-shrink-0 rounded-md bg-surface-gray-1 p-1.5 object-contain"
-    />
-
-    <div class="min-w-0 flex-1 flex flex-col gap-1.5">
-      <div class="flex items-center gap-1.5">
-        <LivePing v-if="!ticket.is_concluded" />
-        <span v-else class="w-2 h-2 rounded-full bg-surface-gray-4 flex-shrink-0" />
-        <p class="text-base font-medium text-ink-gray-9 truncate">{{ ticket.event_name }}</p>
-      </div>
-
-      <div class="flex items-center gap-1.5 text-sm text-ink-gray-5 truncate">
-        <IconTicket class="w-5 h-5 flex-shrink-0" aria-hidden="true" />
-        <span class="truncate">{{ ticket.tier }}</span>
-      </div>
-      <div class="flex items-center gap-1.5 text-sm text-ink-gray-5 truncate">
-        <IconCalendar class="w-5 h-5 flex-shrink-0" aria-hidden="true" />
-        <span class="truncate">{{
-          getFormattedEventDate(ticket.event_start_date, ticket.event_end_date)
-        }}</span>
-      </div>
-      <div
-        v-if="ticket.event_location"
-        class="flex items-center gap-1.5 text-sm text-ink-gray-5 truncate"
-      >
-        <IconMapPin class="w-5 h-5 flex-shrink-0" aria-hidden="true" />
-        <span class="truncate">{{ ticket.event_location }}</span>
-      </div>
-      <span
-        v-if="ticket.wants_tshirt"
-        class="inline-flex items-center gap-1.5 text-sm px-2 py-0.5 rounded-md border w-fit"
-        :class="tshirtState.class"
-        :title="tshirtState.tooltip"
-      >
-        <IconShirt class="w-5 h-5 flex-shrink-0" aria-hidden="true" />
-        {{ ticket.tshirt_size }}
-      </span>
-
-      <Badge
-        v-if="ticket.is_transfer_ticket"
-        class="w-fit"
-        variant="subtle"
-        theme="blue"
-        label="Transferred"
+    <button
+      type="button"
+      class="flex-1 min-w-0 flex gap-4 items-start p-5 text-left rounded-l-lg hover:bg-surface-gray-1 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-outline-gray-4"
+      @click="$emit('select', ticket)"
+    >
+      <img
+        :src="qrUrl"
+        alt=""
+        class="w-28 h-28 flex-shrink-0 rounded-md bg-surface-gray-1 p-1.5 object-contain"
       />
-    </div>
+
+      <div class="min-w-0 flex-1 flex flex-col gap-1.5">
+        <div class="flex items-center gap-1.5">
+          <LivePing v-if="!ticket.is_concluded" />
+          <span
+            v-else
+            class="w-2 h-2 rounded-full bg-surface-gray-4 flex-shrink-0"
+            aria-hidden="true"
+          />
+          <span class="sr-only">{{
+            ticket.is_concluded ? 'Concluded event.' : 'Upcoming event.'
+          }}</span>
+          <p class="text-base font-medium text-ink-gray-9 truncate">{{ ticket.event_name }}</p>
+        </div>
+
+        <div class="flex items-center gap-1.5 text-sm text-ink-gray-5 truncate">
+          <IconTicket class="w-5 h-5 flex-shrink-0" aria-hidden="true" />
+          <span class="truncate">{{ ticket.tier }}</span>
+        </div>
+        <div class="flex items-center gap-1.5 text-sm text-ink-gray-5 truncate">
+          <IconCalendar class="w-5 h-5 flex-shrink-0" aria-hidden="true" />
+          <span class="truncate">{{
+            getFormattedEventDate(ticket.event_start_date, ticket.event_end_date)
+          }}</span>
+        </div>
+        <div
+          v-if="ticket.event_location"
+          class="flex items-center gap-1.5 text-sm text-ink-gray-5 truncate"
+        >
+          <IconMapPin class="w-5 h-5 flex-shrink-0" aria-hidden="true" />
+          <span class="truncate">{{ ticket.event_location }}</span>
+        </div>
+        <span
+          v-if="ticket.wants_tshirt"
+          class="inline-flex items-center gap-1.5 text-sm px-2 py-0.5 rounded-md border w-fit"
+          :class="tshirtState.class"
+        >
+          <component :is="tshirtState.icon" class="w-5 h-5 flex-shrink-0" aria-hidden="true" />
+          {{ ticket.tshirt_size }}
+          <span class="sr-only">, {{ tshirtState.tooltip }}</span>
+        </span>
+
+        <Badge
+          v-if="ticket.is_transfer_ticket"
+          class="w-fit"
+          variant="subtle"
+          theme="blue"
+          label="Transferred"
+        />
+      </div>
+    </button>
 
     <button
       type="button"
-      class="w-9 h-9 flex items-center justify-center rounded-md hover:bg-surface-gray-2 flex-shrink-0 disabled:cursor-not-allowed disabled:opacity-60"
+      class="w-9 h-9 flex items-center justify-center rounded-md hover:bg-surface-gray-1 transition-colors flex-shrink-0 mt-5 mr-5 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-outline-gray-4"
       title="Download ticket"
       aria-label="Download ticket"
       :disabled="downloading"
-      @click.stop="onDownloadClick"
+      :aria-busy="downloading"
+      @click="onDownloadClick"
     >
       <LoadingIndicator v-if="downloading" class="w-5 h-5 text-ink-gray-6" />
       <IconDownload v-else class="w-5 h-5 text-ink-gray-6" />
@@ -74,7 +82,7 @@
 <script setup>
 import { computed } from 'vue'
 import { Badge, LoadingIndicator } from 'frappe-ui'
-import { IconDownload, IconTicket, IconCalendar, IconMapPin, IconShirt } from '@tabler/icons-vue'
+import { IconDownload, IconTicket, IconCalendar, IconMapPin } from '@tabler/icons-vue'
 import LivePing from '@/components/animation/LivePing.vue'
 import { getTicketQrUrl, getTicketDownloadUrl, getTshirtState } from '@/helpers/tickets'
 import { getFormattedEventDate } from '@/helpers/date'

--- a/dashboard/src/composables/useDownloadAction.js
+++ b/dashboard/src/composables/useDownloadAction.js
@@ -1,0 +1,24 @@
+import { ref } from 'vue'
+import { showError } from '@/helpers/utils'
+
+/**
+ * Wraps an async download/file action with a loading flag and a guard
+ * against double-clicks firing it again while one is already in flight.
+ */
+export function useDownloadAction(errorMessage = 'Could not complete download') {
+  const loading = ref(false)
+
+  async function run(action) {
+    if (loading.value) return
+    loading.value = true
+    try {
+      await action()
+    } catch (error) {
+      showError(error, errorMessage)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { loading, run }
+}

--- a/dashboard/src/helpers/tickets.js
+++ b/dashboard/src/helpers/tickets.js
@@ -1,3 +1,5 @@
+import { IconShirt, IconAlertTriangle } from '@tabler/icons-vue'
+
 export const getTicketQrUrl = (ticketId) =>
   `/api/method/fossunited.api.tickets.get_ticket_qr?ticket_id=${encodeURIComponent(ticketId)}`
 
@@ -25,23 +27,29 @@ export const getTicketEventUrl = (ticket) =>
 /**
  * T-shirt chip state for a ticket: collected (green, filled), ordered and
  * event still upcoming (green, border only), or ordered but never collected
- * and the event has already concluded (red, border only).
+ * and the event has already concluded (red, border only, flagged).
+ *
+ * The two "not collected" states are distinguished by icon, not just color
+ * (green vs red border alone is a red-green colorblind confusion pair).
  */
 export const getTshirtState = (ticket) => {
   if (ticket.tshirt_delivered) {
     return {
       tooltip: 'Collected',
+      icon: IconShirt,
       class: 'bg-surface-green-2 text-ink-green-4 border-transparent',
     }
   }
   if (ticket.is_concluded) {
     return {
-      tooltip: 'Not collected',
+      tooltip: 'Not collected, event has ended',
+      icon: IconAlertTriangle,
       class: 'bg-transparent text-ink-red-4 border-outline-red-3',
     }
   }
   return {
     tooltip: 'Not collected yet',
+    icon: IconShirt,
     class: 'bg-transparent text-ink-green-4 border-outline-green-3',
   }
 }

--- a/dashboard/src/helpers/tickets.js
+++ b/dashboard/src/helpers/tickets.js
@@ -1,0 +1,47 @@
+export const getTicketQrUrl = (ticketId) =>
+  `/api/method/fossunited.api.tickets.get_ticket_qr?ticket_id=${encodeURIComponent(ticketId)}`
+
+export const getTicketDownloadUrl = (ticketId) =>
+  `/api/method/fossunited.api.tickets.download_ticket?ticket_id=${encodeURIComponent(ticketId)}`
+
+/** Single ticket downloads via download_ticket; multiple get bundled into one PDF. */
+export const getTicketsDownloadUrl = (ticketIds) =>
+  ticketIds.length === 1
+    ? getTicketDownloadUrl(ticketIds[0])
+    : `/api/method/fossunited.api.tickets.download_all_tickets?ticket_ids=${encodeURIComponent(
+        JSON.stringify(ticketIds),
+      )}`
+
+export const getTicketIcsUrl = (eventId) =>
+  `/api/method/fossunited.api.chapter.generate_ics?event_ids=${encodeURIComponent(
+    JSON.stringify([eventId]),
+  )}&download=1`
+
+export const getTicketEventUrl = (ticket) =>
+  ticket.has_external_webpage
+    ? ticket.external_event_url
+    : window.location.origin + '/' + ticket.route
+
+/**
+ * T-shirt chip state for a ticket: collected (green, filled), ordered and
+ * event still upcoming (green, border only), or ordered but never collected
+ * and the event has already concluded (red, border only).
+ */
+export const getTshirtState = (ticket) => {
+  if (ticket.tshirt_delivered) {
+    return {
+      tooltip: 'Collected',
+      class: 'bg-surface-green-2 text-ink-green-4 border-transparent',
+    }
+  }
+  if (ticket.is_concluded) {
+    return {
+      tooltip: 'Not collected',
+      class: 'bg-transparent text-ink-red-4 border-outline-red-3',
+    }
+  }
+  return {
+    tooltip: 'Not collected yet',
+    class: 'bg-transparent text-ink-green-4 border-outline-green-3',
+  }
+}

--- a/dashboard/src/helpers/utils.js
+++ b/dashboard/src/helpers/utils.js
@@ -22,6 +22,36 @@ export const copyToClipboard = (text) => {
   navigator.clipboard.writeText(text)
 }
 
+export const triggerDownload = (url, filename) => {
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+}
+
+/**
+ * Fetch a URL and return an object URL for its blob
+ */
+export async function fetchBlobUrl(url) {
+  const res = await fetch(url)
+  if (!res.ok) throw new Error(`Request failed (${res.status})`)
+  const blob = await res.blob()
+  return URL.createObjectURL(blob)
+}
+
+/**
+ * Fetch a file and trigger its download, resolving once the download has
+ * started; unlike a plain <a download> click, this gives callers a promise
+ * to await, so a "loading" state can be shown until the file is ready.
+ */
+export async function fetchAndDownload(url, filename) {
+  const blobUrl = await fetchBlobUrl(url)
+  triggerDownload(blobUrl, filename)
+  URL.revokeObjectURL(blobUrl)
+}
+
 // Remove any empty <p> tag, and add custom margins
 export const cleanedHTML = (htmlData) => {
   const html = htmlData || ''

--- a/dashboard/src/pages/MyTickets.vue
+++ b/dashboard/src/pages/MyTickets.vue
@@ -1,0 +1,248 @@
+<template>
+  <div v-if="tickets.data" class="p-4">
+    <div class="prose">
+      <h2 class="mb-1">My Tickets</h2>
+      <p class="text-sm mb-4">All the paid event tickets booked with your account.</p>
+    </div>
+
+    <div v-if="tickets.data.length" class="flex flex-col gap-6">
+      <div v-if="upcomingTickets.length" class="flex flex-col gap-2">
+        <div class="flex items-center gap-2">
+          <LivePing />
+          <h4 class="text-sm font-medium text-ink-gray-8">Upcoming</h4>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <TicketCard
+            v-for="ticket in upcomingTickets"
+            :key="ticket.name"
+            :ticket="ticket"
+            @select="selectedTicket = ticket"
+          />
+        </div>
+      </div>
+
+      <div v-if="concludedTickets.length" class="flex flex-col gap-2">
+        <div class="flex items-center gap-2">
+          <span class="w-2 h-2 rounded-full bg-surface-gray-4" />
+          <h4 class="text-sm font-medium text-ink-gray-8">Concluded</h4>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <TicketCard
+            v-for="ticket in concludedTickets"
+            :key="ticket.name"
+            :ticket="ticket"
+            @select="selectedTicket = ticket"
+          />
+        </div>
+      </div>
+    </div>
+    <div v-else class="flex flex-col gap-2 rounded-sm p-4 border bg-surface-gray-1">
+      <div class="text-sm font-medium uppercase text-ink-gray-8">No Tickets</div>
+      <div class="text-xs text-ink-gray-5">You haven't booked any event tickets yet.</div>
+    </div>
+  </div>
+  <div v-else class="p-4 text-sm text-ink-gray-5">Loading tickets...</div>
+
+  <Dialog
+    :model-value="!!selectedTicket"
+    class="z-50"
+    :options="{ title: selectedTicket?.event_name }"
+    @update:model-value="(val) => !val && (selectedTicket = null)"
+  >
+    <template #body-content>
+      <div v-if="selectedTicket" class="flex flex-col gap-4 text-sm">
+        <div class="flex flex-col items-center gap-2">
+          <img
+            :src="getTicketQrUrl(selectedTicket.name)"
+            :alt="`QR code for ticket ${selectedTicket.name}`"
+            class="w-48 h-48 object-contain rounded-md bg-surface-gray-1 p-3"
+          />
+          <p class="text-xs text-ink-gray-5 font-mono">{{ selectedTicket.name }}</p>
+          <div class="flex items-center gap-1.5">
+            <LivePing v-if="!selectedTicket.is_concluded" />
+            <span v-else class="w-2 h-2 rounded-full bg-surface-gray-4" />
+            <span class="text-xs text-ink-gray-5">
+              {{ selectedTicket.is_concluded ? 'Concluded' : 'Upcoming' }}
+            </span>
+          </div>
+        </div>
+
+        <div
+          v-if="selectedTicket.is_transfer_ticket"
+          class="text-xs text-ink-blue-4 bg-surface-blue-1 rounded-md px-3 py-2"
+        >
+          This is a transferred ticket from another person.
+        </div>
+
+        <div
+          v-if="selectedTicket.is_concluded"
+          class="text-xs text-ink-gray-6 bg-surface-gray-2 rounded-md px-3 py-2"
+        >
+          This event has concluded. Check the event page for photos, recordings, and more.
+        </div>
+
+        <div class="grid grid-cols-2 gap-3">
+          <div>
+            <p class="text-xs text-ink-gray-5">Event</p>
+            <a
+              :href="getTicketEventUrl(selectedTicket)"
+              target="_blank"
+              rel="noopener"
+              class="text-ink-gray-9 font-medium inline-flex items-center gap-1 hover:underline"
+            >
+              {{ selectedTicket.event_name }}
+              <IconExternalLink
+                class="w-3.5 h-3.5 text-ink-gray-5 flex-shrink-0"
+                aria-hidden="true"
+              />
+            </a>
+          </div>
+          <div>
+            <p class="text-xs text-ink-gray-5">Date</p>
+            <button
+              type="button"
+              class="text-ink-gray-9 inline-flex items-center gap-1 hover:underline disabled:cursor-not-allowed disabled:opacity-60"
+              title="Click to add to calendar"
+              :disabled="addingToCalendar"
+              @click="onAddToCalendarClick"
+            >
+              <LoadingIndicator
+                v-if="addingToCalendar"
+                class="w-3.5 h-3.5 text-ink-gray-5 flex-shrink-0"
+              />
+              <IconCalendar
+                v-else
+                class="w-3.5 h-3.5 text-ink-gray-5 flex-shrink-0"
+                aria-hidden="true"
+              />
+              {{
+                getFormattedEventDate(
+                  selectedTicket.event_start_date,
+                  selectedTicket.event_end_date,
+                )
+              }}
+            </button>
+          </div>
+          <div v-if="selectedTicket.event_location">
+            <p class="text-xs text-ink-gray-5">Venue</p>
+            <a
+              v-if="selectedTicket.map_link"
+              :href="selectedTicket.map_link"
+              target="_blank"
+              rel="noopener"
+              class="text-ink-gray-9 inline-flex items-center gap-1 hover:underline"
+            >
+              <IconMapPin class="w-3.5 h-3.5 text-ink-gray-5 flex-shrink-0" aria-hidden="true" />
+              {{ selectedTicket.event_location }}
+            </a>
+            <p v-else class="text-ink-gray-9 inline-flex items-center gap-1">
+              <IconMapPin class="w-3.5 h-3.5 text-ink-gray-5 flex-shrink-0" aria-hidden="true" />
+              {{ selectedTicket.event_location }}
+            </p>
+          </div>
+          <div>
+            <p class="text-xs text-ink-gray-5">Tier</p>
+            <p class="text-ink-gray-9 inline-flex items-center gap-1">
+              <IconTicket class="w-3.5 h-3.5 text-ink-gray-5 flex-shrink-0" aria-hidden="true" />
+              {{ selectedTicket.tier }}
+            </p>
+          </div>
+          <div>
+            <p class="text-xs text-ink-gray-5">Name</p>
+            <p class="text-ink-gray-9 inline-flex items-center gap-1">
+              <IconUser class="w-3.5 h-3.5 text-ink-gray-5 flex-shrink-0" aria-hidden="true" />
+              {{ selectedTicket.full_name }}
+            </p>
+          </div>
+          <div>
+            <p class="text-xs text-ink-gray-5">Booked on</p>
+            <p class="text-ink-gray-9 inline-flex items-center gap-1">
+              <IconClock class="w-3.5 h-3.5 text-ink-gray-5 flex-shrink-0" aria-hidden="true" />
+              {{ formatCheckinDateTime(selectedTicket.creation) }}
+            </p>
+          </div>
+          <div v-if="selectedTicket.wants_tshirt" class="col-span-2">
+            <p class="text-xs text-ink-gray-5">T-shirt</p>
+            <span
+              class="inline-flex items-center gap-1 px-2 py-0.5 rounded-md border w-fit"
+              :class="getTshirtState(selectedTicket).class"
+              :title="getTshirtState(selectedTicket).tooltip"
+            >
+              <IconShirt class="w-3.5 h-3.5 flex-shrink-0" aria-hidden="true" />
+              {{ selectedTicket.tshirt_size }}
+            </span>
+          </div>
+        </div>
+
+        <Button
+          label="Download ticket"
+          variant="solid"
+          class="w-full"
+          :loading="downloadingTicket"
+          @click="onDownloadClick"
+        />
+      </div>
+    </template>
+  </Dialog>
+</template>
+
+<script setup>
+import { createResource, Dialog, Button, LoadingIndicator } from 'frappe-ui'
+import { ref, computed } from 'vue'
+import {
+  IconShirt,
+  IconExternalLink,
+  IconCalendar,
+  IconClock,
+  IconMapPin,
+  IconTicket,
+  IconUser,
+} from '@tabler/icons-vue'
+import TicketCard from '@/components/tickets/TicketCard.vue'
+import LivePing from '@/components/animation/LivePing.vue'
+import { getFormattedEventDate, formatCheckinDateTime } from '@/helpers/date'
+import {
+  getTicketQrUrl,
+  getTicketDownloadUrl,
+  getTicketIcsUrl,
+  getTicketEventUrl,
+  getTshirtState,
+} from '@/helpers/tickets'
+import { fetchAndDownload } from '@/helpers/utils'
+import { useDownloadAction } from '@/composables/useDownloadAction'
+
+const selectedTicket = ref(null)
+
+const tickets = createResource({
+  url: 'fossunited.api.tickets.get_session_user_tickets',
+  auto: true,
+})
+
+const upcomingTickets = computed(() => tickets.data?.filter((t) => !t.is_concluded) ?? [])
+const concludedTickets = computed(() => tickets.data?.filter((t) => t.is_concluded) ?? [])
+
+const { loading: downloadingTicket, run: downloadTicket } = useDownloadAction(
+  'Could not download ticket',
+)
+const { loading: addingToCalendar, run: addToCalendar } = useDownloadAction(
+  'Could not add to calendar',
+)
+
+function onDownloadClick() {
+  downloadTicket(() =>
+    fetchAndDownload(
+      getTicketDownloadUrl(selectedTicket.value.name),
+      `${selectedTicket.value.name}.pdf`,
+    ),
+  )
+}
+
+function onAddToCalendarClick() {
+  addToCalendar(() =>
+    fetchAndDownload(
+      getTicketIcsUrl(selectedTicket.value.event),
+      `${selectedTicket.value.event}.ics`,
+    ),
+  )
+}
+</script>

--- a/dashboard/src/pages/MyTickets.vue
+++ b/dashboard/src/pages/MyTickets.vue
@@ -9,7 +9,7 @@
       <div v-if="upcomingTickets.length" class="flex flex-col gap-2">
         <div class="flex items-center gap-2">
           <LivePing />
-          <h4 class="text-sm font-medium text-ink-gray-8">Upcoming</h4>
+          <h3 class="text-sm font-medium text-ink-gray-8">Upcoming</h3>
         </div>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
           <TicketCard
@@ -23,8 +23,8 @@
 
       <div v-if="concludedTickets.length" class="flex flex-col gap-2">
         <div class="flex items-center gap-2">
-          <span class="w-2 h-2 rounded-full bg-surface-gray-4" />
-          <h4 class="text-sm font-medium text-ink-gray-8">Concluded</h4>
+          <span class="w-2 h-2 rounded-full bg-surface-gray-4" aria-hidden="true" />
+          <h3 class="text-sm font-medium text-ink-gray-8">Concluded</h3>
         </div>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
           <TicketCard
@@ -60,7 +60,7 @@
           <p class="text-xs text-ink-gray-5 font-mono">{{ selectedTicket.name }}</p>
           <div class="flex items-center gap-1.5">
             <LivePing v-if="!selectedTicket.is_concluded" />
-            <span v-else class="w-2 h-2 rounded-full bg-surface-gray-4" />
+            <span v-else class="w-2 h-2 rounded-full bg-surface-gray-4" aria-hidden="true" />
             <span class="text-xs text-ink-gray-5">
               {{ selectedTicket.is_concluded ? 'Concluded' : 'Upcoming' }}
             </span>
@@ -104,6 +104,7 @@
               class="text-ink-gray-9 inline-flex items-center gap-1 hover:underline disabled:cursor-not-allowed disabled:opacity-60"
               title="Click to add to calendar"
               :disabled="addingToCalendar"
+              :aria-busy="addingToCalendar"
               @click="onAddToCalendarClick"
             >
               <LoadingIndicator
@@ -115,12 +116,14 @@
                 class="w-3.5 h-3.5 text-ink-gray-5 flex-shrink-0"
                 aria-hidden="true"
               />
+              <span class="sr-only">Add </span>
               {{
                 getFormattedEventDate(
                   selectedTicket.event_start_date,
                   selectedTicket.event_end_date,
                 )
               }}
+              <span class="sr-only"> to your calendar</span>
             </button>
           </div>
           <div v-if="selectedTicket.event_location">
@@ -165,11 +168,16 @@
             <p class="text-xs text-ink-gray-5">T-shirt</p>
             <span
               class="inline-flex items-center gap-1 px-2 py-0.5 rounded-md border w-fit"
-              :class="getTshirtState(selectedTicket).class"
-              :title="getTshirtState(selectedTicket).tooltip"
+              :class="selectedTshirtState.class"
+              :title="selectedTshirtState.tooltip"
             >
-              <IconShirt class="w-3.5 h-3.5 flex-shrink-0" aria-hidden="true" />
+              <component
+                :is="selectedTshirtState.icon"
+                class="w-3.5 h-3.5 flex-shrink-0"
+                aria-hidden="true"
+              />
               {{ selectedTicket.tshirt_size }}
+              <span class="sr-only">, {{ selectedTshirtState.tooltip }}</span>
             </span>
           </div>
         </div>
@@ -179,6 +187,7 @@
           variant="solid"
           class="w-full"
           :loading="downloadingTicket"
+          :aria-busy="downloadingTicket"
           @click="onDownloadClick"
         />
       </div>
@@ -190,7 +199,6 @@
 import { createResource, Dialog, Button, LoadingIndicator } from 'frappe-ui'
 import { ref, computed } from 'vue'
 import {
-  IconShirt,
   IconExternalLink,
   IconCalendar,
   IconClock,
@@ -220,6 +228,9 @@ const tickets = createResource({
 
 const upcomingTickets = computed(() => tickets.data?.filter((t) => !t.is_concluded) ?? [])
 const concludedTickets = computed(() => tickets.data?.filter((t) => t.is_concluded) ?? [])
+const selectedTshirtState = computed(
+  () => selectedTicket.value && getTshirtState(selectedTicket.value),
+)
 
 const { loading: downloadingTicket, run: downloadTicket } = useDownloadAction(
   'Could not download ticket',

--- a/dashboard/src/pages/PaymentSuccess.vue
+++ b/dashboard/src/pages/PaymentSuccess.vue
@@ -79,6 +79,14 @@
           />
         </div>
 
+        <router-link
+          v-if="session.isLoggedIn"
+          to="/my-tickets"
+          class="text-sm text-ink-gray-6 underline hover:text-ink-gray-8"
+        >
+          View this anytime in My Tickets
+        </router-link>
+
         <p class="text-xs text-ink-gray-4">
           For any assistance, email
           <a :href="`mailto:${contactEmail}`" class="underline">{{ contactEmail }}</a>
@@ -98,6 +106,7 @@ import { IconCircleCheck, IconDownload, IconEye } from '@tabler/icons-vue'
 import { fetchBlobUrl, fetchAndDownload, showError } from '@/helpers/utils'
 import { getTicketsDownloadUrl } from '@/helpers/tickets'
 import { useDownloadAction } from '@/composables/useDownloadAction'
+import { session } from '@/data/session'
 
 const route = useRoute()
 const orderId = route.query.order_id

--- a/dashboard/src/pages/PaymentSuccess.vue
+++ b/dashboard/src/pages/PaymentSuccess.vue
@@ -45,8 +45,8 @@
             variant="solid"
             size="md"
             class="w-full"
-            :loading="downloading"
-            @click="downloadAll"
+            :loading="downloadingAll"
+            @click="onDownloadAllClick"
           >
             <span class="flex items-center justify-center gap-2">
               <IconDownload class="w-4 h-4" /> Download Tickets (PDF)
@@ -95,7 +95,9 @@ import { createResource, Button } from 'frappe-ui'
 import Header from '@/components/Header.vue'
 import EventHeader from '@/components/common/EventHeader.vue'
 import { IconCircleCheck, IconDownload, IconEye } from '@tabler/icons-vue'
-import { showError } from '@/helpers/utils'
+import { fetchBlobUrl, fetchAndDownload, showError } from '@/helpers/utils'
+import { getTicketsDownloadUrl } from '@/helpers/tickets'
+import { useDownloadAction } from '@/composables/useDownloadAction'
 
 const route = useRoute()
 const orderId = route.query.order_id
@@ -104,7 +106,6 @@ const eventId = route.query.event
 const confettiCanvas = ref(null)
 const ticketCount = ref(null)
 const ticketIds = ref([])
-const downloading = ref(false)
 const previewing = ref(false)
 const pdfPreviewUrl = ref(null)
 
@@ -136,22 +137,12 @@ watch(ticketIds, (ids) => {
   if (ids.length > 0 && !pdfPreviewUrl.value) loadPreview()
 })
 
-function apiUrl() {
-  if (ticketIds.value.length === 1) {
-    return `/api/method/fossunited.api.tickets.download_ticket?ticket_id=${encodeURIComponent(ticketIds.value[0])}`
-  }
-  return `/api/method/fossunited.api.tickets.download_all_tickets?ticket_ids=${encodeURIComponent(JSON.stringify(ticketIds.value))}`
-}
-
 async function loadPreview() {
   if (previewing.value || ticketIds.value.length === 0) return
   previewing.value = true
   try {
-    const res = await fetch(apiUrl())
-    if (!res.ok) throw new Error('Failed to fetch PDF')
-    const blob = await res.blob()
     if (pdfPreviewUrl.value) URL.revokeObjectURL(pdfPreviewUrl.value)
-    pdfPreviewUrl.value = URL.createObjectURL(blob)
+    pdfPreviewUrl.value = await fetchBlobUrl(getTicketsDownloadUrl(ticketIds.value))
   } catch (err) {
     showError(err, 'Could not preview ticket')
   } finally {
@@ -168,19 +159,10 @@ function togglePreview() {
   }
 }
 
-function downloadAll() {
-  if (downloading.value || ticketIds.value.length === 0) return
-  downloading.value = true
-  try {
-    const a = document.createElement('a')
-    a.href = apiUrl()
-    a.download = 'tickets.pdf'
-    document.body.appendChild(a)
-    a.click()
-    document.body.removeChild(a)
-  } finally {
-    downloading.value = false
-  }
+const { loading: downloadingAll, run: downloadAll } = useDownloadAction('Could not download tickets')
+
+function onDownloadAllClick() {
+  downloadAll(() => fetchAndDownload(getTicketsDownloadUrl(ticketIds.value), 'tickets.pdf'))
 }
 
 function launchConfetti() {

--- a/dashboard/src/router.js
+++ b/dashboard/src/router.js
@@ -27,6 +27,11 @@ const routes = [
         component: () => import('@/pages/profile/MyProposals.vue'),
       },
       {
+        path: '/my-tickets',
+        name: 'MyTickets',
+        component: () => import('@/pages/MyTickets.vue'),
+      },
+      {
         path: '/my-hackathons',
         name: 'MyHackathons',
         component: () => import('@/pages/hackathon/MyHackathons.vue'),

--- a/fossunited/api/sidebar.py
+++ b/fossunited/api/sidebar.py
@@ -23,7 +23,7 @@ def get_sidebar_items(user: str = frappe.session.user):
                 {
                     "label": "My Tickets",
                     "route": "/my-tickets",
-                    "icon": "ticket",
+                    "icon": "credit-card",
                 },
             ],
         },

--- a/fossunited/api/sidebar.py
+++ b/fossunited/api/sidebar.py
@@ -20,6 +20,11 @@ def get_sidebar_items(user: str = frappe.session.user):
                     "route": "/my-proposals",
                     "icon": "file-text",
                 },
+                {
+                    "label": "My Tickets",
+                    "route": "/my-tickets",
+                    "icon": "ticket",
+                },
             ],
         },
         {

--- a/fossunited/api/tickets.py
+++ b/fossunited/api/tickets.py
@@ -2,6 +2,7 @@
 APIs for Tickets and Transfer Tickets
 """
 
+import io
 from datetime import timedelta
 
 import frappe
@@ -47,6 +48,79 @@ def get_ticket_details(ticket_id: str):
         as_dict=True,
     )
     return ticket
+
+
+@frappe.whitelist()
+def get_session_user_tickets() -> list:
+    """
+    Get all tickets belonging to the logged-in user, for the "My Tickets" page.
+
+    A ticket belongs to the user if its email matches the session user, or if
+    the session user created the ticket (e.g. on someone else's behalf).
+    """
+    tickets = frappe.get_all(
+        EVENT_TICKET,
+        or_filters={"email": frappe.session.user, "owner": frappe.session.user},
+        fields=[
+            "name",
+            "event",
+            "tier",
+            "full_name",
+            "wants_tshirt",
+            "tshirt_size",
+            "tshirt_delivered",
+            "is_transfer_ticket",
+            "creation",
+            "event.event_name as event_name",
+            "event.event_start_date as event_start_date",
+            "event.event_end_date as event_end_date",
+            "event.event_location as event_location",
+            "event.map_link as map_link",
+            "event.banner_image as banner_image",
+            "event.route as route",
+            "event.has_external_webpage as has_external_webpage",
+            "event.external_event_url as external_event_url",
+        ],
+        order_by="creation desc",
+    )
+
+    today = frappe.utils.getdate(frappe.utils.today())
+    for ticket in tickets:
+        event_date = ticket.event_end_date or ticket.event_start_date
+        ticket["is_concluded"] = bool(event_date and frappe.utils.getdate(event_date) < today)
+
+    return tickets
+
+
+@frappe.whitelist()
+def get_ticket_qr(ticket_id: str):
+    """
+    Render a QR code (SVG) for a ticket, encoding the plain ticket ID.
+
+    Ownership-gated: only the ticket's email owner or its creator may fetch it.
+    A ticket's QR content never changes once issued, so the response is
+    cacheable by the requesting browser.
+
+    Uses pyqrcode's .svg() (same as frappe.twofactor.get_qr_svg_code) since
+    .png() needs the separate `pypng` package, which isn't installed here.
+    """
+    import pyqrcode
+    from werkzeug.wrappers import Response
+
+    ticket = frappe.db.get_value(EVENT_TICKET, ticket_id, ["email", "owner"], as_dict=True)
+    # Same error for "doesn't exist" and "not yours"; avoids leaking which
+    # ticket IDs are valid to a caller who doesn't own them.
+    if not ticket or frappe.session.user not in (ticket.email, ticket.owner):
+        frappe.throw(_("Not permitted to access this ticket"), frappe.PermissionError)
+
+    buf = io.BytesIO()
+    pyqrcode.create(ticket_id).svg(buf, scale=6, background="#fff")
+
+    return Response(
+        buf.getvalue(),
+        mimetype="image/svg+xml",
+        headers={"Cache-Control": "private, max-age=86400"},
+    )
 
 
 # nosemgrep: guest-whitelisted-method

--- a/fossunited/tests/test_ticket_download.py
+++ b/fossunited/tests/test_ticket_download.py
@@ -2,6 +2,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from fossunited.api.tickets import (
+    get_ticket_qr,
     search_tickets,
 )
 from fossunited.doctype_ids import CHAPTER, EVENT, EVENT_TICKET, FREE_TICKET_CODE
@@ -11,6 +12,7 @@ from fossunited.tests.utils import (
     insert_test_coupon_application,
     insert_test_event,
     insert_test_ticket,
+    insert_user_profile,
 )
 
 
@@ -79,3 +81,63 @@ class TestTicketAPI(FrappeTestCase):
         allowed_fields = {"name", "full_name", "email", "tier", "organization"}
         for ticket_data in result:
             self.assertTrue(set(ticket_data.keys()).issubset(allowed_fields))
+
+
+class TestTicketQrAuth(FrappeTestCase):
+    """get_ticket_qr must only be reachable by the ticket's email match or its creator."""
+
+    def setUp(self):
+        frappe.set_user("Administrator")
+        self.buyer = "test_ticket_buyer@example.com"
+        self.stranger = "test_ticket_stranger@example.com"
+        insert_user_profile(self.buyer)
+        insert_user_profile(self.stranger)
+
+        self.chapter = insert_test_chapter()
+        self.event = insert_test_event(self.chapter, is_paid_event=1, tickets_status="Live")
+
+        # email match: created by Administrator, but the email field is the buyer's
+        self.email_match_ticket = insert_test_ticket(self.event.name, email=self.buyer)
+
+        # owner match: created while logged in as the buyer, email is unrelated.
+        # ignore_permissions=True since a plain user has no create perm on the
+        # doctype (real ticket creation always goes through ignore_permissions);
+        # owner is still set from the active session user regardless.
+        frappe.set_user(self.buyer)
+        self.owner_match_ticket = insert_test_ticket(
+            self.event.name, email="someone-else@example.com", ignore_permissions=True
+        )
+        frappe.set_user("Administrator")
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+        frappe.delete_doc(EVENT_TICKET, self.email_match_ticket.name, force=True)
+        frappe.delete_doc(EVENT_TICKET, self.owner_match_ticket.name, force=True)
+        frappe.delete_doc(EVENT, self.event.name, force=True)
+        frappe.delete_doc(CHAPTER, self.chapter.name, force=True)
+        frappe.db.delete("User", {"name": ["in", [self.buyer, self.stranger]]})
+        frappe.db.rollback()
+
+    def test_email_match_can_fetch_qr(self):
+        """Session user matching ticket.email (but not its creator) is allowed"""
+        frappe.set_user(self.buyer)
+        response = get_ticket_qr(self.email_match_ticket.name)
+        self.assertEqual(response.mimetype, "image/svg+xml")
+
+    def test_owner_match_can_fetch_qr(self):
+        """Session user matching ticket.owner (but not its email) is allowed"""
+        frappe.set_user(self.buyer)
+        response = get_ticket_qr(self.owner_match_ticket.name)
+        self.assertEqual(response.mimetype, "image/svg+xml")
+
+    def test_stranger_is_denied(self):
+        """Session user matching neither email nor owner is denied"""
+        frappe.set_user(self.stranger)
+        with self.assertRaises(frappe.PermissionError):
+            get_ticket_qr(self.email_match_ticket.name)
+
+    def test_nonexistent_ticket_denied_same_as_stranger(self):
+        """A made-up ticket_id must fail the same way as a real ticket owned by someone else"""
+        frappe.set_user(self.stranger)
+        with self.assertRaises(frappe.PermissionError):
+            get_ticket_qr("NON_EXISTENT_TICKET_ID")


### PR DESCRIPTION
## Status

- [x] Ready for review

---

## Related Issue

Closes / Addresses: #1718 

---

## Problem

<!-- Briefly describe the problem or motivation for this PR -->
When user buy ticket all they get is confirmed by email and they make it to event by that.

When we have a platform we should facilitate the UX by providing, what all data they have here, must be display for whatever reason it exists.

---

## Solution

<!-- Describe your solution and what you changed -->
Simple `/dashboard/my-tickets` page that lists all paid event ticket they've bought or got for free, and show with basic details along with t-shirt data.

- Added two safe API endpoints.

- `get_session_user_tickets` : Which only grabs ticket owner by user or email that match. No args, just fetch via frappe.session.user

- `get_ticket_qr`: use framework deps `pyqrcode` in bench to generated a svg with ID embedded, so ticket scanning works as intended for checkin.
- Anyway they can take a screenshot or download PDF from print format.
- These QR images are cached, so server load is not added.

---

## Progress (All must be checked to merge)

- [x] Tested locally 
- [x] added test to ensure only session.user tickets are given out as data.

---

## Changelog

<commit>: <!-- e.g., feat: add user login endpoint -->

---

## Visualization

<!-- Add screenshots, diagrams, or screen recordings if applicable -->
- Image showing all tickets bought by a session user (matching email and owner mostly)
- grouped into live and concluded, shows t-shirt for info as well

<img width="1853" height="877" alt="2026-08-31-195129_hyprshot" src="https://github.com/user-attachments/assets/e74df828-8a42-4c0b-b9aa-4b6a3fcfa744" />

- ticket dialog popup showing more info, with download ticket, add to calendar, event details and so on.

<img width="877" height="863" alt="2026-08-31-195143_hyprshot" src="https://github.com/user-attachments/assets/ea46fb31-8a2d-4fae-9b44-db2aeba031ee" />
