### PR TITLE
fix(if26): link tab to open section, update childcare notice

### DIFF
--- a/fossunited/www/indiafoss/2026/index.css
+++ b/fossunited/www/indiafoss/2026/index.css
@@ -45,6 +45,8 @@
 .if-hero-meta-link { color: inherit; text-decoration: none; border-bottom: 1px dotted currentColor; }
 .if-hero-meta-link:hover { opacity: .75; color: inherit; text-decoration: none; }
 .if-hero-desc { max-width: 540px; color: #f4f4f4; margin: 0; }
+/* Desktop has room for the whole subtitle on one line; mobile keeps wrapping */
+@media (min-width: 840px) { .if-hero-desc { max-width: none; white-space: nowrap; } }
 /* Tagline white on dark image regardless of theme */
 .if-hero .if-tagline { color: #fff; }
 

--- a/fossunited/www/indiafoss/2026/index.html
+++ b/fossunited/www/indiafoss/2026/index.html
@@ -618,10 +618,10 @@
               <li class="nav-item">
                 <a class="nav-link {% if loop.first %}active{% endif %}"
                    data-toggle="tab"
-                   href="#panel-{{ tab_id }}"
+                   href="#{{ tab_id }}"
                    role="tab"
                    id="tab-btn-{{ tab_id }}"
-                   aria-controls="panel-{{ tab_id }}"
+                   aria-controls="{{ tab_id }}"
                    aria-selected="{{ 'true' if loop.first else 'false' }}"
                    tabindex="{{ '0' if loop.first else '-1' }}">
                   {{ tab_label }}
@@ -633,7 +633,7 @@
           <div class="tab-content">
             {% for tab_id, tab_label, people in vol_tabs %}
               <div class="tab-pane {% if loop.first %}active{% endif %}"
-                   id="panel-{{ tab_id }}"
+                   id="{{ tab_id }}"
                    role="tabpanel"
                    aria-labelledby="tab-btn-{{ tab_id }}">
                 {% if people %}
@@ -836,7 +836,7 @@ frappe.ready(function() { $('[data-toggle="tooltip"]').tooltip(); });
   });
 })();
 
-// Deep-link the team tabs: #panel-<id> in the URL opens that tab and scrolls to it;
+// Deep-link the team tabs: #<id> in the URL opens that tab and scrolls to it;
 // clicking a tab reflects its id back into the URL so it stays shareable.
 // Runs in frappe.ready so jQuery + the Bootstrap tab plugin are loaded first.
 frappe.ready(function() {

--- a/fossunited/www/indiafoss/2026/index.html
+++ b/fossunited/www/indiafoss/2026/index.html
@@ -607,10 +607,10 @@
           </h2>
 
           {% set vol_tabs = [
-            ('co-chairs',  'Co-Chairs',       co_chairs),
-            ('volunteers', 'Volunteers',       volunteers),
-            ('devrooms',   'Devroom Managers', devroom_managers),
-            ('reviewers',  'Reviewers',        reviewers),
+            ('cochairs',          'Co-Chairs',        co_chairs),
+            ('volunteers',        'Volunteers',       volunteers),
+            ('devroom-managers',  'Devroom Managers', devroom_managers),
+            ('reviewers',         'Reviewers',        reviewers),
           ] %}
 
           <ul class="nav v3-nav-pills" role="tablist" aria-label="Conference team categories">
@@ -661,8 +661,8 @@
 
       {# 7. SUPPORT & ACCESSIBILITY (shown early for A11Y tabbing) #}
       {% set support = [
-        {'title': 'Child Care',    'desc': 'On-site childcare during both the conference days.',                    'form_url': 'https://fossunited.org/indiafoss/childcare/new', 'has_form': true, 'icon': 'ti-baby-carriage'},
-        {'title': 'Accessibility', 'desc': 'We give support to make the conference accessible for all.',            'form_url': 'https://fossunited.org/indiafoss/accessibility/new', 'has_form': true, 'icon': 'ti-accessible'},
+        {'title': 'Child Care',    'desc': 'On-site childcare during both the conference days.',                    'form_url': 'https://fossunited.org/indiafoss/childcare/new',     'has_form': true, 'note': 'No requests came in this year, so this will not be available. Read more.', 'icon': 'ti-baby-carriage'},
+        {'title': 'Accessibility', 'desc': 'Support to make the conference accessible for all.',                   'form_url': 'https://fossunited.org/indiafoss/accessibility/new', 'has_form': true, 'note': 'No requests came in this year, so this will not be available. Read more.', 'icon': 'ti-accessible'},
         {'title': 'Low Waste',    'desc': 'Bring your own bottles. Help our conference produce low waste output.', 'form_url': '', 'has_form': false, 'icon': 'ti-leaf'},
       ] %}
       <section aria-labelledby="support-heading">
@@ -678,7 +678,13 @@
                   <i class="ti {{ card.icon }} support-icon text-4xl" aria-hidden="true"></i>
                   <p class="semi-bold mb-0">{{ card.title }}</p>
                   <p class="text-sm  mb-0">{{ card.desc }}</p>
-                  {% if card.form_url %}
+                  {% if card.note %}
+                    {% if card.form_url %}
+                      <a href="{{ card.form_url }}" class="text-sm v3-text-tertiary" style="text-decoration: underline;">{{ card.note }}</a>
+                    {% else %}
+                      <p class="text-sm v3-text-tertiary mb-0">{{ card.note }}</p>
+                    {% endif %}
+                  {% elif card.form_url %}
                     <a href="{{ card.form_url }}" class="text-sm" style="text-decoration: underline;">Fill the {{ card.title }} form</a>
                   {% elif card.has_form %}
                     <p class="text-sm v3-text-tertiary mb-0">Form opening soon.</p>

--- a/fossunited/www/indiafoss/2026/index.html
+++ b/fossunited/www/indiafoss/2026/index.html
@@ -835,5 +835,25 @@ frappe.ready(function() { $('[data-toggle="tooltip"]').tooltip(); });
     });
   });
 })();
