### PR TITLE
fix(frappe): frappe.request.path is not global safe exec point

### DIFF
--- a/fossunited/fossunited/utils.py
+++ b/fossunited/fossunited/utils.py
@@ -45,6 +45,16 @@ def is_user_team_member(chapter, user):
     return False
 
 
+def get_request_path():
+    """Current request path, for use in Jinja templates.
+
+    frappe.request is no longer exposed to the sandboxed Jinja globals
+    (frappe/frappe#42390 removed it from exec_safe_globals).
+    """
+    request = getattr(frappe.local, "request", None)
+    return request.path if request else ""
+
+
 # Filter
 def make_badge(text="Default", size="sm"):
     # stored in the form of (background-color, text-color)

--- a/fossunited/hooks.py
+++ b/fossunited/hooks.py
@@ -52,6 +52,7 @@ jinja = {
     "methods": [
         "fossunited.fossunited.utils.make_badge",
         "fossunited.fossunited.utils.get_doc_likes",
+        "fossunited.fossunited.utils.get_request_path",
         "fossunited.fossunited.utils.get_user_socials",
         "fossunited.fossunited.utils.get_user_editable_doctype_fields",
         "fossunited.fossunited.utils.get_signup_optin_checks",

--- a/fossunited/templates/macros/breadcrumb.html
+++ b/fossunited/templates/macros/breadcrumb.html
@@ -13,7 +13,7 @@
       {% set ignore_segments = ignore_segments or [] %}
       {% set rename_map = rename_map or {} %}
       {% set ignore_indices = ignore_indices or [] %}
-      {% set path_parts = frappe.request.path.strip('/').split('/') %}
+      {% set path_parts = get_request_path().strip('/').split('/') %}
 
       {% set filtered_parts = [] %}
       {% set filtered_indices = [] %}

--- a/fossunited/templates/pages/timeline_base.html
+++ b/fossunited/templates/pages/timeline_base.html
@@ -211,16 +211,16 @@
         <button id="toggle-club" class="v3-btn v3-text-primary w-50" aria-pressed="false">Club Events</button>
       </div>
 
-      <div class="d-flex justify-content-center gap-3 mb-4">
+      <div class="d-flex gap-2 w-100 mb-4" role="group" aria-label="Event timeline filter">
         <a
           href="/events/timeline"
-          class="v3-btn {% if page_type == 'upcoming' %}v3-btn-dark{% else %}v3-btn-secondary{% endif %}"
+          class="v3-btn w-50 text-wrap text-xs {% if page_type == 'upcoming' %}v3-btn-dark{% else %}v3-btn-secondary{% endif %}"
         >
           Upcoming Events
         </a>
         <a
           href="/events/timeline/completed"
-          class="v3-btn {% if page_type == 'completed' %}v3-btn-dark{% else %}v3-btn-secondary{% endif %}"
+          class="v3-btn w-50 text-wrap text-xs {% if page_type == 'completed' %}v3-btn-dark{% else %}v3-btn-secondary{% endif %}"
         >
           Completed Events
         </a>


### PR DESCRIPTION
- Tried updated frpape v15 to latest thinking for security and fixes, but it removed frappe.request completely in jinja globals as safe exec.

- Had to fix it in ssh temporarily, but reported the issue and frappe contributor seem to have reverted for path 

https://github.com/frappe/frappe/pull/42748

Will keep this documented in case we want to update cloud and avoid getting that error.

To remove/revert after commit is backported to latest release