### PR TITLE
doctype(schedule): add BOF and Invited talk as session type

### DIFF
--- a/fossunited/fossunited/doctype/foss_event_schedule/foss_event_schedule.json
+++ b/fossunited/fossunited/doctype/foss_event_schedule/foss_event_schedule.json
@@ -80,7 +80,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Category",
-   "options": "Talk\nLightning Talk\nWorkshop\nPanel Discussion\nOpening Note\nBreak\nOther"
+   "options": "Talk\nLightning Talk\nWorkshop\nPanel Discussion\nOpening Note\nInvited Talk\nBirds of Feather(BoF)\nBreak\nOther"
   },
   {
    "depends_on": "eval:doc.category=='Other'",
@@ -115,7 +115,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2026-03-07 16:36:59.875870",
+ "modified": "2026-09-07 14:29:44.504189",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "FOSS Event Schedule",

--- a/fossunited/fossunited/doctype/foss_event_schedule/foss_event_schedule.json
+++ b/fossunited/fossunited/doctype/foss_event_schedule/foss_event_schedule.json
@@ -76,6 +76,8 @@
    "label": "Speakers"
   },
   {
+   "fetch_from": "linked_cfp.session_type",
+   "fetch_if_empty": 1,
    "fieldname": "category",
    "fieldtype": "Select",
    "in_list_view": 1,
@@ -115,7 +117,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2026-09-07 14:29:44.504189",
+ "modified": "2026-09-07 16:06:27.565074",
  "modified_by": "Administrator",
  "module": "FOSSUnited",
  "name": "FOSS Event Schedule",

--- a/fossunited/fossunited/doctype/foss_event_schedule/foss_event_schedule.py
+++ b/fossunited/fossunited/doctype/foss_event_schedule/foss_event_schedule.py
@@ -19,6 +19,8 @@ class FOSSEventSchedule(Document):
             "Workshop",
             "Panel Discussion",
             "Opening Note",
+            "Invited Talk",
+            "Birds of Feather(BoF)",
             "Break",
             "Other",
         ]


### PR DESCRIPTION
* so we can keep in sync with proposal itself without being warned

+ More fixes to come

  - Remove default A-z sorting for schedule halls
  - unwrap halls in schedule page below so users dont need to scroll.