### PR TITLE
refactor(schedulePage): cleanup and bug fixes on schedule page

### DIFF
--- a/dashboard/src/components/Breadcrumb.vue
+++ b/dashboard/src/components/Breadcrumb.vue
@@ -4,16 +4,16 @@
       v-for="(item, index) in items"
       :key="index"
       class="text-base flex gap-1 items-center"
-      :class="index == items.length - 1 ? 'font-medium text-ink-gray-8' : 'text-ink-gray-5 '"
+      :class="index == items.length - 1 ? 'font-medium text-ink-gray-8' : 'text-ink-gray-7 dark:text-ink-gray-8 '"
     >
       <router-link
         v-if="item.route"
-        class="hover:text-ink-gray-6 transition-colors"
+        class="hover:text-ink-gray-9 transition-colors"
         :to="item.route"
       >
         {{ item.label }}
       </router-link>
-      <a v-else-if="item.link" :href="item.link" class="hover:text-ink-gray-6 transition-colors">
+      <a v-else-if="item.link" :href="item.link" class="hover:text-ink-gray-9 transition-colors">
         {{ item.label }}
       </a>
       <span v-else>

--- a/dashboard/src/components/Header.vue
+++ b/dashboard/src/components/Header.vue
@@ -1,6 +1,7 @@
 <template>
   <header
-    class="sticky top-0 z-50 flex items-center justify-between border-b bg-surface-white px-5 py-2.5"
+    class="z-50 flex items-center justify-between border-b bg-surface-white px-5 py-2.5"
+    :class="{ 'sticky top-0': sticky }"
   >
     <router-link
       to="/"
@@ -64,6 +65,12 @@ import { inject } from 'vue'
 import { Avatar, Dropdown } from 'frappe-ui'
 import FossUnitedLogo from '@/components/FossUnitedLogo.vue'
 import { fetchSessionProfile, sessionProfileResource } from '@/data/session'
+
+defineProps({
+  // Pages with their own sticky toolbar (e.g. Schedule) opt out, so two sticky
+  // layers do not compete for the same top edge.
+  sticky: { type: Boolean, default: true },
+})
 
 const session = inject('$session')
 

