### PR TITLE
dashboard(eventDetails): add missing deck_link and schedule_description field

### DIFF
--- a/dashboard/src/pages/EventDetails.vue
+++ b/dashboard/src/pages/EventDetails.vue
@@ -151,6 +151,13 @@
           label="Show Speakers Tab"
           description="Show speakers (added in event schedule) profile linked to their proposals."
         />
+        <FormControl
+          v-model="event.doc.deck_link"
+          type="url"
+          size="md"
+          label="Deck Link"
+          description="Link to the event's slide/sponsorship deck. Shared with partners and sponsors."
+        />
         <TextEditor
           label="Event Description"
           class="col-span-2"

--- a/dashboard/src/pages/EventDetails.vue
+++ b/dashboard/src/pages/EventDetails.vue
@@ -250,7 +250,7 @@
           type="textarea"
           size="md"
           label="Ticket Form Description"
-          description="Supports markdown (bold, italic, bullet points, headings). Shown at the top of the ticket purchase page."
+          description="Input markdown (bold, italic, bullet points, headings). Shown at the top of the ticket purchase page."
           class="col-span-2 [&_textarea]:min-h-[200px]"
         />
       </div>

--- a/dashboard/src/pages/EventPartner.vue
+++ b/dashboard/src/pages/EventPartner.vue
@@ -1,6 +1,20 @@
 <template>
   <div v-if="event.doc" class="px-4 py-8 md:p-8 w-full z-0 min-h-screen">
     <EventHeader :event="event.doc" />
+    <div class="flex flex-col my-6">
+      <div class="font-semibold text-ink-gray-8 border-b-2 pb-2">Sponsorship Deck</div>
+      <div class="p-2 my-1 flex flex-col sm:flex-row gap-4 sm:items-end max-w-lg">
+        <FormControl
+          v-model="event.doc.deck_link"
+          type="url"
+          size="md"
+          label="Deck Link"
+          description="Link to the event's slide/sponsorship deck. Shared with partners and sponsors."
+          class="flex-1"
+        />
+        <Button label="Save" :loading="event.setValue.loading" @click="saveDeckLink" />
+      </div>
+    </div>
     <ManageSponsorView />
     <ManagePartnerView />
   </div>
@@ -8,8 +22,17 @@
 <script setup>
 import EventHeader from '@/components/EventHeader.vue'
 import { inject } from 'vue'
+import { FormControl } from 'frappe-ui'
+import { toast } from 'vue-sonner'
 import ManageSponsorView from '@/layout/event/ManageSponsorView.vue'
 import ManagePartnerView from '@/layout/event/ManagePartnerView.vue'
 
 const event = inject('event')
+
+const saveDeckLink = () => {
+  event.setValue
+    .submit({ deck_link: event.doc.deck_link })
+    .then(() => toast.success('Deck link updated successfully'))
+    .catch((error) => toast.error('Failed to update deck link', { description: error.message }))
+}
 </script>

--- a/dashboard/src/pages/EventSchedule.vue
+++ b/dashboard/src/pages/EventSchedule.vue
@@ -204,7 +204,7 @@ const saveScheduleDescription = () => {
           type="textarea"
           size="md"
           label="Schedule Page Description"
-          description="Supports markdown (bold, italic, bullet points, headings). Shown at the top of this event's schedule page."
+          description="Input markdown and can embed Html. Shown at the top of this event's schedule page."
           class="[&_textarea]:min-h-[200px]"
         />
         <Button

--- a/dashboard/src/pages/EventSchedule.vue
+++ b/dashboard/src/pages/EventSchedule.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { IconArrowUpRight } from '@tabler/icons-vue'
-import { Breadcrumbs, createResource, Switch } from 'frappe-ui'
+import { Breadcrumbs, createResource, FormControl, Switch } from 'frappe-ui'
 import { inject, onMounted, ref, computed, provide } from 'vue'
 import { toast } from 'vue-sonner'
 import { redirectRoute, isSmallScreen } from '@/helpers/utils'
@@ -154,6 +154,15 @@ const toggleShowSchedule = () => {
 }
 
 const showModifyScheduleItemDrawer = ref(false)
+
+const saveScheduleDescription = () => {
+  event.setValue
+    .submit({ schedule_page_description: event.doc.schedule_page_description })
+    .then(() => toast.success('Schedule page description updated successfully'))
+    .catch((error) =>
+      toast.error('Failed to update schedule page description', { description: error.message }),
+    )
+}
 </script>
 <template>
   <div class="flex h-screen overflow-hidden">
@@ -189,6 +198,23 @@ const showModifyScheduleItemDrawer = ref(false)
           @click="redirectRoute(`${event.doc?.route}/schedule`)"
         />
       </div>
+      <div class="flex flex-col gap-2 my-4">
+        <FormControl
+          v-model="event.doc.schedule_page_description"
+          type="textarea"
+          size="md"
+          label="Schedule Page Description"
+          description="Supports markdown (bold, italic, bullet points, headings). Shown at the top of this event's schedule page."
+          class="[&_textarea]:min-h-[200px]"
+        />
+        <Button
+          class="w-fit"
+          size="sm"
+          label="Save Description"
+          @click="saveScheduleDescription"
+        />
+      </div>
+      <hr class="my-4" />
       <ManageHallOptions v-if="event.doc" v-model="event.doc.hall_options" />
       <hr class="my-4" />
       <ManageDates


### PR DESCRIPTION
- We missed both these fields in dashboard and until now were filling manually by DM request from organiser to add them.

- These are essential and missing gaps for conducting paid (ticket) events and dashboard should facilitate this.

- manage page showing deck link form field
<img width="1769" height="304" alt="image" src="https://github.com/user-attachments/assets/482036ed-aa49-48d3-8867-6568bd8a2781" />

- Sponsors manage page showing same for handy note
<img width="751" height="572" alt="image" src="https://github.com/user-attachments/assets/8ba50628-f137-4b35-a007-00c3012590a2" />

- Schedule page showing description text in plain markdown
<img width="918" height="877" alt="image" src="https://github.com/user-attachments/assets/15a44282-24ef-482b-886e-18b286fdc5da" />
