### PR TITLE
fix(if26): split sponsors from main tiers and show others in its own section

### DIFF
--- a/fossunited/www/indiafoss/2026/index.html
+++ b/fossunited/www/indiafoss/2026/index.html
@@ -511,6 +511,34 @@
       </section>
       {% endif %}
 
+      {# ── 5a. OTHER-TIER SPONSORS (Diversity Scholar, etc.) — Contributor grid size #}
+      {% if other_sponsors %}
+      <section id="other-sponsors" aria-label="Additional tier sponsors">
+        {% for grp in other_sponsors %}
+        <div class="{% if not loop.first %}mt-5{% endif %}">
+          <h3 class="text-xl semi-bold v3-text-primary mb-4">{{ grp.tier }} Sponsors</h3>
+          <div class="if-sponsor-grid-t2" role="list" aria-label="{{ grp.tier }} sponsors">
+            {% for s in grp.sponsor_list %}
+              <div role="listitem" style="display:contents">
+                <a href="{{ s.link }}" target="_blank" rel="noopener noreferrer"
+                   class="if-sponsor-logo"
+                   data-toggle="tooltip" data-container="body"
+                   title="{{ s.sponsor_name }}"
+                   aria-label="{{ s.sponsor_name }}, {{ grp.tier }} sponsor">
+                  {% if s.image %}
+                    <img src="{{ s.image }}" alt="{{ s.sponsor_name }} logo">
+                  {% else %}
+                    <span class="text-sm" style="color:#888;padding:8px;">{{ s.sponsor_name }}</span>
+                  {% endif %}
+                </a>
+              </div>
+            {% endfor %}
+          </div>
+        </div>
+        {% endfor %}
+      </section>
+      {% endif %}
+
       {# ── 5b. COMMUNITY PARTNERS ───────────────────── #}
       {% if partners %}
       <section id="community-partners" aria-labelledby="partners-heading">

--- a/fossunited/www/indiafoss/2026/index.py
+++ b/fossunited/www/indiafoss/2026/index.py
@@ -10,6 +10,9 @@ from fossunited.fossunited.utils import get_event_sponsors
 
 INDIAFOSS_2026_EVENT = "IndiaFOSS 2026"
 TIER1 = {"Maintainer", "Patrons", "Platinum", "Gold", "Maintainer Tier"}
+# Tiers that belong in the main Sponsors section. Anything else (e.g. "Diversity
+# Scholar") drops into its own section below, at the Contributor (tier-2) grid size.
+MAIN_TIERS = TIER1 | {"Contributor", "Contributor Tier"}
 
 
 # TODO: replace all short form url to /2026/ form
@@ -41,7 +44,12 @@ def get_context(context):
     # Sponsors — use shared util, split into tier1/tier2
     sponsors_dict = get_event_sponsors(event.sponsor_list)
     context.sponsors = [
-        {"tier": t, "sponsor_list": sl, "is_tier1": t in TIER1} for t, sl in sponsors_dict.items()
+        {"tier": t, "sponsor_list": sl, "is_tier1": t in TIER1}
+        for t, sl in sponsors_dict.items()
+        if t in MAIN_TIERS
+    ]
+    context.other_sponsors = [
+        {"tier": t, "sponsor_list": sl} for t, sl in sponsors_dict.items() if t not in MAIN_TIERS
     ]
     context.partners = event.community_partners
 
@@ -159,6 +167,7 @@ def _empty_context(context):
             k: []
             for k in (
                 "sponsors",
+                "other_sponsors",
                 "partners",
                 "co_chairs",
                 "reviewers",


### PR DESCRIPTION
- maint and contributor tier show up at top

- rest custom show below in each section
  for now we will only have "Diversity"

<img width="1441" height="978" alt="image" src="https://github.com/user-attachments/assets/5f123528-c3d9-464b-b33f-61082ccbe4d4" />
