### PR TITLE
docs: add umami anlaytics + helper commands to zensical serve

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -117,6 +117,15 @@ lint:
 logs:
     {{COMPOSE_CMD}} logs -f
 
+# Serve the Zensical docs site locally (see package.json for the actual command)
+docs:
+    yarn docs
+
+# Run the Bruno API test collection
+alias bruno := bru
+bru:
+    yarn bru
+
 # Complete demo setup: up → setup → seed → build-dashboard → ready to start
 # This is the one-click local demo deploy. Run 'just start' (or 'just launch') afterwards.
 demo: up

--- a/docs/overrides/partials/integrations/analytics/custom.html
+++ b/docs/overrides/partials/integrations/analytics/custom.html
@@ -1,0 +1,1 @@
+<script defer src="https://analytics.fossunited.org/script.js" data-website-id="{{ config.extra.analytics.property }}"></script>

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -111,12 +111,17 @@ font.text = "Inter"
 font.code = "JetBrains Mono"
 logo = "./assets/fossunited-white.svg"
 favicon = "./assets/fossunited-white.svg"
+custom_dir = "overrides"
 features = [
   "search.highlight",
   "content.action.edit",
   "content.action.view",
   "navigation.footer"
 ]
+
+[project.extra.analytics]
+provider = "custom"
+property = "e2023d8d-f808-4486-bc8e-97839d36b631"
 
 [[project.theme.palette]]
 scheme = "default"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint .",
     "format": "prettier --write .",
-    "purge-css": "purgecss --config purgecss.config.cjs"
+    "purge-css": "purgecss --config purgecss.config.cjs",
+    "docs": "command -v zensical >/dev/null 2>&1 && zensical serve -f docs/zensical.toml -o || uv run --with zensical zensical serve -f docs/zensical.toml -o"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "postinstall": "cd dashboard && yarn install",
     "dev": "cd dashboard && yarn dev --host",
     "bru": "cd bruno-collection && yarn bru",
+    "bruno": "yarn bru",
     "build": "yarn build-tailwind && yarn build-dashboard",
     "build-tailwind": "npx tailwindcss -i ./fossunited/templates/base.css -o ./fossunited/public/css/styles.css",
     "build-dashboard": "cd dashboard && yarn build",


### PR DESCRIPTION
- We might really want to know how often docs are used or even if we should care to update.

- We need counts on how many visit and read just in case. Getting lot of DM queries burns me out, when I become the only person to get pinged all time.

- Added helper commands to serve zensical locally via `yarn docs` or even `just docs`