### PR TITLE
fix: name the ticket registration progressbar for assistive tech

### DIFF
--- a/dashboard/src/pages/BuyTickets.vue
+++ b/dashboard/src/pages/BuyTickets.vue
@@ -50,20 +50,32 @@
           <div class="flex-1 min-w-0 flex flex-col gap-4">
             <!-- Step Progress -->
             <nav aria-label="Registration steps">
-              <Progress
-                :value="currentStep * 25"
-                :intervals="true"
-                :interval-count="4"
-                size="lg"
-                :label="stepTitle"
-                :hint="true"
-              >
-                <template #hint>
+              <div class="w-full space-y-[10px]">
+                <div class="flex items-baseline justify-between">
+                  <span id="ticket-reg-progress-label" class="text-base font-medium text-ink-gray-8">{{
+                    stepTitle
+                  }}</span>
                   <span class="text-sm font-medium text-ink-gray-4" aria-live="polite"
                     >{{ currentStep }} / 4</span
                   >
-                </template>
-              </Progress>
+                </div>
+                <div
+                  role="progressbar"
+                  aria-labelledby="ticket-reg-progress-label"
+                  :aria-valuenow="currentStep"
+                  aria-valuemin="1"
+                  aria-valuemax="4"
+                  :aria-valuetext="`Registration progress: ${stepTitle}, step ${currentStep} of 4`"
+                  class="flex h-2 space-x-1 overflow-hidden rounded-lg"
+                >
+                  <div
+                    v-for="n in 4"
+                    :key="n"
+                    class="h-full w-full"
+                    :class="n <= currentStep ? 'bg-surface-gray-10' : 'bg-surface-gray-2'"
+                  />
+                </div>
+              </div>
             </nav>
 
             <!-- Step Content -->
@@ -511,7 +523,6 @@ import {
   ErrorMessage,
   Badge,
   Dialog,
-  Progress,
 } from 'frappe-ui'
 import { markdownToHTML } from 'frappe-ui/src/utils/markdown'
 import { toast } from 'vue-sonner'


### PR DESCRIPTION
## Summary
- Names the ticket-registration progressbar so screen readers get the same context sighted users see (`Select your Tickets` + step 1 of 4).
- Keeps the existing 4-interval visual; does not wait on the frappe-ui 1.0 bump (#1437).

Fixes #1696

## Why this instead of bumping frappe-ui
`Progress` from frappe-ui puts the visible title in a sibling span and `role="progressbar"` on the inner track. Lighthouse flags that as an unnamed progressbar. A dashboard-wide 1.0 upgrade is already tracked separately; this is a local, low-risk a11y fix on `/dashboard/buy-tickets`.

## Test plan
- [ ] Open `/dashboard/buy-tickets?event=<event>`
- [ ] Confirm the visual title + `1 / 4` (through `4 / 4`) still look correct on each step
- [ ] Inspect the progressbar: it has `aria-labelledby`, `aria-valuenow` 1–4, and `aria-valuetext` like `Registration progress: Select your Tickets, step 1 of 4`
- [ ] Chrome Lighthouse accessibility: no “progressbar elements do not have accessible names” on this page