### PR TITLE
fix(free-ticket-code): avoid giving it to duplicate emails + avoid speaker coupon to mulitple counts

### DIFF
--- a/development/run_bruno_tests.sh
+++ b/development/run_bruno_tests.sh
@@ -26,10 +26,10 @@ resolve_bru() {
 
   if command -v yarn >/dev/null 2>&1; then
     echo "Bruno CLI not found — installing dependencies with yarn..." >&2
-    (cd "$ROOT_DIR" && yarn install --silent)
+    (cd "$BRUNO_DIR" && yarn install --silent)
   elif command -v npm >/dev/null 2>&1; then
     echo "Bruno CLI not found — installing dependencies with npm..." >&2
-    (cd "$ROOT_DIR" && npm install --silent)
+    (cd "$BRUNO_DIR" && npm install --silent)
   else
     return
   fi

--- a/fossunited/api/tickets.py
+++ b/fossunited/api/tickets.py
@@ -591,11 +591,12 @@ def get_free_coupon_info(coupon_id: str) -> dict:
     }
 
 
-def _get_approved_speaker_emails_for_event(event: str) -> dict[str, tuple[str, int]]:
-    """Return {email: (full_name, talk_count)} for unique speakers across approved proposals.
+def _get_approved_speaker_emails_for_event(event: str) -> dict[str, str]:
+    """Return {email: full_name} for unique speakers across approved proposals.
 
-    talk_count is the number of approved proposals this speaker appears in.
-    Speaker child rows take priority; proposal-level email is a fallback when no child rows exist.
+    One coupon per speaker regardless of how many approved proposals they
+    appear in. Speaker child rows take priority; proposal-level email is a
+    fallback when no child rows exist.
     """
     proposals = frappe.get_all(
         PROPOSAL,
@@ -616,7 +617,7 @@ def _get_approved_speaker_emails_for_event(event: str) -> dict[str, tuple[str, i
     for r in speaker_rows:
         rows_by_proposal.setdefault(r.parent, []).append(r)
 
-    email_data = {}  # email → [full_name, talk_count]
+    email_data = {}  # email → full_name
 
     for p in proposals:
         p_emails = set()
@@ -625,18 +626,15 @@ def _get_approved_speaker_emails_for_event(event: str) -> dict[str, tuple[str, i
             if r.email:
                 key = r.email.strip().lower()
                 p_emails.add(key)
-                email_data.setdefault(key, [r.full_name or "", 0])
+                email_data.setdefault(key, r.full_name or "")
 
         # Fallback: proposal-level email if no speaker child rows on this proposal
         if not p_emails and p.email:
             key = p.email.strip().lower()
             p_emails.add(key)
-            email_data.setdefault(key, [p.full_name or "", 0])
+            email_data.setdefault(key, p.full_name or "")
 
-        for key in p_emails:
-            email_data[key][1] += 1
-
-    return {email: (name, count) for email, (name, count) in email_data.items()}
+    return email_data
 
 
 def _get_existing_coupon_emails_for_event(event: str) -> set[str]:
@@ -664,7 +662,9 @@ def bulk_create_speaker_coupons(event: str, max_count: int = 1, tshirt_included:
     """
     Idempotently create EventFreeTicketCode docs for approved CFP speakers.
 
