### PR TITLE
fix(ticketTransfer): make get_transfer_details pure GET req to avoid CSRF mismatch error

### DIFF
--- a/dashboard/src/pages/BuyTickets.vue
+++ b/dashboard/src/pages/BuyTickets.vue
@@ -72,7 +72,7 @@
                     v-for="n in 4"
                     :key="n"
                     class="h-full w-full"
-                    :class="n <= currentStep ? 'bg-surface-gray-10' : 'bg-surface-gray-2'"
+                    :class="n <= currentStep ? 'bg-surface-gray-7' : 'bg-surface-gray-3'"
                   />
                 </div>
               </div>

--- a/dashboard/src/pages/TicketTransferProcess.vue
+++ b/dashboard/src/pages/TicketTransferProcess.vue
@@ -62,6 +62,7 @@ const isValidStatus = () => {
 
 const transferDoc = createResource({
   url: 'fossunited.api.tickets.get_transfer_details',
+  method: 'GET',
   makeParams() {
     return {
       id: transferID,


### PR DESCRIPTION
* pure edge case scenario of having stale csrf token in browser and thus frappe throwing "invalid request" error on ticket transfer page

* minor fix on color to be distinguishable for progress on buy ticket page.

Error thrown by auth.py here:

https://github.com/frappe/frappe/blob/version-15/frappe/auth.py#L83-L99

