### PR TITLE
ci: bump node 20 -> 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Node.js with Cache
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'yarn'
 
       - name: Install System Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           cache: 'pip'
 
       - name: Setup Node.js with Cache
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '24.x'
           cache: 'yarn'


### PR DESCRIPTION
* just checking if it works and installs fine

- Adding bruno to package.json #1738  dev dependency complains on requiring node > 22..

frappe 16 needs > 24 only, so bumping to test if CI runs fine.