+
+// Deep-link the team tabs: #panel-<id> in the URL opens that tab and scrolls to it;
+// clicking a tab reflects its id back into the URL so it stays shareable.
+// Runs in frappe.ready so jQuery + the Bootstrap tab plugin are loaded first.
+frappe.ready(function() {
+  var $ = window.jQuery;
+  if (!$ || !$.fn.tab) return;
+  function open(hash) {
+    var link = hash && document.querySelector('.v3-nav-pills a[href="' + hash + '"]');
+    if (!link) return;
+    $(link).tab('show');
+    var team = document.getElementById('team');
+    if (team) team.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+  open(location.hash);
+  window.addEventListener('hashchange', function() { open(location.hash); });
+  $('.v3-nav-pills a[data-toggle="tab"]').on('shown.bs.tab', function() {
+    history.replaceState(null, '', this.getAttribute('href'));
+  });
+});
 </script>
 {% endblock %}

--- a/fossunited/www/indiafoss/2026/index.py
+++ b/fossunited/www/indiafoss/2026/index.py
@@ -3,7 +3,7 @@ import json
 
 import frappe
 
-from fossunited.doctype_ids import COMMUNITY_PARTNER, EVENT, EVENT_CFP
+from fossunited.doctype_ids import EVENT, EVENT_CFP
 from fossunited.fossunited.event_media import get_indiafoss_years
 from fossunited.fossunited.user_utils import fetch_user_profiles
 from fossunited.fossunited.utils import get_event_sponsors
@@ -43,12 +43,7 @@ def get_context(context):
     context.sponsors = [
         {"tier": t, "sponsor_list": sl, "is_tier1": t in TIER1} for t, sl in sponsors_dict.items()
     ]
-    context.partners = frappe.db.get_all(
-        COMMUNITY_PARTNER,
-        {"parent": event_docname, "parenttype": EVENT},
-        ["org_name", "link", "logo"],
-        page_length=99,
-    )
+    context.partners = event.community_partners
 
     devrooms = frappe.get_all(
         "Devroom Custom",
@@ -109,7 +104,11 @@ def get_context(context):
         context.timeline, today
     )
     context.progress_pct = round(
-        max(0.0, min(100.0, (today - BAR_START).days * 100.0 / (BAR_END - BAR_START).days)), 1
+        max(
+            0.0,
+            min(100.0, (today - BAR_START).days * 100.0 / (BAR_END - BAR_START).days),
+        ),
+        1,
     )
     context.action_cards = _enrich_action_cards(
         event_data.get("action_cards", []), context.timeline, today

--- a/fossunited/www/indiafoss/2026/index.py
+++ b/fossunited/www/indiafoss/2026/index.py
@@ -9,7 +9,7 @@ from fossunited.fossunited.user_utils import fetch_user_profiles
 from fossunited.fossunited.utils import get_event_sponsors
 
 INDIAFOSS_2026_EVENT = "IndiaFOSS 2026"
-TIER1 = {"Maintainer", "Patrons", "Platinum", "Gold"}
+TIER1 = {"Maintainer", "Patrons", "Platinum", "Gold", "Maintainer Tier"}
 
 
 # TODO: replace all short form url to /2026/ form


### PR DESCRIPTION
- Grab community partners directly from event doc instead of another query
- show note for closure on childcare and accessibility
- show subtitle in single line for desktop (clean)
- fix navigating to tab section directly to share for volunteers and so