### PR TITLE
docs(bruno): update to use yarn instead of npm, resolve bru binary path in pre-commit script

### DIFF
--- a/bruno-collection/README.md
+++ b/bruno-collection/README.md
@@ -15,10 +15,9 @@ End-to-end security tests for the fossunited API layer, written in
    docker exec -w /workspace/development/fossu-bench/sites \
      devcontainer-frappe-1 ../env/bin/python /workspace/development/run_seed.py
    ```
-3. **Bruno CLI** (`@usebruno/cli`) installed:
+3. **Bruno CLI** (`@usebruno/cli`) or via Linux package managers:
    ```bash
-   npm install -g @usebruno/cli
-   # or use npx (auto-installs)
+   yarn install # or: npm install @usebruno/cli
    ```
 
 ## Running tests
@@ -27,11 +26,13 @@ From the `bruno-collection/` directory:
 
 ```bash
 # Run a single folder
-npx @usebruno/cli run api/hackathon --env local-development
+yarn bru run api/hackathon --env local-development
+# npm users: npx bru run api/hackathon --env local-development
 
 # Run all test folders
 for folder in api/*/; do
-  npx @usebruno/cli run "$folder" --env local-development
+  yarn bru run "$folder" --env local-development
+  # npm users: npx bru run "$folder" --env local-development
 done
 ```
 

--- a/development/run_bruno_tests.sh
+++ b/development/run_bruno_tests.sh
@@ -4,9 +4,41 @@ set -euo pipefail
 # Maps changed Python API files and Bruno test files to the Bruno folders
 # that need to run. Skips gracefully if the Frappe server is unreachable.
 
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BRUNO_DIR="bruno-collection"
 ENV="local-development"
 BASE_URL="http://foss.localhost/api"
+
+# Resolve how to invoke `bru`:
+#   1. Already on PATH (e.g. installed globally via distro package manager, or via nix).
+#   2. Already installed locally under node_modules/.bin (yarn/npm install already ran).
+#   3. Not installed yet: install it via whichever of yarn/npm is available.
+resolve_bru() {
+  if command -v bru >/dev/null 2>&1; then
+    command -v bru
+    return
+  fi
+
+  if [[ -x "$ROOT_DIR/node_modules/.bin/bru" ]]; then
+    echo "$ROOT_DIR/node_modules/.bin/bru"
+    return
+  fi
+
+  if command -v yarn >/dev/null 2>&1; then
+    echo "Bruno CLI not found — installing dependencies with yarn..." >&2
+    (cd "$ROOT_DIR" && yarn install --silent)
+  elif command -v npm >/dev/null 2>&1; then
+    echo "Bruno CLI not found — installing dependencies with npm..." >&2
+    (cd "$ROOT_DIR" && npm install --silent)
+  else
+    return
+  fi
+
+  if [[ -x "$ROOT_DIR/node_modules/.bin/bru" ]]; then
+    echo "$ROOT_DIR/node_modules/.bin/bru"
+  fi
+}
+
 
 # Python module → Bruno test folder mapping
 declare -A API_MAP=(
@@ -49,7 +81,13 @@ fi
 # Check if Frappe server is reachable
 if ! curl -sf --max-time 3 "$BASE_URL/method/frappe.ping" > /dev/null 2>&1; then
   echo "⚠  Frappe server not reachable at $BASE_URL — skipping Bruno tests"
-  echo "   Start the server and run manually: npx @usebruno/cli run bruno-collection/<folder> --env $ENV"
+  echo "   Start the server and run manually: bru run bruno-collection/<folder> --env $ENV"
+  exit 0
+fi
+
+BRU_BIN="$(resolve_bru)"
+if [[ -z "$BRU_BIN" ]]; then
+  echo "⚠  Bruno CLI (bru) not found, and neither yarn nor npm is available — skipping Bruno tests"
   exit 0
 fi
 
@@ -60,7 +98,7 @@ for folder in "${FOLDERS_TO_RUN[@]}"; do
     continue
   fi
   echo "▶ Running Bruno tests: $folder"
-  if ! (cd "$BRUNO_DIR" && npx @usebruno/cli run "$folder" --env "$ENV"); then
+  if ! (cd "$BRUNO_DIR" && "$BRU_BIN" run "$folder" --env "$ENV"); then
     echo "✗ FAILED: $folder"
     FAILED=1
   fi

--- a/docs/docs/development.md
+++ b/docs/docs/development.md
@@ -306,10 +306,11 @@ traversal) against a running Frappe instance with seed data.
 ### Setup
 
 1. Seed your dev site (see [Seed Script](#seed-script) above).
-2. Install Bruno CLI:
-   ```sh
-   npm install -g @usebruno/cli
-   ```
+2. Install dependencies:
+
+```sh
+yarn install # or: npm install @bru
+```
 
 ### Running Tests
 
@@ -317,11 +318,13 @@ From the `bruno-collection/` directory:
 
 ```sh
 # Run a single test folder
-npx @usebruno/cli run api/hackathon --env local-development
+yarn bru run api/hackathon --env local-development
+# npm users: npx bru run api/hackathon --env local-development
 
 # Run all test folders
 for folder in api/*/; do
-  npx @usebruno/cli run "$folder" --env local-development
+  yarn bru run "$folder" --env local-development
+  # npm users: npx bru run "$folder" --env local-development
 done
 ```
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@tailwindcss/typography": "^0.5.16",
+    "@usebruno/cli": "^4.1.0",
     "eslint": "^10.6.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.6",
@@ -34,7 +35,7 @@
     "globals": "^17.7.0",
     "prettier": "^3.9.3",
     "prettier-plugin-jinja-template": "^2.2.0",
-    "tailwindcss": "^3.4.1",
-    "purgecss": "^8.0.0"
+    "purgecss": "^8.0.0",
+    "tailwindcss": "^3.4.1"
   }
 }


### PR DESCRIPTION
- add bruno-cli to dev dependency in package.json so yarn install gets it and easy to use

- update docs to use `yarn bru ...` commands

- `run_bruno_tests.sh` : update to resolve finding bru cli
  - check if installed by linux PATH (distro pkm)
  - Check if in node_modules as bin or if yarn/npm then install it
  - If not found anyway warn and dont block commit and skip