### PR TITLE
fix(free-code): revert blocking dup email + simply warn via notify/toast

### DIFF
--- a/dashboard/src/components/event/FreeTicketCodeDialog.vue
+++ b/dashboard/src/components/event/FreeTicketCodeDialog.vue
@@ -95,6 +95,10 @@ const props = defineProps({
     type: Object,
     default: () => ({}),
   },
+  existingCodes: {
+    type: Array,
+    default: () => [],
+  },
 })
 
 const emit = defineEmits(['refresh'])
@@ -150,6 +154,19 @@ const validateFields = () => {
   return errors
 }
 
+// Soft, non-blocking heads-up on dup email and info on prev coupon
+const findDuplicateWarning = () => {
+  const email = code.mapped_email.trim().toLowerCase()
+  const duplicate = props.existingCodes.find(
+    (c) => c.name !== code.name && (c.mapped_email || '').trim().toLowerCase() === email,
+  )
+  return duplicate
+    ? `${code.mapped_email} already has a coupon (${duplicate.name}) for this event.`
+    : null
+}
+
+let pendingDuplicateWarning = null
+
 const createCode = createResource({
   url: 'frappe.client.insert',
   makeParams() {
@@ -169,6 +186,7 @@ const createCode = createResource({
   },
   onSuccess() {
     toast.success('Free code created successfully')
+    if (pendingDuplicateWarning) toast.info(pendingDuplicateWarning)
     emit('refresh')
     showDialog.value = false
     resetCode()
@@ -198,6 +216,7 @@ const updateCode = createResource({
   },
   onSuccess() {
     toast.success('Free code updated successfully')
+    if (pendingDuplicateWarning) toast.info(pendingDuplicateWarning)
     emit('refresh')
     showDialog.value = false
     errorMessages.value = ''
@@ -234,6 +253,7 @@ const handleCreate = () => {
     return
   }
   errorMessages.value = ''
+  pendingDuplicateWarning = findDuplicateWarning()
   createCode.fetch()
 }
 
@@ -244,6 +264,7 @@ const handleSave = () => {
     return
   }
   errorMessages.value = ''
+  pendingDuplicateWarning = findDuplicateWarning()
   updateCode.fetch()
 }
 

--- a/dashboard/src/components/event/FreeTicketCodeSection.vue
+++ b/dashboard/src/components/event/FreeTicketCodeSection.vue
@@ -5,6 +5,7 @@
       :event="event"
       :in-create-mode="inCreateMode"
       :row="selectedRow"
+      :existing-codes="freeCodes.data || []"
       @refresh="freeCodes.fetch()"
     />
     <div>

--- a/fossunited/fossunited/doctype/event_free_ticket_code/event_free_ticket_code.py
+++ b/fossunited/fossunited/doctype/event_free_ticket_code/event_free_ticket_code.py
@@ -61,12 +61,18 @@ class EventFreeTicketCode(Document):
                 "mapped_email": self.mapped_email,
                 "name": ["!=", self.name or ""],
             },
-            "name",
+            ["name", "tier", "other_tier"],
+            as_dict=True,
         )
         if existing:
+            tier_label = (
+                existing.other_tier
+                if existing.tier == "Other" and existing.other_tier
+                else existing.tier
+            )
             frappe.msgprint(
-                _("{0} already has a coupon ({1}) for this event.").format(
-                    self.mapped_email, existing
+                _('note: {0} already has a coupon ({1}) under "{2}" for this event.').format(
+                    self.mapped_email, existing.name, tier_label
                 ),
                 indicator="orange",
                 alert=True,

--- a/fossunited/fossunited/doctype/event_free_ticket_code/event_free_ticket_code.py
+++ b/fossunited/fossunited/doctype/event_free_ticket_code/event_free_ticket_code.py
@@ -6,7 +6,6 @@ from frappe import _
 from frappe.model.document import Document
 
 from fossunited.api.chapter import check_if_chapter_or_event_core_member
-from fossunited.doctype_ids import FREE_TICKET_CODE
 
 
 class EventFreeTicketCode(Document):
@@ -43,27 +42,6 @@ class EventFreeTicketCode(Document):
 
     def before_save(self):
         self.permit_only_team()
-        self.validate_duplicate_email()
-
-    def validate_duplicate_email(self):
-        """Warn if this email already has a coupon for the same event."""
-        if not self.mapped_email or not self.event:
-            return
-
-        if frappe.db.exists(
-            FREE_TICKET_CODE,
-            {
-                "event": self.event,
-                "mapped_email": self.mapped_email,
-                "name": ["!=", self.name or ""],
-            },
-        ):
-            frappe.throw(
-                _(
-                    "{0} already has a coupon for this event. If this is deliberate, "
-                    "use an email alias like name+ticket@domain.com."
-                ).format(self.mapped_email)
-            )
 
     def permit_only_team(self):
         """Allow only event/chapter team members to modify."""

--- a/fossunited/fossunited/doctype/event_free_ticket_code/event_free_ticket_code.py
+++ b/fossunited/fossunited/doctype/event_free_ticket_code/event_free_ticket_code.py
@@ -37,11 +37,40 @@ class EventFreeTicketCode(Document):
         used_count: DF.Int
     # end: auto-generated types
 
+    def before_insert(self):
+        self.warn_duplicate_email()
+
     def on_trash(self):
         self.permit_only_team()
 
     def before_save(self):
         self.permit_only_team()
+
+    def warn_duplicate_email(self):
+        """Non-blocking heads-up in Desk: this email already has a coupon
+        for this event. Doesn't stop the save - duplicates are allowed
+        (e.g. a deliberate resend via an email alias).
+        """
+        if not self.mapped_email or not self.event:
+            return
+
+        existing = frappe.db.get_value(
+            self.doctype,
+            {
+                "event": self.event,
+                "mapped_email": self.mapped_email,
+                "name": ["!=", self.name or ""],
+            },
+            "name",
+        )
+        if existing:
+            frappe.msgprint(
+                _("{0} already has a coupon ({1}) for this event.").format(
+                    self.mapped_email, existing
+                ),
+                indicator="orange",
+                alert=True,
+            )
 
     def permit_only_team(self):
         """Allow only event/chapter team members to modify."""

--- a/fossunited/fossunited/doctype/event_free_ticket_code/test_event_free_ticket_code.py
+++ b/fossunited/fossunited/doctype/event_free_ticket_code/test_event_free_ticket_code.py
@@ -49,17 +49,3 @@ class TestEventFreeTicketCodeController(FrappeTestCase):
     def test_invalid_mapped_email_throws_error(self):
         with self.assertRaises(frappe.ValidationError):
             FreeTicketCodeFactory.create(event=self.event.name, mapped_email="not-an-email")
-
-    def test_duplicate_email_for_same_event_throws_error(self):
-        FreeTicketCodeFactory.create(event=self.event.name, mapped_email="dupe@test.com")
-        with self.assertRaises(frappe.ValidationError):
-            FreeTicketCodeFactory.create(event=self.event.name, mapped_email="dupe@test.com")
-
-    def test_same_email_allowed_across_different_events(self):
-        other_event = FOSSChapterEventFactory.create(
-            chapter=self.chapter.name, event_name="Other Test Event"
-        )
-        FreeTicketCodeFactory.create(event=self.event.name, mapped_email="shared@test.com")
-        # Should not raise - duplicate check is scoped per event
-        FreeTicketCodeFactory.create(event=other_event.name, mapped_email="shared@test.com")
-        frappe.delete_doc(EVENT, other_event.name, force=True)


### PR DESCRIPTION
- It became pain to track blocking email and repeat send for booth managers.

- I think its better to simply warn via desk UI and dashboard toast to notify the sender.
Except that its their choice to send it again.

Even IDK if email aliasing with "+booth" will work fine for every email provider

Fixed:

- Simple warn that email has another coupon under <tier> ...