-    Skips speakers who already have a coupon for this event.
+    One coupon per unique speaker email, regardless of how many approved
+    proposals they appear in. Skips speakers who already have a coupon for
+    this event.
     """
 
     max_count = int(max_count)
@@ -676,7 +676,7 @@ def bulk_create_speaker_coupons(event: str, max_count: int = 1, tshirt_included:
     existing = _get_existing_coupon_emails_for_event(event)
     to_create = {e: v for e, v in info.items() if e not in existing}
 
-    for email, (full_name, talk_count) in to_create.items():
+    for email, full_name in to_create.items():
         frappe.get_doc(
             {
                 "doctype": FREE_TICKET_CODE,
@@ -684,7 +684,7 @@ def bulk_create_speaker_coupons(event: str, max_count: int = 1, tshirt_included:
                 "mapped_email": email,
                 "full_name": full_name,
                 "tier": "Speaker/Workshop Host",
-                "max_count": max_count * talk_count,
+                "max_count": max_count,
                 "tshirt_included": tshirt_included,
             }
         ).insert(ignore_permissions=True)

--- a/fossunited/fossunited/doctype/event_free_ticket_code/event_free_ticket_code.py
+++ b/fossunited/fossunited/doctype/event_free_ticket_code/event_free_ticket_code.py
@@ -6,6 +6,7 @@ from frappe import _
 from frappe.model.document import Document
 
 from fossunited.api.chapter import check_if_chapter_or_event_core_member
+from fossunited.doctype_ids import FREE_TICKET_CODE
 
 
 class EventFreeTicketCode(Document):
@@ -42,6 +43,27 @@ class EventFreeTicketCode(Document):
 
     def before_save(self):
         self.permit_only_team()
+        self.validate_duplicate_email()
+
+    def validate_duplicate_email(self):
+        """Warn if this email already has a coupon for the same event."""
+        if not self.mapped_email or not self.event:
+            return
+
+        if frappe.db.exists(
+            FREE_TICKET_CODE,
+            {
+                "event": self.event,
+                "mapped_email": self.mapped_email,
+                "name": ["!=", self.name or ""],
+            },
+        ):
+            frappe.throw(
+                _(
+                    "{0} already has a coupon for this event. If this is deliberate, "
+                    "use an email alias like name+ticket@domain.com."
+                ).format(self.mapped_email)
+            )
 
     def permit_only_team(self):
         """Allow only event/chapter team members to modify."""

--- a/fossunited/fossunited/doctype/event_free_ticket_code/test_event_free_ticket_code.py
+++ b/fossunited/fossunited/doctype/event_free_ticket_code/test_event_free_ticket_code.py
@@ -49,3 +49,17 @@ class TestEventFreeTicketCodeController(FrappeTestCase):
     def test_invalid_mapped_email_throws_error(self):
         with self.assertRaises(frappe.ValidationError):
             FreeTicketCodeFactory.create(event=self.event.name, mapped_email="not-an-email")
+
+    def test_duplicate_email_for_same_event_throws_error(self):
+        FreeTicketCodeFactory.create(event=self.event.name, mapped_email="dupe@test.com")
+        with self.assertRaises(frappe.ValidationError):
+            FreeTicketCodeFactory.create(event=self.event.name, mapped_email="dupe@test.com")
+
+    def test_same_email_allowed_across_different_events(self):
+        other_event = FOSSChapterEventFactory.create(
+            chapter=self.chapter.name, event_name="Other Test Event"
+        )
+        FreeTicketCodeFactory.create(event=self.event.name, mapped_email="shared@test.com")
+        # Should not raise - duplicate check is scoped per event
+        FreeTicketCodeFactory.create(event=other_event.name, mapped_email="shared@test.com")
+        frappe.delete_doc(EVENT, other_event.name, force=True)

--- a/fossunited/tests/test_speaker_coupons.py
+++ b/fossunited/tests/test_speaker_coupons.py
@@ -77,20 +77,21 @@ class TestSpeakerCoupons(FrappeTestCase):
             )
         )
 
-    def test_multi_talk_speaker_gets_multiplied_max_count(self):
-        # Same speaker, two approved proposals
+    def test_multi_talk_speaker_gets_exactly_one_coupon(self):
+        # Same speaker, two approved proposals - strictly one coupon either way
         self._approved([_speaker("bob@test.com")])
         self._approved([_speaker("bob@test.com")])
         frappe.set_user(self.team_member.name)
 
-        bulk_create_speaker_coupons(event=self.event.name, max_count=2)
+        result = bulk_create_speaker_coupons(event=self.event.name, max_count=2)
 
+        self.assertEqual(result["created"], 1)
         max_count = frappe.db.get_value(
             FREE_TICKET_CODE,
             {"event": self.event.name, "mapped_email": "bob@test.com"},
             "max_count",
         )
-        self.assertEqual(int(max_count), 4)  # 2 per talk * 2 talks
+        self.assertEqual(int(max_count), 2)
 
     def test_tshirt_included_flag_is_stored_on_coupon(self):
         self._approved([_speaker("frank@test.com")])
@@ -140,6 +141,25 @@ class TestSpeakerCoupons(FrappeTestCase):
 
         self.assertEqual(result["created"], 0)
         self.assertEqual(result["skipped"], 1)
+
+    def test_bulk_create_continues_past_a_duplicate_in_the_batch(self):
+        # heidi already has a coupon (not from a prior bulk run); ivan is new
+        self._approved([_speaker("heidi@test.com")])
+        self._approved([_speaker("ivan@test.com")])
+        FreeTicketCodeFactory.create(
+            event=self.event.name, mapped_email="heidi@test.com", tier="Volunteer"
+        )
+        frappe.set_user(self.team_member.name)
+
+        result = bulk_create_speaker_coupons(event=self.event.name, max_count=1)
+
+        self.assertEqual(result["created"], 1)
+        self.assertEqual(result["skipped"], 1)
+        self.assertTrue(
+            frappe.db.exists(
+                FREE_TICKET_CODE, {"event": self.event.name, "mapped_email": "ivan@test.com"}
+            )
+        )
 
     def test_non_approved_proposals_excluded(self):
         # Status defaults to "Review Pending" — no approved proposals


### PR DESCRIPTION
- Auto speaker coupon incremented claim count with number of talk appearance they had in accepted proposal
  My bad for thinking it was appreciated to provide

  But now every speaker gets only one claim ticket for an event

- Avoid giving out coupon code for same email. This is to avoid giving out to same email for diversity and speaker if they co-exist.
- Just an helper, if need to be deliberate then organiser can use "+ticket" alias suffix to send.

This keeps it clean and avoid repeating for multiple external people.