### PR TITLE
fix(search): support orderless haystack searching over proposal pages

### DIFF
--- a/dashboard/src/components/cfp-public/SubmissionsListView.vue
+++ b/dashboard/src/components/cfp-public/SubmissionsListView.vue
@@ -4,6 +4,7 @@ import Filter from '@/components/ui/Filter.vue'
 import { IconSearch, IconDownload, IconX } from '@tabler/icons-vue'
 import { createResource, FormControl, LoadingText, Select } from 'frappe-ui'
 import { filterSubmissions } from '@/helpers/cfp'
+import { matchesQuery, tokenizeQuery } from '@/helpers/search'
 import { watch, ref, computed, onUnmounted } from 'vue'
 import { useStorage } from '@vueuse/core'
 import { useRoute } from 'vue-router'
@@ -13,7 +14,7 @@ const route = useRoute()
 const filters = useStorage(`submission-filters:${route.params.route}`, {})
 const sortBy = useStorage(`submission-sort:${route.params.route}`, 'creation_desc')
 const searchTitle = ref('')
-const debouncedSearch = ref('')
+const debouncedSearch = ref([])
 
 const SORT_OPTIONS = [
   { label: 'Newest', value: 'creation_desc' },
@@ -151,23 +152,21 @@ const filteredSubmissions = computed(() => {
   }
 
   // Apply search filter
-  if (search) {
+  if (search.length) {
     result = result.filter((item) => {
       const { talk_title, speaker_name, speakers, _speaker, session_type, session_categories } =
         item
+      const speakerList = speakers ?? _speaker ?? []
 
-      const titleMatch = talk_title?.toLowerCase().includes(search)
-      const categoryMatch = session_categories?.toLowerCase().includes(search)
-      const sessionTypeMatch = session_type?.toLowerCase().includes(search)
-
-      const allNames = [
-        ...(speaker_name ? [speaker_name.toLowerCase()] : []),
-        ...((speakers ?? _speaker)?.map((s) => s?.full_name?.toLowerCase() ?? '') ?? []),
-        ...((speakers ?? _speaker)?.map((s) => s?.organization?.toLowerCase() ?? '') ?? []),
-      ]
-
-      return (
-        titleMatch || categoryMatch || sessionTypeMatch || allNames.some((n) => n.includes(search))
+      return matchesQuery(
+        [
+          talk_title,
+          session_categories,
+          session_type,
+          speaker_name,
+          speakerList.map((s) => [s?.full_name, s?.organization]),
+        ],
+        search,
       )
     })
   }
@@ -243,7 +242,7 @@ let searchTimer = null
 watch(searchTitle, (val) => {
   clearTimeout(searchTimer)
   searchTimer = setTimeout(() => {
-    debouncedSearch.value = val.trim().toLowerCase()
+    debouncedSearch.value = tokenizeQuery(val)
   }, 200)
 })
 onUnmounted(() => clearTimeout(searchTimer))

--- a/dashboard/src/components/schedule/SearchSession.vue
+++ b/dashboard/src/components/schedule/SearchSession.vue
@@ -35,6 +35,7 @@
 <script setup>
 import { computed } from 'vue'
 import SessionCard from '@/components/schedule/SessionCard.vue'
+import { matchesQuery, tokenizeQuery } from '@/helpers/search'
 
 const props = defineProps({
   schedule: {
@@ -78,22 +79,22 @@ const allSessions = computed(() => flattenSchedule(props.schedule))
 const filteredSessions = computed(() => {
   if (props.filter) return allSessions.value.filter(props.filter)
 
-  const q = props.query.trim().toLowerCase()
-  if (!q) return []
+  const tokens = tokenizeQuery(props.query)
+  if (!tokens.length) return []
 
   return allSessions.value.filter((session) => {
     const speakers = session.cfp_speakers ?? []
-    const parts = [
-      session.name,
-      session.title,
-      session.category,
-      session.other_category,
-      session.hall,
-      ...speakers.flatMap((s) => [s.full_name, s.designation, s.organization]),
-    ]
-      .filter(Boolean)
-      .map((s) => String(s).toLowerCase())
-    return parts.join(' ').includes(q)
+    return matchesQuery(
+      [
+        session.name,
+        session.title,
+        session.category,
+        session.other_category,
+        session.hall,
+        ...speakers.flatMap((s) => [s.full_name, s.designation, s.organization]),
+      ],
+      tokens,
+    )
   })
 })
 </script>

--- a/dashboard/src/components/schedule/SearchSession.vue
+++ b/dashboard/src/components/schedule/SearchSession.vue
@@ -36,6 +36,7 @@
 import { computed } from 'vue'
 import SessionCard from '@/components/schedule/SessionCard.vue'
 import { matchesQuery, tokenizeQuery } from '@/helpers/search'
+import { resolveSpeakers } from '@/composables/useSession'
 
 const props = defineProps({
   schedule: {
@@ -83,7 +84,7 @@ const filteredSessions = computed(() => {
   if (!tokens.length) return []
 
   return allSessions.value.filter((session) => {
-    const speakers = session.cfp_speakers ?? []
+    const speakers = resolveSpeakers(session)
     return matchesQuery(
       [
         session.name,
@@ -91,7 +92,7 @@ const filteredSessions = computed(() => {
         session.category,
         session.other_category,
         session.hall,
-        ...speakers.flatMap((s) => [s.full_name, s.designation, s.organization]),
+        ...speakers.flatMap((s) => [s?.full_name, s?.designation, s?.organization]),
       ],
       tokens,
     )

--- a/dashboard/src/components/ui/SearchListView.vue
+++ b/dashboard/src/components/ui/SearchListView.vue
@@ -106,6 +106,7 @@
 import { ListView, FormControl, Button, Dialog } from 'frappe-ui'
 import { ref, computed, reactive, watch, onUnmounted } from 'vue'
 import { debounce } from 'lodash-es'
+import { matchesQuery, tokenizeQuery } from '@/helpers/search'
 import { toast } from 'vue-sonner'
 
 const props = defineProps({
@@ -252,27 +253,19 @@ watch(debouncedSearch, (term, prev) => {
 })
 
 // Row matching
-const getSearchText = (row) => {
-  if (props.searchFields) {
-    return props.searchFields
-      .map((f) => row[f])
-      .filter(Boolean)
-      .join(' ')
-      .toLowerCase()
-  }
-  return props.columns
-    .map((col) => {
-      const v = row[col.key]
-      return typeof v === 'boolean' ? (v ? 'yes' : 'no') : v
-    })
-    .filter(Boolean)
-    .join(' ')
-    .toLowerCase()
+// Tokenized once per search change rather than once per row.
+const searchTokens = computed(() => tokenizeQuery(debouncedSearch.value))
+
+const getSearchParts = (row) => {
+  if (props.searchFields) return props.searchFields.map((f) => row[f])
+  return props.columns.map((col) => {
+    const v = row[col.key]
+    return typeof v === 'boolean' ? (v ? 'yes' : 'no') : v
+  })
 }
 
 const matchesRow = (row) => {
-  const term = debouncedSearch.value.toLowerCase().trim()
-  if (term && !getSearchText(row).includes(term)) return false
+  if (!matchesQuery(getSearchParts(row), searchTokens.value)) return false
   if (activeFilterApplied.value && row[props.filterField] !== selectedFilter.value) return false
   return true
 }

--- a/dashboard/src/composables/useSession.js
+++ b/dashboard/src/composables/useSession.js
@@ -5,6 +5,24 @@ import dayjs from 'dayjs'
 import { createAbsoluteUrlFromRoute } from '@/helpers/utils'
 
 /**
+ * Speakers arrive either as a child table (`cfp_speakers`) or as a JSON string
+ * (`speakers`), depending on how the session was created. Callers outside a
+ * component setup (search filters, etc.) need this without the composable.
+ */
+export function resolveSpeakers(session) {
+  if (!session) return []
+  if (session.cfp_speakers?.length) return session.cfp_speakers
+  if (session.speakers) {
+    try {
+      return JSON.parse(session.speakers)
+    } catch {
+      return []
+    }
+  }
+  return []
+}
+
+/**
  * Shared session logic for SessionCard and TimeCapsule.
  * @param {import('vue').Ref} session - a ref to the session object (toRef(props, 'session'))
  */
@@ -16,14 +34,7 @@ export function useSession(session) {
     return dayjs(`1970-01-01 ${timeStr}`).format('h:mm A')
   }
 
-  const speakers = computed(() => {
-    const s = session.value
-    if (s.cfp_speakers?.length) return s.cfp_speakers
-    if (s.speakers) {
-      try { return JSON.parse(s.speakers) } catch { return [] }
-    }
-    return []
-  })
+  const speakers = computed(() => resolveSpeakers(session.value))
 
   const visibleSpeakers = computed(() => speakers.value.slice(0, 4))
 

--- a/dashboard/src/helpers/search.js
+++ b/dashboard/src/helpers/search.js
@@ -1,0 +1,41 @@
+/**
+ * Order-independent ("haystack") text search.
+ *
+ * The query is split into whitespace-separated tokens and every token must
+ * appear somewhere in the haystack, in any order. So "malan david" matches a
+ * speaker named "David Malan", and "malan keynote" matches a talk titled
+ * "Keynote" by "David Malan" even though the words live in different fields.
+ *
+ * Tokens never contain whitespace, so joining the fields with a space keeps
+ * them from matching across a field boundary.
+ */
+
+export function tokenizeQuery(query) {
+  return String(query ?? '')
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean)
+}
+
+export function buildHaystack(parts) {
+  return parts
+    .flat(Infinity)
+    .filter(Boolean)
+    .map((part) => String(part).toLowerCase())
+    .join(' ')
+}
+
+/**
+ * @param {Array} parts  fields to search across (nested arrays are flattened,
+ *                       falsy entries dropped)
+ * @param {string|string[]} query  raw query string, or pre-tokenized tokens
+ * @returns {boolean}  true when every token is found; an empty query matches
+ */
+export function matchesQuery(parts, query) {
+  const tokens = Array.isArray(query) ? query : tokenizeQuery(query)
+  if (!tokens.length) return true
+
+  const haystack = buildHaystack(parts)
+  return tokens.every((token) => haystack.includes(token))
+}


### PR DESCRIPTION
- Speaker name with "David malan" could not be found via linear search if typed "malan david"

- Add a simple space based tokenizer to match query without strict order.
- helpful for easy search