--- a/dashboard/src/components/common/EventHeader.vue
+++ b/dashboard/src/components/common/EventHeader.vue
@@ -73,10 +73,10 @@ const eventDetailItems = computed(() => [
               class="md:hidden h-7 w-7 object-contain rounded shrink-0"
             />
             <h2 class="font-semibold flex-grow">{{ event.event_name }}</h2>
-            <IconArrowUpRight class="w-4 h-4 text-ink-gray-4 shrink-0" />
+            <IconArrowUpRight class="w-4 h-4 text-ink-gray-7 dark:text-ink-gray-8 shrink-0" />
           </a>
           <button
-            class="shrink-0 px-2 rounded border bg-surface-gray-2 hover:bg-surface-gray-3 transition-colors text-ink-gray-5"
+            class="shrink-0 px-2 rounded border bg-surface-gray-2 hover:bg-surface-gray-3 transition-colors text-ink-gray-7 dark:text-ink-gray-8 hover:text-ink-gray-9"
             :aria-label="collapsed ? 'Expand event details' : 'Collapse event details'"
             @click="collapsed = !collapsed"
           >
@@ -89,7 +89,7 @@ const eventDetailItems = computed(() => [
           <div
             v-for="(item, index) in eventDetailItems"
             :key="index"
-            class="flex items-center gap-2 text-base text-ink-gray-5"
+            class="flex items-center gap-2 text-base text-ink-gray-7 dark:text-ink-gray-8"
           >
             <component :is="item.icon" class="w-5 h-5" />
             <a
@@ -98,7 +98,7 @@ const eventDetailItems = computed(() => [
               :target="item.target || '_self'"
               :rel="item.target === '_blank' ? 'noopener noreferrer' : undefined"
               :title="item.tooltip"
-              class="no-underline hover:underline text-ink-gray-5 hover:text-ink-gray-7"
+              class="no-underline hover:underline text-ink-gray-7 dark:text-ink-gray-8 hover:text-ink-gray-9"
               >{{ item.label }}</a
             >
             <span v-else>{{ item.label }}</span>

--- a/dashboard/src/components/event/schedule/ManageHallOptions.vue
+++ b/dashboard/src/components/event/schedule/ManageHallOptions.vue
@@ -68,6 +68,6 @@ const addHallOption = () => {
         class="border-0 text-sm focus:!outline-none focus:ring-0 focus-visible:outline-none resize-none"
       ></textarea>
     </div>
-    <small class="text-ink-gray-5">Separate each option with a new line</small>
+    <small class="text-ink-gray-7 dark:text-ink-gray-8">Separate each option with a new line</small>
   </div>
 </template>

--- a/dashboard/src/components/schedule/AllDayGridView.vue
+++ b/dashboard/src/components/schedule/AllDayGridView.vue
@@ -1,98 +1,106 @@
 <template>
   <div class="w-full mt-4" role="region" aria-label="Timeline schedule for selected day">
-    <div v-if="!sortedHalls.length" class="py-16 text-center text-ink-gray-4" role="status">
+    <div
+      v-if="!orderedHalls.length"
+      class="py-16 text-center text-ink-gray-7 dark:text-ink-gray-8"
+      role="status"
+    >
       No sessions for this day.
     </div>
 
-    <!--
-      Narrow (≤ 840px): container matches the 840px page column so content starts
-      from the same left edge as the nav. overflow-y:clip prevents the implicit
-      overflow-y:auto browsers apply when overflow-x is set.
-
-      Wide (> 840px): container is full-width and mx-auto on the w-max inner block
-      centers the content (time axis + halls together) symmetrically on the viewport.
-    -->
-    <div
-      v-else
-      :class="shouldCenter ? 'w-full' : 'max-w-[840px] mx-auto'"
-      style="overflow-x: auto; overflow-y: clip; padding-bottom: 360px"
-    >
+    <div v-else :class="shouldCenter ? 'w-full' : 'max-w-[840px] mx-auto'">
+      <!-- The hall header row lives outside the horizontal scroller to stay sticky-->
       <div
-        class="flex w-max"
-        :class="{ 'mx-auto': shouldCenter }"
+        ref="headerEl"
+        class="sticky top-0 z-20 bg-surface-gray-2 dark:bg-surface-gray-1"
+        style="overflow-x: hidden"
       >
-        <!-- Time axis: sticky so it stays visible during horizontal scroll -->
-        <div
-          class="sticky left-0 z-30 shrink-0 w-14 relative border-r border-outline-gray-2 bg-surface-gray-2 dark:bg-surface-gray-1"
-          :style="{ height: totalHeight + 74 + 'px' }"
-          aria-label="Time of day"
-        >
-          <div
-            v-for="label in timeLabels"
-            :key="label.minutes"
-            class="sticky absolute right-1.5 flex items-center gap-1"
-            :style="{ top: offsetFor(label.minutes) + 74 + 'px', transform: 'translateY(-50%)' }"
-          >
-            <span class="text-[10px] font-semibold text-ink-gray-5 whitespace-nowrap">
-              {{ label.label }}
-            </span>
-            <div class="w-2 h-px bg-outline-gray-3" />
-          </div>
-          <div
-            v-for="label in halfLabels"
-            :key="'h' + label.minutes"
-            class="absolute right-1"
-            :style="{ top: offsetFor(label.minutes) + 74 + 'px', transform: 'translateY(-50%)' }"
-          >
-            <div class="w-1.5 h-px bg-outline-gray-2" />
-          </div>
-        </div>
-
-        <!-- Hall columns -->
-        <div class="flex">
-          <div
-            v-for="hall in sortedHalls"
-            :key="hall"
-            class="flex flex-col"
-            style="min-width: 200px; width: 200px"
-          >
-            <!-- Hall header: sticky top so it stays visible on page scroll-down -->
-            <div class="h-[74px] flex items-end pb-3 px-3 shrink-0 sticky top-0 z-20 bg-surface-gray-2 dark:bg-surface-gray-1">
+        <div class="flex w-max" :class="{ 'mx-auto': shouldCenter }">
+          <!-- Spacer matching the time axis width -->
+          <div class="shrink-0 w-[34px] md:w-14 border-r border-outline-gray-3" />
+          <div class="flex">
+            <div
+              v-for="hall in orderedHalls"
+              :key="hall"
+              class="h-[74px] flex items-end pb-3 px-3 shrink-0"
+              style="min-width: 200px; width: 200px"
+            >
               <div
-                class="bg-surface-gray-3 dark:bg-surface-gray-4 text-ink-gray-7 text-xs font-semibold uppercase px-3 py-2 rounded-lg border border-outline-gray-2 whitespace-nowrap w-full text-center"
+                class="bg-surface-gray-3 dark:bg-surface-gray-4 text-ink-gray-9 text-xs font-semibold uppercase leading-tight px-3 py-2 rounded-lg border border-outline-gray-3 w-full text-center"
               >
                 {{ hall }}
               </div>
             </div>
+          </div>
+        </div>
+      </div>
 
-            <!-- Sessions area -->
-            <div class="relative" :style="{ height: totalHeight + 'px' }">
-              <div class="absolute inset-y-0 left-4 border-l border-outline-gray-5" />
-              <div
-                v-for="label in timeLabels"
-                :key="'grid-' + label.minutes"
-                class="absolute left-0 right-0 border-t border-outline-gray-2"
-                :style="{ top: offsetFor(label.minutes) + 'px' }"
-              />
-              <div
-                v-for="session in hallSessions(hall)"
-                :key="session.name || session.title"
-                class="absolute left-0 right-0 px-2"
-                :style="{ top: offsetFor(toMinutes(session.start_time)) + 'px' }"
+      <!-- Scrollable content - drives the scroll sync. -->
+      <div
+        ref="contentEl"
+        style="overflow-x: auto; overflow-y: clip; padding-bottom: 360px"
+        @scroll.passive="syncHeader"
+      >
+        <div class="flex w-max" :class="{ 'mx-auto': shouldCenter }">
+          <!-- Time axis, sticky left during horizontal scroll  -->
+          <div
+            class="sticky left-0 z-20 shrink-0 w-[34px] md:w-14 border-r border-outline-gray-3 bg-surface-gray-2 dark:bg-surface-gray-1"
+            :style="{ height: totalHeight + 'px' }"
+            aria-label="Time of day"
+          >
+            <div
+              v-for="label in timeLabels"
+              :key="label.minutes"
+              class="absolute right-0 md:right-1.5 flex items-center gap-1"
+              :style="{ top: offsetFor(label.minutes) + 'px', transform: 'translateY(-50%)' }"
+            >
+              <span
+                class="text-[10px] font-semibold text-ink-gray-7 dark:text-ink-gray-8 whitespace-nowrap"
               >
-                <TimeCapsule :session="session" />
+                {{ label.label }}
+              </span>
+              <div class="hidden md:block w-2 h-px bg-surface-gray-5" />
+            </div>
+            <div
+              v-for="label in halfLabels"
+              :key="'h' + label.minutes"
+              class="hidden md:block absolute right-1"
+              :style="{ top: offsetFor(label.minutes) + 'px', transform: 'translateY(-50%)' }"
+            >
+              <div class="w-1.5 h-px bg-surface-gray-4" />
+            </div>
+          </div>
+
+          <!-- Hall columns -- sessions only, headers live in the pinned row above -->
+          <div class="flex">
+            <div v-for="hall in orderedHalls" :key="hall" style="min-width: 200px; width: 200px">
+              <div class="relative" :style="{ height: totalHeight + 'px' }">
+                <div class="absolute inset-y-0 left-4 border-l border-outline-gray-5" />
+                <div
+                  v-for="label in timeLabels"
+                  :key="'grid-' + label.minutes"
+                  class="absolute left-0 right-0 border-t border-outline-gray-3"
+                  :style="{ top: offsetFor(label.minutes) + 'px' }"
+                />
+                <div
+                  v-for="session in hallSessions(hall)"
+                  :key="session.name || session.title"
+                  class="absolute left-0 right-0 px-2"
+                  :style="{ top: offsetFor(toMinutes(session.start_time)) + 'px' }"
+                >
+                  <TimeCapsule :session="session" />
+                </div>
               </div>
             </div>
           </div>
         </div>
-
       </div>
     </div>
   </div>
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import TimeCapsule from '@/components/schedule/TimeCapsule.vue'
 
 const props = defineProps({
@@ -100,24 +108,45 @@ const props = defineProps({
     type: Object,
     required: true, // { hall: [sessions] }
   },
+  // Hall names in the organiser's order, from the event's `hall_options`.
+  // Falls back to the schedule's own key order when not supplied.
+  halls: {
+    type: Array,
+    default: null,
+  },
 })
 
-const PIXELS_PER_MINUTE = 6  // 60px = 10 min
-const HALL_WIDTH = 200        // px per hall column
-const TIME_AXIS_WIDTH = 56    // px (w-14)
-const CENTER_THRESHOLD = 840  // px — center only when content exceeds this
+const PIXELS_PER_MINUTE = 6 // 60px = 10 min
+const HALL_WIDTH = 200 // px per hall column
+const TIME_AXIS_WIDTH = 56 // px (w-14 on desktop)
 
-const sortedHalls = computed(() => Object.keys(props.schedule || {}).sort())
+const headerEl = ref(null)
+const contentEl = ref(null)
+
+function syncHeader() {
+  if (headerEl.value && contentEl.value) {
+    headerEl.value.scrollLeft = contentEl.value.scrollLeft
+  }
+}
+const CENTER_THRESHOLD = 840 // px — center only when content exceeds this
+
+const orderedHalls = computed(() => {
+  const present = Object.keys(props.schedule || {})
+  if (!props.halls?.length) return present
+  // Trust the page's order, but never render a column with no data behind it.
+  const presentSet = new Set(present)
+  return props.halls.filter((hall) => presentSet.has(hall))
+})
 
 // Apply mx-auto centering only when total content width exceeds the threshold
 const shouldCenter = computed(
-  () => sortedHalls.value.length * HALL_WIDTH + TIME_AXIS_WIDTH > CENTER_THRESHOLD,
+  () => orderedHalls.value.length * HALL_WIDTH + TIME_AXIS_WIDTH > CENTER_THRESHOLD,
 )
 
 function hallSessions(hall) {
-  return (props.schedule[hall] || []).slice().sort(
-    (a, b) => toMinutes(a.start_time) - toMinutes(b.start_time),
-  )
+  return (props.schedule[hall] || [])
+    .slice()
+    .sort((a, b) => toMinutes(a.start_time) - toMinutes(b.start_time))
 }
 
 function toMinutes(timeStr) {
@@ -131,20 +160,24 @@ function offsetFor(minutes) {
   return (minutes - timeRange.value.min) * PIXELS_PER_MINUTE
 }
 
+const DEFAULT_RANGE = { min: 9 * 60, max: 18 * 60 }
+
 const timeRange = computed(() => {
   const all = Object.values(props.schedule || {}).flat()
-  if (!all.length) return { min: 9 * 60, max: 18 * 60 }
-  const starts = all.map((s) => toMinutes(s.start_time)).filter(Boolean)
-  const ends = all.map((s) => toMinutes(s.end_time || s.start_time)).filter(Boolean)
+  const starts = all.filter((s) => s?.start_time).map((s) => toMinutes(s.start_time))
+  const ends = all
+    .filter((s) => s?.end_time || s?.start_time)
+    .map((s) => toMinutes(s.end_time || s.start_time))
+
+  if (!starts.length || !ends.length) return DEFAULT_RANGE
+
   return {
     min: Math.floor(Math.min(...starts) / 30) * 30,
     max: Math.ceil((Math.max(...ends) + 30) / 30) * 30,
   }
 })
 
-const totalHeight = computed(
-  () => (timeRange.value.max - timeRange.value.min) * PIXELS_PER_MINUTE,
-)
+const totalHeight = computed(() => (timeRange.value.max - timeRange.value.min) * PIXELS_PER_MINUTE)
 
 const timeLabels = computed(() => {
   const labels = []

--- a/dashboard/src/components/schedule/HallDayView.vue
+++ b/dashboard/src/components/schedule/HallDayView.vue
@@ -1,9 +1,9 @@
 <template>
   <div
-    class="w-full mt-3 bg-surface-white dark:bg-surface-gray-2 border border-outline-gray-2 rounded-xl overflow-hidden"
+    class="w-full mt-3 bg-surface-white dark:bg-surface-gray-2 border border-outline-gray-3 rounded-xl overflow-hidden"
   >
     <div class="p-3">
-      <div v-if="sessions.length === 0" class="py-16 text-center text-ink-gray-4 text-sm">
+      <div v-if="sessions.length === 0" class="py-16 text-center text-ink-gray-7 dark:text-ink-gray-8 text-sm">
         No sessions scheduled for this hall.
       </div>
       <div v-else class="flex flex-col">

--- a/dashboard/src/components/schedule/ScheduleDownload.vue
+++ b/dashboard/src/components/schedule/ScheduleDownload.vue
@@ -1,129 +1,105 @@
 <template>
   <div>
     <button
-      class="h-8 sm:h-10 flex items-center gap-1.5 sm:gap-2 px-2.5 sm:px-3 rounded-lg bg-surface-gray-2 dark:bg-surface-gray-3 text-ink-gray-7 text-xs sm:text-sm font-semibold uppercase hover:bg-surface-gray-3 dark:hover:bg-surface-gray-4 transition-colors shrink-0"
+      type="button"
+      class="h-8 sm:h-10 flex items-center gap-1.5 sm:gap-2 px-2.5 sm:px-3 rounded-lg bg-surface-gray-2 dark:bg-surface-gray-3 text-ink-gray-7 dark:text-ink-gray-8 text-xs sm:text-sm font-semibold uppercase hover:bg-surface-white dark:hover:bg-surface-gray-1 transition-colors shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-5"
       aria-label="Download schedule"
+      aria-haspopup="dialog"
+      :aria-expanded="showModal"
       @click="showModal = true"
     >
-      <IconDownload class="w-4 h-4" />
+      <IconDownload class="w-4 h-4" aria-hidden="true" />
       <span class="hidden sm:inline">Download</span>
     </button>
 
-    <!-- Modal backdrop -->
-    <Teleport to="body">
-      <Transition name="fade">
-        <div
-          v-if="showModal"
-          class="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-4"
-          @click.self="showModal = false"
-        >
-          <div class="absolute inset-0 bg-black/50" @click="showModal = false" />
-          <div
-            class="relative bg-surface-white dark:bg-surface-gray-1 rounded-xl shadow-xl w-full max-w-lg max-h-[90vh] overflow-y-auto"
-            @click.stop
-          >
-            <div class="p-6">
-              <div class="flex items-center justify-between mb-5">
-                <h2 class="text-lg font-semibold text-ink-gray-9">Download Schedule</h2>
-                <button
-                  class="text-ink-gray-5 hover:text-ink-gray-9 transition-colors"
-                  @click="showModal = false"
-                >
-                  <IconX class="w-5 h-5" />
-                </button>
-              </div>
+    <Dialog v-model="showModal" :options="{ title: 'Download schedule', size: 'md' }">
+      <template #body-content>
+        <div class="flex flex-col gap-5">
+          <!-- Format names say what the file is for, not just its extension. -->
+          <FormControl
+            v-model="selectedFormat"
+            type="select"
+            label="Format"
+            size="sm"
+            variant="subtle"
+            :options="formatOptions"
+          />
 
-              <!-- Format selector -->
-              <div class="mb-5">
-                <label class="block text-sm font-medium text-ink-gray-7 mb-2">Format</label>
-                <div class="flex gap-2 flex-wrap">
-                  <label
-                    v-for="fmt in formats"
-                    :key="fmt"
-                    class="cursor-pointer px-3 py-1.5 rounded-lg border text-sm font-semibold uppercase select-none transition-colors"
-                    :class="
-                      selectedFormat === fmt
-                        ? 'bg-surface-gray-7 text-ink-white border-surface-gray-7'
-                        : 'bg-surface-white dark:bg-surface-gray-2 text-ink-gray-6 border-outline-gray-2 hover:bg-surface-gray-2'
-                    "
-                    @click="selectedFormat = fmt"
-                  >
-                    {{ fmt }}
-                  </label>
-                </div>
-              </div>
-
-              <!-- Days selector -->
-              <div class="mb-5">
-                <label class="block text-sm font-medium text-ink-gray-7 mb-2">Days</label>
-                <div class="flex gap-2 flex-wrap">
-                  <label
-                    v-for="day in allDates"
-                    :key="day.value"
-                    class="cursor-pointer px-3 py-1.5 rounded-lg border text-sm select-none transition-colors"
-                    :class="
-                      selectedDays.includes(day.value)
-                        ? 'bg-surface-gray-7 text-ink-white border-surface-gray-7'
-                        : 'bg-surface-white dark:bg-surface-gray-2 text-ink-gray-6 border-outline-gray-2 hover:bg-surface-gray-2'
-                    "
-                  >
-                    <input
-                      v-model="selectedDays"
-                      type="checkbox"
-                      :value="day.value"
-                      class="sr-only"
-                    />
-                    {{ day.display }}
-                  </label>
-                </div>
-              </div>
-
-              <!-- Halls selector -->
-              <div class="mb-6">
-                <label class="block text-sm font-medium text-ink-gray-7 mb-2">Halls</label>
-                <div class="flex gap-2 flex-wrap">
-                  <label
-                    v-for="hall in allHalls"
-                    :key="hall"
-                    class="cursor-pointer px-3 py-1.5 rounded-lg border text-sm select-none transition-colors"
-                    :class="
-                      selectedHalls.includes(hall)
-                        ? 'bg-surface-gray-7 text-ink-white border-surface-gray-7'
-                        : 'bg-surface-white dark:bg-surface-gray-2 text-ink-gray-6 border-outline-gray-2 hover:bg-surface-gray-2'
-                    "
-                  >
-                    <input v-model="selectedHalls" type="checkbox" :value="hall" class="sr-only" />
-                    {{ hall }}
-                  </label>
-                </div>
-              </div>
-
-              <!-- Actions -->
-              <div class="flex justify-end gap-3">
-                <button
-                  class="text-sm text-ink-gray-5 hover:text-ink-gray-9 transition-colors px-4 py-2"
-                  @click="showModal = false"
-                >
-                  Cancel
-                </button>
-                <button
-                  class="px-5 py-2 rounded-lg bg-surface-gray-7 text-ink-white text-sm font-semibold hover:bg-surface-gray-6 transition-colors"
-                  @click="downloadSchedule"
-                >
-                  Download
-                </button>
-              </div>
+          <!-- A single day or a single hall is not a choice, so it is not offered. -->
+          <fieldset v-if="allDates.length > 1">
+            <legend class="text-sm font-medium text-ink-gray-7 dark:text-ink-gray-8 mb-2">
+              Days
+            </legend>
+            <div class="flex gap-2 flex-wrap">
+              <label
+                v-for="day in allDates"
+                :key="day.value"
+                :class="[pillBase, selectedDays.includes(day.value) ? pillOn : pillOff]"
+              >
+                <input v-model="selectedDays" type="checkbox" :value="day.value" class="sr-only" />
+                {{ day.display }}
+              </label>
             </div>
-          </div>
+          </fieldset>
+
+          <fieldset v-if="allHalls.length > 1">
+            <legend class="text-sm font-medium text-ink-gray-7 dark:text-ink-gray-8 mb-2">
+              Halls
+            </legend>
+            <div class="flex gap-2 flex-wrap">
+              <label
+                v-for="hall in allHalls"
+                :key="hall"
+                :class="[pillBase, selectedHalls.includes(hall) ? pillOn : pillOff]"
+              >
+                <input v-model="selectedHalls" type="checkbox" :value="hall" class="sr-only" />
+                {{ hall }}
+              </label>
+            </div>
+          </fieldset>
+
+          <p
+            v-if="validationMessage"
+            id="schedule-download-error"
+            class="text-sm text-ink-red-4"
+            role="alert"
+          >
+            {{ validationMessage }}
+          </p>
         </div>
-      </Transition>
-    </Teleport>
+      </template>
+
+      <template #actions="{ close }">
+        <div class="flex justify-end gap-3">
+          <button
+            type="button"
+            class="text-sm text-ink-gray-7 dark:text-ink-gray-8 hover:text-ink-gray-9 transition-colors px-4 py-2 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-5"
+            @click="close"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            class="px-5 py-2 rounded-lg bg-surface-gray-7 text-ink-white text-sm font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-5"
+            :class="
+              validationMessage ? 'opacity-50 cursor-not-allowed' : 'hover:bg-surface-gray-6'
+            "
+            :aria-disabled="Boolean(validationMessage)"
+            :aria-describedby="validationMessage ? 'schedule-download-error' : undefined"
+            @click="downloadSchedule(close)"
+          >
+            Download
+          </button>
+        </div>
+      </template>
+    </Dialog>
   </div>
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
-import { IconDownload, IconX } from '@tabler/icons-vue'
+import { ref, computed, watch } from 'vue'
+import { Dialog, FormControl } from 'frappe-ui'
+import { IconDownload } from '@tabler/icons-vue'
 import dayjs from 'dayjs'
 
 const props = defineProps({
@@ -135,9 +111,28 @@ const props = defineProps({
     type: Object,
     required: true, // { "YYYY-MM-DD": { hall: [sessions] } }
   },
+  // Hall names in the organiser's order, parsed from `hall_options` by the page.
+  hallOrder: {
+    type: Array,
+    default: () => [],
+  },
 })
 
-const formats = ['ics', 'csv', 'txt', 'md', 'org', 'json']
+const formatOptions = [
+  { label: 'Calendar (.ics)', value: 'ics' },
+  { label: 'Spreadsheet (.csv)', value: 'csv' },
+  { label: 'Plain text (.txt)', value: 'txt' },
+  { label: 'Markdown (.md)', value: 'md' },
+  { label: 'Org mode (.org)', value: 'org' },
+  { label: 'JSON (.json)', value: 'json' },
+]
+
+const pillBase =
+  'cursor-pointer px-3 py-1.5 rounded-lg border text-sm select-none transition-colors focus-within:ring-2 focus-within:ring-outline-gray-5'
+const pillOn = 'bg-surface-gray-7 text-ink-white border-transparent'
+const pillOff =
+  'bg-surface-white dark:bg-surface-gray-2 text-ink-gray-7 dark:text-ink-gray-8 border-outline-gray-3 hover:bg-surface-gray-2 dark:hover:bg-surface-gray-3'
+
 const showModal = ref(false)
 const selectedFormat = ref('ics')
 const selectedDays = ref([])
@@ -150,35 +145,52 @@ const allDates = computed(() =>
   })),
 )
 
+// Union across every day, in the organiser's order. Unlisted halls come last in
+// schedule order. Never sorted -- this has to match the hall row on the page.
 const allHalls = computed(() => {
-  const halls = new Set()
+  const present = new Set()
   for (const day of Object.values(props.schedule || {})) {
-    for (const hall of Object.keys(day)) halls.add(hall)
+    for (const hall of Object.keys(day)) present.add(hall)
   }
-  return Array.from(halls).sort()
+  if (!props.hallOrder.length) return [...present]
+
+  const configuredSet = new Set(props.hallOrder)
+  return [
+    ...props.hallOrder.filter((hall) => present.has(hall)),
+    ...[...present].filter((hall) => !configuredSet.has(hall)),
+  ]
 })
 
-function downloadSchedule() {
-  showModal.value = false
+// Everything starts selected. An empty set used to mean "all" to the endpoint,
+// which read on screen as "nothing will be downloaded".
+watch(allDates, (dates) => (selectedDays.value = dates.map((d) => d.value)), { immediate: true })
+watch(allHalls, (halls) => (selectedHalls.value = [...halls]), { immediate: true })
+
+const validationMessage = computed(() => {
+  if (!selectedDays.value.length) return 'Select at least one day.'
+  if (!selectedHalls.value.length) return 'Select at least one hall.'
+  return ''
+})
+
+function downloadSchedule(close) {
+  if (validationMessage.value) return
+
   const query = new URLSearchParams()
   query.set('event', props.event.name)
   query.set('format', selectedFormat.value)
-  selectedDays.value.forEach((d) => query.append('days', d))
-  selectedHalls.value.forEach((h) => query.append('halls', h))
+
+  // Send a filter only when it actually narrows the result
+  if (selectedDays.value.length < allDates.value.length) {
+    selectedDays.value.forEach((d) => query.append('days', d))
+  }
+  if (selectedHalls.value.length < allHalls.value.length) {
+    selectedHalls.value.forEach((h) => query.append('halls', h))
+  }
+
   window.open(
     `/api/method/fossunited.api.schedule.download_schedule?${query.toString()}`,
     '_blank',
   )
+  close()
 }
 </script>
-
-<style scoped>
-.fade-enter-active,
-.fade-leave-active {
-  transition: opacity 0.2s ease;
-}
-.fade-enter-from,
-.fade-leave-to {
-  opacity: 0;
-}
-</style>

--- a/dashboard/src/components/schedule/SearchSession.vue
+++ b/dashboard/src/components/schedule/SearchSession.vue
@@ -2,7 +2,7 @@
   <div class="mt-4">
     <div class="flex items-center gap-2 mb-4">
       <span class="text-sm font-semibold text-ink-gray-7 dark:text-ink-gray-8 uppercase tracking-wide">
-        Search results
+        {{ label }}
       </span>
       <span
         class="px-2 py-0.5 rounded-full bg-surface-gray-2 text-ink-gray-7 dark:text-ink-gray-8 text-xs font-semibold"
@@ -11,9 +11,15 @@
       </span>
     </div>
 
-    <div v-if="filteredSessions.length === 0" class="py-16 text-center text-ink-gray-7 dark:text-ink-gray-8">
-      No sessions found matching <strong class="text-ink-gray-7 dark:text-ink-gray-8">{{ query }}</strong
-      >.
+    <div
+      v-if="filteredSessions.length === 0"
+      class="py-16 text-center text-ink-gray-7 dark:text-ink-gray-8"
+    >
+      <template v-if="filter">{{ emptyText }}</template>
+      <template v-else>
+        No sessions found matching
+        <strong class="text-ink-gray-7 dark:text-ink-gray-8">{{ query }}</strong>.
+      </template>
     </div>
 
     <div v-else class="flex flex-col gap-1">
@@ -37,7 +43,20 @@ const props = defineProps({
   },
   query: {
     type: String,
-    required: true,
+    default: '',
+  },
+  // When given, replaces the query search entirely.
+  filter: {
+    type: Function,
+    default: null,
+  },
+  label: {
+    type: String,
+    default: 'Search results',
+  },
+  emptyText: {
+    type: String,
+    default: '',
   },
 })
 
@@ -57,6 +76,8 @@ function flattenSchedule(schedule) {
 const allSessions = computed(() => flattenSchedule(props.schedule))
 
 const filteredSessions = computed(() => {
+  if (props.filter) return allSessions.value.filter(props.filter)
+
   const q = props.query.trim().toLowerCase()
   if (!q) return []
 

--- a/dashboard/src/components/schedule/SearchSession.vue
+++ b/dashboard/src/components/schedule/SearchSession.vue
@@ -1,18 +1,18 @@
 <template>
   <div class="mt-4">
     <div class="flex items-center gap-2 mb-4">
-      <span class="text-sm font-semibold text-ink-gray-6 uppercase tracking-wide">
+      <span class="text-sm font-semibold text-ink-gray-7 dark:text-ink-gray-8 uppercase tracking-wide">
         Search results
       </span>
       <span
-        class="px-2 py-0.5 rounded-full bg-surface-gray-2 text-ink-gray-6 text-xs font-semibold"
+        class="px-2 py-0.5 rounded-full bg-surface-gray-2 text-ink-gray-7 dark:text-ink-gray-8 text-xs font-semibold"
       >
         {{ filteredSessions.length }}
       </span>
     </div>
 
-    <div v-if="filteredSessions.length === 0" class="py-16 text-center text-ink-gray-4">
-      No sessions found matching <strong class="text-ink-gray-6">{{ query }}</strong
+    <div v-if="filteredSessions.length === 0" class="py-16 text-center text-ink-gray-7 dark:text-ink-gray-8">
+      No sessions found matching <strong class="text-ink-gray-7 dark:text-ink-gray-8">{{ query }}</strong
       >.
     </div>
 

--- a/dashboard/src/components/schedule/SessionCard.vue
+++ b/dashboard/src/components/schedule/SessionCard.vue
@@ -3,7 +3,7 @@
   <div class="sm:hidden flex flex-col w-full py-2">
     <!-- Top panel: time+cal overlap | speaker thumbs -->
     <div
-      class="relative z-10 flex items-center justify-between bg-surface-white dark:bg-surface-gray-2 border border-outline-gray-2 rounded-2xl p-2 mb-[-14px]"
+      class="relative z-10 flex items-center justify-between bg-surface-white dark:bg-surface-gray-2 border border-outline-gray-3 rounded-2xl p-2 mb-[-14px]"
     >
       <!-- Overlapping time chip + calendar button -->
       <div class="isolate flex">
@@ -14,7 +14,7 @@
           {{ formatTime(session.start_time) }}
         </div>
         <button
-          class="relative z-[1] -ml-2 h-11 w-[52px] rounded-r-lg bg-surface-gray-2 dark:bg-surface-gray-3 flex items-center justify-center pl-4 pr-2.5 text-ink-gray-6 transition-colors hover:bg-surface-gray-3"
+          class="relative z-[1] -ml-2 h-11 w-[52px] rounded-r-lg bg-surface-gray-2 dark:bg-surface-gray-3 flex items-center justify-center pl-4 pr-2.5 text-ink-gray-7 dark:text-ink-gray-8 transition-colors hover:bg-surface-gray-3 hover:text-ink-gray-9"
           title="Add to calendar"
           @click.stop="downloadIcs"
         >
@@ -27,7 +27,7 @@
         :href="session.talk_video"
         target="_blank"
         rel="noopener noreferrer"
-        class="shrink-0 w-9 h-9 rounded-lg bg-surface-gray-2 dark:bg-surface-gray-3 flex items-center justify-center text-ink-gray-5 hover:text-red-500 transition-colors"
+        class="shrink-0 w-9 h-9 rounded-lg bg-surface-gray-2 dark:bg-surface-gray-3 flex items-center justify-center text-ink-gray-7 dark:text-ink-gray-8 hover:text-ink-red-4 transition-colors"
         title="Watch recording"
         @click.stop
       >
@@ -38,7 +38,7 @@
         <div
           v-for="(speaker, i) in visibleSpeakers.slice(0, 2)"
           :key="i"
-          class="w-11 h-11 rounded-lg overflow-hidden border border-outline-gray-2 shrink-0"
+          class="w-11 h-11 rounded-lg overflow-hidden border border-outline-gray-3 shrink-0"
         >
           <img
             :src="speaker.photo || ''"
@@ -55,7 +55,7 @@
     <component
       :is="cfpHref ? 'a' : 'div'"
       v-bind="cfpHref ? { href: cfpHref, target: '_blank', rel: 'noopener noreferrer' } : {}"
-      class="relative z-0 bg-surface-white dark:bg-surface-gray-2 border border-outline-gray-2 rounded-b-2xl px-3 pt-[22px] pb-3 flex flex-col gap-1.5"
+      class="relative z-0 bg-surface-white dark:bg-surface-gray-2 border border-outline-gray-3 rounded-b-2xl px-3 pt-[22px] pb-3 flex flex-col gap-1.5"
     >
       <h3 class="text-sm font-normal leading-snug text-ink-gray-9 line-clamp-2">
         {{ session.title }}
@@ -64,7 +64,7 @@
         <span
           v-for="(speaker, i) in speakers"
           :key="i"
-          class="text-xs text-ink-gray-5 pr-2.5 py-0.5 whitespace-nowrap"
+          class="text-xs text-ink-gray-7 dark:text-ink-gray-8 pr-2.5 py-0.5 whitespace-nowrap"
         >
           {{ speaker.full_name }}
         </span>
@@ -72,7 +72,7 @@
       <div class="flex items-center gap-1.5 flex-wrap">
         <span
           v-if="sessionDuration"
-          class="h-6 px-2 rounded-lg bg-surface-gray-2 dark:bg-surface-gray-3 text-ink-gray-5 text-xs font-semibold uppercase flex items-center whitespace-nowrap"
+          class="h-6 px-2 rounded-lg bg-surface-gray-2 dark:bg-surface-gray-3 text-ink-gray-7 dark:text-ink-gray-8 text-xs font-semibold uppercase flex items-center whitespace-nowrap"
         >
           {{ sessionDuration }}
         </span>
@@ -85,6 +85,18 @@
           ]"
         >
           {{ sessionCategory }}
+        </span>
+        <span
+          v-if="session._date"
+          class="h-6 px-2 rounded-lg bg-surface-blue-2 text-ink-gray-8 text-xs font-semibold flex items-center whitespace-nowrap"
+        >
+          {{ formatIsoDate(session._date) }}
+        </span>
+        <span
+          v-if="session._hall"
+          class="h-6 px-2 rounded-lg bg-surface-gray-2 dark:bg-surface-gray-3 text-ink-gray-7 dark:text-ink-gray-8 text-xs font-semibold flex items-center whitespace-nowrap"
+        >
+          {{ session._hall }}
         </span>
       </div>
     </component>
@@ -117,7 +129,7 @@
         :href="session.talk_video"
         target="_blank"
         rel="noopener noreferrer"
-        class="ml-2 shrink-0 w-8 h-8 rounded-lg bg-surface-gray-2 dark:bg-surface-gray-3 flex items-center justify-center text-ink-gray-5 hover:text-red-500 transition-colors"
+        class="ml-2 shrink-0 w-8 h-8 rounded-lg bg-surface-gray-2 dark:bg-surface-gray-3 flex items-center justify-center text-ink-gray-7 dark:text-ink-gray-8 hover:text-ink-red-4 transition-colors"
         title="Watch recording"
         @click.stop
       >
@@ -129,7 +141,7 @@
       <div class="flex items-center gap-1.5 shrink-0 flex-wrap justify-end">
         <span
           v-if="sessionDuration"
-          class="h-6 px-2 rounded-lg bg-surface-gray-2 dark:bg-surface-gray-3 text-ink-gray-5 text-xs font-semibold uppercase flex items-center whitespace-nowrap"
+          class="h-6 px-2 rounded-lg bg-surface-gray-2 dark:bg-surface-gray-3 text-ink-gray-7 dark:text-ink-gray-8 text-xs font-semibold uppercase flex items-center whitespace-nowrap"
         >
           {{ sessionDuration }}
         </span>
@@ -145,13 +157,13 @@
         </span>
         <span
           v-if="session._date"
-          class="h-6 px-2 rounded-lg bg-surface-blue-2 text-ink-blue-3 text-xs font-semibold flex items-center whitespace-nowrap"
+          class="h-6 px-2 rounded-lg bg-surface-blue-2 text-ink-gray-8 text-xs font-semibold flex items-center whitespace-nowrap"
         >
           {{ formatIsoDate(session._date) }}
         </span>
         <span
           v-if="session._hall"
-          class="h-6 px-2 rounded-lg bg-surface-gray-2 dark:bg-surface-gray-3 text-ink-gray-6 text-xs font-semibold flex items-center whitespace-nowrap"
+          class="h-6 px-2 rounded-lg bg-surface-gray-2 dark:bg-surface-gray-3 text-ink-gray-7 dark:text-ink-gray-8 text-xs font-semibold flex items-center whitespace-nowrap"
         >
           {{ session._hall }}
         </span>
@@ -173,7 +185,7 @@
         <!-- Speaker photos 80×80 -->
         <div
           v-if="speakers.length"
-          class="shrink-0 size-20 overflow-hidden rounded-lg border border-outline-gray-2 grid gap-0.5"
+          class="shrink-0 size-20 overflow-hidden rounded-lg border border-outline-gray-3 grid gap-0.5"
           :class="speakerGridClass"
         >
           <img
@@ -198,14 +210,14 @@
             <span
               v-for="(speaker, i) in speakers"
               :key="i"
-              class="px-2 py-0.5 rounded bg-surface-gray-2 dark:bg-surface-gray-3 text-ink-gray-7 text-sm font-medium whitespace-nowrap"
+              class="px-2 py-0.5 rounded bg-surface-gray-2 dark:bg-surface-gray-3 text-ink-gray-7 dark:text-ink-gray-8 text-sm font-medium whitespace-nowrap"
             >
               {{ speaker.full_name }}
             </span>
           </div>
           <p
             v-if="speakerMeta"
-            class="text-xs text-ink-gray-5 line-clamp-2 leading-relaxed"
+            class="text-xs text-ink-gray-7 dark:text-ink-gray-8 line-clamp-2 leading-relaxed"
             v-html="speakerMeta"
           />
         </div>

--- a/dashboard/src/components/schedule/SessionCard.vue
+++ b/dashboard/src/components/schedule/SessionCard.vue
@@ -1,26 +1,27 @@
 <template>
   <!-- Mobile card: two-panel stacked ──────────────────────────────────── -->
   <div class="sm:hidden flex flex-col w-full py-2">
-    <!-- Top panel: time+cal overlap | speaker thumbs -->
+    <!-- Top panel: calendar+time | speaker thumbs -->
     <div
       class="relative z-10 flex items-center justify-between bg-surface-white dark:bg-surface-gray-2 border border-outline-gray-3 rounded-2xl p-2 mb-[-14px]"
     >
-      <!-- Overlapping time chip + calendar button -->
-      <div class="isolate flex">
+      <button
+        class="flex items-center h-11 shrink-0 rounded-lg overflow-hidden transition-opacity hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-5"
+        :aria-label="calendarLabel"
+        @click.stop="downloadIcs"
+      >
+        <div
+          class="h-11 w-11 shrink-0 bg-surface-gray-7 flex items-center justify-center text-ink-white"
+        >
+          <IconCalendarPlus class="w-5 h-5" aria-hidden="true" />
+        </div>
         <div
           v-if="!preview"
-          class="relative z-[2] h-11 w-[94px] rounded-lg bg-surface-gray-7 text-ink-white text-sm font-semibold uppercase flex items-center justify-center whitespace-nowrap px-2.5 shrink-0"
+          class="h-11 px-3 bg-surface-gray-7 text-ink-white text-sm font-semibold uppercase flex items-center whitespace-nowrap"
         >
           {{ formatTime(session.start_time) }}
         </div>
-        <button
-          class="relative z-[1] -ml-2 h-11 w-[52px] rounded-r-lg bg-surface-gray-2 dark:bg-surface-gray-3 flex items-center justify-center pl-4 pr-2.5 text-ink-gray-7 dark:text-ink-gray-8 transition-colors hover:bg-surface-gray-3 hover:text-ink-gray-9"
-          title="Add to calendar"
-          @click.stop="downloadIcs"
-        >
-          <IconCalendarPlus class="w-5 h-5" />
-        </button>
-      </div>
+      </button>
       <!-- YouTube (mobile) -->
       <a
         v-if="session.talk_video"
@@ -106,19 +107,18 @@
   <div class="hidden sm:flex flex-col w-full py-1">
     <div class="flex items-center flex-wrap gap-y-2">
       <button
-        class="flex items-center h-10 shrink-0 transition-opacity hover:opacity-80"
-        title="Add to calendar"
+        class="flex items-center h-10 shrink-0 rounded-lg overflow-hidden transition-opacity hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-5"
+        :aria-label="calendarLabel"
         @click.stop="downloadIcs"
       >
         <div
-          class="h-10 w-10 shrink-0 bg-surface-gray-7 rounded-l-lg flex items-center justify-center text-ink-white transition-opacity hover:opacity-80"
+          class="h-10 w-10 shrink-0 bg-surface-gray-7 flex items-center justify-center text-ink-white"
         >
-          <IconCalendarPlus class="w-5 h-5" />
+          <IconCalendarPlus class="w-5 h-5" aria-hidden="true" />
         </div>
         <div
           v-if="!preview"
-          class="h-10 px-3 bg-surface-gray-7 rounded-r-lg text-ink-white text-base font-semibold uppercase flex items-center whitespace-nowrap"
-          @click.stop="downloadIcs"
+          class="h-10 px-3 bg-surface-gray-7 text-ink-white text-base font-semibold uppercase flex items-center whitespace-nowrap"
         >
           {{ formatTime(session.start_time) }}
         </div>
@@ -250,6 +250,13 @@ const {
   cfpHref,
   downloadIcs,
 } = useSession(toRef(props, 'session'))
+
+// Names the action AND contains the visible text, so it satisfies both
+// 4.1.2 and 2.5.3. Without it the button announces only "10:30 AM".
+const calendarLabel = computed(() => {
+  const time = formatTime(props.session.start_time)
+  return time ? `Add ${time} session to calendar` : 'Add session to calendar'
+})
 
 function formatIsoDate(isoDate) {
   return dayjs(isoDate).format('D MMM')

--- a/dashboard/src/components/schedule/TimeCapsule.vue
+++ b/dashboard/src/components/schedule/TimeCapsule.vue
@@ -26,7 +26,7 @@
     <Transition name="fade-up">
       <div
         v-if="isExpanded"
-        class="absolute left-0 top-full z-50 w-[300px] shadow-xl bg-surface-white dark:bg-surface-gray-2 rounded-[16px] px-2 md:px-4"
+        class="absolute left-0 top-full z-30 w-[300px] shadow-xl bg-surface-white dark:bg-surface-gray-2 rounded-[16px] px-2 md:px-4"
         @click.stop
       >
         <SessionCard :session="session" preview />

--- a/dashboard/src/components/schedule/TimeCapsule.vue
+++ b/dashboard/src/components/schedule/TimeCapsule.vue
@@ -7,7 +7,7 @@
   >
     <!-- Compact 60px card: hover expands, click navigates to CFP -->
     <div
-      class="h-[60px] bg-surface-white dark:bg-surface-gray-2 border border-outline-gray-2 rounded-[16px] flex items-center gap-2 px-2 cursor-pointer select-none overflow-hidden"
+      class="h-[60px] bg-surface-white dark:bg-surface-gray-2 border border-outline-gray-3 rounded-[16px] flex items-center gap-2 px-2 cursor-pointer select-none overflow-hidden"
       :title="session.title"
       @click="handleClick($event)"
       @mouseenter="openExpanded"

--- a/dashboard/src/helpers/date.js
+++ b/dashboard/src/helpers/date.js
@@ -1,3 +1,4 @@
+import { ref } from 'vue'
 import dayjs from 'dayjs'
 
 // Plugins
@@ -84,3 +85,16 @@ export const isCheckedInToday = (attendee) =>
 
 // default export for raw dayjs
 export default dayjs
+
+export const now = ref(dayjs())
+setInterval(() => (now.value = dayjs()), 30_000)
+
+/** Is this schedule row running right now, by wall clock? */
+export const isSessionLive = (session) => {
+  if (!session?.scheduled_date || !session.start_time || !session.end_time) return false
+  const day = dayjs(session.scheduled_date).format('YYYY-MM-DD')
+  return (
+    now.value.isAfter(dayjs(`${day} ${session.start_time}`)) &&
+    now.value.isBefore(dayjs(`${day} ${session.end_time}`))
+  )
+}

--- a/dashboard/src/pages/schedule/Schedule.vue
+++ b/dashboard/src/pages/schedule/Schedule.vue
@@ -1,62 +1,88 @@
 <template>
-  <Header />
+  <Header :sticky="false" />
 
-  <div v-if="event.data && schedule.data" class="w-full min-h-screen bg-surface-gray-2 dark:bg-surface-gray-1">
+  <div
+    v-if="event.data && schedule.data"
+    class="w-full min-h-screen bg-surface-gray-2 dark:bg-surface-gray-1"
+  >
     <!-- ── Non-sticky: Event header ──────────────────────────────────────── -->
     <div class="max-w-[840px] mx-auto px-3 sm:px-4 pt-4 pb-2">
       <Breadcrumb :items="breadcrumb_items" />
-      <EventHeader :event="event.data" class="mt-3 pb-4 border-b border-outline-gray-2" />
-      <p
-        v-if="event.data.schedule_page_description"
-        class="mt-3 text-sm text-ink-gray-5 leading-relaxed max-w-2xl"
+      <EventHeader :event="event.data" class="mt-3 pb-4 border-b border-outline-gray-3" />
+      <!-- Organiser note, rendered from the event's Markdown Editor field. -->
+      <div
+        v-if="sanitizedDesc"
+        class="schedule-note mt-3 rounded-lg border border-outline-gray-3 bg-surface-gray-1 dark:bg-surface-gray-2 px-4 py-3 text-sm text-ink-gray-7 dark:text-ink-gray-8 leading-relaxed"
         v-html="sanitizedDesc"
       />
     </div>
 
-    <!-- ── Sticky navigation ─────────────────────────────────────────────── -->
-    <div class="sticky top-0 z-30 bg-surface-gray-2 dark:bg-surface-gray-1">
+    <!-- Sticky navigation. It slides out of sight on scroll down and back on scroll up -->
+    <div
+      ref="navEl"
+      class="sticky top-0 z-40 bg-surface-gray-2 dark:bg-surface-gray-1 transition-transform duration-300 ease-in-out motion-reduce:transition-none"
+      :class="{ '-translate-y-full': !navVisible }"
+      @focusin="navVisible = true"
+    >
       <div class="max-w-[840px] mx-auto px-3 sm:px-4 pt-2 sm:pt-3">
         <div
-          class="bg-surface-white dark:bg-surface-gray-2 border border-outline-gray-2 rounded-xl p-2 flex flex-col gap-2 shadow-sm"
+          class="bg-surface-white dark:bg-surface-gray-2 border border-outline-gray-3 rounded-xl p-2 flex flex-col gap-2 shadow-sm"
         >
-          <!-- Row 1: Day selector + View toggle -->
+          <!-- Row 1: Day selector + View switch -->
           <div class="flex items-center gap-2">
-            <div class="flex border border-outline-gray-2 rounded-lg overflow-hidden overflow-x-auto scrollbar-none flex-1 min-w-0">
+            <div
+              class="flex border border-outline-gray-3 rounded-lg overflow-hidden overflow-x-auto scrollbar-none flex-1 min-w-0"
+              role="group"
+              aria-label="Select event day"
+            >
               <button
                 v-for="(date, index) in eventDays"
                 :key="date"
-                class="flex flex-col items-center justify-center w-[64px] sm:w-[72px] h-[44px] sm:h-[48px] shrink-0 border-r border-outline-gray-2 last:border-r-0 transition-colors"
-                :class="selectedDay === date ? 'bg-surface-gray-3 dark:bg-surface-gray-4' : 'hover:bg-surface-gray-2 dark:hover:bg-surface-gray-3'"
+                type="button"
+                :aria-pressed="selectedDay === date"
+                :aria-label="`Day ${index + 1}, ${formatFullDate(date)}`"
+                class="flex-1 flex flex-col items-center justify-center min-w-[64px] sm:min-w-[72px] h-[44px] sm:h-[48px] border-r border-outline-gray-3 last:border-r-0 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-outline-gray-5"
+                :class="selectedDay === date ? SEG_ON : SEG_OFF"
                 @click="selectedDay = date"
               >
                 <span
                   class="text-[10px] sm:text-xs font-semibold uppercase tracking-wide leading-none"
-                  :class="selectedDay === date ? 'text-ink-gray-9' : 'text-ink-gray-5'"
                 >
                   Day {{ index + 1 }}
                 </span>
-                <span
-                  class="text-[9px] sm:text-[10px] mt-0.5 leading-none"
-                  :class="selectedDay === date ? 'text-ink-gray-7' : 'text-ink-gray-4'"
-                >
+                <span class="text-[9px] sm:text-[10px] mt-0.5 leading-none">
                   {{ formatDateLabel(date) }}
                 </span>
               </button>
             </div>
-            <!-- View toggle -->
-            <button
-              class="shrink-0 h-8 flex items-center gap-1.5 px-2.5 rounded-lg bg-surface-gray-2 dark:bg-surface-gray-3 text-ink-gray-7 text-xs font-semibold uppercase tracking-wide transition-colors hover:bg-surface-gray-3 dark:hover:bg-surface-gray-4"
-              @click="toggleView"
+            <!-- Toggle buttons -->
+            <div
+              class="shrink-0 flex border border-outline-gray-3 rounded-lg overflow-hidden"
+              role="group"
+              aria-label="Schedule view"
             >
-              <IconTimelineEventText class="w-4 h-4 shrink-0" v-if="view === 'list'" />
-              <IconAlignLeft class="w-4 h-4 shrink-0" v-else />
-              <span class="hidden sm:inline">{{ view === 'list' ? 'Timeline' : 'List View' }}</span>
-            </button>
+              <button
+                v-for="option in viewOptions"
+                :key="option.value"
+                type="button"
+                :aria-pressed="view === option.value"
+                :aria-label="option.label + ' view'"
+                class="h-8 flex items-center gap-1.5 px-2.5 text-xs font-semibold uppercase tracking-wide transition-colors border-r border-outline-gray-3 last:border-r-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-outline-gray-5"
+                :class="view === option.value ? SEG_ON : SEG_OFF"
+                @click="view = option.value"
+              >
+                <component :is="option.icon" class="w-4 h-4 shrink-0" aria-hidden="true" />
+                <span class="hidden sm:inline">{{ option.label }}</span>
+              </button>
+            </div>
           </div>
           <!-- Row 2: Search + Download -->
           <div class="flex items-center gap-2">
             <div class="relative flex-1 min-w-0">
-              <IconSearch class="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-ink-gray-4 pointer-events-none" />
+              <IconSearch
+                class="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-ink-gray-7 dark:text-ink-gray-8 pointer-events-none"
+                aria-hidden="true"
+              />
               <input
                 v-model="searchQuery"
                 type="search"
@@ -65,67 +91,123 @@
                 autocomplete="off"
                 autocapitalize="off"
                 spellcheck="false"
-                class="w-full h-8 pl-8 pr-3 border border-outline-gray-2 rounded-lg text-xs bg-surface-gray-1 dark:bg-surface-gray-3 text-ink-gray-9 placeholder:text-ink-gray-4 focus:outline-none focus:border-outline-gray-4 transition-colors"
+                class="w-full h-8 pl-8 pr-3 border border-outline-gray-3 rounded-lg text-xs bg-surface-gray-1 dark:bg-surface-gray-3 text-ink-gray-9 placeholder:text-ink-gray-7 dark:placeholder:text-ink-gray-8 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-5 focus:border-outline-gray-4 transition-colors"
               />
             </div>
-            <ScheduleDownload :schedule="schedule.data" :event="event.data" />
+            <ScheduleDownload
+              :schedule="schedule.data"
+              :event="event.data"
+              :hall-order="hallOrder"
+            />
           </div>
-          <!-- Row 3: Halls (list view only — same sticky card as search/days) -->
+          <!-- All | Live | Mine. Only rendered once there is something to switch to -->
           <div
-            v-if="view === 'list' && !isSearching && halls.length > 0"
-            class="overflow-x-auto scrollbar-none -mx-0.5 px-0.5"
+            v-if="modes.length > 1 && !isSearching"
+            class="flex border border-outline-gray-3 rounded-lg overflow-hidden"
+            role="group"
+            aria-label="Filter sessions"
           >
-            <div class="flex border border-outline-gray-2 rounded-lg overflow-hidden w-max min-w-full">
-              <button
-                v-for="hall in halls"
-                :key="hall"
-                type="button"
-                class="flex-1 min-w-[94px] h-10 flex items-center justify-center px-3 border-r border-outline-gray-2 last:border-r-0 text-xs font-semibold uppercase tracking-wide transition-colors shrink-0"
-                :class="
-                  selectedHall === hall
-                    ? 'bg-surface-gray-3 dark:bg-surface-gray-4 text-ink-gray-9'
-                    : 'text-ink-gray-5 hover:bg-surface-gray-2 dark:hover:bg-surface-gray-3'
-                "
-                @click="selectedHall = hall"
-              >
-                {{ hall }}
-              </button>
-            </div>
+            <button
+              v-for="m in modes"
+              :key="m.id"
+              type="button"
+              :aria-pressed="mode === m.id"
+              class="flex-1 h-8 flex items-center justify-center gap-1.5 border-r border-outline-gray-3 last:border-r-0 text-[10px] font-semibold uppercase tracking-wide transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-outline-gray-5"
+              :class="mode === m.id ? SEG_ON : SEG_OFF"
+              @click="mode = m.id"
+            >
+              <span
+                v-if="m.id === 'live'"
+                class="w-1.5 h-1.5 rounded-full bg-current animate-pulse motion-reduce:animate-none"
+                aria-hidden="true"
+              />
+              {{ m.label }}
+              <span v-if="m.count" class="font-normal">{{ m.count }}</span>
+            </button>
+          </div>
+
+          <!--
+            Row 4: Halls (list view only). One boxy group like the day selector,
+            but wrapping so every hall is visible. The 1px gaps over a tinted
+            container draw the dividers, which is what makes a joined group
+            survive a wrap -- border-r alone cannot rule between two rows.
+
+            min-h rather than a fixed height, and no truncate: a name too long
+            for the row wraps inside its own button instead of being cut off.
+          -->
+          <div
+            v-if="view === 'list' && !isSearching && !narrowed && halls.length > 0"
+            class="flex flex-wrap gap-px bg-surface-gray-4 border border-outline-gray-3 rounded-lg overflow-hidden"
+            role="group"
+            aria-label="Select hall"
+          >
+            <button
+              v-for="hall in halls"
+              :key="hall"
+              type="button"
+              :aria-pressed="selectedHall === hall"
+              class="flex-1 min-h-[44px] flex items-center justify-center px-4 py-1.5 text-xs font-semibold uppercase tracking-wide leading-tight text-center transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-outline-gray-5"
+              :class="
+                selectedHall === hall
+                  ? SEG_ON
+                  : `bg-surface-white dark:bg-surface-gray-2 ${SEG_OFF}`
+              "
+              @click="selectedHall = hall"
+            >
+              {{ hall }}
+            </button>
           </div>
         </div>
       </div>
       <!-- Fade shadow -->
-      <div class="h-2 bg-gradient-to-b from-surface-gray-2 to-transparent pointer-events-none dark:from-surface-gray-1" />
+      <div
+        class="h-2 bg-gradient-to-b from-surface-gray-2 to-transparent pointer-events-none dark:from-surface-gray-1"
+      />
     </div>
 
     <!-- ── Main content ──────────────────────────────────────────────────── -->
-    <template v-if="!isSearching">
+    <!--
+      Live and Mine: one flat cross-hall list each, the same SessionCard the
+      search results use, with the hall shown on the card instead of picked
+      from a selector.
+    -->
+    <div v-if="narrowed && !isSearching" class="max-w-[840px] mx-auto px-3 sm:px-4 pb-12 w-full">
+      <SearchSession
+        :schedule="schedule.data"
+        :filter="narrowed.filter"
+        :label="narrowed.title"
+        :empty-text="narrowed.empty"
+      />
+    </div>
+
+    <template v-else-if="!isSearching">
       <!-- List view -->
       <div v-if="view === 'list'" class="max-w-[840px] mx-auto px-3 sm:px-4 pb-12 w-full">
         <HallDayView :sessions="selectedHallSessions" />
       </div>
       <!-- Timeline view: expands to full viewport width if halls exceed 840px -->
       <div v-else class="w-full pb-12 px-3 sm:px-4">
-        <AllDayGridView :schedule="selectedDaySchedule" />
+        <AllDayGridView :schedule="selectedDaySchedule" :halls="halls" />
       </div>
     </template>
-    <div v-else class="max-w-[840px] mx-auto px-3 sm:px-4 pb-12 w-full">
+    <div v-if="isSearching" class="max-w-[840px] mx-auto px-3 sm:px-4 pb-12 w-full">
       <SearchSession :schedule="schedule.data" :query="searchQuery" />
     </div>
   </div>
 
   <!-- Loading state -->
   <div v-else class="flex items-center justify-center min-h-[400px]">
-    <LoadingText text="Loading schedule..." class="text-ink-gray-5" />
+    <LoadingText text="Loading schedule..." class="text-ink-gray-7 dark:text-ink-gray-8" />
   </div>
 </template>
 
 <script setup>
-import { ref, computed, watch, provide } from 'vue'
+import { ref, computed, watch, provide, onMounted, onUnmounted } from 'vue'
 import { createResource, LoadingText, usePageMeta } from 'frappe-ui'
 import { useRoute } from 'vue-router'
 import { IconTimelineEventText, IconAlignLeft, IconSearch } from '@tabler/icons-vue'
 import DOMPurify from 'dompurify'
+import { markdownToHTML } from 'frappe-ui/src/utils/markdown'
 import dayjs from 'dayjs'
 
 import Header from '@/components/Header.vue'
@@ -134,6 +216,7 @@ import EventHeader from '@/components/common/EventHeader.vue'
 import ScheduleDownload from '@/components/schedule/ScheduleDownload.vue'
 import SearchSession from '@/components/schedule/SearchSession.vue'
 import HallDayView from '@/components/schedule/HallDayView.vue'
+import { isSessionLive } from '@/helpers/date'
 import AllDayGridView from '@/components/schedule/AllDayGridView.vue'
 
 const route = useRoute()
@@ -145,12 +228,96 @@ const view = ref('list') // 'list' | 'allday'
 const searchQuery = ref('')
 const isSearching = computed(() => searchQuery.value.trim().length > 0)
 
-function toggleView() {
-  view.value = view.value === 'list' ? 'allday' : 'list'
+// ── All | Live now
+const countMatching = (predicate) =>
+  Object.values(schedule.data ?? {})
+    .flatMap((day) => Object.values(day).flat())
+    .filter(predicate).length
+
+const NARROWED = {
+  live: {
+    label: 'Live Now',
+    title: 'Live Now',
+    empty: 'Nothing running right now.',
+    filter: isSessionLive,
+    count: () => countMatching(isSessionLive),
+  },
 }
+
+const mode = ref('all')
+
+const modes = computed(() => [
+  { id: 'all', label: 'All' },
+  ...Object.entries(NARROWED)
+    .map(([id, m]) => ({ ...m, id, count: m.count() }))
+    .filter((m) => m.count),
+])
+
+// Null on All, and falls back to it the moment the active option stops existing
+// -- the last live session ending mid-view.
+const narrowed = computed(() => modes.value.find((m) => m.id === mode.value && m.filter))
+
+// Days, view switch and All/Live/Mine are the same segmented control, so they
+// share one pair of state classes rather than three copies of each.
+const SEG_ON = 'bg-surface-gray-7 text-ink-white'
+const SEG_OFF =
+  'text-ink-gray-7 dark:text-ink-gray-8 hover:bg-surface-gray-2 dark:hover:bg-surface-gray-3'
+
+const viewOptions = [
+  { value: 'list', label: 'List', icon: IconAlignLeft },
+  { value: 'allday', label: 'Timeline', icon: IconTimelineEventText },
+]
+
+// ── Scroll-reveal nav ─────────────────────────────────────────────────────
+const SCROLL_DELTA_MIN = 6 // px — swallows iOS rubber-band and trackpad jitter
+
+const navEl = ref(null)
+const navVisible = ref(true)
+let lastScrollY = 0
+let scrollQueued = false
+
+function readScroll() {
+  scrollQueued = false
+  const y = Math.max(0, window.scrollY)
+  const delta = y - lastScrollY
+
+  // Leave lastScrollY untouched below the threshold so slow scrolls still accumulate.
+  if (Math.abs(delta) < SCROLL_DELTA_MIN) return
+
+  /*
+   * Hide only once the nav has actually reached the top and stuck. Until then it
+   * still occupies its slot in normal flow, so translating it away leaves a hole
+   * exactly its own height -- which is the blank space that showed up on a short
+   * scroll. offsetTop is a layout value, so neither the sticky offset nor the
+   * transform skews it, and reading it live keeps up with the event header being
+   * collapsed or the viewport being resized.
+   */
+  const stickPoint = navEl.value?.offsetTop ?? 0
+
+  if (delta > 0 && y > stickPoint) navVisible.value = false
+  else if (delta < 0) navVisible.value = true
+  lastScrollY = y
+}
+
+function onScroll() {
+  if (scrollQueued) return
+  scrollQueued = true
+  requestAnimationFrame(readScroll)
+}
+
+onMounted(() => {
+  lastScrollY = Math.max(0, window.scrollY)
+  window.addEventListener('scroll', onScroll, { passive: true })
+})
+
+onUnmounted(() => window.removeEventListener('scroll', onScroll))
 
 function formatDateLabel(isoDate) {
   return dayjs(isoDate).format('D MMM')
+}
+
+function formatFullDate(isoDate) {
+  return dayjs(isoDate).format('dddd, D MMMM YYYY')
 }
 
 // Data fetching
@@ -176,8 +343,7 @@ const schedule = createResource({
   onSuccess(data) {
     eventDays.value = Object.keys(data)
     const today = dayjs().format('YYYY-MM-DD')
-    const todayIdx = eventDays.value.indexOf(today)
-    selectedDay.value = todayIdx !== -1 ? eventDays.value[todayIdx] : eventDays.value[0]
+    selectedDay.value = eventDays.value.includes(today) ? today : eventDays.value[0]
   },
 })
 
@@ -188,7 +354,38 @@ const selectedDaySchedule = computed(() => {
   return schedule.data[selectedDay.value] || {}
 })
 
-const halls = computed(() => Object.keys(selectedDaySchedule.value).sort())
+/**
+ * Hall order is the organiser's: the line order of the event's `hall_options`
+ * field. Never sorted. Parsed once here and handed to everything that renders a
+ * hall list, so the page and the download dialog cannot disagree.
+ */
+const hallOrder = computed(() =>
+  (event.data?.hall_options || '')
+    .split('\n')
+    .map((hall) => hall.trim())
+    .filter(Boolean),
+)
+
+/**
+ * Halls in the selected day, in the organiser's order. Halls `hall_options` does
+ * not mention keep the schedule's own order and come last, so a session in an
+ * unlisted hall is never dropped. With no `hall_options` set, schedule order stands.
+ */
+const halls = computed(() => {
+  const present = Object.keys(selectedDaySchedule.value)
+  // No hall_options: busiest hall first, so the main track leads instead of
+  // whichever hall happened to open earliest.
+  if (!hallOrder.value.length) {
+    const day = selectedDaySchedule.value
+    return present.slice().sort((a, b) => day[b].length - day[a].length)
+  }
+
+  const configuredSet = new Set(hallOrder.value)
+  return [
+    ...hallOrder.value.filter((hall) => present.includes(hall)),
+    ...present.filter((hall) => !configuredSet.has(hall)),
+  ]
+})
 
 watch(
   halls,
@@ -205,9 +402,13 @@ const selectedHallSessions = computed(() => {
   return selectedDaySchedule.value[selectedHall.value] || []
 })
 
-const sanitizedDesc = computed(() =>
-  DOMPurify.sanitize(event.data?.schedule_page_description ?? ''),
-)
+// schedule_page_description is a Markdown Editor field. marked does not
+// sanitise -- it passes inline HTML straight through -- so DOMPurify is doing
+// real work here, not belt-and-braces.
+const sanitizedDesc = computed(() => {
+  const markdown = event.data?.schedule_page_description
+  return markdown ? DOMPurify.sanitize(markdownToHTML(markdown)) : ''
+})
 
 const breadcrumb_items = computed(() => {
   if (!event.data) return []
@@ -228,6 +429,79 @@ usePageMeta(() => ({
 </script>
 
 <style scoped>
+.schedule-note :deep(> *:first-child) {
+  margin-top: 0;
+}
+.schedule-note :deep(> *:last-child) {
+  margin-bottom: 0;
+}
+.schedule-note :deep(p),
+.schedule-note :deep(ul),
+.schedule-note :deep(ol) {
+  margin: 0 0 0.5rem;
+}
+.schedule-note :deep(ul),
+.schedule-note :deep(ol) {
+  padding-left: 1.25rem;
+}
+.schedule-note :deep(ul) {
+  list-style: disc;
+}
+.schedule-note :deep(ol) {
+  list-style: decimal;
+}
+.schedule-note :deep(li) {
+  margin-bottom: 0.125rem;
+}
+.schedule-note :deep(h1),
+.schedule-note :deep(h2),
+.schedule-note :deep(h3),
+.schedule-note :deep(h4) {
+  margin: 0.75rem 0 0.25rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: rgb(var(--ink-gray-9));
+}
+.schedule-note :deep(strong) {
+  font-weight: 600;
+  color: rgb(var(--ink-gray-9));
+}
+/* Underlined, not colour-only: colour alone as the link cue fails WCAG 1.4.1. */
+.schedule-note :deep(a) {
+  color: rgb(var(--ink-gray-9));
+  text-decoration: underline;
+}
+.schedule-note :deep(a:hover) {
+  text-decoration-thickness: 2px;
+}
+.schedule-note :deep(code) {
+  padding: 0.0625rem 0.25rem;
+  border-radius: 0.25rem;
+  background-color: rgb(var(--surface-gray-3));
+  color: rgb(var(--ink-gray-9));
+  font-size: 0.8125rem;
+}
+.schedule-note :deep(pre) {
+  margin: 0 0 0.5rem;
+  padding: 0.5rem 0.75rem;
+  overflow-x: auto;
+  border-radius: 0.375rem;
+  background-color: rgb(var(--surface-gray-3));
+}
+.schedule-note :deep(pre code) {
+  padding: 0;
+  background: none;
+}
+.schedule-note :deep(hr) {
+  margin: 0.75rem 0;
+  border-color: rgb(var(--outline-gray-3));
+}
+.schedule-note :deep(blockquote) {
+  margin: 0 0 0.5rem;
+  padding-left: 0.75rem;
+  border-left: 2px solid rgb(var(--outline-gray-3));
+}
+
 .scrollbar-none {
   scrollbar-width: none;
 }

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.json
@@ -420,7 +420,7 @@
   },
   {
    "fieldname": "schedule_page_description",
-   "fieldtype": "Long Text",
+   "fieldtype": "Markdown Editor",
    "label": "Schedule Page Description"
   },
   {
@@ -526,7 +526,7 @@
    "link_fieldname": "event"
   }
  ],
- "modified": "2026-08-14 12:53:55.260169",
+ "modified": "2026-09-07 19:03:43.903035",
  "modified_by": "Administrator",
  "module": "Chapters",
  "name": "FOSS Chapter Event",

--- a/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
+++ b/fossunited/chapters/doctype/foss_chapter_event/foss_chapter_event.py
@@ -97,7 +97,7 @@ class FOSSChapterEvent(WebsiteGenerator):
         project_showcase: DF.Table[EventProjectShowcase]
         proposal_page_description: DF.Text | None
         route: DF.Data | None
-        schedule_page_description: DF.LongText | None
+        schedule_page_description: DF.MarkdownEditor | None
         show_photos: DF.Check
         show_schedule: DF.Check
         show_speakers: DF.Check

--- a/fossunited/patches.txt
+++ b/fossunited/patches.txt
@@ -1,7 +1,6 @@
 [pre_model_sync]
 # Patches added in this section will be executed before doctypes are migrated
 # Read docs to understand patches: https://frappeframework.com/docs/v14/user/en/database-migrations
-fossunited.patches.v1_0.migrate_only_flags_to_allowed_session_types
 
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated


### PR DESCRIPTION
<img width="250" height="500" alt="image" src="https://github.com/user-attachments/assets/1c904177-22e0-4550-b378-8d2c26d1dcb5" />

<img width="500" height="450" alt="image" src="https://github.com/user-attachments/assets/dc41651e-6915-4e10-befe-987be6add288" />

*Same same, but different*

- many bug fixes and improvements to UX

- Render Schedule description as markdown to enrich the text
- Keep header non sticky to save space and immerse more for users
- A11Y: Lots of low contrast color fixing for schedule components #1707 (no time to update frappe-ui :{ 
- All day Grid: Show header as sticky for referencing while scroll
- Refactor Schedule download modal UI for accessibility using native html semantics
- Do not order the halls and let organiser show as they put halls in order (hall_options field)
- One easter to view "Live now" - only shown if today is event day and shows current on-going talk (helpful)